### PR TITLE
Fixed issue with MAC address verification

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -269,7 +269,7 @@ def is_mac(strdata):
     # needs testcase
     if strdata is None:
         return False
-    if re.search(r'[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F:0-9]{2}:[A-F:0-9]{2}',strdata, re.IGNORECASE):
+    if re.search(r'^[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}$',strdata, re.IGNORECASE):
         return True
     return False
 


### PR DESCRIPTION
- Removed errant ':' systems from the last two octet matches
- Added checks that the string does not start or end with extra characters
