### PR TITLE
cobbler buildiso --standalone fix for SUSE based Systems

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -474,7 +474,7 @@ class BuildIso:
             if distro.breed == "redhat":
                append_line += " ks=cdrom:/isolinux/%s.cfg" % descendant.name
             if distro.breed == "suse":
-               append_line += " autoyast=file:///isolinux/%s.cfg install=file:///" % descendant.name
+               append_line += " autoyast=file:///isolinux/%s.cfg install=cdrom:///" % descendant.name
                if data["kernel_options"].has_key("install"):
                   del data["kernel_options"]["install"]
             if distro.breed in ["ubuntu","debian"]:
@@ -489,8 +489,9 @@ class BuildIso:
             elif descendant.COLLECTION_TYPE == 'system':
                 kickstart_data = self.api.kickgen.generate_kickstart_for_system(descendant.name)
 
-            cdregex = re.compile("url .*\n", re.IGNORECASE)
-            kickstart_data = cdregex.sub("cdrom\n", kickstart_data)
+            if distro.breed == "redhat":
+                cdregex = re.compile("url .*\n", re.IGNORECASE)
+                kickstart_data = cdregex.sub("cdrom\n", kickstart_data)
 
             ks_name = os.path.join(isolinuxdir, "%s.cfg" % descendant.name)
             ks_file = open(ks_name, "w+")


### PR DESCRIPTION
I have patched cobbler so, that the option cobbler buildiso --standalone works for AutoYaST based installations.
