### PR TITLE
koan: trivial fix to correctly detect newer libvirt version, beyond 0.9

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -735,7 +735,7 @@ class Koan:
                 # is libvirt new enough?
                 rc, version_str = utils.subprocess_get_response(
                     shlex.split('/usr/bin/virt-install --version'), True)
-                if rc != 0 or re.match('^0\.[01].*', version_str):
+                if rc != 0 or re.match('^0\.[01]\..*', version_str):
                     raise InfoException(
                         "need python-virtinst >= 0.2 or virt-install package to do installs for qemu/kvm (depending on your OS)")
 


### PR DESCRIPTION
Hello, 

Please merge this trivial fix to allow koan to detect newer libvirt versions ala 0.10.x

Best regards,
Andreas
