### PR TITLE
Improve bonding configuration for debian/ubuntu

### DIFF
--- a/snippets/post_install_network_config_deb
+++ b/snippets/post_install_network_config_deb
@@ -119,8 +119,27 @@ echo "   address $ip" >> /etc/network/interfaces
                 #if $netmask != ""
 echo "   netmask $netmask" >> /etc/network/interfaces 
                 #end if
+                #if $iface_type in ("master","bond")
+                  #set $bondslaves = ""
+                  #for $bondiname in $ikeys
+                      #set $bondidata                = $interfaces[$bondiname]
+                      #set $bondiface_type           = $bondidata.get("interface_type", "").lower()
+                      #set $bondiface_master         = $bondidata.get("interface_master", "")
+                      #if $bondiface_master == $iname
+                         #set $bondslaves += $bondiname + " "
+                      #end if
+                  #end for
+echo "   bond-slaves $bondslaves" >> /etc/network/interfaces
+		  #for $bondopts in $bonding_opts.split(" ")
+		      #set [$bondkey, $bondvalue] = $bondopts.split("=")
+echo "   bond-$bondkey $bondvalue" >> /etc/network/interfaces
+                  #end for
+                #end if
             #else
 echo "iface $iname inet manual" >> /etc/network/interfaces 
+            #end if
+            #if $iface_type in ("slave","bond_slave") and $iface_master != ""
+echo "bond-master $iface_master" >> /etc/network/interfaces
             #end if
             #if $enableipv6 == True and $ipv6_autoconfiguration == False
                 #if $ipv6_address != ""


### PR DESCRIPTION
This commit will improve bonding configuration up to the point where it actually configures it correctly. It does not accommodate for properly configuring the bonding module, though.

Furthermore, it will parse the existing Bonding Opts as key=value pairs and assign them as:

bond-$key $value

in the interface stanza for /etc/network/interfaces
