### PR TITLE
Fix esxi vlan network config snippet

### DIFF
--- a/snippets/network_config_esxi
+++ b/snippets/network_config_esxi
@@ -16,6 +16,7 @@
             ## about VLANs.
             #set $is_vlan = "true"
             #set $vlanid = " --vlanid=" + $iname.split('.')[1]
+            #set $iname = $iname.split('.')[0]
         #else
             #set $is_vlan = "false"
         #end if


### PR DESCRIPTION
According to http://kb.vmware.com/selfservice/microsites/search.do?language=en_US&cmd=displayKC&externalId=2004582 

esxi has a network option called --vlanid= which is used to set the management VLAN.
