### PR TITLE
Make `options` parameter a **kwarg in `background_sync` method.

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -183,7 +183,7 @@ class CobblerXMLRPCInterface:
             return self.remote.api.dlcontent(self.options.get("force",False), self.logger)
         return self.__start_task(runner, token, "get_loaders", "Download Bootloader Content", options)
 
-    def background_sync(self, options, token):
+    def background_sync(self, token, **options):
         def runner(self):
             return self.remote.api.sync(self.options.get("verbose",False),logger=self.logger)
         return self.__start_task(runner, token, "sync", "Sync", options) 


### PR DESCRIPTION
Options are not necessarily set every time. The only required parameter is
token.
