### PR TITLE
SLES11-SP3: also pass install=$tree to installer kernel

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -536,7 +536,7 @@
     "initrd_file":"initrd[64]?",
     "isolinux_ok":false,
     "default_autoinstall":"sample_autoyast.xml",
-    "kernel_options":"",
+    "kernel_options":"install=$tree",
     "kernel_options_post":"",
     "boot_files":[]
    },


### PR DESCRIPTION
This wasn't present in the signatures when I originally added SLES11-SP3
support, but it was missed in a subsequent BUGFIX.

Fixes: f3b2a10b ("distro_signatures: add SLES11-SP3")
Fixes: 5ff99da3 ("BUGFIX - multiple fixes for koan, ubuntu, and suse")
Signed-off-by: Nishanth Aravamudan <nacc@linux.vnet.ibm.com>