### PR TITLE
Fix for issue #17 - Make cobbler import be more squeaky when it doesn't import anything

### DIFF
--- a/cobbler/modules/manage_import_debian_ubuntu.py
+++ b/cobbler/modules/manage_import_debian_ubuntu.py
@@ -145,6 +145,10 @@ class ImportDebianUbuntuManager:
         # FIXME : search below self.path for isolinux configurations or known directories from TRY_LIST
         os.path.walk(self.path, self.distro_adder, distros_added)
 
+        if len(distros_added) == 0:
+            self.logger.warning("No distros imported, bailing out")
+            return False
+
         # find out if we can auto-create any repository records from the install tree
 
         if self.network_root is None:

--- a/cobbler/modules/manage_import_freebsd.py
+++ b/cobbler/modules/manage_import_freebsd.py
@@ -135,6 +135,10 @@ class ImportFreeBSDManager:
         # FIXME : search below self.path for isolinux configurations or known directories from TRY_LIST
         os.path.walk(self.path, self.distro_adder, distros_added)
 
+        if len(distros_added) == 0:
+            self.logger.warning("No distros imported, bailing out")
+            return False
+
         # find out if we can auto-create any repository records from the install tree
 
         if self.network_root is None:

--- a/cobbler/modules/manage_import_redhat.py
+++ b/cobbler/modules/manage_import_redhat.py
@@ -155,6 +155,10 @@ class ImportRedhatManager:
         # FIXME : search below self.path for isolinux configurations or known directories from TRY_LIST
         os.path.walk(self.path, self.distro_adder, distros_added)
 
+        if len(distros_added) == 0:
+            self.logger.warning("No distros imported, bailing out")
+            return False
+
         # find out if we can auto-create any repository records from the install tree
 
         if self.network_root is None:

--- a/cobbler/modules/manage_import_suse.py
+++ b/cobbler/modules/manage_import_suse.py
@@ -125,6 +125,10 @@ class ImportSuseManager:
         # FIXME : search below self.path for isolinux configurations or known directories from TRY_LIST
         os.path.walk(self.path, self.distro_adder, distros_added)
 
+        if len(distros_added) == 0:
+            self.logger.warning("No distros imported, bailing out")
+            return False
+
         # find out if we can auto-create any repository records from the install tree
 
         if self.network_root is None:

--- a/cobbler/modules/manage_import_vmware.py
+++ b/cobbler/modules/manage_import_vmware.py
@@ -135,6 +135,10 @@ class ImportVMWareManager:
         # FIXME : search below self.path for isolinux configurations or known directories from TRY_LIST
         os.path.walk(self.path, self.distro_adder, distros_added)
 
+        if len(distros_added) == 0:
+            self.logger.warning("No distros imported, bailing out")
+            return False
+
         # find the most appropriate answer files for each profile object
 
         self.logger.info("associating kickstarts")

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -87,7 +87,10 @@ class CobblerThread(Thread):
         time.sleep(1)
         try:
             rc = self._run(self)
-            self.remote._set_task_state(self,self.event_id,EVENT_COMPLETE)
+            if not rc:
+                self.remote._set_task_state(self,self.event_id,EVENT_FAILED)
+            else:
+                self.remote._set_task_state(self,self.event_id,EVENT_COMPLETE)
             self.on_done()
             return rc
         except:


### PR DESCRIPTION
Task will now fail and return code will be 1 if no new distros are added.

Example:

$ cobbler import --name=sl6.1 --path=/data/test/
task started: 2012-04-04_233518_import
task started (id=Media import, time=Wed Apr  4 23:35:18 2012)
Found a redhat compatible signature: Packages
adding distros
- Warning : Multiple archs found : ['x86_64', 'i386']
  skipping import, as distro name already exists: sl6.1-x86_64
  skipping import, as distro name already exists: sl6.1-i386
  No distros imported, bailing out
  !!! TASK FAILED !!!

$ echo $?
1
