### PR TITLE
Update post_install_network_config_deb

### DIFF
--- a/snippets/post_install_network_config_deb
+++ b/snippets/post_install_network_config_deb
@@ -62,7 +62,7 @@ echo "" >> /etc/network/interfaces
         #set $static               = $idata.get("static", "")
         #set $ip                   = $idata.get("ip_address", "")
         #set $netmask              = $idata.get("netmask", "")
-        #set $if_gateway           = $idata.get("if_gateway", "")
+        #set $if_gateway           = $idata.get("gateway", "")
         #set $static_routes        = $idata.get("static_routes", "")
         #set $iface_type           = $idata.get("interface_type", "").lower()
         #set $iface_master         = $idata.get("interface_master", "")


### PR DESCRIPTION
post_install_network_config_deb refers to wrong system var when setting gateway for an interface.  At line 65, RHS refers to "if_gateway".  Should just be "gateway".
