### PR TITLE
Revert "We force the use of https; but dont require the mod_ssl pacakge....

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -24,7 +24,6 @@ Requires: python >= 2.3
 Requires: httpd
 Requires: tftp-server
 Requires: mod_wsgi
-Requires: mod_ssl
 Requires: createrepo
 Requires: python-cheetah
 Requires: python-netaddr
@@ -100,8 +99,8 @@ mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 install -m0644 config/cobblerd.service $RPM_BUILD_ROOT%{_unitdir}
 
 %post
-if [ $1 -eq 1 ] ; then 
-    # Initial installation 
+if [ $1 -eq 1 ] ; then
+    # Initial installation
     /bin/systemctl daemon-reload >/dev/null 2>&1 || :
 elif [ "$1" -ge "2" ]; then
     # backup config
@@ -308,7 +307,6 @@ Requires: cobbler
 Requires: httpd
 Requires: Django >= 1.1.2
 Requires: mod_wsgi
-Requires: mod_ssl
 %if 0%{?fedora} >= 11 || 0%{?rhel} >= 6
 Requires: python(abi) >= %{pyver}
 %endif


### PR DESCRIPTION
..."

Commit d95628420b6f73de6d86f4c37f72e9bfb3a256fc removed the "requires
mod_ssl" line because what cobbler needs is an ssl enabled httpd
server, _NOT_ mod_ssl, and in particular (free)ipa uses mod_nss
to provide ssl services. So, over time expect to see far more
systems using mod_nss rather than mod_ssl.

Cobbler works fine with mod_nss or mod_ssl, but mod_nss and mod_ssl
conflict, _both_ cannot be installed. As rpm has no mechanism to
specify "either/or" conditions, the only solution is to specify
neither.

This reverts commit 1e731294d148e729c1064b0fd53b037a82cf0386.
