### PR TITLE
CentOS 7 has a release of 7.0.1406

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1016,7 +1016,9 @@ def os_release():
         tokens = rest.split(" ")
         for t in tokens:
             try:
-                return (make, float(t))
+                match = re.match('^\d+(?:\.\d+)?', t)
+                if match:
+                    return (make, float(match.group(0)))
             except ValueError:
                 pass
         raise CX("failed to detect local OS version from /etc/redhat-release")


### PR DESCRIPTION
`os_release` in `utils/cobbler.py` fails on CentOS 7 as it cannot find a valid "float" in `/etc/redhat-release`.

```
> rpm -qf /etc/redhat-release
centos-release-7-0.1406.el7.centos.2.3.x86_64
> cat /etc/redhat-release
CentOS Linux release 7.0.1406 (Core)
```

This may also be cherry-picked in release26 as well.
