### PR TITLE
Update koan/virtinstall.py

### DIFF
--- a/koan/virtinstall.py
+++ b/koan/virtinstall.py
@@ -333,7 +333,7 @@ def build_commandline(uri,
         if disk_bus:
             cmd += ",bus=%s" % disk_bus
         if driver_type and not disable_driver_type:
-            cmd += ",driver_type=%s" % driver_type
+            cmd += ",format=%s" % driver_type
         cmd += " "
 
     if floppy:


### PR DESCRIPTION
'driver_type' replace with 'format'. makes it better work with image formats. with this replacement qcow2 works fine. 'driver_type' is an atavism in virt-install
