### PR TITLE
Allow koan to install "image" based virtual machines

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1478,10 +1478,11 @@ class CobblerXMLRPCInterface:
             image_based = False
             profile = obj.get_conceptual_parent()
             distro  = profile.get_conceptual_parent()
-            arch = distro.arch
-            if distro is None and profile.COLLECTION_TYPE == "profile":
+            if distro is None and profile.COLLECTION_TYPE == "image":
                 image_based = True
                 arch = profile.arch
+            else:
+                arch = distro.arch
 
             if obj.is_management_supported():
                 if not image_based:


### PR DESCRIPTION
Currently, koan reproducibly breaks when trying to access a virtual machine definition, if the virtual machine is inheriting an "image":

```
$ koan --display --system=system1
DEBUG: get_data(<koan.app.Koan instance at 0x7f613ea0bd40>,system,system1)
...
Fault: <Fault 1: "<type 'exceptions.AttributeError'>:'NoneType' object has no attribute 'arch'">
```

And in cobbler.log:

```
  File "/usr/lib/python2.6/site-packages/cobbler/remote.py", line 1970, in _dispatch
    return method_handle(*params)
   File "/usr/lib/python2.6/site-packages/cobbler/remote.py", line 1481, in get_system_for_koan
    arch = distro.arch
```
