### PR TITLE
BUGFIX - Issue #278 - cobbler import fails for ubuntu images due to rsync args

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -69,7 +69,7 @@ INFO  = 10
 DEBUG = 5
 
 # FIXME: add --quiet depending on if not --verbose?
-RSYNC_CMD =  "rsync -aL %s '%s' %s --progress"
+RSYNC_CMD =  "rsync -a %s '%s' %s --progress"
 
 # notes on locking:
 # BootAPI is a singleton object


### PR DESCRIPTION
Removing -L option from RSYNC_CMD in api.py so that links are not followed and are copied as-is
