### PR TITLE
Fix puppet 3.0.0 compatibility

### DIFF
--- a/snippets/puppet_register_if_enabled
+++ b/snippets/puppet_register_if_enabled
@@ -1,7 +1,7 @@
 #if $str($getVar('puppet_auto_setup','')) == "1"
 # generate puppet certificates and trigger a signing request, but
 # don't wait for signing to complete
-/usr/sbin/puppetd --test --waitforcert 0
+/usr/sbin/puppet agent --test --waitforcert 0
 
 # turn puppet service on for reboot
 /sbin/chkconfig puppet on


### PR DESCRIPTION
In puppet 3.0.0, puppetd no longer exists, so the snippet
'puppet_register_if_enabled' no longer works.

Fix this by running 'puppet agent' instead of 'puppetd'.
