### PR TITLE
Fix koan test initialization.

### DIFF
--- a/tests/koan/virtinstall.py
+++ b/tests/koan/virtinstall.py
@@ -1,6 +1,14 @@
 import unittest
+import koan
 
 from koan.virtinstall import build_commandline
+
+def setup():
+    try:
+        from virtinst import version as vi_version
+        koan.virtinstall.virtinst_version = vi_version.__version__.split('.')
+    except:
+        koan.virtinstall.virtinst_version = 6
 
 class KoanVirtInstallTest(unittest.TestCase):
     def testXenPVBasic(self):


### PR DESCRIPTION
Now, tests/koan/virtinstall.py haven't virt-install version initialiation, test case Failed.
so I add test setup.
( I forget include this change in #219. sorry. :( )
