### PR TITLE
pre_install_network_config: only use slaves with a valid MAC address

### DIFF
--- a/snippets/pre_install_network_config
+++ b/snippets/pre_install_network_config
@@ -75,17 +75,21 @@ get_ifname() {
                 #for $tiname in $ikeys
                     #set $tidata = $interfaces[$tiname]
                     #if $tidata["interface_type"].lower() in ("slave","bond_slave","bridge_slave") and $tidata["interface_master"].lower() == $iname
-                        #set $mac = $tidata["mac_address"]
+                        #if $tidata["mac_address"] != '':
+                            #set $mac = $tidata["mac_address"]
 #  Found a slave for this interface: $tiname ($mac)
-                        #break
+                            #break
+                        #end if
                     #else if $tidata["interface_type"].lower() == "bonded_bridge_slave" and $tidata["interface_master"].lower() == $iname
                         ## find a slave for this slave interface...
                         #for $stiname in $ikeys
                             #set $stidata = $interfaces[$stiname]
                             #if $stidata["interface_type"].lower() in ("slave","bond_slave","bridge_slave") and $stidata["interface_master"].lower() == $tiname
-                                #set $mac = $stidata["mac_address"]
+                                #if $stidata["mac_address"] != '':
+                                    #set $mac = $stidata["mac_address"]
 #  Found a slave for this interface: $tiname -> $stiname ($mac)
-                                #break
+                                    #break
+                                #end if
                             #end if
                         #end for
                     #end if


### PR DESCRIPTION
without this patch, a slave can be chosen that does not have MAC address,
which leads to network configuration failure in anaconda because
no interface name is found by the subroutine in the snippet

 # cobbler system report --name ztest
Name                           : ztest
...
Interface =====                : bond0
Bonding Opts                   : mode=4 miimon=100
Bridge Opts                    :
CNAMES                         : []
DHCP Tag                       :
DNS Name                       : ztest.example.com
Per-Interface Gateway          :
Master Interface               :
Interface Type                 : bond
IP Address                     : 1.2.3.4
IPv6 Address                   :
IPv6 Default Gateway           :
IPv6 MTU                       :
IPv6 Secondaries               : []
IPv6 Static Routes             : []
MAC Address                    :
Management Interface           : False
MTU                            :
Subnet Mask                    : 255.255.255.0
Static                         : True
Static Routes                  : []
Virt Bridge                    :
Interface =====                : eth1
Bonding Opts                   :
Bridge Opts                    :
CNAMES                         : []
DHCP Tag                       :
DNS Name                       :
Per-Interface Gateway          :
Master Interface               : bond0
Interface Type                 : bond_slave
IP Address                     : 1.2.3.4
IPv6 Address                   :
IPv6 Default Gateway           :
IPv6 MTU                       :
IPv6 Secondaries               : []
IPv6 Static Routes             : []
MAC Address                    :
Management Interface           : False
MTU                            :
Subnet Mask                    :
Static                         : True
Static Routes                  : []
Virt Bridge                    :
Interface =====                : eth0
Bonding Opts                   :
Bridge Opts                    :
CNAMES                         : []
DHCP Tag                       :
DNS Name                       :
Per-Interface Gateway          :
Master Interface               : bond0
Interface Type                 : bond_slave
IP Address                     : 1.2.3.4
IPv6 Address                   :
IPv6 Default Gateway           :
IPv6 MTU                       :
IPv6 Secondaries               : []
IPv6 Static Routes             : []
MAC Address                    : aa:bb:cc:dd:ee:ff
Management Interface           : False
MTU                            :
Subnet Mask                    :
Static                         : True
Static Routes                  : []
Virt Bridge                    :

 ## unpatched
 # cobbler system getks --name ztest | sed '/Start bond0/,/^%end/ !d'
 #  Start bond0
 #  Found a slave for this interface: eth1 ()
 # Configuring bond0 ()
if mac_exists
then
  get_ifname
  echo "network --device=$IFNAME --bootproto=static --ip=1.2.3.4 --netmask=255.255.255.0 --gateway=1.2.3.1 --hostname=ztest.example.com" >> /tmp/pre_install_network_config
fi
 #  Start eth1
 #  Skipping (slave-interface)
 #  Start eth0
 #  Skipping (slave-interface)
 # End pre_install_network_config generated code

%end

 ## patched
 # cobbler system getks --name ztest | sed '/Start bond0/,/^%end/ !d'
 #  Start bond0
 #  Found a slave for this interface: eth0 (aa:bb:cc:dd:ee:ff)
 # Configuring bond0 (aa:bb:cc:dd:ee:ff)
if mac_exists aa:bb:cc:dd:ee:ff
then
  get_ifname aa:bb:cc:dd:ee:ff
  echo "network --device=$IFNAME --bootproto=static --ip=1.2.3.4 --netmask=255.255.255.0 --gateway=1.2.3.1 --hostname=ztest.example.com" >> /tmp/pre_install_network_config
fi
 #  Start eth1
 #  Skipping (slave-interface)
 #  Start eth0
 #  Skipping (slave-interface)
 # End pre_install_network_config generated code

%end
