### PR TITLE
django.conf.urls.defaults was removed.

### DIFF
--- a/web/cobbler_web/urls.py
+++ b/web/cobbler_web/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns
 from views import *
 
 # Uncomment the next two lines to enable the admin:

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import patterns
 
 # Uncomment the next two lines to enable the admin:
 #from django.contrib import admin


### PR DESCRIPTION
Import stuff from django.conf.urls instead. If we need to support django versions less than 1.4
then we need some compatibility stuff here.

Since 1.4 deprecated and moved to the new location.
https://docs.djangoproject.com/en/1.4/releases/1.4/#django-conf-urls-defaults

Removed in 1.6
https://docs.djangoproject.com/en/1.6/internals/deprecation/
