### PR TITLE
Some versions of virt-install respond to --version on stderr. Adapt.

### DIFF
--- a/koan/utils.py
+++ b/koan/utils.py
@@ -150,18 +150,24 @@ def subprocess_call(cmd, ignore_rc=0):
     return rc
 
 
-def subprocess_get_response(cmd, ignore_rc=False):
+def subprocess_get_response(cmd, ignore_rc=False, get_stderr=False):
     """
     Wrapper around subprocess.check_output(...)
     """
     print "- %s" % cmd
     rc = 0
     result = ""
-    p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-    result = p.communicate()[0]
+    if get_stderr:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE)
+    else:
+        p = subprocess.Popen(cmd, stdout=subprocess.PIPE)
+    result, stderr_result = p.communicate()
     rc = p.wait()
     if not ignore_rc and rc != 0:
         raise InfoException("command failed (%s)" % rc)
+    if get_stderr:
+        return rc, result, stderr_result
     return rc, result
 
 

--- a/koan/virtinstall.py
+++ b/koan/virtinstall.py
@@ -37,10 +37,14 @@ from cexceptions import InfoException
 # command line tool. This should work on both old and new variants,
 # as the virt-install command line tool has always been provided by
 # python-virtinst (and now the new virt-install rpm).
-rc, response = utils.subprocess_get_response(
-    shlex.split('virt-install --version'), True)
+# virt-install 1.0.1 responds to --version on stderr. WTF? Check both.
+rc, response, stderr_response = utils.subprocess_get_response(
+    shlex.split('virt-install --version'), True, True)
 if rc == 0:
-    virtinst_version = response
+    if response:
+        virtinst_version = response
+    else:
+        virtinst_version = stderr_response
 else:
     virtinst_version = None
 


### PR DESCRIPTION
Some versions of virt-install stupidly respond to --version on stderr, which currently breaks virt-install detection. This change checks for a response on both stdout or stderr for this subprocess call, but retains backwards compatibility for other users of the utility method.
