### PR TITLE
Super tiny nitpick tweak, but IMHO better to defer to the package mainta...

### DIFF
--- a/snippets/puppet_register_if_enabled
+++ b/snippets/puppet_register_if_enabled
@@ -4,6 +4,6 @@
 /usr/sbin/puppetd --test --waitforcert 0
 
 # turn puppet service on for reboot
-/sbin/chkconfig --level 345 puppet on
+/sbin/chkconfig puppet on
 
 #end if


### PR DESCRIPTION
...iners #chkconfig line in their init scripts to determine runlevels than to explicitly hardcode it here.  The fedora (and epel) 'puppet' rpm already have the line.
