### PR TITLE
Remove support for configuring LDAP through Koan.

### DIFF
--- a/cobbler/collection.py
+++ b/cobbler/collection.py
@@ -163,7 +163,6 @@ class Collection:
         'virt-group': 'virt_group',
         'dhcp-tag': 'dhcp_tag',
         'netboot-enabled': 'netboot_enabled',
-        'ldap-enabled': 'ldap_enabled'
     }
 
 

--- a/cobbler/configgen.py
+++ b/cobbler/configgen.py
@@ -36,8 +36,7 @@ import clogger
 class ConfigGen:
     """
     Generate configuration data for Cobbler's management resources:
-    repos, ldap, files and packages. Mainly used by Koan to
-    configure remote systems.
+    repos, files and packages. Mainly used by Koan to configure systems.
     """
 
     def __init__(self, hostname):
@@ -75,13 +74,12 @@ class ConfigGen:
 
     def gen_config_data(self):
         """
-        Generate configuration data for repos, ldap, files and packages.
+        Generate configuration data for repos, files and packages.
         Returns a dict.
         """
         config_data = {
             'repo_data': self.handle.get_repo_config_for_system(self.system),
             'repos_enabled': self.get_cobbler_resource('repos_enabled'),
-            'ldap_enabled': self.get_cobbler_resource('ldap_enabled'),
         }
         package_set = set()
         file_set = set()
@@ -92,16 +90,6 @@ class ConfigGen:
                 package_set.add(package)
             for file in _mgmtclass.files:
                 file_set.add(file)
-
-        # Generate LDAP data
-        if self.get_cobbler_resource("ldap_enabled"):
-            if self.system.ldap_type in ["", "none"]:
-                utils.die(self.logger, "LDAP management type not set for this system (%s, %s)" % (self.system.ldap_type, self.system.name))
-            else:
-                template = utils.get_ldap_template(self.system.ldap_type)
-                t = Template(file=template, searchList=[self.host_vars])
-                print t
-                config_data['ldap_data'] = t.respond()
 
         # Generate Package data
         pkg_data = {}

--- a/cobbler/field_info.py
+++ b/cobbler/field_info.py
@@ -77,8 +77,6 @@ USES_CHECKBOX = [
     "virt_pxe_boot",
     "*repos_enabled",
     "repos_enabled",
-    "*ldap_enabled",
-    "ldap_enabled",
     "is_definition",
 ]
 
