### PR TITLE
don't overwrite existing kernel+initrd when fetching files

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -1221,8 +1221,8 @@ class Koan:
         initrd = self.safe_load(profile_data,'initrd')
         kernel_short = os.path.basename(kernel)
         initrd_short = os.path.basename(initrd)
-        kernel_save = "%s/%s" % (download_root, kernel_short)
-        initrd_save = "%s/%s" % (download_root, initrd_short)
+        kernel_save = "%s/%s_koan" % (download_root, kernel_short)
+        initrd_save = "%s/%s_koan" % (download_root, initrd_short)
 
         if self.server:
             if kernel[0] == "/":


### PR DESCRIPTION
when koan is doing a reinstalltion of a system, it fetches kernel and initrd from cobbler and modifies the local boot config.
At least on a SUSE system, the existing initrd is overwritten - so there is now way back.
This patch appends a postfix to the kernel and initrd.
