### PR TITLE
sync: move around check for manage_dhcp

### DIFF
--- a/cobbler/action_sync.py
+++ b/cobbler/action_sync.py
@@ -128,7 +128,8 @@ class BootSync:
         # make the default pxe menu anyway...
         self.pxegen.make_pxe_menu()
 
-        self.write_dhcp()
+        if self.settings.manage_dhcp:
+            self.write_dhcp()
         if self.settings.manage_dns:
             self.logger.info("rendering DNS files")
             self.dns.regen_hosts()
@@ -213,17 +214,16 @@ class BootSync:
         utils.rmtree_contents(self.rendered_dir,logger=self.logger)
 
     def write_dhcp(self):
-        if self.settings.manage_dhcp:
-            self.logger.info("rendering DHCP files")
-            self.dhcp.write_dhcp_file()
-            self.dhcp.regen_ethers()
+        self.logger.info("rendering DHCP files")
+        self.dhcp.write_dhcp_file()
+        self.dhcp.regen_ethers()
 
     def sync_dhcp(self):
-        self.write_dhcp()
         restart_dhcp = str(self.settings.restart_dhcp).lower()
         which_dhcp_module = module_loader.get_module_from_file("dhcp","module",just_name=True).strip()
 
         if self.settings.manage_dhcp:
+            self.write_dhcp()
             if which_dhcp_module == "manage_isc":
                 if restart_dhcp != "0":
                     rc = utils.subprocess_call(self.logger, "dhcpd -t -q", shell=True)


### PR DESCRIPTION
Based upon feedback from James Cammarata, rearrange the logic so that
write_dhcp() unconditionally writes the files back, requiring the caller
to check if manage_dhcp is set.

Signed-off-by: Nishanth Aravamudan nacc@us.ibm.com
