### PR TITLE
cobbler.spec - don't overwrite generated httpd files

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -79,9 +79,8 @@ other applications.
 %install
 test "x$RPM_BUILD_ROOT" != "x" && rm -rf $RPM_BUILD_ROOT
 %{__python} setup.py install --optimize=1 --root=$RPM_BUILD_ROOT $PREFIX
-mkdir -p $RPM_BUILD_ROOT/etc/httpd/conf.d
-mv config/cobbler.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/
-mv config/cobbler_web.conf $RPM_BUILD_ROOT/etc/httpd/conf.d/
+rm $RPM_BUILD_ROOT/etc/cobbler/cobbler.conf
+rm $RPM_BUILD_ROOT/etc/cobbler/cobbler_web.conf
 mkdir -p $RPM_BUILD_ROOT/etc/logrotate.d
 mv config/cobblerd_rotate $RPM_BUILD_ROOT/etc/logrotate.d/cobblerd
 
@@ -98,7 +97,7 @@ rm -f $RPM_BUILD_ROOT/etc/cobbler/cobblerd
 %if 0%{?fedora} >= 16
 rm -rf $RPM_BUILD_ROOT/etc/init.d
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
-install -m0644 config/cobblerd.service $RPM_BUILD_ROOT%{_unitdir}
+mv $RPM_BUILD_ROOT/etc/cobbler/cobblerd.service $RPM_BUILD_ROOT%{_unitdir}
 
 %post
 if [ $1 -eq 1 ] ; then


### PR DESCRIPTION
Commits f550ad5485430ee7c6bd7554a0fe4a45456d7b49 and
9eb1f39df9d9c430cc30fadd271a6df69f21ce43, changed the httpd/*.conf
files to be generated, so don't copy the raw files over the
generated ones.
