### PR TITLE
Let koan support CentOS 7 version numbering scheme

### DIFF
--- a/koan/utils.py
+++ b/koan/utils.py
@@ -25,6 +25,7 @@ from __future__ import print_function
 
 import os
 import random
+import re
 import traceback
 import tempfile
 import urllib2


### PR DESCRIPTION
Borrowing code of os_release from cobbler/utils.py
Ref: http://lwn.net/Articles/601914/
