### PR TITLE
Don't assume repos exists in the object (even if it should)

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -675,7 +675,7 @@ def blender(api_handle,remove_hashes, root_obj):
     # repo data for repos that belong to the object chain
     if root_obj.COLLECTION_TYPE in ("profile","system"):
         repo_data = []
-        for r in results["repos"]:
+        for r in results.get("repos",[]):
             repo = api_handle.find_repo(name=r)
             if repo:
                 repo_data.append(repo.to_datastruct())


### PR DESCRIPTION
Fix for Issue #535 - cobbler sync fails on "Exception value: 'repos'"
