### PR TITLE
Allow for easy relocation during make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@
 
 TOP_DIR:=$(shell pwd)
 
+DESTDIR=/
+
 prefix=devinstall
 statepath=/tmp/cobbler_settings/$(prefix)
 
@@ -40,68 +42,68 @@ build:
 # otherwise Debian / Ubuntu ('www-data' user)
 install: build
 	if [ -n "`getent passwd apache`" ] ; then \
-		python setup.py install -f; \
-		chown -R apache /usr/share/cobbler/web; \
-		chown -R apache /var/lib/cobbler/webui_sessions; \
+		python setup.py install --root $(DESTDIR) -f; \
+		chown -R apache $(DESTDIR)/usr/share/cobbler/web; \
+		chown -R apache $(DESTDIR)/var/lib/cobbler/webui_sessions; \
 	else \
-		python setup.py install -f --install-layout=deb; \
-		chown -R www-data /usr/share/cobbler/web; \
-		chown -R www-data /var/lib/cobbler/webui_sessions; \
+		python setup.py install --root $(DESTDIR) -f --install-layout=deb; \
+		chown -R www-data $(DESTDIR)/usr/share/cobbler/web; \
+		chown -R www-data $(DESTDIR)/var/lib/cobbler/webui_sessions; \
 	fi
 
 devinstall:
-	-rm -rf /usr/share/cobbler
+	-rm -rf $(DESTDIR)/usr/share/cobbler
 	make savestate
 	make install
 	make restorestate
 
 savestate:
 	mkdir -p $(statepath)
-	cp -a /var/lib/cobbler/config $(statepath)
-	cp /etc/cobbler/settings $(statepath)/settings
-	cp /etc/cobbler/modules.conf $(statepath)/modules.conf
+	cp -a $(DESTDIR)/var/lib/cobbler/config $(statepath)
+	cp $(DESTDIR)/etc/cobbler/settings $(statepath)/settings
+	cp $(DESTDIR)/etc/cobbler/modules.conf $(statepath)/modules.conf
 	@if [ -d /etc/httpd ] ; then \
-		cp /etc/httpd/conf.d/cobbler.conf $(statepath)/http.conf; \
-		cp /etc/httpd/conf.d/cobbler_web.conf $(statepath)/cobbler_web.conf; \
+		cp $(DESTDIR)/etc/httpd/conf.d/cobbler.conf $(statepath)/http.conf; \
+		cp $(DESTDIR)/etc/httpd/conf.d/cobbler_web.conf $(statepath)/cobbler_web.conf; \
 	else \
-		cp /etc/apache2/conf.d/cobbler.conf $(statepath)/http.conf; \
-		cp /etc/apache2/conf.d/cobbler_web.conf $(statepath)/cobbler_web.conf; \
+		cp $(DESTDIR)/etc/apache2/conf.d/cobbler.conf $(statepath)/http.conf; \
+		cp $(DESTDIR)/etc/apache2/conf.d/cobbler_web.conf $(statepath)/cobbler_web.conf; \
 	fi
-	cp /etc/cobbler/users.conf $(statepath)/users.conf
-	cp /etc/cobbler/users.digest $(statepath)/users.digest
-	cp /etc/cobbler/dhcp.template $(statepath)/dhcp.template
-	cp /etc/cobbler/rsync.template $(statepath)/rsync.template
+	cp $(DESTDIR)/etc/cobbler/users.conf $(statepath)/users.conf
+	cp $(DESTDIR)/etc/cobbler/users.digest $(statepath)/users.digest
+	cp $(DESTDIR)/etc/cobbler/dhcp.template $(statepath)/dhcp.template
+	cp $(DESTDIR)/etc/cobbler/rsync.template $(statepath)/rsync.template
 
 
 # Assume we're on RedHat by default, otherwise Debian / Ubuntu
 restorestate:
-	cp -a $(statepath)/config /var/lib/cobbler
-	cp $(statepath)/settings /etc/cobbler/settings
-	cp $(statepath)/modules.conf /etc/cobbler/modules.conf
-	cp $(statepath)/users.conf /etc/cobbler/users.conf
-	cp $(statepath)/users.digest /etc/cobbler/users.digest
+	cp -a $(statepath)/config $(DESTDIR)/var/lib/cobbler
+	cp $(statepath)/settings $(DESTDIR)/etc/cobbler/settings
+	cp $(statepath)/modules.conf $(DESTDIR)/etc/cobbler/modules.conf
+	cp $(statepath)/users.conf $(DESTDIR)/etc/cobbler/users.conf
+	cp $(statepath)/users.digest $(DESTDIR)/etc/cobbler/users.digest
 	if [ -d /etc/httpd ] ; then \
-		cp $(statepath)/http.conf /etc/httpd/conf.d/cobbler.conf; \
-		cp $(statepath)/cobbler_web.conf /etc/httpd/conf.d/cobbler_web.conf; \
+		cp $(statepath)/http.conf $(DESTDIR)/etc/httpd/conf.d/cobbler.conf; \
+		cp $(statepath)/cobbler_web.conf $(DESTDIR)/etc/httpd/conf.d/cobbler_web.conf; \
 	else \
-		cp $(statepath)/http.conf /etc/apache2/conf.d/cobbler.conf; \
-		cp $(statepath)/cobbler_web.conf /etc/apache2/conf.d/cobbler_web.conf; \
+		cp $(statepath)/http.conf $(DESTDIR)/etc/apache2/conf.d/cobbler.conf; \
+		cp $(statepath)/cobbler_web.conf $(DESTDIR)/etc/apache2/conf.d/cobbler_web.conf; \
 	fi
-	cp $(statepath)/dhcp.template /etc/cobbler/dhcp.template
-	cp $(statepath)/rsync.template /etc/cobbler/rsync.template
-	find /var/lib/cobbler/triggers | xargs chmod +x
+	cp $(statepath)/dhcp.template $(DESTDIR)/etc/cobbler/dhcp.template
+	cp $(statepath)/rsync.template $(DESTDIR)/etc/cobbler/rsync.template
+	find $(DESTDIR)/var/lib/cobbler/triggers | xargs chmod +x
 	if [ -n "`getent passwd apache`" ] ; then \
-		chown -R apache /var/www/cobbler; \
+		chown -R apache $(DESTDIR)/var/www/cobbler; \
 	else \
-		chown -R www-data /usr/share/cobbler/web/cobbler_web; \
+		chown -R www-data $(DESTDIR)/usr/share/cobbler/web/cobbler_web; \
 	fi
-	if [ -d /var/www/cobbler ] ; then \
-		chmod -R +x /var/www/cobbler/web; \
-		chmod -R +x /var/www/cobbler/svc; \
+	if [ -d $(DESTDIR)/var/www/cobbler ] ; then \
+		chmod -R +x $(DESTDIR)/var/www/cobbler/web; \
+		chmod -R +x $(DESTDIR)/var/www/cobbler/svc; \
 	fi
-	if [ -d /usr/share/cobbler/web ] ; then \
-		chmod -R +x /usr/share/cobbler/web/cobbler/cobbler_web; \
-		chmod -R +x /srv/www/cobbler/svc; \
+	if [ -d $(DESTDIR)/usr/share/cobbler/web ] ; then \
+		chmod -R +x $(DESTDIR)/usr/share/cobbler/web/cobbler/cobbler_web; \
+		chmod -R +x $(DESTDIR)/srv/www/cobbler/svc; \
 	fi
 	rm -rf $(statepath)
 


### PR DESCRIPTION
Introduce standard make semantics of DESTDIR to install into a different
root. This is often used by packagers, so we're adding this convinients
to everyone's benefit!
