### PR TITLE
[BUGFIX] Issue #13 - reposync with --tries > 1 always repeats, even on success

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -118,6 +118,7 @@ class RepoSync:
                 try:
                     self.sync(repo) 
                     success = True
+                    break
                 except:
                     utils.log_exc(self.logger)
                     self.logger.warning("reposync failed, tries left: %s" % (x-2))


### PR DESCRIPTION
The success flag was being set when the reposync ran, but didn't break out of the retry loop - easy fix
