### PR TITLE
Hacky attempt to support mirroring ssl-protected katello repos

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -590,6 +590,14 @@ class RepoSync:
         # FIXME: potentially might want a way to turn this on/off on a per-repo basis
         if not optgpgcheck:
             config_file.write("gpgcheck=0\n")
+        # user may have options specific to certain yum plugins
+        # add them to the file
+        for x in repo.yumopts:
+            config_file.write("%s=%s\n" % (x, repo.yumopts[x]))
+            if x == "enabled":
+                optenabled = True
+            if x == "gpgcheck":
+                optgpgcheck = True
         config_file.close()
         return fname 
 


### PR DESCRIPTION
I needed to support mirroring from katello repos which are protected by client SSL certs.

This code supports that by using ssl options passed in via --yumopts

This is not ideal since the yum options used by clients to pull from cobbler will be different to those needed to pull from the katello mirror. ie. the "real" fix would need to generate someway to specify upstream yum opts.

References ticket #692
