### PR TITLE
Module manage_in_tftpd.py now returns 'in_tftpd'  from what().

### DIFF
--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -40,7 +40,7 @@ def register():
 class InTftpdManager:
 
     def what(self):
-        return "tftpd"
+        return "in_tftpd"
 
     def __init__(self, config, logger):
         """


### PR DESCRIPTION
Besides this being a bit more consistent this also fixes some
warnings in 'cobbler check'.
