### PR TITLE
Ensure we copy OBJ_TYPES rather than simply generating a new pointer to the same object

### DIFF
--- a/cobbler/action_replicate.py
+++ b/cobbler/action_replicate.py
@@ -137,7 +137,7 @@ class Replicate:
 
         if self.prune:
             self.logger.info("Removing Objects Not Stored On Master")
-            obj_types = OBJ_TYPES
+            obj_types = OBJ_TYPES[:]
             if len(self.system_patterns) == 0 and "system" in obj_types:
                 obj_types.remove("system")
             for what in obj_types:


### PR DESCRIPTION
This prevents us from removing "system" from the globally scoped list of objects to synchronise for the next time
around.
