### PR TITLE
Rename file serializer/deserializer name

### DIFF
--- a/cobbler/modules/serializer_file.py
+++ b/cobbler/modules/serializer_file.py
@@ -57,7 +57,7 @@ def what():
     """
     Module identification function
     """
-    return "serializer/catalog"
+    return "serializer/file"
 
 
 def serialize_item(obj, item):

--- a/cobbler/serializer.py
+++ b/cobbler/serializer.py
@@ -162,7 +162,7 @@ def __get_storage_module(collection_type):
     Look up serializer in /etc/cobbler/modules.conf
     """
     capi = cobbler_api.CobblerAPI()
-    return capi.get_module_from_file("serializers", collection_type, "serializer_catalog")
+    return capi.get_module_from_file("serializers", collection_type, "serializer_file")
 
 if __name__ == "__main__":
     __grab_lock()


### PR DESCRIPTION
Old name was serializer_catalog.py. Catalog is not an intuitive name,
serializer_file.py is more intuitive.
