### PR TITLE
Fixed assumption that cnames key exists on interface dictionary

### DIFF
--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -450,10 +450,10 @@ zone "%(arpa)s." {
         
         for system in self.systems:
             for (name, interface) in system.interfaces.iteritems():
-                cnames = interface.get("cnames")
+                cnames = interface.get("cnames", [])
         
                 try:
-                    if interface.get("dns_name") != "":
+                    if interface.get("dns_name", "") != "":
                         dnsname = interface["dns_name"].split('.')[0] 
                         for cname in cnames:
                             s += "%s  %s  %s;\n" % (cname.split('.')[0], rectype, dnsname)                    


### PR DESCRIPTION
In manage_bind.py, there is an assumption at the cname key will exist in the interface dictionary in __pretty_print_cname_records(). On my system, this caused a key error when running "cobbler sync".
