### PR TITLE
Added debian 7 (wheezy) to the list of OS versions

### DIFF
--- a/cobbler/codes.py
+++ b/cobbler/codes.py
@@ -43,7 +43,7 @@ VALID_OS_BREEDS = [
 VALID_OS_VERSIONS = {
     "redhat"  : [ "rhel3", "rhel4", "rhel5", "rhel6", "fedora14", "fedora15", "fedora16", "fedora17", "fedora18", "rawhide", "generic24", "generic26", "virtio26", "other" ],
     "suse"    : [ "sles9", "sles10", "sles11", "opensuse11.2", "opensuse11.3", "opensuse11.4", "opensuse12.1", "opensuse12.2", "generic24", "generic26", "virtio26", "other" ],
-    "debian"  : [ "lenny", "squeeze", "stable", "testing", "unstable", "generic24", "generic26", "other" ],
+    "debian"  : [ "lenny", "squeeze", "wheezy", "stable", "testing", "unstable", "generic24", "generic26", "other" ],
     "ubuntu"  : [ "hardy", "lucid", "maverick", "natty", "oneiric", "precise", "quantal" ],
     "generic" : [ "generic24", "generic26", "other" ],
     "windows" : [ "winxp", "win2k", "win2k3", "vista", "other" ],


### PR DESCRIPTION
New Debian 7 is out. Can we add wheezy to the list of OS versions?
Thanks!
