### PR TITLE
add optional grublocal.template for disabling netboot in efi/grub setups

### DIFF
--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -543,7 +543,7 @@ class PXEGen:
 					template = os.path.join(self.settings.pxe_template_dir, "grubsystem.template")
 				else:
 					local = os.path.join(self.settings.pxe_template_dir, "grublocal.template")
-					if os.path_exists(local):
+					if os.path.exists(local):
 						template = local
             else: # pxe
                 if system.netboot_enabled:


### PR DESCRIPTION
I have cobbler working with a bunch of UEFI boxes except that I could not disable netboot. This patch fixes that by letting me write a grublocal.template file that is used to generate confs in /var/lib/tftboot/grub when netboot is disabled. 

I wanted to add a grublocal.template as well, but I am having difficulties writing a generic one that works like pxelocal.template. For the time being, I'm just making grublocal.template optional. 
