### PR TITLE
Found some bugs while testing for the 2.2.3 release

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -275,6 +275,8 @@ class BuildIso:
              if dist.breed == "redhat":
                 if data["kernel_options"].has_key("ksdevice") and data["kernel_options"]["ksdevice"] != "":
                    my_int = data["kernel_options"]["ksdevice"]
+                   if my_int == "bootif":
+                      my_int = None
                    del data["kernel_options"]["ksdevice"]
                 if data["kernel_options"].has_key("ip") and data["kernel_options"]["ip"] != "":
                    my_ip = data["kernel_options"]["ip"]


### PR DESCRIPTION
Buildiso:
Allow override of the autoyast keyword for SuSE systems.
Add kickstart through proxy support for RedHat based systems.

Tested with, see: https://github.com/cobbler/cobbler/wiki/2.2.3
