### PR TITLE
Fix for simple interface configs

### DIFF
--- a/snippets/post_install_network_config_deb
+++ b/snippets/post_install_network_config_deb
@@ -156,7 +156,7 @@ echo "   mtu $mtu" >> /etc/network/interfaces
                 #if $netmask != ""
 echo "   netmask $netmask" >> /etc/network/interfaces 
                 #end if
-                #if $iface_type in ("bond")
+                #if $iface_type == "bond"
                   #set $bondslaves = ""
                   #for $bondiname in $ikeys
                       #set $bondidata                = $interfaces[$bondiname]


### PR DESCRIPTION
Previous patch  "add support for tagged vlan only bonding interfaces"  ebfab5f872074d1989c90abceb25d3841b93274e broke simple configurations without bonding , this fixes it