@@ -173,8 +171,6 @@ BLOCK_MAPPINGS = {
     "packages": "Resources",
     "files": "Resources",
     "repos_enabled": "Management",
-    "ldap_enabled": "Management",
-    "ldap_type": "Management",
 }
 
 BLOCK_MAPPINGS_ORDER = {

--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -96,8 +96,6 @@ FIELDS = [
     ["fetchable_files", {}, '<<inherit>>', "Fetchable Files", True, "Templates for tftp or wget", 0, "dict"],
     ["template_files", {}, 0, "Template Files", True, "File mappings for built-in configuration management", 0, "dict"],
     ["repos_enabled", False, 0, "Repos Enabled", True, "(re)configure local repos on this machine at next config update?", 0, "bool"],
-    ["ldap_enabled", False, 0, "LDAP Enabled", True, "(re)configure LDAP on this machine at next config update?", 0, "bool"],
-    ["ldap_type", "SETTINGS:ldap_management_default_type", 0, "LDAP Management Type", True, "Ex: authconfig", 0, "str"],
     ["*cnames", [], 0, "CNAMES", True, "Cannonical Name Records, should be used with --interface, In quotes, space delimited", 0, "list"],
 ]
 
@@ -839,21 +837,8 @@ class System(item.Item):
         return True
 
 
-    def set_ldap_enabled(self, ldap_enabled):
-        self.ldap_enabled = utils.input_boolean(ldap_enabled)
-        return True
-
-
     def set_repos_enabled(self, repos_enabled):
         self.repos_enabled = utils.input_boolean(repos_enabled)
-        return True
-
-
-    def set_ldap_type(self, ldap_type):
-        if ldap_type is None:
-            ldap_type = ""
-        ldap_type = ldap_type.lower()
-        self.ldap_type = ldap_type
         return True
 
 # EOF

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2007,17 +2007,6 @@ def local_get_cobbler_api_url():
     return "%s://%s:%s/cobbler_api" % (protocol, ip, port)
 
 
-def get_ldap_template(ldaptype=None):
-    """
-    Return ldap command for type
-    """
-    if ldaptype:
-        ldappath = "/etc/cobbler/ldap/ldap_%s.template" % ldaptype
-        if os.path.isfile(ldappath):
-            return ldappath
-    return None
-
-
 def local_get_cobbler_xmlrpc_url():
     # Load xmlrpc port
     try:

--- a/docs/man/cobbler.1.pod
+++ b/docs/man/cobbler.1.pod
@@ -323,10 +323,6 @@ While it is recommended that the --kickstart parameter is only used within for t
 If set false, the system will be provisionable through koan but not through
 standard PXE.  This will allow the system to fall back to default PXE boot behavior without deleting the cobbler system object.  The default value allows PXE.   Cobbler contains a PXE boot loop prevention feature (pxe_just_once, can be enabled in /etc/cobbler/settings) that can automatically trip off this value after a system gets done installing.  This can prevent installs from appearing in an endless loop when the system is set to PXE first in the BIOS order.
 
-=item --ldap-enabled, --ldap-type
-
-Cobbler contains features that enable ldap management for easier configuration after system provisioning. If set true, koan will run the ldap command as defined by the systems ldap_type. The default value is false. 
-
 =item --repos-enabled
 
 If set true, koan can reconfigure repositories after installation. This is described further on the Cobbler Wiki, https://github.com/cobbler/cobbler/wiki/Manage-yum-repos.

--- a/docs/quickstart-guide.rst
+++ b/docs/quickstart-guide.rst
@@ -285,8 +285,6 @@ First, we'll create a system object based on the profile that was created during
     Kernel Options (Post Install)  : {}
     Kickstart                      : <<inherit>>
     Kickstart Metadata             : {}
-    LDAP Enabled                   : False
-    LDAP Management Type           : authconfig
     Management Classes             : []
     Management Parameters          : <<inherit>>
     Name Servers                   : []

--- a/docs/release-notes.rst
+++ b/docs/release-notes.rst
@@ -56,6 +56,7 @@ Bugfixes
 Upgrade notes
 =============
 
+* Support for LDAP configuration through Koan has been removed.
 * Support for redhat_management (Spacewalk/Satelite) has been moved to contrib. Users of this functionality should checkout contrib/redhat-management/README.
 * Monit support has been removed; you really need to use a CMS to manage your services.
 * Support for remote kickstart templates and files been removed (eg. kickstart=http://).

--- a/koan/app.py
+++ b/koan/app.py
@@ -1030,7 +1030,7 @@ class Koan:
             print("\tTotal Resources: %d" % total_resources)
             print("\t  Total Runtime: %.02f" % total_runtime)
 
-            for status in ["repos_status", "ldap_status"]:
+            for status in ["repos_status"]:
                 if status in stats:
                     print('')
                     print("\t%s" % status)

--- a/koan/configurator.py
+++ b/koan/configurator.py
@@ -19,7 +19,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 
-module for configuring repos, ldap, packages and files
+module for configuring repos, packages and files
 """
 
 from __future__ import print_function
@@ -50,7 +50,7 @@ class KoanConfigure:
 
     """
     Used for all configuration methods, used by koan
-    to configure repos, ldap, files and packages.
+    to configure repos, files and packages.
     """
 
     def __init__(self, config):
@@ -88,15 +88,6 @@ class KoanConfigure:
             utils.sync_file(old_repo, new_repo, 0, 0, 644)
             self.stats['repos_status'] = "Success: Repos in sync"
         _tempfile.close()
-
-    def configure_ldap(self):
-        """Configure LDAP by running the specified LDAP command."""
-        print("- Configuring LDAP")
-        rc = subprocess.call(self.config['ldap_data'], shell="True")
-        if rc == 0:
-            self.stats['ldap_status'] = "Success: LDAP has been configured"
-        else:
-            self.stats['ldap_status'] = "ERROR: configuring LDAP failed"
 
     def configure_packages(self):
         # Enables the possibility to use different types of package
@@ -310,12 +301,10 @@ class KoanConfigure:
             'fail': fail}
 
     def run(self):
-        # Configure resources in a specific order: repos, ldap, packages,
+        # Configure resources in a specific order: repos, packages,
         # directories, files
         if self.config['repos_enabled']:
             self.configure_repos()
-        if self.config['ldap_enabled']:
-            self.configure_ldap()
         self.configure_packages()
         self.configure_directories()
         self.configure_files()

--- a/setup.py
+++ b/setup.py
@@ -644,7 +644,6 @@ if __name__ == "__main__":
             ("%spxe" % etcpath, glob("templates/pxe/*")),
             ("%sreporting" % etcpath, glob("templates/reporting/*")),
             ("%spower" % etcpath, glob("templates/power/*")),
-            ("%sldap" % etcpath, glob("templates/ldap/*")),
             # Build empty directories to hold triggers
             ("%striggers/add/distro/pre" % libpath, []),
             ("%striggers/add/distro/post" % libpath, []),

--- a/templates/ldap/ldap_authconfig.template
+++ b/templates/ldap/ldap_authconfig.template
@@ -1,1 +1,0 @@
-authconfig --enableshadow --enableldap --enableldapauth --enablelocauthorize --enablecache --enablemkhomedir --updateall --ldapserver=$ldapserver --ldapbasedn=$ldapbasedn

--- a/tests/cobbler_xmlrpc_test.py
+++ b/tests/cobbler_xmlrpc_test.py
@@ -185,8 +185,6 @@ class Test_DistroProfileSystem(CobblerXmlRpcTest):
           ["kernel_options_post",["a=1 b=2 c=3 c=4 c=5 d e"],[]],
           ["kickstart",[self.redhat_kickstart,self.suse_autoyast,self.ubuntu_preseed],["/path/to/bad/kickstart",]],
           ["ks_meta",["a=1 b=2 c=3 c=4 c=5 d e",],[]],
-          ["ldap_enabled", [], []],
-          ["ldap_type", [], []],
           ["mgmt_classes",["one two three",],[]],
           ["mgmt_parameters",["<<inherit>>"],["badyaml"]], # needs more test cases that are valid yaml
           ["name",["testsystem0"],[]],


### PR DESCRIPTION
Cobbler should not try to implement typical configuration management
tasks as there are many free and better solutions available.
Instead Cobbler should focus on proper integration with these solutions.
