### PR TITLE
Fix gateway-per-if change for release26

### DIFF
--- a/snippets/pre_install_network_config
+++ b/snippets/pre_install_network_config
@@ -56,7 +56,6 @@ get_ifname() {
         #set $static        = $idata["static"]
         #set $ip            = $idata["ip_address"]
         #set $netmask       = $idata["netmask"]
-        #set $gateway       = $idata["gateway"]
         #set $if_gateway    = $idata["if_gateway"]
         #set $iface_type    = $idata["interface_type"]
         #set $iface_master  = $idata["interface_master"]


### PR DESCRIPTION
This reverts part of 4c039ae3eb178caca7ade71b8deab79e328f3d3f. The
'gateway' variable is not part of the interface data in 2.6 and
causes any system with network information to fail template generation.