### PR TITLE
fix install=... kernel parameter when importing a SUSE distro

### DIFF
--- a/cobbler/modules/manage_import_suse.py
+++ b/cobbler/modules/manage_import_suse.py
@@ -352,7 +352,7 @@ class ImportSuseManager:
             distro.set_initrd(initrd)
             distro.set_arch(pxe_arch)
             distro.set_breed(self.breed)
-            distro.set_kernel_options("install=http://@@http_server@@/cblr/links/%s" % (name))
+            distro.set_kernel_options("install=http://%s/cblr/links/%s" % (self.settings.server, name))
             # If a version was supplied on command line, we set it now
             if self.os_version:
                 distro.set_os_version(self.os_version)


### PR DESCRIPTION
when importing a SUSE distro, we need to set a kernel parameter "install=...." pointing to the installation source. That was broken because @@http_server@@ was not available for kopts.
I use settings.server now 
