### PR TITLE
Add bind chroot and secondary template functionality

### DIFF
--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -180,7 +180,10 @@ class BindManager:
         """
         Write out the named.conf main config file from the template.
         """
-        settings_file = "/etc/named.conf"
+        if self.settings.manage_bind_chroot:
+            settings_file = "/var/named/chroot/etc/named.conf"
+        else:
+            settings_file = "/etc/named.conf"
         template_file = "/etc/cobbler/named.template"
         forward_zones = self.settings.manage_forward_zones
         reverse_zones = self.settings.manage_reverse_zones
@@ -209,6 +212,62 @@ zone "%(arpa)s." {
     file "%(zone)s";
 };
 """ % {'arpa': arpa, 'zone': zone}
+                metadata['zone_include'] = metadata['zone_include'] + txt
+
+        try:
+            f2 = open(template_file,"r")
+        except:
+            raise CX(_("error reading template from file: %s") % template_file)
+        template_data = ""
+        template_data = f2.read()
+        f2.close()
+
+        if self.logger is not None:
+            self.logger.info("generating %s" % settings_file)
+        self.templar.render(template_data, metadata, settings_file, None)
+
+    def __write_secondary_conf(self):
+        """
+        Write out the secondary.conf secondary config file from the template.
+        """
+        if self.settings.manage_bind_chroot:
+            settings_file = "/var/named/chroot/etc/secondary.conf"
+        else:
+            settings_file = "/etc/secondary.conf"
+        template_file = "/etc/cobbler/secondary.template"
+        forward_zones = self.settings.manage_forward_zones
+        reverse_zones = self.settings.manage_reverse_zones
+
+        metadata = {'forward_zones': self.__forward_zones().keys(),
+                    'reverse_zones': [],
+                    'zone_include': ''}
+
+        for zone in metadata['forward_zones']:
+                txt =  """
+zone "%(zone)s." {
+    type slave;
+    masters {
+        %(master)s;
+    }; 
+    file "data/%(zone)s";
+};
+""" % {'zone': zone, 'master': self.settings.bind_master}
+                metadata['zone_include'] = metadata['zone_include'] + txt
+
+        for zone in self.__reverse_zones().keys():
+                tokens = zone.split('.')
+                tokens.reverse()
+                arpa = '.'.join(tokens) + '.in-addr.arpa'
+                metadata['reverse_zones'].append((zone, arpa))
+                txt = """
+zone "%(arpa)s." {
+    type slave;
+    masters {
+        %(master)s;
+    }; 
+    file "data/%(zone)s";
+};
+""" % {'arpa': arpa, 'zone': zone, 'master': self.settings.bind_master}
                 metadata['zone_include'] = metadata['zone_include'] + txt
 
         try:
@@ -274,6 +333,11 @@ zone "%(arpa)s." {
         default_template_data = f2.read()
         f2.close()
 
+        if self.settings.manage_bind_chroot:
+            zonefileprefix = '/var/named/chroot/var/named/'
+        else:
+            zonefileprefix = '/var/named/'
+
         for (zone, hosts) in forward.iteritems():
             metadata = {
                 'cobbler_server': cobbler_server,
@@ -291,7 +355,7 @@ zone "%(arpa)s." {
 
             metadata['host_record'] = self.__pretty_print_host_records(hosts)
 
-            zonefilename='/var/named/' + zone
+            zonefilename=zonefileprefix + zone
             if self.logger is not None:
                self.logger.info("generating (forward) %s" % zonefilename)
             self.templar.render(template_data, metadata, zonefilename, None)
@@ -313,7 +377,7 @@ zone "%(arpa)s." {
 
             metadata['host_record'] = self.__pretty_print_host_records(hosts, rectype='PTR')
 
-            zonefilename='/var/named/' + zone
+            zonefilename=zonefileprefix + zone
             if self.logger is not None:
                self.logger.info("generating (reverse) %s" % zonefilename)
             self.templar.render(template_data, metadata, zonefilename, None)
@@ -326,6 +390,7 @@ zone "%(arpa)s." {
         """
 
         self.__write_named_conf()
+        self.__write_secondary_conf()
         self.__write_zone_files()
 
 def get_manager(config,logger):

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -35,6 +35,7 @@ DEFAULTS = {
     "allow_duplicate_hostnames"   : 0,
     "allow_duplicate_macs"        : 0,
     "allow_duplicate_ips"         : 0,
+    "bind_master"                 : "1.1.1.1",
     "build_reporting_enabled"     : 0,
     "build_reporting_to_address"  : "",
     "build_reporting_sender"      : "",
@@ -75,6 +76,7 @@ DEFAULTS = {
         "ksdevice"                : "eth0"
     },
     "kernel_options_s390x"        : {},
+    "manage_bind_chroot"          : 0,
     "manage_dhcp"                 : 0,
     "manage_dns"                  : 0,
     "manage_tftp"                 : 1,

--- a/config/settings
+++ b/config/settings
@@ -218,6 +218,13 @@ manage_dhcp: 0
 # the choice of DNS mangement engine is in /etc/cobbler/modules.conf
 manage_dns: 0
 
+# set to 1 to create bind-chroot compatible bind configuration files
+manage_bind_chroot: 0
+
+# set to the ip address of the master bind DNS server for creating secondary
+# bind configuration files
+bind_master: 1.1.1.1
+
 # set to 1 to enable Cobbler's TFTP management features.
 # the choice of TFTP mangement engine is in /etc/cobbler/modules.conf
 manage_tftpd: 1


### PR DESCRIPTION
Add manage_bind_chroot option to be able to use /var/named/chroot for bind files.
Add bind_master option and the ability to generate secondary master config files.

I use the bind-chroot configuration on my server, so the config files are in /var/named/chroot.  If manage_bind_chroot is set, /var/named/chroot/ is prefixed to the names of the bind files generates.

It also now generates a file /etc/secondary.conf from /etc/cobbler/secondary.template that is suitable for use by a secondary nameserver.
