### PR TITLE
Speedup reposync by avoiding deletion of the createrepo cache.

### DIFF
--- a/config/rsync.exclude
+++ b/config/rsync.exclude
@@ -10,3 +10,5 @@
 **/kde-i18n**
 pool/**/*.dsc
 pool/**/*.gz
+### Avoid deleting the local cache created by createrepo
+**/cache/**


### PR DESCRIPTION
rsync copies the repositories with --delete hence deleting everything local that isn't on the source server. The createrepo then creates (following the default settings) a cache directory ... which is deleted by the next rsync run. Putting the cache directory in the rsync exclude list avoids this deletion and speeds up running reposync dramatically.
