### PR TITLE
Allow ks.cfg to be embedded in initrd file on RHEL6 when kickstarting with static IP

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -920,7 +920,7 @@ class Koan:
 
             (make, version) = utils.os_release()
 
-            if (make == "centos" and version < 6) or (make == "redhat" and version < 6) or (make == "fedora" and version < 10):
+            if (make == "centos" and version < 7) or (make == "redhat" and version < 7) or (make == "fedora" and version < 10):
 
                 # embed the initrd in the kickstart file because of libdhcp and/or pump
                 # needing the help due to some DHCP timeout potential in some certain
@@ -1010,7 +1010,7 @@ class Koan:
 
             kickstart = self.safe_load(profile_data,'kickstart')
 
-            if (make == "centos" and version < 6) or (make == "redhat" and version < 6) or (make == "fedora" and version < 10):
+            if (make == "centos" and version < 7) or (make == "redhat" and version < 7) or (make == "fedora" and version < 10):
 
                 # embed the initrd in the kickstart file because of libdhcp and/or pump
                 # needing the help due to some DHCP timeout potential in some certain
@@ -1159,7 +1159,7 @@ class Koan:
         return r"""
         cd /var/spool/koan
         mkdir initrd
-        gzip -dc %s > initrd.tmp
+        gzip -dc %s > initrd.tmp || xz -dc %s > initrd.tmp
         if mount -o loop -t ext2 initrd.tmp initrd >&/dev/null ; then
             cp ks.cfg initrd/
             ln initrd/ks.cfg initrd/tmp/ks.cfg


### PR DESCRIPTION
This patch fixes a bug where RHEL6 based systems wouldn't embed the ks.cfg file into the initrd image when booting with a static IP address.  This fix aligns RH6 functionality with that of RH5.

The two changes made were to allow the app.py script to properly decompress the RHEL6 initrd file which is now compressed using xz --format=lzma rather than simple gzip.

Additionally, there was a check (written back in 2009 before RHEL6 was released) that limits the rebuilding of the initrd file to RHEL5 and below only.  I bumped the version number up to include RHEL6.  This same check also limits fedora to version 10, but since I don't have any Fedora clients to play with, I left that as is.
