### PR TITLE
CollectionManager always raises CX exception

### DIFF
--- a/cobbler/collection_manager.py
+++ b/cobbler/collection_manager.py
@@ -190,8 +190,7 @@ class CollectionManager:
             self._files,
         ):
             try:
-                if not serializer.deserialize(collection):
-                    raise ""
+                serializer.deserialize(collection)
             except:
                 raise CX("serializer: error loading collection %s. Check /etc/cobbler/modules.conf" % collection.collection_type())
 


### PR DESCRIPTION
`serializer.deserialize` does not have any return value; therefore the conditional statement will always evaluate to `True` and an exception will be raised.
