### PR TITLE
Exit with an error if the cobblerd executable can't be found (fixes #110...

### DIFF
--- a/config/cobblerd
+++ b/config/cobblerd
@@ -24,7 +24,10 @@
 # processname: @@install_scripts@@/cobblerd
 
 # Sanity checks.
-[ -x @@install_scripts@@/cobblerd ] || exit 0
+[ -x @@install_scripts@@/cobblerd ] || ( 
+    echo "Error, could not find executable: @@install_scripts@@/cobblerd"
+    exit 1
+)
 
 DEBIAN_VERSION=/etc/debian_version
 SUSE_RELEASE=/etc/SuSE-release


### PR DESCRIPTION
...8 #1135).
