### PR TITLE
The webui_sessions directory belongs only to cobbler-web (master)

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -239,6 +239,7 @@ test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %{python_sitelib}/cobbler
 
 %config(noreplace) /var/lib/cobbler
+%exclude /var/lib/cobbler/webui_sessions
 
 /var/log/cobbler
 /var/www/cobbler


### PR DESCRIPTION
Right now reinstalling the cobbler package would mangle the ownership
on /var/lib/cobbler/webui_sessions to root:root. It is better if this
directory only belonged to cobbler-web.

Same as issue #232, but requesting to pull into master.
