### PR TITLE
add feature for lpxelinux.0 for http based kernel and randisk

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -463,6 +463,9 @@ class TFTPGen:
             if 'nexenta' == distro.breed:
                 kernel_path = os.path.join("/images", distro.name, 'platform', 'i86pc', 'kernel', 'amd64', os.path.basename(distro.kernel))
                 initrd_path = os.path.join("/images", distro.name, 'platform', 'i86pc', 'amd64', os.path.basename(distro.initrd))
+            elif 'http' in distro.kernel and 'http' in distro.initrd:
+                kernel_path = distro.kernel
+                initrd_path = distro.initrd
             else:
                 kernel_path = os.path.join("/images", distro.name, os.path.basename(distro.kernel))
                 initrd_path = os.path.join("/images", distro.name, os.path.basename(distro.initrd))


### PR DESCRIPTION
with this setting you can do 
        
kernel http://abcdefg.com/vmlinuz
ipappend 2
append initrd=http://abcdefg.com/initrd.img ksdevice=bootif

and please make sure lpxelunux.0 are used to replace pxelinux.0 for version over 5.10
http://www.syslinux.org/wiki/index.php/PXELINUX#HTTP_and_FTP
