### PR TITLE
[BUGFIX] Don't allow Templar classes to be created without a valid config

### DIFF
--- a/cobbler/modules/install_post_report.py
+++ b/cobbler/modules/install_post_report.py
@@ -84,7 +84,7 @@ def run(api, args, logger):
     input_data = input_template.read()
     input_template.close()
 
-    message = templar.Templar().render(input_data, metadata, None)
+    message = templar.Templar(self.api._config).render(input_data, metadata, None)
     # for debug, call
     # print message
 

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -50,20 +50,19 @@ except:
 
 class Templar:
 
-    def __init__(self,config=None,logger=None):
+    def __init__(self,config,logger=None):
         """
         Constructor
         """
 
+        self.config      = config
+        self.api         = config.api
+        self.settings    = config.settings()
+        self.last_errors = []
+
         if logger is None:
             logger = clogger.Logger()
         self.logger = logger
-
-        if config is not None:
-            self.config      = config
-            self.api         = config.api
-            self.settings    = config.settings()
-        self.last_errors = []
 
     def check_for_invalid_imports(self,data):
         """


### PR DESCRIPTION
There are a LOT of places in the templar.py code that use self.settings without checking to make sure a valid config was passed in. This could cause random stack dumps when templating, so it's better to force a config to be passed in. Thankfully, there were only two pieces of code that actually did this, one of which was the tftpd management module which was fixed elsewhere.
