### PR TITLE
Feature: MAC lookup support for gPXE/iPXE

### DIFF
--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -66,11 +66,19 @@ class CobblerSvc(object):
         data = self.remote.generate_autoinstall(profile, system, REMOTE_ADDR, REMOTE_MAC)
         return u"%s" % data
 
-    def gpxe(self, profile=None, system=None, **rest):
+    def gpxe(self, profile=None, system=None, mac=None, **rest):
         """
         Generate a gPXE config
         """
         self.__xmlrpc_setup()
+        if not system and mac:
+            query = {"mac_address": mac}
+            if profile:
+                query["profile"] = profile
+            found = self.remote.find_system(query)
+            if found:
+                system = found[0]
+
         data = self.remote.generate_gpxe(profile, system)
         return u"%s" % data
 


### PR DESCRIPTION
Adding support to lookup the gPXE/iPXE boot instructions via the MAC address of the machine. The main use case of this feature is to be able to use a generic gPXE/iPXE boot CD without having to control a DHCP server.

This can be used with [iPXE](http://ipxe.org) embedded scripts to boot machines via Cobbler if one has no control over the DHCP server and/or the next-server parameter:

    #!ipxe
    
    dhcp
    chain http://<your_cobbler_server>/cblr/svc/op/gpxe/mac/${net0/mac}

