### PR TITLE
Modified sample.seed to make use kickstart_start and kickstart_done snip...

### DIFF
--- a/kickstarts/sample.seed
+++ b/kickstarts/sample.seed
@@ -114,7 +114,8 @@ d-i finish-install/reboot_in_progress note
 
 # This first command is run as early as possible, just after preseeding is read.
 # d-i preseed/early_command string [command]
-
+d-i preseed/early_command string \
+$SNIPPET('kickstart_start')
 # This command is run immediately before the partitioner starts. It may be
 # useful to apply dynamic partitioner preseeding that depends on the state
 # of the disks (which may not be visible when preseed/early_command runs).
@@ -126,3 +127,8 @@ d-i finish-install/reboot_in_progress note
 # directly, or use the apt-install and in-target commands to easily install
 # packages and run commands in the target system.
 # d-i preseed/late_command string [command]
+d-i preseed/late_command string chroot /target sh -c ' \
+$SNIPPET('download_config_files_deb')
+$SNIPPET('post_run_deb')
+'; \
+$SNIPPET('kickstart_done')

--- a/snippets/download_config_files_deb
+++ b/snippets/download_config_files_deb
@@ -1,0 +1,25 @@
+## Start download cobbler managed config files (if applicable)
+#import os
+#import stat
+## set $cmd = "chroot /target sh -c '\\"
+#set $cmd = '\\'
+## set $cmd = "in-target \\"
+#for $tkey, $tpath in $template_files.items()
+    #set $orig = $tpath
+    #set $tpath = $tpath.replace("_","__").replace("/","_")
+    #if $getVar("system_name","") != ""
+        #set $ttype = "system"
+        #set $tname = $system_name
+    #else
+        #set $ttype = "profile"
+        #set $tname = $profile_name
+    #end if
+    #set $turl = "http://"+$http_server+"/cblr/svc/op/template/"+$ttype+"/"+$tname+"/path/"+$tpath
+#if $orig.startswith("/")
+#set $perms = oct(stat.S_IMODE(os.stat($tkey).st_mode))[-3:]
+#set $cmd = $cmd + "\n" + "mkdir -p " + "`dirname " + $orig+"`; wget -nv " + $turl + " --output-document=" + $orig + "; chmod " + $perms +" " + $orig +"; \\"
+#end if
+#end for
+## #set $cmd = $cmd + "\n" + "'\\"
+#echo $cmd
+## End download cobbler managed config files (if applicable)

--- a/snippets/kickstart_done
+++ b/snippets/kickstart_done
@@ -9,9 +9,7 @@
 #set nopxe = ""
 #set saveks = ""
 #set runpost = ""
-
 #if $system_name != ''
-
     ## PXE JUST ONCE
     #if $pxe_just_once in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
@@ -20,9 +18,10 @@
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'vmware' and $os_version == 'esxi4'
             #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
+        #else if $breed == 'debian' 
+            #set nopxe = "wget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null;" % (srv, system_name)
         #end if
     #end if
-
     ## SAVE KICKSTART
     #if $kickstart != ''
         #if $breed == 'redhat'
@@ -31,9 +30,10 @@
             #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.ks" % (srv, "system", system_name)
         #else if $breed == 'vmware' and $os_version == 'esxi4'
             #set saveks = "\nwget \"http://%s/cblr/svc/op/ks/%s/%s\" -O /var/log/cobbler.ks" % (srv, "system", system_name)
+        #else if $breed == 'debian'
+            #set saveks = "wget \"http://%s/cblr/svc/op/ks/%s/%s\" -O /target/var/log/cobbler.seed;" % (srv, "system", system_name)
         #end if
     #end if
-
     ## RUN POST TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
@@ -42,11 +42,11 @@
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
         #else if $breed == 'vmware' and $os_version == 'esxi4'
             #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "system", system_name)
+        #else if $breed == 'debian'
+            #set runpost = "wget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null;" % (srv, "system", system_name)
         #end if
     #end if
-
 #else if $profile_name != ''
-
     ## SAVE KICKSTART
     #if $kickstart != ''
         #if $breed == 'redhat'
@@ -57,7 +57,6 @@
             #set saveks = "\nwget \"http://%s/cblr/svc/op/ks/%s/%s\" -O /var/log/cobbler.ks" % (srv, "profile", profile_name)
         #end if
     #end if
-
     ## RUN POST TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
@@ -68,9 +67,7 @@
             #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
         #end if
     #end if
-
 #end if
-
 #echo $saveks
 #echo $runpost
 #echo $nopxe

--- a/snippets/kickstart_start
+++ b/snippets/kickstart_start
@@ -4,20 +4,18 @@
 #set srv = $getVar('http_server','')
 #set run_install_triggers = $str($getVar('run_install_triggers',''))
 #set runpre = ""
-
 #if $system_name != ''
-
     ## RUN PRE TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #else if $breed == 'vmware'
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
+        #else if $breed == 'debian' 
+            #set runpre = "wget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #end if
     #end if
-
 #else if $profile_name != ''
-
     ## RUN PRE TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
@@ -26,7 +24,5 @@
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
         #end if
     #end if
-
 #end if
-
 #echo $runpre

--- a/snippets/post_run_deb
+++ b/snippets/post_run_deb
@@ -1,0 +1,6 @@
+## for this script to work put the file somewhere on the cobbler server 
+## and in 'Template Files' field put /path/to/the/file/some_shell_script.sh=/tmp/some_shell_script.sh
+## That will work with 'download_config_files_deb' snippet
+#set $run_cmd = '/tmp/some_shell_script.sh; \\'
+## put more commands here
+#echo $run_cmd


### PR DESCRIPTION
...pets for debian.

As a result the following cobbler features work for debian:
- prevent net boot looping
- cobbler status reflects debian installations
- preseed file is downloaded a nd saved on the installed system as /var/log/cobbler.seed
  Also made download_config_files_deb snippet, make use of late_command
  New post_run_deb snippet allows to execute post installation script.
