### PR TITLE
REMOTE_ADDR not being added to the form dict in services.py

### DIFF
--- a/scripts/services.py
+++ b/scripts/services.py
@@ -57,6 +57,10 @@ def application(environ, start_response):
     # like: eth0 XX:XX:XX:XX:XX:XX
     form["REMOTE_MAC"]  = form.get("HTTP_X_RHN_PROVISIONING_MAC_0", None)
 
+    # REMOTE_ADDR isn't a required wsgi attribute so it may be naive to assume
+    # it's always present in this context.
+    form["REMOTE_ADDR"] = environ.get("REMOTE_ADDR", None)
+
     # Read config for the XMLRPC port to connect to:
     fd = open("/etc/cobbler/settings")
     data = fd.read()


### PR DESCRIPTION
The REMOTE_ADDR value was not being added to the form dict in services.py.

This lead directly to install.log not having any ip address associated with pre and post triggers and `cobbler status` or get_status on the xmlrpc api not behaving correctly.

The fix I created might be a bit naive since REMOTE_ADDR isn't listed as a required value in the wsgi spec, but in my environment (apache and mod_wsgi) it worked as expected.
