### PR TITLE
Moved "-v -s" from manage_in_tftpd.py to tftpd.template

### DIFF
--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -126,7 +126,7 @@ class InTftpdManager:
         metadata = {
             "user"      : "root",
             "binary"    : "/usr/sbin/in.tftpd",
-            "args"      : "-v -s %s" % self.bootloc
+            "args"      : "%s" % self.bootloc
         }
         self.logger.info("generating %s" % self.settings_file)
         self.templar.render(template_data, metadata, self.settings_file, None)

--- a/templates/etc/tftpd.template
+++ b/templates/etc/tftpd.template
@@ -11,7 +11,7 @@ service tftp
         wait                    = yes
         user                    = $user
         server                  = $binary
-        server_args             = -B 1380 $args
+        server_args             = -B 1380 -v -s $args
         per_source              = 11
         cps                     = 100 2
         flags                   = IPv4


### PR DESCRIPTION
Moved "-v -s" from manage_in_tftpd.py to tftpd.template.  The -s breaks atftpd in EL6 and moving this server arg to the template should make it easier for el6 users to find and change.
