### PR TITLE
Fix pyflakes warnings in utils.py

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1962,8 +1962,8 @@ def get_valid_archs():
     archs = []
     try:
         for breed in get_valid_breeds():
-            for os in SIGNATURE_CACHE["breeds"][breed].keys():
-                archs += SIGNATURE_CACHE["breeds"][breed][os]["supported_arches"]
+            for operating_system in SIGNATURE_CACHE["breeds"][breed].keys():
+                archs += SIGNATURE_CACHE["breeds"][breed][operating_system]["supported_arches"]
     except:
         pass
     return uniquify(archs)


### PR DESCRIPTION
When running `make qa` (which is a dependency of `make rpms`), pyflakes throws a warning:

> cobbler/utils.py:1965: import 'os' from line 24 shadowed by loop variable
