### PR TITLE
BUGFIX - issue #28 - Cobbler drops errors on the floor during a replicate

### DIFF
--- a/cobbler/action_replicate.py
+++ b/cobbler/action_replicate.py
@@ -88,7 +88,8 @@ class Replicate:
                  newobj.from_datastruct(rdata)
                  try:
                      self.logger.info("adding %s %s" % (obj_type, rdata["name"]))
-                     self.api.add_item(obj_type, newobj)
+                     if not self.api.add_item(obj_type, newobj):
+                         self.logger.error("failed to add %s %s" % (obj_type, rdata["name"]))
                  except Exception, e:
                      utils.log_exc(self.logger)
 
@@ -116,7 +117,8 @@ class Replicate:
                      newobj.from_datastruct(rdata)
                      try:
                          self.logger.info("updating %s %s" % (obj_type, rdata["name"]))
-                         self.api.add_item(obj_type, newobj)
+                         if not self.api.add_item(obj_type, newobj):
+                             self.logger.error("failed to update %s %s" % (obj_type, rdata["name"]))
                      except Exception, e:
                          utils.log_exc(self.logger)
 


### PR DESCRIPTION
Added additional logging to add_ functions to report an error if the add_item call returns False
