### PR TITLE
Refactor function cobbler.utils.is_mac

### DIFF
--- a/cobbler/test_basic.py
+++ b/cobbler/test_basic.py
@@ -463,6 +463,8 @@ class Utilities(BootTest):
     def test_matching(self):
         self.assertTrue(utils.is_mac("00:C0:B7:7E:55:50"))
         self.assertTrue(utils.is_mac("00:c0:b7:7E:55:50"))
+        self.assertFalse(utils.is_mac("00:c0:b7:7E:55"))
+        self.assertFalse(utils.is_mac("00:c0:b7:7E:55:50:0F"))
         self.assertFalse(utils.is_mac("00.D0.B7.7E.55.50"))
         self.assertFalse(utils.is_mac("testsystem0"))
         self.assertTrue(utils.is_ip("127.0.0.1"))

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -116,6 +116,7 @@ SIGNATURE_CACHE = {}
 
 _re_kernel = re.compile(r'(vmlinu[xz]|kernel.img)')
 _re_initrd = re.compile(r'(initrd(.*).img|ramdisk.image.gz)')
+_re_is_mac = re.compile(':'.join(('[0-9A-F][0-9A-F]',)*6) + '$', re.IGNORECASE)
 
 # all logging from utils.die goes to the main log even if there
 # is another log.
@@ -266,12 +267,9 @@ def is_mac(strdata):
     """
     Return whether the argument is a mac address.
     """
-    # needs testcase
     if strdata is None:
         return False
-    if re.search(r'^[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}:[A-F0-9]{2}$',strdata, re.IGNORECASE):
-        return True
-    return False
+    return bool(_re_is_mac.match(strdata))
 
 def get_random_mac(api_handle,virt_type="xenpv"):
     """


### PR DESCRIPTION
Use a precompiled and faster regular expression and add more tests.
timeit with 64M iterations: 48.32 versus 42.38 seconds.
