### PR TITLE
snippets: save/restore boot-device on ppc64 on fedora17

### DIFF
--- a/snippets/restore_boot_device
+++ b/snippets/restore_boot_device
@@ -1,2 +1,5 @@
-nvsetenv boot-device "$(cat /root/inst-sys/boot-device.bak)"
-
+if [ "$os_version" == "sles11" ]; then
+    nvsetenv boot-device "$(cat /root/inst-sys/boot-device.bak)"
+elif
+    nvsetenv boot-device "$(cat /root/boot-device.bak)"
+fi

--- a/snippets/save_boot_device
+++ b/snippets/save_boot_device
@@ -1,1 +1,12 @@
-cat /proc/device-tree/options/boot-device > /root/boot-device.bak
+if [ "$os_version" == "sles11" ]; then
+    cat /proc/device-tree/options/boot-device > /root/boot-device.bak
+elif [ "$os_version" == "fedora17" ]; then
+    while : ; do
+        sleep 10
+        if [ -d /mnt/sysimage/root ]; then
+            cat /proc/device-tree/options/boot-device > /mnt/sysimage/root/boot-device.bak
+            logger "Copied boot-device.bak to system"
+            break
+        fi
+    done &
+fi


### PR DESCRIPTION
I previously added some example snippets for sles11 to support saving
and restoring the boot-device on ppc64, as the sles11 installer
overwrites this information. The fedora17 installer also does this now,
so the snippets need some extension, as the installer disk layout is
slightly different. Handle the two known cases distinctly.

Tested with SLES11-SP2 and FC17-prebeta3 on ppc64.

Signed-off-by: Nishanth Aravamudan nacc@us.ibm.com
