### PR TITLE
Blacklist 'gpgkey' as an invalid option to the repo statement.

### DIFF
--- a/cobbler/kickgen.py
+++ b/cobbler/kickgen.py
@@ -183,7 +183,7 @@ class KickGen:
             if repo_obj is not None:
                 yumopts=''
                 for opt in repo_obj.yumopts:
-                    if not opt in ['enabled', 'gpgcheck']:
+                    if not opt in ['enabled', 'gpgcheck', 'gpgkey']:
                         yumopts = yumopts + " %s=%s" % (opt, repo_obj.yumopts[opt])
                 if 'enabled' not in repo_obj.yumopts or repo_obj.yumopts['enabled'] == '1':
                     if repo_obj.mirror_locally:


### PR DESCRIPTION
The use of the repo statement in kickstarts is somewhat limited
compared to normal .repo files.
