### PR TITLE
Fix python printf format

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1282,7 +1282,7 @@ def mkdir(path,mode=0755,logger=None):
        if not oe.errno == 17: # already exists (no constant for 17?)
            if logger is not None:
                log_exc(logger)
-           raise CX(_("Error creating") % path)
+           raise CX(_("Error creating %s") % path)
 
 def path_tail(apath, bpath):
     """


### PR DESCRIPTION
This fixes an obscure traceback in Spacewalk:
Caused by: java.lang.RuntimeException: redstone.xmlrpc.XmlRpcFault: <type 'exceptions.TypeError'>:not all arguments converted during string formatting
        at com.redhat.rhn.manager.kickstart.tree.BaseTreeEditOperation.store(BaseTreeEditOperation.java:116)
        at com.redhat.rhn.manager.kickstart.tree.TreeCreateOperation.store(TreeCreateOperation.java:61)
        at com.redhat.rhn.frontend.action.BaseEditAction.execute(BaseEditAction.java:64)
        at org.apache.struts.action.RequestProcessor.processActionPerform(RequestProcessor.java:425)
        ... 40 more

which was traced to cobbler:
Thu Dec  8 17:09:16 2011 - INFO | Exception occured: <type 'exceptions.TypeError'>
Thu Dec  8 17:09:16 2011 - INFO | Exception value: not all arguments converted during string formatting
Thu Dec  8 17:09:16 2011 - INFO | Exception Info:
  File "/usr/lib/python2.6/site-packages/cobbler/remote.py", line 1763, in _dispatch
    return method_handle(*params)
   File "/usr/lib/python2.6/site-packages/cobbler/remote.py", line 874, in save_distro
    return self.save_item("distro",object_id,token,editmode=editmode)
   File "/usr/lib/python2.6/site-packages/cobbler/remote.py", line 870, in save_item
    rc = self.api.add_item(what,obj)
   File "/usr/lib/python2.6/site-packages/cobbler/api.py", line 395, in add_item
    return self.get_items(what).add(ref,check_for_duplicate_names=check_for_duplicate_names,save=save,logger=logger)
   File "/usr/lib/python2.6/site-packages/cobbler/collection.py", line 311, in add
    self.lite_sync.add_single_distro(ref.name)
   File "/usr/lib/python2.6/site-packages/cobbler/action_litesync.py", line 62, in add_single_distro
    self.sync.pxegen.copy_single_distro_files(distro)
   File "/usr/lib/python2.6/site-packages/cobbler/pxegen.py", line 169, in copy_single_distro_files
    utils.mkdir(distro_dir)
   File "/usr/lib/python2.6/site-packages/cobbler/utils.py", line 1221, in mkdir
    raise CX(_("Error creating") % path)
