### PR TITLE
Prevent disappearing profiles after cobblerd restart (#1030).

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -890,9 +890,11 @@ class CobblerXMLRPCInterface:
 
         if edit_type == "add":
             is_subobject = object_type == "profile" and "parent" in attributes
+            if is_subobject and "distro" in attributes:
+                raise CX("You can't change both 'parent' and 'distro'")
             if object_type == "system":
                 if "profile" not in attributes and "image" not in attributes:
-                    raise CX("You must specify a --profile or --image for new systems")
+                    raise CX("You must specify a 'profile' or 'image' for new systems")
             handle = self.new_item(object_type, token, is_subobject=is_subobject)
         else:
             handle = self.get_item_handle(object_type, object_name)
@@ -900,12 +902,22 @@ class CobblerXMLRPCInterface:
         if edit_type == "rename":
             self.rename_item(object_type, handle, attributes["newname"], token)
             handle = self.get_item_handle(object_type, attributes["newname"], token)
+
         if edit_type == "copy":
-            self.copy_item(object_type, handle, attributes["newname"], token)
-            handle = self.get_item_handle(object_type, attributes["newname"], token)
-        if edit_type in [ "copy", "rename" ]:
-            del attributes["name"] 
-            del attributes["newname"] 
+            is_subobject = object_type == "profile" and "parent" in attributes
+            if is_subobject:
+                if "distro" in attributes:
+                    raise CX("You can't change both 'parent' and 'distro'")
+                self.copy_item(object_type, handle, attributes["newname"], token)
+                handle = self.get_item_handle("profile", attributes["newname"], token)
+                self.modify_item("profile", handle, "parent", attributes["parent"], token)
+            else:
+                self.copy_item(object_type, handle, attributes["newname"], token)
+                handle = self.get_item_handle(object_type, attributes["newname"], token)
+
+        if edit_type in ["copy", "rename"]:
+            del attributes["name"]
+            del attributes["newname"]
 
         if edit_type != "remove":
             # FIXME: this doesn't know about interfaces yet!
@@ -943,13 +955,19 @@ class CobblerXMLRPCInterface:
                     ifargs = [attributes.get("interface",""),attributes.get("rename_interface","")]
                     self.modify_system(handle, 'rename_interface', ifargs, token)
         else:
-           recursive = attributes.get("recursive",False)
-           return self.remove_item(object_type, object_name, token, recursive=recursive)
+            # remove item
+            recursive = attributes.get("recursive", False)
+            if object_type == "profile" and recursive is False:
+                childs = len(self.api.find_items(object_type, criteria={'parent': attributes['name']}))
+                if childs > 0:
+                    raise CX("Can't delete this profile there are %s subprofiles and 'recursive' is set to 'False'" % childs)
+
+            return self.remove_item(object_type, object_name, token, recursive=recursive)
 
         # FIXME: use the bypass flag or not?
         return self.save_item(object_type, handle, token)
-        
- 
+
+
     def save_item(self,what,object_id,token,editmode="bypass"):
         """
         Saves a newly created or modified object to disk.

--- a/web/cobbler_web/views.py
+++ b/web/cobbler_web/views.py
@@ -132,14 +132,6 @@ def get_fields(what, is_subobject, seed_item=None):
     fields = []
     for row in field_data:
 
-        # if we are subprofile and see the field "distro", make it say parent
-        # with this really sneaky hack here
-        if is_subobject and row[0] == "distro":
-            row[0] = "parent"
-            row[3] = "Parent object"
-            row[5] = "Inherit settings from this profile"
-            row[6] = []
-
         elem = {
             "name"                    : row[0],
             "dname"                   : row[0].replace("*",""),
@@ -502,7 +494,12 @@ def generic_delete(request, what, obj_name=None):
    elif not remote.check_access_no_fail(request.session['token'], "remove_%s" % what, obj_name):
       return error_page(request,"You do not have permission to delete this %s" % what)
    else:
-      remote.remove_item(what, obj_name, request.session['token'])
+      # check whether object is to be deleted recursively
+      recursive = simplejson.loads(request.POST.get("recursive", "false"))
+      try:
+         remote.xapi_object_edit(what, obj_name, "remove", {'name': obj_name, 'recursive': recursive}, request.session['token'])
+      except Exception, e:
+         return error_page(request, str(e))
       return HttpResponseRedirect("/cobbler_web/%s/list" % what)
 
 
@@ -511,23 +508,26 @@ def generic_delete(request, what, obj_name=None):
 @require_POST
 @csrf_protect
 def generic_domulti(request, what, multi_mode=None, multi_arg=None):
-
     """
     Process operations like profile reassignment, netboot toggling, and deletion
     which occur on all items that are checked on the list page.
     """
-    if not test_user_authenticated(request): return login(request, next="/cobbler_web/%s/multi/%s/%s" % (what,multi_mode,multi_arg), expired=True)
-
-    # FIXME: cleanup
-    # FIXME: COMMENTS!!!11111???
+    if not test_user_authenticated(request):
+        return login(request, next="/cobbler_web/%s/multi/%s/%s" % (what,multi_mode,multi_arg), expired=True)
 
     names = request.POST.get('names', '').strip().split()
     if names == "":
-        return error_page(request, "Need to select some systems first")
+        return error_page(request, "Need to select some '%s' objects first" % what)
 
     if multi_mode == "delete":
-         for obj_name in names:
-            remote.remove_item(what,obj_name, request.session['token'])
+        # check whether the objects are to be deleted recursively
+        recursive = simplejson.loads(request.POST.get("recursive_batch", "false"))
+        for obj_name in names:
+            try:
+                remote.xapi_object_edit(what, obj_name, "remove", {'name': obj_name, 'recursive': recursive}, request.session['token'])
+            except Exception, e:
+                return error_page(request, str(e))
+
     elif what == "system" and multi_mode == "netboot":
         netboot_enabled = multi_arg # values: enable or disable
         if netboot_enabled is None:
@@ -542,6 +542,7 @@ def generic_domulti(request, what, multi_mode=None, multi_arg=None):
             obj_id = remote.get_system_handle(obj_name, request.session['token'])
             remote.modify_system(obj_id, "netboot_enabled", netboot_enabled, request.session['token'])
             remote.save_system(obj_id, request.session['token'], "edit")
+
     elif what == "system" and multi_mode == "profile":
         profile = multi_arg
         if profile is None:
@@ -550,28 +551,33 @@ def generic_domulti(request, what, multi_mode=None, multi_arg=None):
             obj_id = remote.get_system_handle(obj_name, request.session['token'])
             remote.modify_system(obj_id, "profile", profile, request.session['token'])
             remote.save_system(obj_id, request.session['token'], "edit")
+
     elif what == "system" and multi_mode == "power":
-        # FIXME: power should not loop, but send the list of all systems
-        # in one set.
+        # FIXME: power should not loop, but send the list of all systems in one set.
         power = multi_arg
         if power is None:
             return error_page(request,"Cannot modify systems without specifying power option")
         options = { "systems" : names, "power" : power }
         remote.background_power_system(options, request.session['token'])
+
     elif what == "system" and multi_mode == "buildiso":
         options = { "systems" : names, "profiles" : [] }
         remote.background_buildiso(options, request.session['token'])
+
     elif what == "profile" and multi_mode == "buildiso":
         options = { "profiles" : names, "systems" : [] }
         remote.background_buildiso(options, request.session['token'])
+
     elif what == "distro" and multi_mode == "buildiso":
         if len(names) > 1:
             return error_page(request,"You can only select one distro at a time to build an ISO for")
         options = { "standalone" : True, "distro": str(names[0]) }
         remote.background_buildiso(options, request.session['token'])
+
     elif what == "repo" and multi_mode == "reposync":
         options = { "repos" : names, "tries" : 3 }
         remote.background_reposync(options,request.session['token'])
+
     else:
         return error_page(request,"Unknown batch operation on %ss: %s" % (what,str(multi_mode)))
 


### PR DESCRIPTION
This diff makes the use of --parent and --distro mutually exclusive.
The consequence is that subprofiles always have the same distro as
the parent profile. I think this has been the intended behaviour
ever since subprofiles got introduced, now it's just better enforced.

This diff also checks for assciated subprofiles first when you try to
delete a parent profile, this should prevent data corruption. Of
course using the 'recursive' flag is still supported.

Cobbler-web has been adjusted to use the (safer) xapi_object_edit API
for the deletion of items.
