### PR TITLE
Fix http check on SUSE platform. Addresses bnc#828453

### DIFF
--- a/cobbler/action_check.py
+++ b/cobbler/action_check.py
@@ -237,8 +237,10 @@ class BootCheck:
        """
        Check if Apache is installed.
        """
-       if self.checked_dist in [ "suse", "redhat" ]:
+       if self.checked_dist == "redhat":
            rc = utils.subprocess_get(self.logger,"httpd -v")
+       elif self.checked_dist == "suse":
+           rc = utils.subprocess_get(self.logger,"httpd2 -v")
        else:
            rc = utils.subprocess_get(self.logger,"apache2 -v")
        if rc.find("Server") == -1:


### PR DESCRIPTION
On SUSE platform Apache's binary is called 'httpd2'.

This addresses one of the issues reported by bnc#828453.

This commit avoids the issues introduced by [pull request #529](https://github.com/cobbler/cobbler/pull/529).
