### PR TITLE
Introduce log_ks_post_nochroot snippet

### DIFF
--- a/kickstarts/legacy.ks
+++ b/kickstarts/legacy.ks
@@ -45,6 +45,10 @@ $SNIPPET('pre_anamon')
 
 %packages
 
+$post --nochroot
+$SNIPPET('log_ks_post_nochroot')
+%end
+
 %post
 $SNIPPET('log_ks_post')
 # Begin yum configuration

--- a/kickstarts/sample.ks
+++ b/kickstarts/sample.ks
@@ -51,6 +51,10 @@ $SNIPPET('pre_anamon')
 $SNIPPET('func_install_if_enabled')
 $SNIPPET('puppet_install_if_enabled')
 
+$post --nochroot
+$SNIPPET('log_ks_post_nochroot')
+%end
+
 %post
 $SNIPPET('log_ks_post')
 # Start yum configuration 

--- a/kickstarts/sample_end.ks
+++ b/kickstarts/sample_end.ks
@@ -55,6 +55,10 @@ $SNIPPET('pre_anamon')
 $SNIPPET('func_install_if_enabled')
 %end
 
+$post --nochroot
+$SNIPPET('log_ks_post_nochroot')
+%end
+
 %post
 $SNIPPET('log_ks_post')
 # Start yum configuration

--- a/snippets/log_ks_post_nochroot
+++ b/snippets/log_ks_post_nochroot
@@ -1,0 +1,2 @@
+set -x -v
+exec 1>/mnt/sysimage/root/ks-post-nochroot.log 2>&1


### PR DESCRIPTION
This snippet is responsible for logging the "%post --nochroot"
kickstart section actions.

Signed-off-by: Nathan Ozelim natoze@linux.vnet.ibm.com
