### PR TITLE
Enforce the use of --interface when no interfaces are defined

### DIFF
--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -151,7 +151,9 @@ class System(item.Item):
 
     def __get_interface(self,name):
 
-        if name == "" and len(self.interfaces.keys()) == 1:
+        if name == "" and len(self.interfaces.keys()) == 0:
+            raise CX(_("No interfaces defined. Please use --interface <interface_name>"))
+        elif name == "" and len(self.interfaces.keys()) == 1:
             name = self.interfaces.keys()[0]
         elif name == "" and len(self.interfaces.keys()) > 1:
             raise CX(_("Multiple interfaces defined. Please use --interface <interface_name>"))


### PR DESCRIPTION
From:
Issue #526 - cobbler system add creates broken record when used
with --dns-name and no interface

This also means that eth0 will no longer be assumed as the default.
