### PR TITLE
sync remote files to tftpdir

### DIFF
--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -163,17 +163,25 @@ class PXEGen:
         if initrd is None:
             raise CX("initrd not found: %(file)s, distro: %(distro)s" % {"file": d.initrd, "distro": d.name})
 
-        # Kernels referenced by remote URL are passed through to koan directly,
-        # no need for copying the kernel locally:
+        # Koan manages remote kernel itself, but for consistent PXE
+        # configurations the synchronization is still necessary
         if not utils.file_is_remote(kernel):
             b_kernel = os.path.basename(kernel)
             dst1 = os.path.join(distro_dir, b_kernel)
             utils.linkfile(kernel, dst1, symlink_ok=symlink_ok, api=self.api, logger=self.logger)
+        else:
+            b_kernel = os.path.basename(kernel)
+            dst1 = os.path.join(distro_dir, b_kernel)
+            utils.copyremotefile(kernel, dst1, api=None, logger=self.logger)
 
         if not utils.file_is_remote(initrd):
             b_initrd = os.path.basename(initrd)
             dst2 = os.path.join(distro_dir, b_initrd)
             utils.linkfile(initrd, dst2, symlink_ok=symlink_ok, api=self.api, logger=self.logger)
+        else:
+            b_initrd = os.path.basename(initrd)
+            dst1 = os.path.join(distro_dir, b_initrd)
+            utils.copyremotefile(initrd, dst1, api=None, logger=self.logger)
 
         if "nexenta" == d.breed:
             try:

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1220,6 +1220,17 @@ def copyfile(src, dst, api=None, logger=None):
             # traceback.print_exc()
             # raise CX(_("Error copying %(src)s to %(dst)s") % { "src" : src, "dst" : dst})
 
+def copyremotefile(src, dst1, api=None, logger=None):
+    try:
+        if logger is not None:
+           logger.info("copying: %s -> %s" % (src, dst1))
+        srcfile = urllib2.urlopen(src)
+        output = open(dst1, 'wb')
+        output.write(srcfile.read())
+        output.close()
+    except Exception, e:
+        raise CX(_("Error while getting remote file (%s -> %s):\n%s" % (src, dst1, e.message)))
+
 
 def copyfile_pattern(pattern, dst, require_match=True, symlink_ok=False, cache=True, api=None, logger=None):
     files = glob.glob(pattern)


### PR DESCRIPTION
before remote kernel and initrd were not synced to tftp dir (see removed
comment) which lead to unusable pxe configs because in pxe config a not
synced kernel/initrd was referenced (e.g.
append initrd=/images/sles-11-sp3-x86_64_test/initrd.gz)
