### PR TITLE
Fix for issue #105 - buildiso fails

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -485,7 +485,7 @@ class BuildIso:
         return
 
 
-    def run(self,iso=None,buildisodir=None,profiles=None,systems=None,distro=None,standalone=None,source=None,exclude_dns=None):
+    def run(self,iso=None,buildisodir=None,profiles=None,systems=None,distro=None,standalone=None,source=None,exclude_dns=None,mkisofs_opts=None):
 
         # the distro option is for stand-alone builds only
         if not standalone and distro is not None:
@@ -559,8 +559,13 @@ class BuildIso:
         else:
             self.generate_netboot_iso(imagesdir,isolinuxdir,profiles,systems,exclude_dns)
 
+        if mkisofs_opts == None:
+            mkisofs_opts = ""
+        else:
+            mkisofs_opts = mkisofs_opts.strip()
+
         # removed --quiet
-        cmd = "mkisofs -o %s -r -b isolinux/isolinux.bin -c isolinux/boot.cat" % iso
+        cmd = "mkisofs -o %s %s -r -b isolinux/isolinux.bin -c isolinux/boot.cat" % (iso,mkisofs_opts)
         cmd = cmd + " -no-emul-boot -boot-load-size 4"
         cmd = cmd + " -boot-info-table -V Cobbler\ Install -R -J -T %s" % buildisodir
 

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -952,10 +952,10 @@ class BootAPI:
 
     # ==========================================================================
 
-    def build_iso(self,iso=None,profiles=None,systems=None,buildisodir=None,distro=None,standalone=None,source=None, exclude_dns=None, logger=None):
+    def build_iso(self,iso=None,profiles=None,systems=None,buildisodir=None,distro=None,standalone=None,source=None, exclude_dns=None, mkisofs_opts=None, logger=None):
         builder = action_buildiso.BuildIso(self._config, logger=logger)
         return builder.run(
-           iso=iso, profiles=profiles, systems=systems, buildisodir=buildisodir, distro=distro, standalone=standalone, source=source, exclude_dns=exclude_dns
+           iso=iso, profiles=profiles, systems=systems, buildisodir=buildisodir, distro=distro, standalone=standalone, source=source, exclude_dns=exclude_dns, mkisofs_opts=mkisofs_opts
         )
 
     # ==========================================================================

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -353,6 +353,7 @@ class BootCLI:
             self.parser.add_option("--standalone", dest="standalone", action="store_true", help="(OPTIONAL) creates a standalone ISO with all required distro files on it")
             self.parser.add_option("--source",   dest="source",   help="(OPTIONAL) used with --standalone to specify a source for the distribution files")
             self.parser.add_option("--exclude-dns", dest="exclude_dns", action="store_true", help="(OPTIONAL) prevents addition of name server addresses to the kernel boot options")
+            self.parser.add_option("--mkisofs-opts", dest="mkisofs_opts", help="(OPTIONAL) extra options for mkisofs")
 
             (options, args) = self.parser.parse_args()
             task_id = self.start_task("buildiso",options)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -152,6 +152,7 @@ class CobblerXMLRPCInterface:
                 self.options.get("standalone",False),
                 self.options.get("source",None),
                 self.options.get("exclude_dns",False),
+                self.options.get("mkisofs_opts",None),
                 self.logger
             )
         def on_done(self):


### PR DESCRIPTION
Added a new option for buildiso: --mkisofs-opts, which allows specifying extra options to mkisofs
TODO: add input box to web interface for this option

Test output:

$ cobbler buildiso --iso=/data/isos/cobbler-test01.iso --systems=sl6test --tempdir=/data/buildiso --mkisofs-opts="-joliet-long"
task started: 2012-03-31_002917_buildiso
task started (id=Build Iso, time=Sat Mar 31 00:29:17 2012)
using/creating buildisodir: /data/buildiso
building tree for isolinux
copying miscellaneous files
processing system: sl6test
running: mkisofs -o /data/isos/cobbler-test01.iso -joliet-long -r -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -V Cobbler\ Install -R -J -T /data/buildiso
received on stdout: 
received on stderr: I: -input-charset not specified, using utf-8 (detected in locale settings)
Size of boot image is 4 sectors -> No emulation
 25.75% done, estimate finish Sat Mar 31 00:29:18 2012
 51.41% done, estimate finish Sat Mar 31 00:29:18 2012
 77.15% done, estimate finish Sat Mar 31 00:29:18 2012
Total translation table size: 4029
Total rockridge attributes bytes: 1320
Total directory bytes: 4096
Path table size(bytes): 40
Max brk space used 1a000
19456 extents written (38 MB)

ISO build complete
You may wish to delete: /data/buildiso
The output file is: /data/isos/cobbler-test01.iso
**\* TASK COMPLETE ***
