### PR TITLE
Fix apache2.4 permission configuration issue

### DIFF
--- a/config/apache/cobbler.conf
+++ b/config/apache/cobbler.conf
@@ -12,8 +12,13 @@ WSGIScriptAliasMatch ^/cblr/svc/([^/]*) @@webroot@@/cobbler/svc/services.py
 <Directory "@@webroot@@/cobbler">
     SetEnv VIRTUALENV @@virtualenv@@
     Options Indexes FollowSymLinks
-    Order allow,deny
-    Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 
 ProxyRequests off
@@ -29,7 +34,12 @@ BrowserMatch "MSIE" AuthDigestEnableQueryStringHack=On
 
 <Directory "@@webroot@@/cobbler/web/">
     Options Indexes FollowSymLinks
-    Order allow,deny
-    Allow from all
+    <IfVersion <= 2.2>
+        Order allow,deny
+        Allow from all
+    </IfVersion>
+    <IfVersion >= 2.4>
+        Require all granted
+    </IfVersion>
 </Directory>
 

--- a/config/apache/cobbler_web.conf
+++ b/config/apache/cobbler_web.conf
@@ -11,8 +11,13 @@
         SetEnv VIRTUALENV @@virtualenv@@
         Options Indexes MultiViews
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        <IfVersion <= 2.2>
+            Order allow,deny
+            Allow from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
 </Directory>
 
 <Directory "@@webroot@@/cobbler_webui_content/">
@@ -24,8 +29,13 @@
         </IfModule>
         Options +Indexes +FollowSymLinks
         AllowOverride None
-        Order allow,deny
-        Allow from all
+        <IfVersion <= 2.2>
+            Order allow,deny
+            Allow from all
+        </IfVersion>
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
 </Directory>
 
 # Use separate process group for wsgi


### PR DESCRIPTION
Fixes the apache2 configuration so that access to all parts of the web interface is possible.

Right now, access to /cobbler_webui_content/logo-cobbler.png fails at least on Ubuntu 14.04.

This extends the fix from https://github.com/cobbler/cobbler/issues/537.
