### PR TITLE
Convert /etc/cobbler/version from Yaml to ConfigParser filetype.

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -56,7 +56,6 @@ Requires: yum-utils
 
 %if 0%{?fedora} >= 18 || 0%{?rhel} >= 6
 BuildRequires: redhat-rpm-config
-BuildRequires: PyYAML
 BuildRequires: python-cheetah
 Requires: python(abi) >= %{pyver}
 Requires: genisoimage

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -45,6 +45,7 @@ import kickgen
 import yumgen
 import pxegen
 from utils import _
+from ConfigParser import ConfigParser
 
 import logging
 import time
@@ -229,13 +230,22 @@ class BootAPI:
             version       -- something like "1.3.2"
             version_tuple -- something like [ 1, 3, 2 ]
         """
-        fd = open("/etc/cobbler/version")
-        ydata = fd.read()
-        fd.close()
-        data = yaml.safe_load(ydata)
+
+        config = ConfigParser()
+        config.read("/etc/cobbler/version")
+        data = {}
+        data["gitdate"] = config.get("cobbler","gitdate")
+        data["gitstamp"] = config.get("cobbler","gitstamp")
+        data["builddate"] = config.get("cobbler","builddate")
+        data["version"] = config.get("cobbler","version")
+        # dont actually read the version_tuple from the version file
+        data["version_tuple"] = []
+        for num in data["version"].split("."):
+            data["version_tuple"].append(int(num))
+
         if not extended:
             # for backwards compatibility and use with koan's comparisons
-            elems = data["version_tuple"] 
+            elems = data["version_tuple"]
             return int(elems[0]) + 0.1*int(elems[1]) + 0.001*int(elems[2])
         else:
             return data

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os, sys, time, yaml
+import os, sys, time
 import glob as _glob
 
 from distutils.core import setup, Command
@@ -11,6 +11,7 @@ from distutils import log
 from distutils import dep_util
 from distutils.dist import Distribution as _Distribution
 from string import Template
+from ConfigParser import ConfigParser
 
 import codecs
 import unittest
@@ -62,7 +63,6 @@ def glob(*args, **kwargs):
 #####################################################################
 
 def gen_build_version():
-    fd = open(os.path.join(OUTPUT_DIR, "version"),"w+")
     gitdate = "?"
     gitstamp = "?"
     builddate = time.asctime()
@@ -72,14 +72,16 @@ def gen_build_version():
        data = cmd.communicate()[0].strip()
        if cmd.returncode == 0:
            gitstamp, gitdate = data.split("\n")
-    data = {
-       "gitdate" : gitdate,
-       "gitstamp"      : gitstamp,
-       "builddate"     : builddate,
-       "version"       : VERSION,
-       "version_tuple" : [ int(x) for x in VERSION.split(".")]
-    }
-    fd.write(yaml.dump(data))
+
+    fd = open(os.path.join(OUTPUT_DIR, "version"), "w+")
+    config = ConfigParser()
+    config.add_section("cobbler")
+    config.set("cobbler","gitdate", gitdate)
+    config.set("cobbler","gitstamp", gitstamp)
+    config.set("cobbler","builddate", builddate)
+    config.set("cobbler","version", VERSION)
+    config.set("cobbler","version_tuple", [ int(x) for x in VERSION.split(".")]) 
+    config.write(fd)
     fd.close()
 
 #####################################################################


### PR DESCRIPTION
This was required to get rid of the buildtime dependency on python-yaml.
PyYAML is not available on the Open Build Service (OBS) for EL6.
Now it's possible to directly provide packages/repos to our users (#737).
