### PR TITLE
Cobbler shouldn't fail trying to re-create broken symlinks

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2105,7 +2105,7 @@ def link_distro(settings, distro):
     # create the links directory only if we are mirroring because with
     # SELinux Apache can't symlink to NFS (without some doing)
 
-    if not os.path.exists(dest_link):
+    if not os.path.lexists(dest_link):
         try:
             os.symlink(base, dest_link)
         except:


### PR DESCRIPTION
This happens a lot with a small stateless Linux distribution I've built for fun and research purposes using Fedora's livecd-to-pxeboot script in livecd-tools. It works by putting the iso inside of the initrd and everything runs in memory. There is no kickstart so the links under /var/www/cobbler/links will always be bogus.
