### PR TITLE
cobbler repsync exclude: Fixes cobbler/cobbler#218

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -536,7 +536,7 @@ class RepoSync:
         config_file = open(fname, "w+")
         config_file.write("[%s]\n" % repo.name)
         config_file.write("name=%s\n" % repo.name)
-	config_file.write("exclude=%s\n" % repo.yumopts['exclude'])
+        config_file.write("exclude=%s\n" % repo.yumopts['exclude'])
         self.logger.debug("excluding: %s" % repo.yumopts['exclude'])
         optenabled = False
         optgpgcheck = False


### PR DESCRIPTION
Credit to dmlb2000 -- this solves exclude not working on reposync for added repos. This doesn't solve it for rhn:// repos though, that will be a separate issue.  Fixes cobbler/cobbler#218
