### PR TITLE
fix bug introduced by 0abd87bd918cb

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -986,7 +986,7 @@ class BootAPI:
         Looks up a module the same as get_module_from_file but returns
         the module name rather than the module itself
         """
-        return module_loader.get_module_from_file(section, name, fallback)
+        return module_loader.get_module_name(section, name, fallback)
 
     def get_modules_in_category(self, category):
         """


### PR DESCRIPTION
previosly module_loader.get_module_from_file(nameOnly=True) returned module names
since 0abd87bd918cbd6db20515087aed3a4b651e13f3 this functionality
is handled with module_loader.get_module_name().

This Bug causes an exception at the web frontend show below

Fault at /do_login
<Fault 1: "<type 'exceptions.TypeError'>:cannot marshal <type
'method_descriptor'> objects">
