### PR TITLE
openldap username case sensitivity fix

### DIFF
--- a/cobbler/modules/authz_configfile.py
+++ b/cobbler/modules/authz_configfile.py
@@ -57,7 +57,7 @@ def authorize(api_handle,user,resource,arg1=None,arg2=None):
 
     data = __parse_config()
     for g in data:
-        if user in data[g]:
+        if user.lower() in data[g]:
            return 1
     return 0
 


### PR DESCRIPTION
quick dirty fix to work around an issue where cobbler would not log in ldap usernames which contain uppercase characters. at line 60 instead of "if user in data", "if user.lower() in data" is used in this fix. It would appear the parser puts the usernames in data[] in lowercase, and the comparison fails because "user" does hold capitalizations.
