### PR TITLE
Allow use of no kickstart for systems

### DIFF
--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -633,7 +633,10 @@ class System(item.Item):
         abstraction layer -- assigning systems to defined and repeatable 
         roles.
         """
-        if kickstart is None or kickstart in [ "", "delete", "<<inherit>>" ]:
+        if kickstart == "":
+            self.kickstart = kickstart
+            return True
+        if kickstart is None or kickstart in [ "delete", "<<inherit>>" ]:
             self.kickstart = "<<inherit>>"
             return True
         kickstart = utils.find_kickstart(kickstart)


### PR DESCRIPTION
Before, if a system had an empty string as kickstart then it would
inherit the one from its profile. It is not desirable if we don't want to use
a kickstart at all, as is the case of attended installations.

Signed-off-by: Alan Evangelista alanoe@linux.vnet.ibm.com
Signed-off-by: Andrea Bucci andreavb@linux.vnet.ibm.com
Signed-off-by: Eduardo Bacchi Kienetz ebacchi@linux.vnet.ibm.com
Signed-off-by: Plinio Freire pleirie@linux.vnet.ibm.com
