### PR TITLE
FIX: fixes typo in ks files s/$post/%post/g

### DIFF
--- a/kickstarts/legacy.ks
+++ b/kickstarts/legacy.ks
@@ -45,7 +45,7 @@ $SNIPPET('pre_anamon')
 
 %packages
 
-$post --nochroot
+%post --nochroot
 $SNIPPET('log_ks_post_nochroot')
 %end
 

--- a/kickstarts/sample.ks
+++ b/kickstarts/sample.ks
@@ -51,7 +51,7 @@ $SNIPPET('pre_anamon')
 $SNIPPET('func_install_if_enabled')
 $SNIPPET('puppet_install_if_enabled')
 
-$post --nochroot
+%post --nochroot
 $SNIPPET('log_ks_post_nochroot')
 %end
 

--- a/kickstarts/sample_end.ks
+++ b/kickstarts/sample_end.ks
@@ -55,7 +55,7 @@ $SNIPPET('pre_anamon')
 $SNIPPET('func_install_if_enabled')
 %end
 
-$post --nochroot
+%post --nochroot
 $SNIPPET('log_ks_post_nochroot')
 %end
 


### PR DESCRIPTION
Subject says it all; $post is not valid kickstart syntax; should be %post
