### PR TITLE
Fix Power management integration

### DIFF
--- a/cobbler/field_info.py
+++ b/cobbler/field_info.py
@@ -55,6 +55,7 @@ USES_SELECT = [
    "breed",
    "os_version",
    "status",
+   "power_type",
 ]
 
 # fields that should use the checkbox in the web app
@@ -108,11 +109,11 @@ BLOCK_MAPPINGS = {
    "*virt_type"      : "Virtualization",
    "*virt_file_size" : "Virtualization",
    "*virt_disk_driver" : "Virtualization",
-   "power_id"        : "Power",
-   "power_address"   : "Power",
-   "power_user"      : "Power",
-   "power_pass"      : "Power",
-   "power_type"      : "Power",
+   "power_id"        : "Power management",
+   "power_address"   : "Power management",
+   "power_user"      : "Power management",
+   "power_pass"      : "Power management",
+   "power_type"      : "Power management",
    "address"         : "Networking", # from network
    "cidr"            : "Networking", # ditto
    "broadcast"       : "Networking", # ..

--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -53,11 +53,11 @@ FIELDS = [
   ["virt_auto_boot","<<inherit>>",0,"Virt Auto Boot",True,"Auto boot this VM?",0,"bool"],
   ["ctime",0,0,"",False,"",0,"float"],
   ["mtime",0,0,"",False,"",0,"float"],
-  ["power_type","SETTINGS:power_management_default_type",0,"Power Management Type",True,"",utils.get_power_types(),"str"],
-  ["power_address","",0,"Power Management Address",True,"Ex: power-device.example.org",0,"str"],
-  ["power_user","",0,"Power Username ",True,"",0,"str"],
-  ["power_pass","",0,"Power Password",True,"",0,"str"],
-  ["power_id","",0,"Power ID",True,"Usually a plug number or blade name, if power type requires it",0,"str"],
+  ["power_type","SETTINGS:power_management_default_type",0,"Type",True,"Power management script to use",utils.get_power_types(),"str"],
+  ["power_address","",0,"Address",True,"Ex: power-device.example.org",0,"str"],
+  ["power_user","",0,"Username ",True,"",0,"str"],
+  ["power_pass","",0,"Password",True,"",0,"str"],
+  ["power_id","",0,"ID",True,"Usually a plug number or blade name, if power type requires it",0,"str"],
   ["hostname","",0,"Hostname",True,"",0,"str"],
   ["gateway","",0,"Gateway",True,"",0,"str"],
   ["name_servers",[],0,"Name Servers",True,"space delimited",0,"list"],
@@ -599,7 +599,7 @@ class System(item.Item):
         choices = utils.get_power_types()
         choices.sort()
         if power_type not in choices:
-            raise CX("power type must be one of: %s" % ",".join(choices))
+            raise CX("power management type must be one of: %s" % ",".join(choices))
         self.power_type = power_type
         return True
 

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1963,6 +1963,7 @@ def get_power_types():
     power_template = re.compile(r'power_(.*).template')
     for x in glob.glob("/etc/cobbler/power/power_*.template"):
         power_types.append(power_template.search(x).group(1))
+    power_types.sort()
     return power_types
 
 def get_power(powertype=None):

--- a/config/settings
+++ b/config/settings
@@ -231,9 +231,9 @@ next_server: 127.0.0.1
 
 # settings for power management features.  optional.
 # see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
-# choices:
-#    bullpap wti apc apc_snmp ether_wake ipmilan
-#    drac ipmitool ilo rsa lpar bladecenter virsh
+# choices (refer to codes.py):
+#    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
+#    ipmilan ipmitool lpar rsa virsh wti
 power_management_default_type: 'ipmitool'
 
 # the commands used by the power management module are sourced


### PR DESCRIPTION
Fix fence-agents integration, by actually proposing the list of available
scripts as a combo list. Also rename the UI section from "Power" to
"Power management", remove "Power" from the field names and reword
Tooltip for better clarity
