### PR TITLE
Add ubuntu 10.04 (lucid) to distro signatures

### DIFF
--- a/config/distro_signatures.json
+++ b/config/distro_signatures.json
@@ -117,6 +117,22 @@
    }
   },
   "ubuntu": {
+   "lucid": {
+    "signatures":["dists"],
+    "version_file":"Release",
+    "version_file_regex":"Codename: lucid",
+    "kernel_arch":"linux-headers-(.*)\\.deb",
+    "kernel_arch_regex":null,
+    "supported_arches":["i386","amd64"],
+    "supported_repo_breeds":["apt"],
+    "kernel_file":"linux(.*)",
+    "initrd_file":"initrd(.*)\\.gz",
+    "isolinux_ok":false,
+    "default_kickstart":"/var/lib/cobbler/kickstarts/sample.seed",
+    "kernel_options":"",
+    "kernel_options_post":"",
+    "boot_files":[]
+   },
    "oneiric": {
     "signatures":["dists"],
     "version_file":"Release",


### PR DESCRIPTION
10.04 LTS is ugly, old, and deservedly unloved, but it's supported until 2015, so I still need to work with them.
