### PR TITLE
FEATURE - adding 'zonetype' variable for DNS zone rendering

### DIFF
--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -329,6 +329,7 @@ zone "%(arpa)s." {
             metadata = {
                 'cobbler_server': cobbler_server,
                 'serial': serial,
+                'zonetype': 'forward',
                 'host_record': ''
             }
 
@@ -351,6 +352,7 @@ zone "%(arpa)s." {
             metadata = {
                 'cobbler_server': cobbler_server,
                 'serial': serial,
+                'zonetype': 'reverse',
                 'host_record': ''
             }
 


### PR DESCRIPTION
This will allow conditional testing during the rendering of zone files so
different options can be added based on the zone type.
