### PR TITLE
add grublocal.template to get the netboot toggle working with uefi

### DIFF
--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -539,7 +539,12 @@ class PXEGen:
         # choose a template
         if system:
             if format == "grub":
-                template = os.path.join(self.settings.pxe_template_dir, "grubsystem.template")
+                if system.netboot_enabled:
+                    template = os.path.join(self.settings.pxe_template_dir, "grubsystem.template")
+                else:
+                    local = os.path.join(self.settings.pxe_template_dir, "grublocal.template")
+                    if os.path.exists(local):
+                        template = local
             else: # pxe
                 if system.netboot_enabled:
                     template = os.path.join(self.settings.pxe_template_dir,"pxesystem.template")

--- a/templates/pxe/grublocal.template
+++ b/templates/pxe/grublocal.template
@@ -1,0 +1,5 @@
+default=0
+timeout=0
+splashimage=(nd)/splash.xpm.gz
+title local
+	quit


### PR DESCRIPTION
I managed to get cobbler working with some UEFI systems, but had to add this small patch to use grublocal.template to get the netboot toggle working. I've included a grublocal.template file that may be a bit of a hack, but seems to work pretty well for me and is the most generic solution I could come up with. 
