### PR TITLE
Post install report mails are not mailed when ignorelist is empty.

### DIFF
--- a/cobbler/modules/install_post_report.py
+++ b/cobbler/modules/install_post_report.py
@@ -91,7 +91,7 @@ def run(api, args, logger):
 
     sendmail = True
     for prefix in settings.build_reporting_ignorelist:
-        if name.lower().startswith(prefix) == True:
+        if prefix != '' and name.lower().startswith(prefix):
             sendmail = False
 
     if sendmail == True:


### PR DESCRIPTION
This fixes #1248.
