### PR TITLE
For puppet cert cleaning, use default_name_servers_search if name_server...

### DIFF
--- a/cobbler/modules/install_pre_puppet.py
+++ b/cobbler/modules/install_pre_puppet.py
@@ -43,6 +43,10 @@ def run(api, args, logger):
         search_domains = system['name_servers_search']
         if search_domains:
             hostname += '.' + search_domains[0]
+    if not re.match(r'[\w-]+\..+', hostname):
+        default_search_domains = system['default_name_servers_search']
+        if default_search_domains:
+            hostname += '.' + default_search_domains[0]
     puppetca_path = settings.puppetca_path
     cmd = [puppetca_path, 'cert', 'clean', hostname]
 


### PR DESCRIPTION
If you don't specify the search domains for individual profiles because your default ones cover all, then the puppet cert clean will run without a domain suffix and therefore fail.

This patch uses the same technique as the lines above to check if there's a dot in the hostname added by the name_servers_search and if not, uses the default_name_servers_search.
