### PR TITLE
Fix for #790. cobbler-ext-nodes was broken with mgmt_classes defined at ...

### DIFF
--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -88,7 +88,7 @@ FIELDS = [
     ["*ipv6_mtu", "", 0, "IPv6 MTU", True, "Should be used with --interface", 0, "str"],
     ["*ipv6_static_routes", [], 0, "IPv6 Static Routes", True, "Should be used with --interface", 0, "list"],
     ["*ipv6_default_gateway", "", 0, "IPv6 Default Gateway", True, "Should be used with --interface", 0, "str"],
-    ["mgmt_classes", [], 0, "Management Classes", True, "For external config management", 0, "list"],
+    ["mgmt_classes", "<<inherit>>", 0, "Management Classes", True, "For external config management", 0, "list"],
     ["mgmt_parameters", "<<inherit>>", 0, "Management Parameters", True, "Parameters which will be handed to your management application (Must be valid YAML dictionary)", 0, "str"],
     ["boot_files", {}, '<<inherit>>', "TFTP Boot Files", True, "Files copied into tftpboot beyond the kernel/initrd", 0, "list"],
     ["fetchable_files", {}, '<<inherit>>', "Fetchable Files", True, "Templates for tftp or wget", 0, "dict"],


### PR DESCRIPTION
...the profile level.
