### PR TITLE
cobbler.spec - do not require tftp-server

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -22,7 +22,6 @@ BuildRequires: python-cheetah
 
 Requires: python >= 2.3
 Requires: httpd
-Requires: tftp-server
 Requires: mod_wsgi
 Requires: createrepo
 Requires: python-cheetah


### PR DESCRIPTION
Cobbler can use dnsmasq's tftp server, or in.tftpd, or the tftpd
provdided with Cobbler itself. Depending upon the configuration,
tftp-server may not be used and therefore its installation should
not be required.
