### PR TITLE
added os_version flag to ksvalidator

### DIFF
--- a/cobbler/action_validate.py
+++ b/cobbler/action_validate.py
@@ -77,6 +77,7 @@ class Validate:
         os_version = blended["os_version"]
 
         self.logger.info("----------------------------")
+        self.logger.debug("osversion: %s" % os_version)
 
         ks = blended["kickstart"]
         if ks is None or ks == "":
@@ -102,7 +103,7 @@ class Validate:
 
         self.logger.info("checking url: %s" % url)
 
-        rc = utils.subprocess_call(self.logger,"/usr/bin/ksvalidator \"%s\"" % url, shell=True)
+        rc = utils.subprocess_call(self.logger,"/usr/bin/ksvalidator -v \"%s\" \"%s\"" % (os_version, url), shell=True)
         if rc != 0:
             return [False, last_errors]
        


### PR DESCRIPTION
Found the validateks option was bailing because of old kickstart configs.

Added option to the validateks to do os_version as an option to the validate step.
