### PR TITLE
Revert "Prohibit object renaming through the modifty_item API (#1079)."

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -817,18 +817,15 @@ class CobblerXMLRPCInterface:
         Allows modification of certain attributes on newly created or
         existing distro object handle.
         """
-        self._log("modify_item(%s)" % what, object_id=object_id, attribute=attribute, token=token)
+        self._log("modify_item(%s)" % what,object_id=object_id,attribute=attribute,token=token)
+        obj = self.__get_object(object_id)
+        self.check_access(token, "modify_%s"%what, obj, attribute)
+        # support 1.6 field name exceptions for backwards compat
+        attribute = REMAP_COMPAT.get(attribute,attribute)
+        method = obj.remote_methods().get(attribute, None)
 
-        # sanity checks
         if what == "system" and attribute == "kickstart":
             self._validate_ks_template_path(arg)
-
-        if attribute == "name":
-            utils.die(self.logger, "Can't rename object. Please use the 'rename_%s' method" % what)
-
-        obj = self.__get_object(object_id)
-        self.check_access(token, "modify_%s" % what, obj, attribute)
-        method = obj.remote_methods().get(attribute, None)
 
         if method is None:
             # it's ok, the CLI will send over lots of junk we can't process


### PR DESCRIPTION
This reverts commit 078b9c064c712a4ad35721b042ed1969f3d98730.
