### PR TITLE
distro_signatures: rhel7.1 adds ppc64le as a supported architecture

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -55,7 +55,7 @@
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*).rpm",
     "kernel_arch_regex":null,
-    "supported_arches":["i386","x86_64","ppc64"],
+    "supported_arches":["i386","x86_64","ppc64","ppc64le"],
     "supported_repo_breeds":["rsync", "rhn", "yum"],
     "kernel_file":"vmlinuz(.*)",
     "initrd_file":"initrd(.*)\\.img",


### PR DESCRIPTION
RHEL7.1 adds support for little endian ppc64. Simply add it to the valid
list of architectures for rhel7. It won't get picked up (as it's not
present in the repo) for rhel7.0. They are separate ISO images for
RHEL7.1.

Signed-off-by: Nishanth Aravamudan nacc@linux.vnet.ibm.com
