### PR TITLE
meta["tree"] assumed in kickgen.generate_kickstart() 

### DIFF
--- a/cobbler/kickgen.py
+++ b/cobbler/kickgen.py
@@ -268,8 +268,9 @@ class KickGen:
         # meta["config_template_files"] = self.generate_template_files_stanza(g, False)
 
         # add extra variables for other distro types
-        urlparts = urlparse.urlsplit(meta["tree"])
-        meta["install_source_directory"] = urlparts[2]
+		if "tree" in meta:
+        	urlparts = urlparse.urlsplit(meta["tree"])
+        	meta["install_source_directory"] = urlparts[2]
 
         try:
             raw_data = utils.read_file_contents(kickstart_path, self.api.logger,


### PR DESCRIPTION
While attempting to kick a Debian box, I received the following when trying to render the preseed (kickstart) template:

Fri Dec 14 17:41:03 2012 - INFO | REMOTE generate_kickstart; user(?)
Fri Dec 14 17:41:03 2012 - INFO | generate_kickstart
Fri Dec 14 17:41:03 2012 - INFO | Exception occured: <type 'exceptions.KeyError'>
Fri Dec 14 17:41:03 2012 - INFO | Exception value: 'tree'
Fri Dec 14 17:41:03 2012 - INFO | Exception Info:
  File "/usr/local/lib/python2.6/dist-packages/cobbler/remote.py", line 1994, in _dispatch
    return method_handle(*params)
   File "/usr/local/lib/python2.6/dist-packages/cobbler/remote.py", line 1017, in generate_kickstart
    return self.api.generate_kickstart(profile,system)
   File "/usr/local/lib/python2.6/dist-packages/cobbler/api.py", line 682, in generate_kickstart
    return self.kickgen.generate_kickstart_for_system(system)
   File "/usr/local/lib/python2.6/dist-packages/cobbler/kickgen.py", line 248, in generate_kickstart_for_system
    return self.generate_kickstart(profile=p, system=s)
   File "/usr/local/lib/python2.6/dist-packages/cobbler/kickgen.py", line 271, in generate_kickstart
    urlparts = urlparse.urlsplit(meta["tree"])

Since "tree" doesn't exist for the system, I added the check for the "tree" key and was able to successfully generate the kickstart template.
