### PR TITLE
Fix wrong address of the Free Software Foundation.

### DIFF
--- a/bin/cobbler
+++ b/bin/cobbler
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import cobbler.cli as app

--- a/bin/cobbler-register
+++ b/bin/cobbler-register
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import sys

--- a/bin/cobblerd
+++ b/bin/cobblerd
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import sys

--- a/bin/koan
+++ b/bin/koan
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import sys

--- a/cobbler/action_report.py
+++ b/cobbler/action_report.py
@@ -11,7 +11,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import re

--- a/cobbler/collection_images.py
+++ b/cobbler/collection_images.py
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import item_image as image

--- a/cobbler/item.py
+++ b/cobbler/item.py
@@ -9,7 +9,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import exceptions

--- a/cobbler/modules/authn_passthru.py
+++ b/cobbler/modules/authn_passthru.py
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import distutils.sysconfig

--- a/cobbler/modules/authz_configfile.py
+++ b/cobbler/modules/authz_configfile.py
@@ -9,7 +9,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import distutils.sysconfig

--- a/cobbler/resource.py
+++ b/cobbler/resource.py
@@ -9,7 +9,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 import item

--- a/koan/live/build.py
+++ b/koan/live/build.py
@@ -10,7 +10,8 @@ general public license.
 
 You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA.
 """
 
 # usage: --server=bootserver.example.com --koan="--profile=FOO"


### PR DESCRIPTION
Some files contained the wrong address of the Free Software Foundation. I noticed that while looking at the output of rpmlint on openSUSE.
