### PR TITLE
Scientific Linux Fermi support

### DIFF
--- a/config/distro_signatures.json
+++ b/config/distro_signatures.json
@@ -35,7 +35,7 @@
    },
    "rhel6": {
     "signatures":["Packages"],
-    "version_file":"(redhat|sl|centos|oraclelinux)-release-(?!notes)([\\w]*-)*6(Server)*[\\.-]+(.*)\\.rpm",
+    "version_file":"(redhat|sl|slf|centos|oraclelinux)-release-(?!notes)([\\w]*-)*6(Server)*[\\.-]+(.*)\\.rpm",
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*).rpm",
     "kernel_arch_regex":null,
@@ -654,7 +654,7 @@
     "kernel_options":"",
     "kernel_options_post":"",
     "boot_files":[]
-   },   
+   },
    "9.0": {
     "signatures":["boot"],
     "version_file":"device\\.hints",

--- a/config/import_rsync_whitelist
+++ b/config/import_rsync_whitelist
@@ -21,6 +21,8 @@
 + Server/
 + Client/
 + SL/
++ FermiPackages/
++ SITERPMS/
 + images/
 + images/pxeboot/
 + images/pxeboot/*


### PR DESCRIPTION
Adds configuration to support http://fermilinux.fnal.gov/ (a fork of
RedHat); see issue #895.
