### PR TITLE
remove stuff copy-pasted from cfengine example

### DIFF
--- a/snippets/keep_ssh_host_keys
+++ b/snippets/keep_ssh_host_keys
@@ -8,11 +8,7 @@ TEMPDIR=ssh
 PATTERN=ssh_host_
 
 keys_found=no
-# /var could be a separate partition
-SHORTDIR=${SEARCHDIR#/var}
-if [ $SHORTDIR = $SEARCHDIR ]; then
-	SHORTDIR=''
-fi	
+	
 insmod /lib/jbd.o
 insmod /lib/ext3.o
 
@@ -36,11 +32,6 @@ function findkeys
 	umount /tmp/$tmpdir
 	rm -r /tmp/$tmpdir
 	break
-    elif [ -n "$SHORTDIR" ] && [ -d /tmp/$tmpdir$SHORTDIR ] && cp -a /tmp/$tmpdir$SHORTDIR/${PATTERN}* /tmp/$TEMPDIR; then 
-	keys_found="yes"
-        umount /tmp/$tmpdir
-	rm -r /tmp/$tmpdir
-        break
     fi
     umount /tmp/$tmpdir
     rm -r /tmp/$tmpdir


### PR DESCRIPTION
Testing for /var to be a separate block device doesn't make sense for ssh, whose keys are in /etc/ssh (/var is not a component of that)