### PR TITLE
Debian network config: add support for tagged vlan only bonding interfaces

### DIFF
--- a/snippets/post_install_network_config_deb
+++ b/snippets/post_install_network_config_deb
@@ -55,6 +55,8 @@ echo "" >> /etc/network/interfaces
     ## =============================================================================
     ## now create the config file for each interface
     #for $iname in $ikeys
+
+
         ## create lots of variables to use later
         #set $idata                = $interfaces[$iname]
         #set $mac                  = $idata.get("mac_address", "").upper()
@@ -112,10 +114,45 @@ echo "  $bridge_opt" >> /etc/network/interfaces
         ## Actions based on static configuration
         ## ===================================================================
         #if $static
-            #if $ip != "" and $iface_type not in ("bond_slave","bridge_slave","bonded_bridge_slave")
+            #if $ip != "" and $iface_type not in ("bond_slave","bridge_slave","bonded_bridge_slave") and $is_vlan == "true"
 echo "iface $iname inet static" >> /etc/network/interfaces 
-echo "   hwaddress $mac" >> /etc/network/interfaces
 echo "   address $ip" >> /etc/network/interfaces 
+                #if $netmask != ""
+echo "   netmask $netmask" >> /etc/network/interfaces 
+                #end if
+        	#if $mtu != ""
+echo "   mtu $mtu" >> /etc/network/interfaces
+	        #end if
+	    #end if
+            #if $ip == "" and $iface_type in ("bond") and $is_vlan == "false"
+echo "iface $iname inet manual" >> /etc/network/interfaces 
+                  #set $bondslaves = ""
+                  #for $bondiname in $ikeys
+                      #set $bondidata                = $interfaces[$bondiname]
+                      #set $bondiface_type           = $bondidata.get("interface_type", "").lower()
+                      #set $bondiface_master         = $bondidata.get("interface_master", "")
+                      #if $bondiface_master == $iname
+                         #set $bondslaves += $bondiname + " "
+                      #end if
+                  #end for
+echo "   bond-slaves $bondslaves" >> /etc/network/interfaces
+		  #for $bondopts in $bonding_opts.split(" ")
+		      #set [$bondkey, $bondvalue] = $bondopts.split("=")
+echo "   bond-$bondkey $bondvalue" >> /etc/network/interfaces
+                  #end for
+        	  #if $mtu != ""
+echo "   mtu $mtu" >> /etc/network/interfaces
+	          #end if
+
+            #else if  $ip != "" and $iface_type not in ("bond_slave","bridge_slave","bonded_bridge_slave") and $is_vlan == "false"
+echo "iface $iname inet static" >> /etc/network/interfaces 
+                #if $mac != ""
+echo "   hwaddress $mac" >> /etc/network/interfaces
+		#end if
+echo "   address $ip" >> /etc/network/interfaces 
+        	#if $mtu != ""
+echo "   mtu $mtu" >> /etc/network/interfaces
+	        #end if
                 #if $netmask != ""
 echo "   netmask $netmask" >> /etc/network/interfaces 
                 #end if
@@ -135,8 +172,10 @@ echo "   bond-slaves $bondslaves" >> /etc/network/interfaces
 echo "   bond-$bondkey $bondvalue" >> /etc/network/interfaces
                   #end for
                 #end if
-            #else
+            #else 
+		    #if $is_vlan == "false"
 echo "iface $iname inet manual" >> /etc/network/interfaces 
+	           #end if
             #end if
             #if $iface_type in ("bond_slave") and $iface_master != ""
 echo "bond-master $iface_master" >> /etc/network/interfaces
@@ -169,9 +208,6 @@ echo "iface $iname inet dhcp" >> /etc/network/interfaces
         ## ===================================================================
         #if $if_gateway != ""
 echo "   gateway $if_gateway" >> /etc/network/interfaces
-        #end if
-        #if $mtu != ""
-echo "   mtu $mtu" >> /etc/network/interfaces
         #end if
         ## ===================================================================
         ## Interface route configuration


### PR DESCRIPTION
Add a case to post_install_network_config_deb for interface type "bond" with no ip address to configure systems which only have tagged vlan bonded interfaces
