### PR TITLE
Ubuntu: fix bootorder on ppc64el

### DIFF
--- a/autoinstall_scripts/preseed_early_default
+++ b/autoinstall_scripts/preseed_early_default
@@ -1,4 +1,5 @@
 # Start preseed_early_default
 # This script is not run in the chroot /target by default
 $SNIPPET('autoinstall_start')
+$SNIPPET('save_boot_device')
 # End preseed_early_default

--- a/autoinstall_scripts/preseed_nochroot_late_default
+++ b/autoinstall_scripts/preseed_nochroot_late_default
@@ -1,0 +1,4 @@
+# Start preseed_nochroot_late_default
+# This script runs in the / directory by default
+$SNIPPET('restore_boot_device')
+# End preseed_nochroot_late_default

--- a/autoinstall_snippets/restore_boot_device
+++ b/autoinstall_snippets/restore_boot_device
@@ -1,4 +1,4 @@
-#if ( "ppc" in $arch ) and ( $breed == "suse" or $breed == "redhat" )
+#if ( "ppc" in $arch ) and ( $breed == "suse" or $breed == "redhat" or $breed == "ubuntu")
 # Some Linux distributions, such as Fedora 17+, SLES 11+ and RHEL 7+, set the disk
 # as first boot device in Power machines. Therefore, restore the original boot
 # order.

--- a/autoinstall_snippets/save_boot_device
+++ b/autoinstall_snippets/save_boot_device
@@ -1,8 +1,8 @@
-#if ( "ppc" in $arch ) and ( $breed == "suse" or $breed == "redhat" )
+#if ( "ppc" in $arch ) and ( $breed == "suse" or $breed == "redhat" or $breed == "ubuntu" )
 # Some Linux distributions, such as Fedora 17+, SLES 11+ and RHEL 7+, set the disk
 # as first boot device in Power machines. Therefore, save the original boot
 # order, so it can be restored after installation is completed.
-#if ( $breed == "suse" )
+#if ( $breed == "suse" or $breed == "ubuntu" )
 nvram --print-config=boot-device > /root/boot-device.bak
 #else
 # Once root's homedir is there, copy over the log.


### PR DESCRIPTION
Much like RH/SUSE, with Ubuntu supported on ppc64, we are seeing the same boot order issues -- that is the install process is overwriting the boot order to be disk-first, regardless of the initial settings in SMS. This series fixes this up on Ubuntu ppc installs by adding a nochroot'd late script to run in the preseed, which restores the value saved in the early script. We must run nochroot, as the early script runs before /target is configured. We could, technically, run a simply cp command nochroot, then run the snippet in the chroot'd late script, but that seems unnecessarily complicated, and it also seems good to have an example of how to run late commands not-chroot'd.
