### PR TITLE
[BUGFIX] instance of Templar() was being created without a config passed in

### DIFF
--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -77,7 +77,7 @@ class InTftpdManager:
                                     utils.tftpboot_location(),
                                     "images",distro.name)
 	# Create the templar instance.  Used to template the target directory
-	templater = templar.Templar()
+	templater = templar.Templar(self.config)
 
         # Loop through the hash of boot files,
         # executing a cp for each one


### PR DESCRIPTION
This caused a stack dump when the manage_in_tftpd module tried to access the config settings
