### PR TITLE
add fedora18 to codes.py

### DIFF
--- a/cobbler/codes.py
+++ b/cobbler/codes.py
@@ -41,7 +41,7 @@ VALID_OS_BREEDS = [
 ]
 
 VALID_OS_VERSIONS = {
-    "redhat"  : [ "rhel3", "rhel4", "rhel5", "rhel6", "fedora14", "fedora15", "fedora16", "fedora17", "rawhide", "generic24", "generic26", "virtio26", "other" ],
+    "redhat"  : [ "rhel3", "rhel4", "rhel5", "rhel6", "fedora14", "fedora15", "fedora16", "fedora17", "fedora18", "rawhide", "generic24", "generic26", "virtio26", "other" ],
     "suse"    : [ "sles9", "sles10", "sles11", "opensuse11.2", "opensuse11.3", "opensuse11.4", "opensuse12.1", "opensuse12.2", "generic24", "generic26", "virtio26", "other" ],
     "debian"  : [ "lenny", "squeeze", "stable", "testing", "unstable", "generic24", "generic26", "other" ],
     "ubuntu"  : [ "hardy", "lucid", "maverick", "natty", "precise" ],


### PR DESCRIPTION
i want f18 included in the test matrix (wiki) for the 2.2.3 release
