### PR TITLE
Change apt_sync mirror parsing

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -477,11 +477,11 @@ class RepoSync:
 
             idx = mirror.find("/")
             host = mirror[:idx]
-            mirror = mirror[idx+1:]
+            mirror = mirror[idx+:]
 
             idx = mirror.rfind("/dists/")
             suite = mirror[idx+7:]
-            mirror = mirror[:idx]
+            mirror = mirror[:idx+1]
 
             mirror_data = "--method=%s --host=%s --root=%s --dist=%s " % ( method , host , mirror , suite )
 


### PR DESCRIPTION
There's a bug in the logic of apt_sync's mirror url parsing code that
only comes out in a very specific case.

When parsing a url like http://apt.puppetlabs.com/dists/oneiric/, where
there are no directories between the servername and the "/dists/<suite>"
directories, the code leaves the debmirror --root argument empty, which
causes an application error in debmirror.

This patch changes the code to include the leading slash in the
path name, which debmirror can handle in any case, so there's no benefit
to stripping it out anyway.

This is my last one for tonight. :)
