### PR TITLE
autoyast_sample: save and restore boot device order

### DIFF
--- a/kickstarts/autoyast_sample.xml
+++ b/kickstarts/autoyast_sample.xml
@@ -49,6 +49,13 @@
   <scripts>
     ## we have to include the pre-scripts tag to get kickstart_start included
     <pre-scripts config:type="list">
+	## SuSE has an annoying habit on ppc64 of changing the system
+	## boot order after installation. This makes it non-trivial to
+	## automatically re-install future OS. If you want to workaround
+	## this, un-comment out the following two lines and the two
+	## lines in the post-scripts section:
+	#set global $wrappedscript = 'save_boot_device'
+	## $SNIPPET('suse_scriptwrapper.xml')
     </pre-scripts>
     <post-scripts config:type="list">
 
@@ -61,6 +68,13 @@
 	## - and remove the '##' in front of the line with suse_scriptwrapper.xml
 	##
 	#set global $wrappedscript = 'name_of_pure_shell_snippet'
+	## $SNIPPET('suse_scriptwrapper.xml')
+	## SuSE has an annoying habit on ppc64 of changing the system
+	## boot order after installation. This makes it non-trivial to
+	## automatically re-install future OS. If you want to workaround
+	## this, un-comment out the following two lines and the two
+	## lines in the pre-scripts section:
+	#set global $wrappedscript = 'restore_boot_device'
 	## $SNIPPET('suse_scriptwrapper.xml')
 
     </post-scripts>

--- a/snippets/restore_boot_device
+++ b/snippets/restore_boot_device
@@ -1,0 +1,2 @@
+nvsetenv boot-device "$(cat /root/inst-sys/boot-device.bak)"
+

--- a/snippets/save_boot_device
+++ b/snippets/save_boot_device
@@ -1,0 +1,1 @@
+cat /proc/device-tree/options/boot-device > /root/boot-device.bak


### PR DESCRIPTION
SLES installs have an annoying habit on ppc64 installations of modifying
the boot device order. This leads to (future) failed automated installs
without manual intervention. Work around this by using two shell
snippets to save and restore, respectively, the system's boot device
configuration before and after the installation. Add the shell snippet
invocation to autoyast_sample.xml for documentation purposes, but
I believe this is only useful on power machines (well, and in
particular, nvsetenv only makes sense there).

Tested with SLES11-SP2.

Signed-off-by: Nishanth Aravamudan nacc@us.ibm.com
