### PR TITLE
Fixed a typo in the power managementc instructions in the settings file.

### DIFF
--- a/config/settings
+++ b/config/settings
@@ -232,7 +232,7 @@ next_server: 127.0.0.1
 # settings for power management features.  optional.
 # see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
 # choices:
-#    bullpap wti apc apc_snmp ether-wake ipmilan
+#    bullpap wti apc apc_snmp ether_wake ipmilan
 #    drac ipmitool ilo rsa lpar bladecenter virsh
 power_management_default_type: 'ipmitool'
 


### PR DESCRIPTION
The script is called power_ether_wake.template hence setting the config to "ether-wake" won't work and "ether_wake" will.
