### PR TITLE
Fix infinite loop in get_file_device_path() in chroot environment #784.

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1699,13 +1699,20 @@ def get_file_device_path(fname):
 
     # convert mtab to a dict
     mtab_dict = {}
-    for ent in get_mtab():
-        mtab_dict[ent.mnt_dir] = ent.mnt_fsname
+    try:
+        for ent in get_mtab():
+            mtab_dict[ent.mnt_dir] = ent.mnt_fsname
+    except:
+        pass
 
     # find a best match
     fdir = os.path.dirname(fname)
     match = mtab_dict.has_key(fdir)
+    chrootfs = False
     while not match:
+        if fdir == os.path.sep:
+            chrootfs = True
+            break
         fdir = os.path.realpath(os.path.join(fdir, os.path.pardir))
         match = mtab_dict.has_key(fdir)
 
@@ -1713,7 +1720,10 @@ def get_file_device_path(fname):
     if fdir != os.path.sep:
         fname = fname[len(fdir):]
 
-    return (mtab_dict[fdir], fname)
+    if chrootfs:
+        return (":", fname)
+    else:
+        return (mtab_dict[fdir], fname)
 
 def is_remote_file(file):
     (dev, path) = get_file_device_path(file)


### PR DESCRIPTION
In a chroot filesystem or if it didn't get the device for the file it will always treat it as a remotefs and cobbler will never try to create hard link in chroot filesystem.
