### PR TITLE
BUGFIX: Importing wrong arch results in silent error

### DIFF
--- a/cobbler/modules/manage_import_redhat.py
+++ b/cobbler/modules/manage_import_redhat.py
@@ -26,7 +26,7 @@ import os.path
 import shutil
 import glob
 import traceback
-
+import string
 
 import utils
 from cexceptions import *


### PR DESCRIPTION
Self explanatory. If you import --arch=invalid, a bug in
manage_import_redhat.py goes down a path that uses the string
module without importing it, resulting in a wierd error to
stdout/stderr which gives no clue what the problem is - and a
not super easy to track down error to the log. This trivial
patch fixes this.
