### PR TITLE
Rolling back that Django change

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -304,7 +304,7 @@ of an existing system.  For use with a boot-server configured with Cobbler
 Summary: Web interface for Cobbler
 Group: Applications/System
 Requires: cobbler
-Requires: Django14
+Requires: Django >= 1.1.2
 Requires: mod_wsgi
 Requires: mod_ssl
 %if 0%{?fedora} >= 11 || 0%{?rhel} >= 6


### PR DESCRIPTION
Not sure if we want to pull the trigger on that yet, plus it looks
like it'll need to be selective based on the distro as Fedora still
calls the package Django and has no Django14 package
