### PR TITLE
BUGFIX: return 1 when no MAC is passed to mac_exists()

### DIFF
--- a/snippets/pre_install_network_config
+++ b/snippets/pre_install_network_config
@@ -3,6 +3,8 @@
 #raw
 # generic functions to be used later for discovering NICs
 mac_exists() {
+  [ -z "$1" ] && return 1
+
   if which ip 2>/dev/null >/dev/null; then
     ip -o link | grep -i "$1" 2>/dev/null >/dev/null
     return $?


### PR DESCRIPTION
If an interface doesn't have a MAC, mac_exists() is called with an
empty string that returns a list of all interfaces names.  Instead,
return 1 from the function so that the "network" line is not
generated.
