### PR TITLE
pretty print JSON output

### DIFF
--- a/cobbler/modules/serializer_catalog.py
+++ b/cobbler/modules/serializer_catalog.py
@@ -87,7 +87,7 @@ def serialize_item(obj, item):
         filename = filename + ".json"
         datastruct = item.to_datastruct()
         fd = open(filename,"w+")
-        data = simplejson.dumps(datastruct, encoding="utf-8")
+        data = simplejson.dumps(datastruct, encoding="utf-8", sort_keys = True, indent = 4)
         #data = data.encode('utf-8')
         fd.write(data)
 


### PR DESCRIPTION
This patch makes the JSON output stored in /var/lib/cobbler/config/_.d/_ easier to read.  

My need arises from:
- deploying a new Cobbler server based on another, but modifying things such as profile metadata
- keeping objects on multiple Cobbler servers on disconnected networks in sync

It also makes storing Cobbler objects in git more useful as you can quickly diff the objects; the current on-disk format makes that pretty-much impossible without doing your own text manipulation.

I'm not sure if there is a performance hit for additional white-space in these files, but I can't imagine there is.
