### PR TITLE
DHCP: add mac address formatting to the template

### DIFF
--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -75,6 +75,7 @@ cheetah_import_whitelist:
  - "random"
  - "re"
  - "time"
+ - "netaddr"
 
 # Default createrepo_flags to use for new repositories. If you have
 # createrepo >= 0.4.10, consider "-c cache --update -C", which can

--- a/templates/etc/dhcp.template
+++ b/templates/etc/dhcp.template
@@ -8,6 +8,8 @@
 #
 # ******************************************************************
 
+#import netaddr
+
 ddns-update-style interim;
 
 allow booting;
@@ -48,8 +50,9 @@ subnet 192.168.1.0 netmask 255.255.255.0 {
 group {
         #for mac in $dhcp_tags[$dhcp_tag].keys():
             #set iface = $dhcp_tags[$dhcp_tag][$mac]
+            #set mac_dhcp_format = netaddr.EUI($mac,dialect=netaddr.mac_unix)
     host $iface.name {
-        hardware ethernet $mac;
+        hardware ethernet $mac_dhcp_format;
         #if $iface.ip_address:
         fixed-address $iface.ip_address;
         #end if


### PR DESCRIPTION
Cobbler allows users to enter mac addresses in a number of formats,
but DHCP requires that it be in unix format. Updated the dhcp
template to format the mac address using netaddr EUI dialect=mac_unix

Signed-off-by: Tomo Berry tbberry@us.ibm.com
