### PR TITLE
fix distro detection on RHEL

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1007,7 +1007,7 @@ def check_dist():
 
 def os_release():
 
-   if check_dist() in ("redhat","fedora","centos","scientific linux"):
+   if re.match("red ?hat|fedora|centos|scientific linux", check_dist()):
       fh = open("/etc/redhat-release")
       data = fh.read().lower()
       if data.find("fedora") != -1:


### PR DESCRIPTION
the new distro detection mechanism doesn't match correctly on RHEL.
this leads to SELinux denials because cobblerd tries to create
/tftpboot instead of the correct /var/lib/tftpboot.
