### PR TITLE
Fix /cblr/svc/op/findks service autodetection FAILED

### DIFF
--- a/bin/services.py
+++ b/bin/services.py
@@ -51,7 +51,7 @@ def application(environ, start_response):
     # This MAC header is set by anaconda during a kickstart booted with the 
     # kssendmac kernel option. The field will appear here as something 
     # like: eth0 XX:XX:XX:XX:XX:XX
-    form["REMOTE_MAC"]  = form.get("HTTP_X_RHN_PROVISIONING_MAC_0", None)
+    form["REMOTE_MAC"]  = environ.get("HTTP_X_RHN_PROVISIONING_MAC_0", None)
 
     # REMOTE_ADDR isn't a required wsgi attribute so it may be naive to assume
     # it's always present in this context.

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -30,6 +30,7 @@ import sys
 import time
 import urlgrabber
 import yaml # PyYAML
+import config
 
 # the following imports are largely for the test code
 import remote
@@ -50,6 +51,7 @@ class CobblerSvc(object):
         self.server = server
         self.remote = None
         self.req    = req
+	self.config  = config.Config(self)
 
     def __xmlrpc_setup(self):
         """
@@ -235,8 +237,7 @@ class CobblerSvc(object):
     def findks(self,system=None,profile=None,**rest):
         self.__xmlrpc_setup()
 
-        serverseg = self.server.replace("http://","")
-        serverseg = self.server.replace("/cobbler_api","")
+        serverseg = "http//%s" % self.config._settings.server
 
         name = "?"    
         type = "system"


### PR DESCRIPTION
findks was returning autodetection FAILED for valid systems.
The fix was proposed in Peter McGowan in
https://bugzilla.redhat.com/show_bug.cgi?id=905129

Tested on Fedora 19, v2.4.0.
