### PR TITLE
signatures: Fedora Core 21 supports ppc64le

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -153,7 +153,7 @@
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*)\\.rpm",
     "kernel_arch_regex":null,
-    "supported_arches":["i386","x86_64","ppc","ppc64"],
+    "supported_arches":["i386","x86_64","ppc","ppc64","ppc64le"],
     "supported_repo_breeds":["rsync", "rhn", "yum"],
     "kernel_file":"vmlinuz(.*)",
     "initrd_file":"initrd(.*)\\.img",


### PR DESCRIPTION
Signed-off-by: Nishanth Aravamudan <nacc@linux.vnet.ibm.com>