### PR TITLE
Make <<inherit>> a valid kickstart location

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -817,6 +817,9 @@ class CobblerXMLRPCInterface:
 
         @param str path  kickstart template file path
         """
+        if path == "<<inherit>>":
+            return
+
         if path.find("..") != -1 or not path.startswith("/"):
             utils.die(self.logger, "Invalid kickstart template file location %s" % path)
 


### PR DESCRIPTION
Without this, the gui rejects modifications to systems / profiles where the kickstart value is "inherit" - with this, we presume the kickstart location is validated when the object where it is defined is modified.

This patch is against release26 as the kickstart validation function is not on master.
