### PR TITLE
Partial revert of commit 3c81dd3081

### DIFF
--- a/web/cobbler_web/templates/import.tmpl
+++ b/web/cobbler_web/templates/import.tmpl
@@ -1,3 +1,5 @@
+{% extends "master.tmpl" %}
+
 {% block content %}
 <h1>DVD Importer</h1>
 <hr />


### PR DESCRIPTION
- incorrectly removed the 'extends' template directive, breaking rendering in django
