### PR TITLE
RPM: put cobbler*.conf files only in /etc/httpd/conf.d

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -80,8 +80,8 @@ other applications.
 test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %{__python} setup.py install --optimize=1 --root=$RPM_BUILD_ROOT $PREFIX
 mkdir -p $RPM_BUILD_ROOT/etc/httpd/conf.d
-install -p -m 644 config/cobbler.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/
-install -p -m 644 config/cobbler_web.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/
+mv config/cobbler.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/
+mv config/cobbler_web.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/
 
 mkdir -p $RPM_BUILD_ROOT/var/spool/koan
 


### PR DESCRIPTION
cobbler.conf and cobbler_web.conf are in both /etc/cobbler and
/etc/httpd/conf.d even if there's no need to.
