### PR TITLE
Properly name the VLAN interface

### DIFF
--- a/docs/man/cobbler.1.pod
+++ b/docs/man/cobbler.1.pod
@@ -350,7 +350,7 @@ By default flags like --ip, --mac, --dhcp-tag, --dns-name, --subnet, --virt-brid
 
 Interface naming notes:
 
-Additional interfaces can be specified (for example: eth1, or any name you like, as long as it does not conflict with any reserved names such as kernel module names) for use with the edit command. Defining VLANs this way is also supported, of you want to add VLAN 5 on interface eth0, simply name your interface eth0:5.
+Additional interfaces can be specified (for example: eth1, or any name you like, as long as it does not conflict with any reserved names such as kernel module names) for use with the edit command. Defining VLANs this way is also supported, of you want to add VLAN 5 on interface eth0, simply name your interface eth0.5.
 
 Example:  
 


### PR DESCRIPTION
In the light of the commit d918359dc4504dd8948933e81ed784ad3d89cb7b.
