### PR TITLE
Change how load_modules behaves if a module raises an exception.  

### DIFF
--- a/cobbler/module_loader.py
+++ b/cobbler/module_loader.py
@@ -30,6 +30,11 @@ from utils import _, log_exc
 from cexceptions import *
 import ConfigParser
 
+# python 2.3 compat.  If we don't need that, drop this test
+try:
+    set()
+except:
+    from sets import Set as set
 
 MODULE_CACHE = {}
 MODULES_BY_CATEGORY = {}
@@ -49,7 +54,7 @@ def load_modules(module_path=mod_path, blacklist=None):
     filenames = filenames + glob.glob("%s/*.pyc" % module_path)
     filenames = filenames + glob.glob("%s/*.pyo" % module_path)
 
-    mods = {}
+    mods = set()
 
 
     for fn in filenames:
@@ -61,6 +66,11 @@ def load_modules(module_path=mod_path, blacklist=None):
         elif basename[-4:] in [".pyc", ".pyo"]:
             modname = basename[:-4]
 
+        # No need to try importing the same module over and over if
+        # we have a .py, .pyc, and .pyo
+        if modname in mods:
+            continue
+        mods.add(modname)
 
         try:
             blip =  __import__("modules.%s" % ( modname), globals(), locals(), [modname])


### PR DESCRIPTION
Currently if load_module encounters an exception in a module that it's attempting to load, it will cause cobbler to traceback.  This branch changes that so that exceptions raised while loading a module will be caught and logged (and the module will not be loaded).

This branch also contains a commit to only attempt to load a module once.  Previously, the code might attempt to load the module up to three times if a the module had a .py, .pyc, and .pyo file.
