### PR TITLE
allow systems without macs to be used by dhcp 

### DIFF
--- a/cobbler/modules/manage_dnsmasq.py
+++ b/cobbler/modules/manage_dnsmasq.py
@@ -97,10 +97,6 @@ class DnsmasqManager:
                 ip = interface["ip_address"]
                 host = interface["dns_name"]
 
-                if mac is None or mac == "":
-                    # can't write a DHCP entry for this system
-                    continue
-
                 counter += 1
 
                 # In many reallife situations there is a need to control the IP address

--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -116,10 +116,6 @@ class IscManager:
                 if distro is not None:
                     interface["distro"] = distro.to_dict()
 
-                if mac is None or mac == "":
-                    # can't write a DHCP entry for this system
-                    continue
-
                 counter = counter + 1
 
                 # the label the entry after the hostname if possible


### PR DESCRIPTION
I have a setup where my dhcp relay agent sends the switchport and I use dhcp_tag to assign ips based on that information. The problem is I need grub to look up the kernel by ip instead of mac address, which only happens if the systems don't have mac addresses. I made this change to allow systems without mac addresses to be used by dhcp. 