### PR TITLE
URI fix

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ Cobbler
 
 Cobbler is a Linux installation server that allows for rapid setup of network installation environments. It glues together and automates many associated Linux tasks so you do not have to hop between lots of various commands and applications when rolling out new systems, and, in some cases, changing existing ones. It can help with installation, DNS, DHCP, package updates, power management, configuration management orchestration, and much more.
 
-read more at https://cobbler.github.com
+read more at http://cobbler.github.com
 
 Documentation is available on the Wiki at https://github.com/cobbler/cobbler/wiki.   To view the manpages, install the RPM and run "man cobbler" or run "perldoc cobbler.pod" from a source checkout.  "koan" also has a manpage.
 


### PR DESCRIPTION
The URI for the cobbler site was fixed to correctly reflect http rather than unavailable https service.
