### PR TITLE
Update action_power.py to support fence_ipmilan

### DIFF
--- a/cobbler/action_power.py
+++ b/cobbler/action_power.py
@@ -103,7 +103,7 @@ class PowerTool:
                 # If the desired state is actually a query for the status
                 # return different information than command return code
                 if desired_state == 'status':
-                    match = re.match('(^Status:\s)(on|off)', output, re.IGNORECASE)
+                    match = re.match('^(Status:|.+power\s=)\s(on|off)$', output, re.IGNORECASE|re.MULTILINE)
                     if match:
                         power_status = match.groups()[1]
                         if power_status.lower() == 'on':


### PR DESCRIPTION
fence_ipmilan output was failing when status was called with the error (note I've replaced the IP with X's):

> xmlrpclib.Fault: <Fault 1: '<class \'cobbler.cexceptions.CX\'>:"command succeeded (rc=0), but output (\'Getting status of IPMI:XXX.XXX.XXX.XXX...Chassis power = On\nDone\n\') was not understood"'>

This was tested with the latest version of fence_impilan:

> tthompso@tthompso-ld:~ » /usr/sbin/fence_ipmilan -V
> fence_ipmilan UNKNOWN (built Apr 24 2014 14:19:25)
> Copyright (C) Red Hat, Inc.  2004-2010  All rights reserved.
> tthompso@tthompso-ld:~ » /usr/sbin/fence_ipmilan -a XXX.XXX.XXX.XXX -o > status -l USERNAME -p PASSWORD
> Getting status of IPMI:XXX.XXX.XXX.XXX...Chassis power = On
> Done

With this patch, it now works:

> server.power_system(server.get_system_handle('HOSTNAME', token), 'status', token)
> True
