### PR TITLE
Speedup function cobbler.utils.is_mac

### DIFF
--- a/cobbler/test_basic.py
+++ b/cobbler/test_basic.py
@@ -463,8 +463,12 @@ class Utilities(BootTest):
     def test_matching(self):
         self.assertTrue(utils.is_mac("00:C0:B7:7E:55:50"))
         self.assertTrue(utils.is_mac("00:c0:b7:7E:55:50"))
+        self.assertFalse(utils.is_mac("00:c0:b:7E:55:50"))
         self.assertFalse(utils.is_mac("00:c0:b7:7E:55"))
         self.assertFalse(utils.is_mac("00:c0:b7:7E:55:50:0F"))
+        self.assertFalse(utils.is_mac("00:c0:bZ:7E:55:50"))
+        self.assertFalse(utils.is_mac("x00:c0:b7:7E:55:50"))
+        self.assertFalse(utils.is_mac("00:c0:b7:7E:55:50x"))
         self.assertFalse(utils.is_mac("00.D0.B7.7E.55.50"))
         self.assertFalse(utils.is_mac("testsystem0"))
         self.assertTrue(utils.is_ip("127.0.0.1"))

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -116,7 +116,7 @@ SIGNATURE_CACHE = {}
 
 _re_kernel = re.compile(r'(vmlinu[xz]|kernel.img)')
 _re_initrd = re.compile(r'(initrd(.*).img|ramdisk.image.gz)')
-_re_is_mac = re.compile(':'.join(('[0-9A-F][0-9A-F]',)*6) + '$', re.IGNORECASE)
+_re_is_mac = re.compile(':'.join(('[0-9A-Fa-f][0-9A-Fa-f]',)*6) + '$')
 
 # all logging from utils.die goes to the main log even if there
 # is another log.


### PR DESCRIPTION
Use both lower case and upper case hexadecimal digits in the regex
instead of using the re.IGNORECASE option. Also add more tests.
timeit with 64M iterations: 42.78 versus 39.74 seconds.
