### PR TITLE
gpgcheck / enabled are not valid in kickstart, only in config.repo

### DIFF
--- a/cobbler/kickgen.py
+++ b/cobbler/kickgen.py
@@ -183,17 +183,18 @@ class KickGen:
             if repo_obj is not None:
                 yumopts=''
                 for opt in repo_obj.yumopts:
-                    yumopts = yumopts + " %s=%s" % (opt,repo_obj.yumopts[opt])
-                if not repo_obj.yumopts.has_key('enabled') or repo_obj.yumopts['enabled'] == '1':
-                   if repo_obj.mirror_locally:
-                       baseurl = "http://%s/cobbler/repo_mirror/%s" % (blended["http_server"], repo_obj.name)
-                       if not included.has_key(baseurl):
-                           buf = buf + "repo --name=%s --baseurl=%s\n" % (repo_obj.name, baseurl)
-                       included[baseurl] = 1
-                   else:
-                       if not included.has_key(repo_obj.mirror):
-                           buf = buf + "repo --name=%s --baseurl=%s %s\n" % (repo_obj.name, repo_obj.mirror, yumopts)
-                       included[repo_obj.mirror] = 1
+                    if not opt in ['enabled', 'gpgcheck']:
+                        yumopts = yumopts + " %s=%s" % (opt, repo_obj.yumopts[opt])
+                if 'enabled' not in repo_obj.yumopts or repo_obj.yumopts['enabled'] == '1':
+                    if repo_obj.mirror_locally:
+                        baseurl = "http://%s/cobbler/repo_mirror/%s" % (blended["http_server"], repo_obj.name)
+                        if baseurl not in included:
+                            buf = buf + "repo --name=%s --baseurl=%s\n" % (repo_obj.name, baseurl)
+                        included[baseurl] = 1
+                    else:
+                        if repo_obj.mirror not in included:
+                            buf = buf + "repo --name=%s --baseurl=%s %s\n" % (repo_obj.name, repo_obj.mirror, yumopts)
+                        included[repo_obj.mirror] = 1
             else:
                 # FIXME: what to do if we can't find the repo object that is listed?
                 # this should be a warning at another point, probably not here


### PR DESCRIPTION
Commit 6f2b3f5b93ec7681f730dc6b847f7bac6decc038 changed kickstart
generation to add all defined yum options for a repo to the
repo line in the kickstart file. However, only some options are
valid in the kickstart (and this no doubt changes with anaconda version).
In particular, gpgcheck is allowed in the yum configuration file, but
not on a kickstart repo line.

Allow gpgcheck to be overridden from the cobbler default,
forcing gpg signature verfication in accordance with STIG requirements,
without including gpgcheck in the kickstart.

Also, never include "enabled" on the repo line.

Signed-off-by: Mark Levedahl mlevedahl@gmail.com
