### PR TITLE
snippets: update {restore,save}_boot_device

### DIFF
--- a/snippets/restore_boot_device
+++ b/snippets/restore_boot_device
@@ -1,5 +1,6 @@
 if [ "$os_version" == "sles11" ]; then
     nvsetenv boot-device "$(cat /root/inst-sys/boot-device.bak)"
-elif
-    nvsetenv boot-device "$(cat /root/boot-device.bak)"
+elif [ "$os_version" == "fedora17" ]; then
+    # must be run from a %post --nochroot section
+    nvsetenv boot-device "$(cat /tmp/boot-device.bak)"
 fi

--- a/snippets/save_boot_device
+++ b/snippets/save_boot_device
@@ -1,12 +1,5 @@
 if [ "$os_version" == "sles11" ]; then
-    cat /proc/device-tree/options/boot-device > /root/boot-device.bak
+    nvram --print-config=boot-device > /root/boot-device.bak
 elif [ "$os_version" == "fedora17" ]; then
-    while : ; do
-        sleep 10
-        if [ -d /mnt/sysimage/root ]; then
-            cat /proc/device-tree/options/boot-device > /mnt/sysimage/root/boot-device.bak
-            logger "Copied boot-device.bak to system"
-            break
-        fi
-    done &
+    nvram --print-config=boot-device > /tmp/boot-device.bak
 fi


### PR DESCRIPTION
Fix a logical error in restore_boot_device. Change the Fedora17
restore_boot_device to write to /tmp and add a comment indicating that
it should be run from a %pre --nochroot environment.

Signed-off-by: Nishanth Aravamudan nacc@us.ibm.com
