### PR TITLE
Fixes: CNAME module

### DIFF
--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -213,9 +213,6 @@ class System(item.Item):
 
         return True
     
-    def get_name(self):
-        return self.name
-    
     def set_redhat_management_key(self,key):
         return utils.set_redhat_management_key(self,key)
 

--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -296,7 +296,7 @@ zone "%(arpa)s." {
         for system in self.systems:
             for (name, interface) in system.interfaces.iteritems():
                 if interface["dns_name"] == "":
-                    self.logger.info(("Warning: dns_name unspecified in the system: %s, while writing host records") % system.get_name())                       
+                    self.logger.info(("Warning: dns_name unspecified in the system: %s, while writing host records") % system.name)                       
                 
         names = [k for k,v in hosts.iteritems()]
         if not names: return '' # zones with no hosts
@@ -335,7 +335,7 @@ zone "%(arpa)s." {
                         for cname in cnames:
                             s += "%s  %s  %s;\n" % (cname.split('.')[0], rectype, dnsname)                    
                     else:
-                        self.logger.info(("Warning: dns_name unspecified in the system: %s, Skipped!, while writing cname records") % system.get_name())
+                        self.logger.info(("Warning: dns_name unspecified in the system: %s, Skipped!, while writing cname records") % system.name)
                         continue
                 except:
                     pass


### PR DESCRIPTION
1) __pretty_print_cname_records() now checks for the existence of dns_name and warns user to add it on the specific system if it did not exist, it skips the host without dns_name but still writes the zone file for the rest of the hosts

2) try/catch added for split() calls

3) __pretty_print_host_records() now displays a warning for hosts without a dns_name. It previously skipped it wihout any verbosity.
