### PR TITLE
BUGFIX - fixing up blender variables

### DIFF
--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -819,8 +819,12 @@ class PXEGen:
         if not success:
             return results
 
-        blended['img_path'] = os.path.join("/images",blended["distro_name"])
-        blended['local_img_path'] = os.path.join(utils.tftpboot_location(),"images",blended["distro_name"])
+        # FIXME: img_path and local_img_path should probably be moved
+        #        up into the blender function to ensure they're consistently
+        #        available to templates across the board
+        if blended["distro_name"]:
+            blended['img_path'] = os.path.join("/images",blended["distro_name"])
+            blended['local_img_path'] = os.path.join(utils.tftpboot_location(),"images",blended["distro_name"])
 
         for template in templates.keys():
             dest = templates[template]
@@ -992,6 +996,9 @@ class PXEGen:
 
        blended['distro'] = ks_mirror_name
 
+       # FIXME: img_path should probably be moved up into the 
+       #        blender function to ensure they're consistently
+       #        available to templates across the board
        if obj.enable_gpxe:
            blended['img_path'] = 'http://%s:%s/cobbler/links/%s' % (self.settings.server,self.settings.http_port,distro.name)
        else:
@@ -1029,6 +1036,9 @@ class PXEGen:
            pass
        blended.update(ksmeta) # make available at top level
 
+       # FIXME: img_path should probably be moved up into the
+       #        blender function to ensure they're consistently
+       #        available to templates across the board
        if obj.enable_gpxe:
            blended['img_path'] = 'http://%s:%s/cobbler/links/%s' % (self.settings.server,self.settings.http_port,distro.name)
        else:

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1533,11 +1533,6 @@ class CobblerXMLRPCInterface:
         obj = self.api.find_system(name=name)
         if obj is not None:
             hash = utils.blender(self.api,True,obj)
-            # FIXME: hackish fix for now, as this is breaking the 
-            #        xmlrpc return because it is an object that
-            #        needs to be flattened (probably)
-            if hash.has_key("repo_data"):
-                hash["repo_data"] = ""
             # Generate a pxelinux.cfg?
             image_based = False
             profile = obj.get_conceptual_parent()

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -678,7 +678,7 @@ def blender(api_handle,remove_hashes, root_obj):
         for r in results["repos"]:
             repo = api_handle.find_repo(name=r)
             if repo:
-                repo_data.append(repo)
+                repo_data.append(repo.to_datastruct())
         # FIXME: sort the repos in the array based on the 
         #        repo priority field so that lower priority
         #        repos come first in the array
@@ -817,8 +817,15 @@ def __consolidate(node,results):
              results[field].extend(data_item)
              results[field] = uniquify(results[field])
           else:
-             # just override scalars
-             results[field] = data_item
+             # distro field gets special handling, since we don't
+             # want to overwrite it ever.
+             # FIXME: should the parent's field too? It will be over-
+             #        written if there are multiple sub-profiles in
+             #        the chain of inheritance
+             if field == "distro" and not results.has_key(field):
+                results[field] = data_item
+             else:
+                results[field] = data_item
        else:
           results[field] = data_item
 


### PR DESCRIPTION
When using sub-profiles, the distro variable was being lost due
to the fact that sub-profiles have an unset distro field, which was
overwriting the value that was set from the actual parent distro
