### PR TITLE
Improve save_boot_device and restore_boot_device snippets

### DIFF
--- a/kickstarts/sample_autoyast.xml
+++ b/kickstarts/sample_autoyast.xml
@@ -63,11 +63,9 @@
     <pre-scripts config:type="list">
 	## SuSE has an annoying habit on ppc64 of changing the system
 	## boot order after installation. This makes it non-trivial to
-	## automatically re-install future OS. If you want to workaround
-	## this, un-comment out the following two lines and the two
-	## lines in the post-scripts section:
+	## automatically re-install future OS.
 	#set global $wrappedscript = 'save_boot_device'
-	## $SNIPPET('suse_scriptwrapper.xml')
+	$SNIPPET('suse_scriptwrapper.xml')
     </pre-scripts>
     <post-scripts config:type="list">
 
@@ -83,11 +81,9 @@
 	## $SNIPPET('suse_scriptwrapper.xml')
 	## SuSE has an annoying habit on ppc64 of changing the system
 	## boot order after installation. This makes it non-trivial to
-	## automatically re-install future OS. If you want to workaround
-	## this, un-comment out the following two lines and the two
-	## lines in the pre-scripts section:
+	## automatically re-install future OS.
 	#set global $wrappedscript = 'restore_boot_device'
-	## $SNIPPET('suse_scriptwrapper.xml')
+	$SNIPPET('suse_scriptwrapper.xml')
 
     </post-scripts>
   </scripts>

--- a/snippets/restore_boot_device
+++ b/snippets/restore_boot_device
@@ -1,6 +1,16 @@
-if [ "$os_version" == "sles11" ]; then
-    nvsetenv boot-device "$(cat /root/inst-sys/boot-device.bak)"
-elif [ "$os_version" == "fedora17" ]; then
-    # must be run from a %post --nochroot section
-    nvsetenv boot-device "$(cat /tmp/boot-device.bak)"
+#if ( "ppc" in $arch ) and ( $breed == "suse" or $breed == "redhat" )
+# Some Linux distributions, such as Fedora 17+, SLES 11+ and RHEL 7+, set the disk
+# as first boot device in Power machines. Therefore, restore the original boot
+# order.
+#if ( $breed == "suse" )
+# we have already chrooted, former /root is available now at /root/inst-sys
+boot_order_orig="\$(cat /root/inst-sys/boot-device.bak)"
+#else
+boot_order_orig="\$(cat /root/boot-device.bak)"
+#end if
+boot_order_cur="\$(nvram --print-config=boot-device)"
+if [[ ( -n "\$boot_order_orig" ) &&  ( "\$boot_order_orig" != "\$boot_order_cur" ) ]]
+then
+    nvsetenv boot-device "\$boot_order_orig"
 fi
+#end if

--- a/snippets/save_boot_device
+++ b/snippets/save_boot_device
@@ -1,5 +1,6 @@
-if [ "$os_version" == "sles11" ]; then
-    nvram --print-config=boot-device > /root/boot-device.bak
-elif [ "$os_version" == "fedora17" ]; then
-    nvram --print-config=boot-device > /tmp/boot-device.bak
-fi
+#if ( "ppc" in $arch ) and ( $breed == "suse" or $breed == "redhat" )
+# Some Linux distributions, such as Fedora 17+, SLES 11+ and RHEL 7+, set the disk
+# as first boot device in Power machines. Therefore, save the original boot
+# order, so it can be restored after installation is completed.
+nvram --print-config=boot-device > /root/boot-device.bak
+#end if


### PR DESCRIPTION
Make sure that boot order is saved/restored for Suse and Red Hat-based
distributions on Power architecture. This worked only in Fedora 17
and SLES 11 before and it was not default behavior.

Signed-off-by: Nathan Ozelim natoze@linux.vnet.ibm.com
