### PR TITLE
release24: add an option to always write DHCP entries regardless of netboot setting

### DIFF
--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -154,8 +154,9 @@ class IscManager:
                 interface["owner"] = blended_system["name"]
                 interface["enable_gpxe"] = blended_system["enable_gpxe"]
 
-                if not interface["netboot_enabled"] and interface['static']:
-                    continue
+                if not self.settings.always_write_dhcp_entries:
+                    if not interface["netboot_enabled"] and interface['static']:
+                        continue
 
                 interface["filename"] = "/pxelinux.0"
                 # can't use pxelinux.0 anymore

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -39,6 +39,7 @@ DEFAULTS = {
     "allow_duplicate_macs"                : [0,"bool"],
     "allow_duplicate_ips"                 : [0,"bool"],
     "allow_dynamic_settings"              : [0,"bool"],
+    "always_write_dhcp_entries"           : [0,"bool"],
     "auth_token_expiration"               : [3600,"int"],
     "bind_chroot_path"                    : ["","str"],
     "bind_master"                         : ["127.0.0.1","str"],

--- a/config/settings
+++ b/config/settings
@@ -449,3 +449,6 @@ replicate_rsync_options: "-avzH"
 
 # replication rsync options for repos set to override default value of "-avzH"
 replicate_repo_rsync_options: "-avzH"
+
+# always write DHCP entries, regardless if netboot is enabled
+always_write_dhcp_entries: 0


### PR DESCRIPTION
please backport to 2.4 for use in EPEL6
