### PR TITLE
Adding missing dependencies in debian build

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -8,7 +8,7 @@ Homepage: https://fedoraproject.org/cobbler
 
 Package: cobbler
 Architecture: all
-Depends: ${python:Depends}, python, apache2, libapache2-mod-python, python-support, python-yaml, python-netaddr, python-cheetah, python-urlgrabber, python-django, debmirror, syslinux | syslinux-common
+Depends: ${python:Depends}, python, apache2, libapache2-mod-python, libapache2-mod-wsgi, python-support, python-yaml, python-netaddr, python-cheetah, python-urlgrabber, python-django, debmirror, syslinux | syslinux-common
 Suggests: rsync, tftpd-hpa, mkisofs, tftpd-hpa, dhcp3-server, createrepo
 Description: Install server
  Cobbler is a network install server.  Cobbler


### PR DESCRIPTION
After switching to the packages provided by cobblerd.org I noticed that there are some required dependencies missing. Please see the commit messages for details.
