### PR TITLE
Fix koan's get_insert_script()

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -1195,7 +1195,7 @@ class Koan:
             find . | cpio -o -H newc | gzip -9 > ../initrd_final
             echo "...done"
         fi
-        """ % initrd
+        """ % (initrd, initrd)
 
     #---------------------------------------------------
 


### PR DESCRIPTION
See https://bugzilla.redhat.com/show_bug.cgi?id=1047350

This is in 2.4.3 as well.
