### PR TITLE
Fixed bug where wildcard in boot_files wouldnt work. 

### DIFF
--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -92,13 +92,13 @@ class InTftpdManager:
                                 shutil.copyfile(f, filedst)
                         self.config.api.log("copied file %s to %s for %s" % (
                                 target["boot_files"][file],
-                                file_dst,
+                                filedst,
                                 distro.name))
 
             except:
                 self.logger.error("failed to copy file %s to %s for %s" % (
                         target["boot_files"][file],
-                        file_dst,
+                        filedst,
                     distro.name))
                 # Continue on to sync what you can
 


### PR DESCRIPTION
Ran into this when trying to get an esxi image to work.
For example $img_path/=/var/www/cobbler/ks_mirror/esxi51/*.*

Im not sure its the best solution. But it seems to work fine. 
