### PR TITLE
Update the puppet snippet to support --server and 'puppet agent'.

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -99,6 +99,8 @@ DEFAULTS = {
     "power_management_default_type"       : ["ipmitool","str"],
     "power_template_dir"                  : ["/etc/cobbler/power","str"],
     "puppet_auto_setup"                   : [0,"bool"],
+    "puppet_server"                       : ["puppet","str"],
+    "puppet_version"                      : [2,"int"],
     "pxe_just_once"                       : [0,"bool"],
     "pxe_template_dir"                    : ["/etc/cobbler/pxe","str"],
     "redhat_management_permissive"        : [0,"bool"],

--- a/snippets/puppet_register_if_enabled
+++ b/snippets/puppet_register_if_enabled
@@ -1,9 +1,15 @@
+# start puppet registration 
 #if $str($getVar('puppet_auto_setup','')) == "1"
 # generate puppet certificates and trigger a signing request, but
 # don't wait for signing to complete
-/usr/bin/puppet agent --test --waitforcert 0
+#if $int($getVar('puppet_version',2)) >= 3
+/usr/bin/puppet agent --test --waitforcert 0 #echo (($str($getVar('puppet_server','')) != '') and "--server '"+$str($getVar('puppet_server',''))+"'" or '')
+#else
+/usr/sbin/puppetd --test --waitforcert 0 #echo (($str($getVar('puppet_server','')) != '') and "--server '"+$str($getVar('puppet_server',''))+"'" or '')
+#end if
 
 # turn puppet service on for reboot
 /sbin/chkconfig puppet on
 
 #end if
+# end puppet registration


### PR DESCRIPTION
Issue #475
This patch also adds two new settings to /etc/cobbler/settings:
- puppet_server: specify a --server param in puppet snippet.
- puppet_version: specify 3, to have snippet use 'puppet agent'.

All of these changes default to the historical status quo.
