### PR TITLE
(issue#407) Enable authn_passthrough for Cobbler Web

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -938,6 +938,13 @@ class BootAPI:
         """
         return module_loader.get_module_from_file(section,name,fallback)
 
+    def get_module_name_from_file(self,section,name,fallback=None):
+        """
+        Looks up a module the same as get_module_from_file but returns
+        the module name rather than the module itself
+        """
+        return module_loader.get_module_from_file(section,name,fallback,just_name=True)
+
     def get_modules_in_category(self,category):
         """
         Returns all modules in a given category, for instance "serializer", or "cli".

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1746,6 +1746,13 @@ class CobblerXMLRPCInterface:
             raise CX("authorization failure for user %s" % user) 
         return rc
 
+    def get_authn_module_name(self, token):
+        validated = self.__validate_token(token)
+        user = self.get_user_from_token(token)
+        if user != "<DIRECT>":
+          raise CX("authorization failure for user %s attempting to access authn module name" %user)
+        return self.api.get_module_name_from_file("authentication", "module")
+
     def login(self,login_user,login_password):
         """
         Takes a username and password, validates it, and if successful

--- a/web/cobbler_web/views.py
+++ b/web/cobbler_web/views.py
@@ -1234,6 +1234,22 @@ def test_user_authenticated(request):
 
     remote = xmlrpclib.Server(url_cobbler_api, allow_none=True)
 
+    token = remote.login("", utils.get_shared_secret())
+    if ( (remote.get_authn_module_name(token) == 'authn_passthru' and 
+          request.META.has_key('REMOTE_USER')) and
+         ( (request.session.has_key('username') and
+            request.META['REMOTE_USER'] != request.session['username']) or
+           (not request.session.has_key('username')))):
+              try:
+                  username = request.META['REMOTE_USER'] 
+                  password = utils.get_shared_secret()
+                  token = remote.login(username, password)
+              except:
+                  token = None
+              if token:
+                  request.session['username'] = username
+                  request.session['token'] = token 
+  
     # if we have a token, get the associated username from
     # the remote server via XMLRPC. We then compare that to 
     # the value stored in the session.  If everything matches up,


### PR DESCRIPTION
There is currently no support for kerberos single sign-on in cobbler web.
This patch allows apache or another web server to set the REMOTE_USER variable which
will be used as the authenticated user for cobbler API authorization calls
