### PR TITLE
Minor fix, since some XMLRPC errors contain colons

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -282,7 +282,7 @@ class BootCLI:
             try:
                 self.remote.xapi_object_edit(object_type, options.name, object_action, utils.strip_none(vars(options), omit_none=True), self.token)
             except xmlrpclib.Fault, (err):
-                (etype, emsg) = err.faultString.split(":")
+                (etype, emsg) = err.faultString.split(":",1)
                 print emsg[1:-1] # don't print the wrapping quotes
                 sys.exit(1)
         elif object_action == "getks":


### PR DESCRIPTION
Hit an error caused by a faultString with more than one colon in it.
