### PR TITLE
Safer rsync_sync options

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -221,7 +221,7 @@ class RepoSync:
             repo.mirror = "%s/" % repo.mirror
 
         # FIXME: wrapper for subprocess that logs to logger
-        cmd = "rsync -rltDv %s --delete --exclude-from=/etc/cobbler/rsync.exclude %s %s" % (spacer, repo.mirror, dest_path)
+        cmd = "rsync -rltDv --copy-unsafe-links --delete-after %s --delete --exclude-from=/etc/cobbler/rsync.exclude %s %s" % (spacer, repo.mirror, dest_path)
         rc = utils.subprocess_call(self.logger, cmd)
 
         if rc !=0:


### PR DESCRIPTION
Added a couple of options to the default rsync
 "--copy-unsafe-links" SymLinks to files outside of the rsync tree will be converted to files.
 "--delete-after" Deleted files will be removed at the end of the rsync.

Have been using these in a local cobbler install for about 6 months, thought I should contribute upstream. If you guys think it would be a good idea I could probably make the rsync options a settting in the settings file or even an option in the web gui per repo?
