### PR TITLE
fix infinite netboot cycle with ppc64 systems

### DIFF
--- a/cobbler/action_sync.py
+++ b/cobbler/action_sync.py
@@ -42,6 +42,7 @@ import item_system
 from Cheetah.Template import Template
 import clogger
 from utils import _
+import cobbler.module_loader as module_loader
 
 
 class BootSync:
@@ -127,10 +128,7 @@ class BootSync:
         # make the default pxe menu anyway...
         self.pxegen.make_pxe_menu()
 
-        if self.settings.manage_dhcp:
-            self.logger.info("rendering DHCP files")
-            self.dhcp.write_dhcp_file()
-            self.dhcp.regen_ethers()
+        self.write_dhcp()
         if self.settings.manage_dns:
             self.logger.info("rendering DNS files")
             self.dns.regen_hosts()
@@ -213,6 +211,30 @@ class BootSync:
         utils.rmtree_contents(self.yaboot_bin_dir,logger=self.logger)
         utils.rmtree_contents(self.yaboot_cfg_dir,logger=self.logger)
         utils.rmtree_contents(self.rendered_dir,logger=self.logger)
+
+    def write_dhcp(self):
+        if self.settings.manage_dhcp:
+            self.logger.info("rendering DHCP files")
+            self.dhcp.write_dhcp_file()
+            self.dhcp.regen_ethers()
+
+    def sync_dhcp(self):
+        self.write_dhcp()
+        restart_dhcp = str(self.settings.restart_dhcp).lower()
+        which_dhcp_module = module_loader.get_module_from_file("dhcp","module",just_name=True).strip()
+
+        if self.settings.manage_dhcp:
+            if which_dhcp_module == "manage_isc":
+                if restart_dhcp != "0":
+                    rc = utils.subprocess_call(self.logger, "dhcpd -t -q", shell=True)
+                    if rc != 0:
+                       self.logger.error("dhcpd -t failed")
+                       return 1
+                    rc = utils.subprocess_call(self.logger,"service dhcpd restart", shell=True)
+            elif which_dhcp_module == "manage_dnsmasq":
+                if restart_dhcp != "0":
+                    rc = utils.subprocess_call(self.logger, "service dnsmasq restart")
+                    has_restarted_dnsmasq = True
 
     def clean_link_cache(self):
         for dirtree in [os.path.join(self.bootloc,'images'), self.settings.webdir]:

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -720,6 +720,15 @@ class BootAPI:
 
     # ==========================================================================
 
+    def sync_dhcp(self, verbose=False, logger=None):
+        """
+        Only build out the DHCP configuration
+        """
+        self.log("sync_dhcp")
+        sync = self.get_sync(verbose=verbose, logger=logger)
+        return sync.sync_dhcp()
+    # ==========================================================================
+
     def get_sync(self,verbose=False,logger=None):
         self.dhcp = self.get_module_from_file(
            "dhcp",

--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -161,6 +161,9 @@ class IscManager:
                 interface["owner"] = blended_system["name"]
                 interface["enable_gpxe"] = blended_system["enable_gpxe"]
 
+                if not interface["netboot_enabled"]:
+                    continue
+
                 interface["filename"] = "/pxelinux.0"
                 # can't use pxelinux.0 anymore
                 if distro is not None:

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1170,6 +1170,8 @@ class CobblerXMLRPCInterface:
         obj.set_netboot_enabled(0)
         # disabling triggers and sync to make this extremely fast.
         systems.add(obj,save=True,with_triggers=False,with_sync=False,quick_pxe_update=True)
+        # re-generate dhcp configuration
+        self.api.sync_dhcp()
         return True
 
     def upload_log_data(self, sys_name, file, size, offset, data, token=None,**rest):
@@ -1777,6 +1779,16 @@ class CobblerXMLRPCInterface:
         Checks to make sure a token is valid or not
         """
         return self.__validate_token(token)
+
+    def sync_dhcp(self,token):
+        """
+        Run sync code, which should complete before XMLRPC timeout.  We can't
+        do reposync this way.  Would be nice to send output over AJAX/other
+        later.
+        """
+        self._log("sync_dhcp",token=token)
+        self.check_access(token,"sync")
+        return self.api.sync_dhcp()
 
     def sync(self,token):
         """


### PR DESCRIPTION
I encountered a rather annoying problem with cobbler for ppc64 systems:
after an install succeeded with pxe_just_once set, the DHCP
configuration file/DHCP server process were left alone. The DHCP server
would then respond on the network on the next boot and the target server
never booted from the disk. The netboot is controlled by SMS/yaboot and
if SMS receives a DHCP response for a file to tftpboot (in this case the
file being yaboot), it will stay in an infinite loop within the netboot
code, even if the netboot eventually fails. That code exists in the
field as-is, so fixing it, while worthwhile (if possible), doesn't help
with existing deployments.

I worked around this by only generating the DHCP configuration if a
system does have netboot_enabled set and re-generating the DHCP files
via a new API, sync_dhcp() whenever disable_netboot() is called.

Signed-off-by: Nishanth Aravamudan nacc@us.ibm.com
