### PR TITLE
Escape hyphens in volume group names too.

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -1831,7 +1831,7 @@ class Koan:
                         raise InfoException, "LVM creation failed"
 
                 # partition location
-                partition_location = "/dev/mapper/%s-%s" % (vgname,lvname.replace('-','--'))
+                partition_location = "/dev/mapper/%s-%s" % (vgname.replace('-','--'),lvname.replace('-','--'))
 
                 # check whether we have SELinux enabled system
                 args = "/usr/sbin/selinuxenabled"


### PR DESCRIPTION
If a VG has a hyphen in the name, partition_location will not have the
correct path. Must escape hyphens there too.
