### PR TITLE
only call get_menu_items once per pxegen.write_all_system_files call

### DIFF
--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -142,7 +142,8 @@ class InTftpdManager:
         system = self.systems.find(name=name)
         if system is None:
             utils.die(self.logger,"error in system lookup for %s" % name)
-        self.pxegen.write_all_system_files(system)
+        menu_items = self.pxegen.get_menu_items()['pxe']
+        self.pxegen.write_all_system_files(system, menu_items)
         # generate any templates listed in the system
         self.pxegen.write_templates(system)
 
@@ -151,7 +152,8 @@ class InTftpdManager:
         Write out new pxelinux.cfg files to /tftpboot
         """
         # write the PXE files for the system
-        self.pxegen.write_all_system_files(system)
+        menu_items = self.pxegen.get_menu_items()['pxe']
+        self.pxegen.write_all_system_files(system, menu_items)
         # generate any templates listed in the distro
         self.pxegen.write_templates(system)
 
@@ -184,8 +186,9 @@ class InTftpdManager:
 
         # the actual pxelinux.cfg files, for each interface
         self.logger.info("generating PXE configuration files")
+        menu_items = self.pxegen.get_menu_items()['pxe']
         for x in self.systems:
-            self.pxegen.write_all_system_files(x)
+            self.pxegen.write_all_system_files(x, menu_items)
 
         self.logger.info("generating PXE menu structure")
         self.pxegen.make_pxe_menu()

--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -211,7 +211,7 @@ class PXEGen:
         utils.linkfile(filename, newfile, api=self.api, logger=self.logger)
         return True
 
-    def write_all_system_files(self, system):
+    def write_all_system_files(self, system, menu_items):
 
         profile = system.get_conceptual_parent()
         if profile is None:
@@ -259,7 +259,7 @@ class PXEGen:
                 utils.rmfile(f2)
             return
 
-        pxe_metadata = {'pxe_menu_items': self.get_menu_items()['pxe'] }
+        pxe_metadata = {'pxe_menu_items': menu_items}
  
         # generate one record for each described NIC ..
  


### PR DESCRIPTION
fixes https://github.com/cobbler/cobbler/issues/609

There's no reason to call get_menu_items for each system, so call it once outside the for loop.  There is probably still some optimization in other code related to a full sync, but this seems to be the biggest culprit for the slowdown.
## original

echo -n 'systems: '; cobbler system list | wc -l; time cobbler sync > /dev/null
systems: 142

real    0m12.209s
user    0m0.158s
sys     0m0.031s
## patched

echo -n 'systems: '; cobbler system list | wc -l; time cobbler sync > /dev/null
systems: 142

real    0m4.226s
user    0m0.193s
sys     0m0.019s

echo -n 'systems: '; cobbler system list | wc -l; time cobbler sync > /dev/null
systems: 542

real    0m9.248s
user    0m0.209s
sys 0m0.020s
