### PR TITLE
several pep8 fixes.

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -27,7 +27,6 @@ import urllib2
 
 from cobbler import action_acl
 from cobbler import action_buildiso
-from cobbler import action_buildiso
 from cobbler import action_check
 from cobbler import action_dlcontent
 from cobbler import action_hardlink

--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -267,7 +267,6 @@ class AutoInstallationManager:
             return [True, None, None]
 
         # generate automatic installation file
-        server = blended["server"]
         os_version = blended["os_version"]
         self.logger.info("----------------------------")
         self.logger.debug("osversion: %s" % os_version)
@@ -292,7 +291,6 @@ class AutoInstallationManager:
         @return bool if all automatic installation files are valid
         """
 
-        failed = False
         for x in self.collection_mgr.profiles():
             (success, errors_type, errors) = self.validate_autoinstall_file(x, True)
             if not success:

--- a/cobbler/item_image.py
+++ b/cobbler/item_image.py
@@ -23,7 +23,6 @@ import string
 from cobbler import autoinstall_manager
 from cobbler import item
 from cobbler import utils
-from cobbler import validate
 from cobbler.cexceptions import CX
 from cobbler.utils import _
 

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -43,7 +43,6 @@ from cobbler import item_repo
 from cobbler import item_system
 from cobbler import tftpgen
 from cobbler import utils
-from cobbler import validate
 from cobbler.cexceptions import CX
 
 

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -18,7 +18,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 
 import netaddr
-import os.path
 import re
 import shlex
 


### PR DESCRIPTION
cobbler/api.py:30: redefinition of unused 'action_buildiso' from line 29
cobbler/autoinstall_manager.py:270: local variable 'server' is assigned to but never used
cobbler/autoinstall_manager.py:295: local variable 'failed' is assigned to but never used
cobbler/item_image.py:26: 'validate' imported but unused
cobbler/remote.py:46: 'validate' imported but unused
cobbler/validate.py:21: 'os' imported but unused
