### PR TITLE
Fixing preseed_apt_repo_config to tell make ubuntu install work

### DIFF
--- a/autoinstall_snippets/preseed_apt_repo_config
+++ b/autoinstall_snippets/preseed_apt_repo_config
@@ -6,9 +6,9 @@
  #set $comps = " ".join($repo.apt_components)
 d-i apt-setup/local${cur}/repository string \
  #if $repo.mirror_locally
-      http://$http_server/cblr/repo_mirror/${repo.name} $dist $comps
+      deb http://$http_server/cblr/repo_mirror/${repo.name} $dist $comps
  #else
-      ${repo.mirror} $dist $comps
+      deb ${repo.mirror} $dist $comps
  #end if
  #if $repo.comment != ""
 d-i apt-setup/local${cur}/comment string ${repo.comment}


### PR DESCRIPTION
I tried getting it to work before, and couldn't figure out the "cannot find suitable kernel package to install" error when installing ubuntu server. I looked in the error console (alt-f4) and noticed that it said that the type "http://&lt;cobbler-ip&gt;/cblr/repo_mirror/ubuntu-14.04-server/" was unknown. I thought, "I wonder if 'deb' is missing off the front" 

I tracked down the preseed_apt_repo_config file as the file that inserts the repo configuration into the preseed file, and added "deb " to the lines before where the repo urls go, and now ubuntu installs happily. 