### PR TITLE
New cobbler setting client_use_localhost

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -102,6 +102,7 @@ DEFAULTS = {
     "scm_track_enabled"           : 0,
     "scm_track_mode"              : "git",
     "server"                      : "127.0.0.1",
+    "client_use_localhost"        : "",
     "snippetsdir"                 : "/var/lib/cobbler/snippets",
     "template_remote_kickstarts"  : 0,
     "virt_auto_boot"              : 0,

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2000,7 +2000,11 @@ def local_get_cobbler_api_url():
     except:
        traceback.print_exc()
        raise CX("/etc/cobbler/settings is not a valid YAML file")
-    return "http://%s:%s/cobbler_api" % (data.get("server","127.0.0.1"),data.get("http_port","80"))
+
+    if data.get("client_use_localhost", False):
+      return "http://%s:%s/cobbler_api" % ("127.0.0.1",data.get("http_port","80"))
+    else:
+      return "http://%s:%s/cobbler_api" % (data.get("server","127.0.0.1"),data.get("http_port","80"))
 
 def get_ldap_template(ldaptype=None):
     """

--- a/config/settings
+++ b/config/settings
@@ -299,6 +299,7 @@ redhat_management_permissive: 0
 register_new_installs: 0
 
 # Flags to use for yum's reposync.  If your version of yum reposync
+client_use_localhost: 0
 # does not support -l, you may need to remove that option.
 reposync_flags: "-l -m -d"
 
@@ -340,6 +341,12 @@ scm_track_mode: "git"
 # (dual homed, etc), you need to read the --server-override section
 # of the manpage for how that works.
 server: 127.0.0.1
+
+# If set to 1, all commands will be forced to use the localhost address
+# instead of using the above value which can force commands like
+# cobbler sync to open a connection to a remote address if one is in the
+# configuration and would traceback.
+client_use_localhost: 0
 
 # this is a directory of files that cobbler uses to make
 # templating easier.  See the Wiki for more information.  Changing


### PR DESCRIPTION
The default in cobbler is to use the server setting for xmlrpc
connections.  Since the server setting could be a remote host this can
cause commands to fail.  By applying this setting all commands will be
force to use the localhost address.
