### PR TITLE
workaround empty password glitch on authn_ldap.py

### DIFF
--- a/cobbler/modules/authn_ldap.py
+++ b/cobbler/modules/authn_ldap.py
@@ -48,7 +48,8 @@ def authenticate(api_handle,username,password):
     """
     Validate an ldap bind, returning True/False
     """
- 
+    if (not password):
+        return False
     import ldap
 
     server    = api_handle.settings().ldap_server


### PR DESCRIPTION
When using cobbler with ldap authentication, people could log in with any username which exists in the active directory without needing to enter a password, very dangerous should someone get hold of an admin's accountname. This quick check verifies a password is present.
