### PR TITLE
Revert "Cleanup PXE files for systems that have netboot disabled. Fixes ...

### DIFF
--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -282,7 +282,7 @@ class PXEGen:
             else:
                 continue 
 
-            if system.is_management_supported() and system.netboot_enabled:
+            if system.is_management_supported():
                 if not image_based:
                     self.write_pxe_file(f2, system, profile, distro, working_arch, metadata=pxe_metadata)
                     if grub_path:


### PR DESCRIPTION
...#618"

This reverts commit bcec38e097c1d8563503309f0c81402cf09bf4f2.

This change destroyed the functionality provided by pxe_just_once and
netboot-enabled:
The reason the pxe files are left is so that the machines are commanded,
via pxe, to boot from the local drive. Once the pxe files are deleted,
each machine will now boot using whatever is in /tftboot/.../default,
which is NOT what should happen. The netboot-enabled flag has no control
of the individual bios configs on the machines, the whole idea if
netboot-enabled is that if a machine does pxe-boot but is disabled,
no installation is attempted.

I suggest this feature be rethought, and when added done so in a way
that is guaranteed to not impact existing users and to guarantee that
a machine with netboot-enable = false will be forced to boot from
the local drive.
