### PR TITLE
cobbler/remote: fix network interface edit/add from CLI

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -904,9 +904,8 @@ class CobblerXMLRPCInterface:
         if f in ("delete_interface", "rename_interface"):
             return True
 
-        k = "*%s" % f
-        for x in item_system.FIELDS:
-            if k == x[0]:
+        for x in item_system.NETWORK_INTERFACE_FIELDS:
+            if f == x[0]:
                 return True
         return False
 


### PR DESCRIPTION
If you try to run `cobbler system edit --interface=<> --mac-address`
with master, no edit results, and interfaces remains an empty
dictionary. The issue is that 38f7e00959 ("Split system's network
interface fields from system fields") removed some of the special hacks
for network interface fields, but did not update the helper function
used by the xapi_edit code.

Fixes: 38f7e00959 ("Split system's network interface fields from system fields")
Signed-off-by: Nishanth Aravamudan <nacc@linux.vnet.ibm.com>