### PR TITLE
Describe changing the default password

### DIFF
--- a/config/settings
+++ b/config/settings
@@ -85,6 +85,9 @@ default_ownership:
 # systems that reference this variable.  The factory
 # default is "cobbler" and cobbler check will warn if
 # this is not changed.
+# The simplest way to change the password is to run 
+# openssl passwd -1
+# and put the output between the "" below.
 default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
 
 # the default template type to use in the absence of any


### PR DESCRIPTION
I found this almost 3 year old email discussion 

  http://www.mail-archive.com/cobbler@lists.fedorahosted.org/msg04373.html
  http://www.mail-archive.com/cobbler@lists.fedorahosted.org/msg04385.html

It essentially says that the settings file should describe how to change the default password.
Apparently no such patch ever made it into the software, so I'm providing it here.
