### PR TITLE
Fix empty source_repos attribute of distro on import.

### DIFF
--- a/cobbler/modules/manage_import_signatures.py
+++ b/cobbler/modules/manage_import_signatures.py
@@ -505,6 +505,7 @@ class ImportSignatureManager:
             for distro in distros_added:
                 if distro.kernel.find("ks_mirror") != -1:
                     repo_adder(distro)
+                    self.distros.add(distro, save=True)
                 else:
                     self.logger.info("skipping distro %s since it isn't mirrored locally" % distro.name)
 


### PR DESCRIPTION
During import, the source_repos attribute is properly calculated
but was not being saved, and as a result, was not populated. Without
this, the yum config for new systems won't point back to the yum
repo created when the distro is imported.

This relates to issue https://github.com/cobbler/cobbler/issues/459
