### PR TITLE
cobblerd cannot start on CentOS 7 (for release26)

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1021,7 +1021,9 @@ def os_release():
       tokens = rest.split(" ")
       for t in tokens:
          try:
-             return (make,float(t))
+             match = re.match('^\d+(?:\.\d+)?', t)
+             if match:
+                 return (make, float(match.group(0)))
          except ValueError, ve:
              pass
       raise CX("failed to detect local OS version from /etc/redhat-release")


### PR DESCRIPTION
CentOS has a release of 7.0.1406, which is not a "float".

Use only the first two digits when assuming it is a float.

```
> rpm -qf /etc/redhat-release
centos-release-7-0.1406.el7.centos.2.3.x86_64
> cat /etc/redhat-release
CentOS Linux release 7.0.1406 (Core)
```

This is the same as #1021, rebased for the release26 branch.
