### PR TITLE
Add support for IPv6-only hosts in dnsmasq management

### DIFF
--- a/cobbler/modules/manage_dnsmasq.py
+++ b/cobbler/modules/manage_dnsmasq.py
@@ -96,6 +96,7 @@ class DnsmasqManager:
                 mac = interface["mac_address"]
                 ip = interface["ip_address"]
                 host = interface["dns_name"]
+                ipv6 = interface["ipv6_address"]
 
                 if mac is None or mac == "":
                     # can't write a DHCP entry for this system
@@ -118,6 +119,8 @@ class DnsmasqManager:
 
                 if ip is not None and ip != "":
                     systxt += "," + ip
+                if ipv6 is not None and ipv6 != "":
+                    systxt += ",[%s]" % ipv6
 
                 systxt += "\n"
 
@@ -175,9 +178,12 @@ class DnsmasqManager:
                 mac = interface["mac_address"]
                 host = interface["dns_name"]
                 ip = interface["ip_address"]
+                ipv6 = interface["ipv6_address"]
                 if mac is None or mac == "":
                     continue
-                if host is not None and host != "" and ip is not None and ip != "":
+                if host is not None and host != "" and ipv6 is not None and ipv6 != "":
+                    fh.write(ipv6 + "\t" + host + "\n")
+                elif host is not None and host != "" and ip is not None and ip != "":
                     fh.write(ip + "\t" + host + "\n")
         fh.close()
 


### PR DESCRIPTION
When generating dnsmasq.conf, include the IPv6 address in the dhcp-host
directive if the address is defined.  This supplements the IPv4 address.

When generating cobbler_hosts, use the IPv6 address if defined, else
use the IPv4 address.

IPv6 addresses are not written to /etc/ethers because dnsmasq does not
read them from /etc/ethers (according to the dnsmasq manual).