### PR TITLE
Add support for importing rhel4AS

### DIFF
--- a/config/distro_signatures.json
+++ b/config/distro_signatures.json
@@ -3,7 +3,7 @@
   "redhat": {
    "rhel4": {
     "signatures":["RedHat/RPMS","CentOS/RPMS"],
-    "version_file":"(redhat|sl|centos)-release-4[\\.-]+(.*)\\.rpm",
+    "version_file":"(redhat|sl|centos)-release-4(AS|WS|ES)[\\.-]+(.*)\\.rpm",
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*).rpm",
     "kernel_arch_regex":null,


### PR DESCRIPTION
Support importing Red Hat Enterprise Linux 4 AS.
This patch wasn't never submitted after closing the issue #387
https://github.com/cobbler/cobbler/issues/387
