### PR TITLE
FEATURE - IPv6 DNS support for manage_bind.py - enhancement for user zone template

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ With patches and other contributions from (alphabetically, by last name):
     Brian Kearney <bkearney@redhat.com>
     Henry Kemp <henrykemp@gmail.com>
     Ruben Kerkhof <ruben@rubenkerkhof.com>
+    Tony Kew <tony.d.r.kew@gmail.com>
     Don Khan <khan_don@emc.com>
     Douglas Kilpatrick <dkilpatrick@verisign.com>
     Hans Lellelid <hans@xmpl.org>

--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -516,19 +516,28 @@ zone "%(arpa)s." {
                 
             }
 
+
+            if ":" in zone:
+               long_zone = (self.__expand_IPv6(zone + '::1'))[:19]
+               tokens = list(re.sub(':', '', long_zone))
+               tokens.reverse()
+               zone_origin = '.'.join(tokens) + '.ip6.arpa.'
+            else:
+               zone_origin = ''
             # grab zone-specific template if it exists
             try:
                fd = open('/etc/cobbler/zone_templates/%s' % zone)
-               template_data = fd.read()
+               # If this is an IPv6 zone, set the origin to the zone for this
+               # template
+               if zone_origin:
+                  template_data = "\$ORIGIN " + zone_origin + "\n" + fd.read()
+               else:
+                  template_data = fd.read()
                fd.close()
             except:
                # If this is an IPv6 zone, set the origin to the zone for this
                # template
-               if ":" in zone:
-                  long_zone = (self.__expand_IPv6(zone + '::1'))[:19]
-                  tokens = list(re.sub(':', '', long_zone))
-                  tokens.reverse()
-                  zone_origin = '.'.join(tokens) + '.ip6.arpa.'
+               if zone_origin:
                   template_data = "\$ORIGIN " + zone_origin + "\n" + default_template_data
                else:
                   template_data = default_template_data


### PR DESCRIPTION
... for

any user provided zone templates, not just the default template.
This makes a better default $ORIGIN value, and without this origin,
any cobbler records are wrong.

You can always add a different $ORIGIN to the user provided template, but
this should be done after including the hosts from cobbler e.g.

\$TTL 300
@                       IN      SOA     $cobbler_server. nobody.example.com. (
                                        $serial   ; Serial
                                        600         ; Refresh
                                        1800         ; Retry
                                        604800       ; Expire
                                        300          ; TTL
                                        )

```
                    IN      NS      $cobbler_server.
```

$host_record

\$ORIGIN .
1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.c.b.a.9.8.7.6.5.4.3.2.1.1.0.0.2.ip6.arpa. IN PTR  myhost.nobody.example.com.

Tony Kew
