### PR TITLE
removing non existing file

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -148,7 +148,6 @@ mkdir -p %{_sysconfdir}/init.d
 rm $RPM_BUILD_ROOT%{_sysconfdir}/cobbler/cobblerd.service
 %else
 # systemd
-rm $RPM_BUILD_ROOT%{_sysconfdir}/cobbler/cobblerd
 rm $RPM_BUILD_ROOT%{_sysconfdir}/init.d/cobblerd
 mkdir -p $RPM_BUILD_ROOT%{_unitdir}
 mv $RPM_BUILD_ROOT%{_sysconfdir}/cobbler/cobblerd.service $RPM_BUILD_ROOT%{_unitdir}


### PR DESCRIPTION
on fedora 20 $RPM_BUILD_ROOT%{_sysconfdir}/cobbler/cobblerd
does not exist 
this make rpms stops with an error
