### PR TITLE
FEATURE - repo improvements

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -479,13 +479,10 @@ class RepoSync:
             host = mirror[:idx]
             mirror = mirror[idx:]
 
-            idx = mirror.rfind("/dists/")
-            suite = mirror[idx+7:].replace("/","")
-            mirror = mirror[:idx+1].replace("/","")
+            dists = ",".join(repo.apt_dists)
+            components = ",".join(repo.apt_components)
 
-            mirror_data = "--method=%s --host=%s --root=%s --dist=%s " % ( method , host , mirror , suite )
-
-            # FIXME : flags should come from repo instead of being hardcoded
+            mirror_data = "--method=%s --host=%s --root=%s --dist=%s --section=%s" % (method,host,mirror,dists,components)
 
             rflags = "--nocleanup"
             for x in repo.yumopts:

--- a/cobbler/field_info.py
+++ b/cobbler/field_info.py
@@ -168,6 +168,8 @@ BLOCK_MAPPINGS = {
    "mirror_locally"           : "Advanced",
    "priority"                 : "Advanced",
    "yumopts"                  : "Advanced",
+   "apt_components"         : "Advanced",
+   "apt_dists"              : "Advanced",
    "packages" : "Resources",
    "files"    : "Resources",
    "repos_enabled" : "Management",

--- a/cobbler/item_repo.py
+++ b/cobbler/item_repo.py
@@ -30,6 +30,8 @@ import codes
 # this datastructure is described in great detail in item_distro.py -- read the comments there.
 
 FIELDS = [
+  ["apt_components","",0,"Apt Components (apt only)",True,"ex: main restricted universe",[],"list"],
+  ["apt_dists","",0,"Apt Dist Names (apt only)",True,"ex: precise precise-updates",[],"list"],
   ["arch","",0,"Arch",True,"ex: i386, x86_64",['i386','x86_64','ia64','ppc','ppc64','s390', "arm", 'noarch', 'src'],"str"],
   ["breed","",0,"Breed",True,"",codes.VALID_REPO_BREEDS,"str"],
   ["comment","",0,"Comment",True,"Free form text description",0,"str"],
@@ -42,7 +44,6 @@ FIELDS = [
   ["owners","SETTINGS:default_ownership",0,"Owners",True,"Owners list for authz_ownership (space delimited)",[],"list"],
   ["parent",None,0,"",False,"",0,"str"],
   ["rpm_list",[],0,"RPM List",True,"Mirror just these RPMs (yum only)",0,"list"],
-#  ["os_version","",0,"OS Version",True,"ex: rhel4"],
   ["uid",None,0,"",False,"",0,"str"],
   ["createrepo_flags",'<<inherit>>',0,"Createrepo Flags",True,"Flags to use with createrepo",0,"dict"],
   ["environment",{},0,"Environment Variables",True,"Use these environment variables during commands (key=value, space delimited)",0,"dict"],
@@ -180,6 +181,14 @@ class Repo(item.Item):
 
     def set_mirror_locally(self,value):
         self.mirror_locally = utils.input_boolean(value)
+        return True
+
+    def set_apt_components(self,value):
+        self.apt_components = utils.input_string_or_list(value)
+        return True
+
+    def set_apt_dists(self,value):
+        self.apt_dists = utils.input_string_or_list(value)
         return True
 
     def get_parent(self):

--- a/cobbler/kickgen.py
+++ b/cobbler/kickgen.py
@@ -272,6 +272,15 @@ class KickGen:
             urlparts = urlparse.urlsplit(meta["tree"])
             meta["install_source_directory"] = urlparts[2]
 
+        # add in all repo data for repos that belong to the
+        # object chain
+        repo_data = []
+        for r in meta["repos"]:
+            repo = self.api.find_repo(name=r)
+            if repo:
+                repo_data.append(repo)
+        meta["repo_data"] = repo_data
+
         try:
             raw_data = utils.read_file_contents(kickstart_path, self.api.logger,
                     self.settings.template_remote_kickstarts)

--- a/cobbler/modules/manage_import_signatures.py
+++ b/cobbler/modules/manage_import_signatures.py
@@ -626,44 +626,32 @@ class ImportSignatureManager:
         if apt_available:
             # Example returned URL: http://us.archive.ubuntu.com/ubuntu
             mirror = self.get_repo_mirror_from_apt()
-            if mirror:
-                mirror = mirror + "/dists"
         if not mirror:
-            mirror = "http://archive.ubuntu.com/ubuntu/dists/"
+            mirror = "http://archive.ubuntu.com/ubuntu"
 
         repo = item_repo.Repo(self.config)
-        repo.set_breed( "apt" )
-        repo.set_arch( distro.arch )
-        repo.set_keep_updated( False )
+        repo.set_breed("apt")
+        repo.set_arch(distro.arch)
+        repo.set_keep_updated(True)
+        repo.set_apt_components("main universe") # TODO: make a setting?
+        repo.set_apt_dists("%s %s-updates %s-security" % (distro.os_version,)*3 )
         repo.yumopts["--ignore-release-gpg"] = None
         repo.yumopts["--verbose"] = None
-        repo.set_name( distro.name )
-        repo.set_os_version( distro.os_version )
+        repo.set_name(distro.name)
+        repo.set_os_version(distro.os_version)
 
         if distro.breed == "ubuntu":
-            repo.set_mirror( "%s/%s" % (mirror, distro.os_version) )
+            repo.set_mirror(mirror)
         else:
             # NOTE : The location of the mirror should come from timezone
             repo.set_mirror( "http://ftp.%s.debian.org/debian/dists/%s" % ( 'us' , distro.os_version ) )
 
-        security_repo = item_repo.Repo(self.config)
-        security_repo.set_breed( "apt" )
-        security_repo.set_arch( distro.arch )
-        security_repo.set_keep_updated( False )
-        security_repo.yumopts["--ignore-release-gpg"] = None
-        security_repo.yumopts["--verbose"] = None
-        security_repo.set_name( distro.name + "-security" )
-        security_repo.set_os_version( distro.os_version )
-        # There are no official mirrors for security updates
-        if distro.breed == "ubuntu":
-            security_repo.set_mirror( "%s/%s-security" % (mirror, distro.os_version) )
-        else:
-            security_repo.set_mirror( "http://security.debian.org/debian-security/dists/%s/updates" % distro.os_version )
-
         self.logger.info("Added repos for %s" % distro.name)
-        repos  = self.config.repos()
+        repos = self.config.repos()
         repos.add(repo,save=True)
-        repos.add(security_repo,save=True)
+        #FIXME:
+        # Add the found/generated repos to the profiles
+        # that were created during the import process
 
     def get_repo_mirror_from_apt(self):
         """

--- a/kickstarts/sample.seed
+++ b/kickstarts/sample.seed
@@ -90,10 +90,7 @@ d-i passwd/make-user boolean false
 # d-i apt-setup/security_host string security.ubuntu.com
 # d-i apt-setup/security_path string /ubuntu
 
-# Additional repositories, local[0-9] available
-# d-i apt-setup/local0/repository string \
-#     http://local.server/ubuntu precise main
-# d-i apt-setup/local0/comment string local server
+$SNIPPET('preseed_apt_repo_config')
 
 # Enable deb-src lines
 # d-i apt-setup/local0/source boolean true

--- a/snippets/preseed_apt_repo_config
+++ b/snippets/preseed_apt_repo_config
@@ -1,0 +1,22 @@
+# Additional repositories, local[0-9] available
+#set $cur=0
+#set $repo_data = $getVar("repo_data",[])
+#for $repo in $repo_data
+ #for $dist in $repo.apt_dists
+ #set $comps = " ".join($repo.apt_components)
+d-i apt-setup/local${cur}/repository string \
+ #if $repo.mirror_locally
+      http://$http_server/cblr/repo_mirror/${repo.name} $dist $comps
+ #else
+      http://${repo.mirror}/cblr/repo_mirror/${repo.name} $dist $comps
+ #end if
+ #if $repo.comment != ""
+d-i apt-setup/local${cur}/comment string ${repo.comment}
+ #end if
+ #if $repo.breed == "src"
+# Enable deb-src lines
+d-i apt-setup/local${cur}/source boolean false
+ #end if
+ #set $cur=$cur+1
+ #end for
+#end for


### PR DESCRIPTION
- Adding full repo data to metadata available in kickstart templating
  so that we can begin to move away from the magic $yum... variables.
- The above also allows us to create local repo lines in preseeds,
  which is now a new snippet (preseed_apt_repo_config). A late-command
  version could be used to create a 'clean' sources.list too.
- Added apt-specific fields to repo objects in order to make it
  much easier and saner to sync apt repos. Rather than one repo folder
  per dist (like it was before), multiple dists can now go in one folder
  which is how it is on actual apt mirror sites. Also added the option
  to specify multiple apt components (ie. main, restricted, universe) so
  those will all go into the same folder as the dists.
- Modified signatures import so that the new apt repos are created per
  the new model from above.
