### PR TITLE
Add gpxe template support to 'windows' breed

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -966,6 +966,9 @@ class TFTPGen:
                 template = os.path.join(self.settings.boot_loader_conf_template_dir, "gpxe_%s_esxi6.template" % what.lower())
         elif distro.breed == 'freebsd':
             template = os.path.join(self.settings.boot_loader_conf_template_dir, "gpxe_%s_freebsd.template" % what.lower())
+        elif distro.breed == 'windows':
+            template = os.path.join(self.settings.boot_loader_conf_template_dir, "gpxe_%s_windows.template" % what.lower())
+
 
         if what == "system":
             if not netboot_enabled:

--- a/templates/boot_loader_conf/gpxe_system_windows.template
+++ b/templates/boot_loader_conf/gpxe_system_windows.template
@@ -1,0 +1,19 @@
+#!gpxe
+#
+# This is a generic Windows gpxe script that uses wimboot to boot
+# a WinPE image.  You may need to modify this for your environment.
+#
+# This expects a autoinstall_meta value to be set for initrd multiple times
+# e.g. autoinstall_meta = initrd=bcd initrd=boot.sdi initrd=boot.wim
+#
+# You will need to either place the files manually or use multiple 
+# 'cobbler distro edit' commands to have cobbler automatically link the
+# files appropriately
+#
+# See http://ipxe.org/wimboot for more details
+#
+kernel http://$server:$http_port/cobbler/images/$distro/wimboot
+#for $init in $initrd
+initrd http://$server:$http_port/cobbler/images/$distro/$init	$init
+#end for
+boot 


### PR DESCRIPTION
The gpxe_generate function lacked support for the 'windows' breed. This
adds that support to the function, as well as a gpxe template file for
Windows that follows the instructions for wimboot-ing Windows at
http://ipxe.org/wimboot

I tested the code with 'make qa' and the changes passed, although there are other errors in tftpgen.py.