### PR TITLE
add a few direct commands in help output

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -57,7 +57,7 @@ OBJECT_TYPES = OBJECT_ACTIONS_MAP.keys()
 OBJECT_ACTIONS = []
 for actions in OBJECT_ACTIONS_MAP.values():
    OBJECT_ACTIONS += actions
-DIRECT_ACTIONS = "aclsetup buildiso import list replicate report reposync sync validateks version".split()
+DIRECT_ACTIONS = "aclsetup buildiso import list replicate report reposync sync validateks version signature get-loaders hardlink".split()
 
 ####################################################
 


### PR DESCRIPTION
I am always hunting these commands down and its useful to see them in the help output 
