### PR TITLE
remove colon from VLAN regex pattern

### DIFF
--- a/snippets/network_config
+++ b/snippets/network_config
@@ -2,7 +2,7 @@
 #if $getVar("system_name","") != ""
     #set ikeys = $interfaces.keys()
     #import re
-    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     ##
     ## Determine if we should use the MAC address to configure the interfaces first
     ## Only physical interfaces are required to have a MAC address
@@ -20,7 +20,7 @@
 %include /tmp/pre_install_network_config
     #else
 # Using "old" style networking config. Make sure all MAC-addresses are in cobbler to use the new-style config
-        #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+        #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
         #for $iname in $ikeys
             #set $idata    = $interfaces[$iname]
             #set $mac      = $idata["mac_address"]

--- a/snippets/network_config_esx
+++ b/snippets/network_config_esx
@@ -2,7 +2,7 @@
 
 #if $getVar("system_name","") != ""
     #set ikeys = $interfaces.keys()
-    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     #for $iname in $ikeys
         #set $idata    = $interfaces[$iname]
         #set $mac      = $idata["mac_address"]

--- a/snippets/network_config_esxi
+++ b/snippets/network_config_esxi
@@ -2,7 +2,7 @@
 
 #if $getVar("system_name","") != ""
     #set ikeys = $interfaces.keys()
-    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     #for $iname in $ikeys
         #set $idata    = $interfaces[$iname]
         #set $mac      = $idata["mac_address"]

--- a/snippets/post_install_network_config
+++ b/snippets/post_install_network_config
@@ -6,7 +6,7 @@
     #set ikeys = $interfaces.keys()
     #set osversion = $getVar("os_version","")
     #import re
-    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     ## Determine if we should use the MAC address to configure the interfaces first
     ## Only physical interfaces are required to have a MAC address
     ## Also determine the number of bonding devices we have, so we can set the

--- a/snippets/post_install_network_config_deb
+++ b/snippets/post_install_network_config_deb
@@ -6,7 +6,7 @@
     #set ikeys = $interfaces.keys()
     #set osversion = $getVar("os_version","")
     #import re
-    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     ## Determine if we should use the MAC address to configure the interfaces first
     ## Only physical interfaces are required to have a MAC address
     ## Also determine the number of bonding devices we have, so we can set the

--- a/snippets/pre_install_network_config
+++ b/snippets/pre_install_network_config
@@ -31,7 +31,7 @@ get_ifname() {
 #end raw
     #set ikeys = $interfaces.keys()
     #import re
-    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.:][0-9]+")
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     #set $routepattern = $re.compile("[0-9/.]+:[0-9.]+")
     ##
     ## Determine if we should use the MAC address to configure the interfaces first


### PR DESCRIPTION
colons are not used to designate VLANs, but rather virtual interfaces
such as eth0:1.  this is commonly used to add a second IP address
to an interface.

from /etc/sysconfig/network-scripts/ifup:
MATCH='^.+.[0-9]{1,4}$'
