### PR TITLE
Make use of system TIME_ZONE in Django

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -299,7 +299,7 @@ of an existing system.  For use with a boot-server configured with Cobbler
 Summary: Web interface for Cobbler
 Group: Applications/System
 Requires: cobbler
-Requires: Django
+Requires: Django >= 1.1.2
 Requires: mod_wsgi
 Requires: mod_ssl
 %if 0%{?fedora} >= 11 || 0%{?rhel} >= 6

--- a/web/settings.py
+++ b/web/settings.py
@@ -18,7 +18,7 @@ DATABASE_HOST = ''
 DATABASE_PORT = ''       
 
 # Force Django to use the systems timezone
-#TIME_ZONE = None
+TIME_ZONE = None
 
 # Language section
 # TBD.


### PR DESCRIPTION
It's a sane default and solves some of the TZ issues i have with Cobbler-web.
Probably it fixes issue #23 aswell.
