### PR TITLE
cli/report: fix interface iteration in cobbler system report

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -144,7 +144,8 @@ def report_item(remote, otype, item=None, name=None):
     elif otype == "profile":
         data = utils.to_string_from_fields(item, item_profile.FIELDS)
     elif otype == "system":
-        data = utils.to_string_from_fields(item, item_system.FIELDS)
+        data = utils.to_string_from_fields(item, item_system.FIELDS,
+                                           item_system.NETWORK_INTERFACE_FIELDS)
     elif otype == "repo":
         data = utils.to_string_from_fields(item, item_repo.FIELDS)
     elif otype == "image":

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1753,7 +1753,7 @@ def to_dict_from_fields(item, fields):
     return _dict
 
 
-def to_string_from_fields(item_dict, fields):
+def to_string_from_fields(item_dict, fields, interface_fields=None):
     """
     item_dict is a dictionary, fields is something like item_distro.FIELDS
     """
@@ -1767,7 +1767,7 @@ def to_string_from_fields(item_dict, fields):
         # FIXME: supress fields users don't need to see?
         # FIXME: interfaces should be sorted
         # FIXME: print ctime, mtime nicely
-        if k.startswith("*") or not editable:
+        if not editable:
             continue
 
         if k != "name":
@@ -1776,14 +1776,17 @@ def to_string_from_fields(item_dict, fields):
 
     # somewhat brain-melting special handling to print the dicts
     # inside of the interfaces more neatly.
-    if "interfaces" in item_dict:
+    if "interfaces" in item_dict and interface_fields is not None:
+        keys = []
+        for elem in interface_fields:
+            keys.append((elem[0], elem[3], elem[4]))
+        keys.sort()
         for iname in item_dict["interfaces"].keys():
             # FIXME: inames possibly not sorted
             buf += "%-30s : %s\n" % ("Interface ===== ", iname)
             for (k, nicename, editable) in keys:
-                nkey = k.replace("*", "")
-                if k.startswith("*") and editable:
-                    buf += "%-30s : %s\n" % (nicename, item_dict["interfaces"][iname].get(nkey, ""))
+                if editable:
+                    buf += "%-30s : %s\n" % (nicename, item_dict["interfaces"][iname].get(k, ""))
 
     return buf
 


### PR DESCRIPTION
`cobbler system report` simply spits out interface names currently, but
doens't print any of their data. This is because the interface data
fields from the system object have been reorganized, but the
pretty-printing code used by system report has not been updated to:

  1) iterate over the new field definitions (stored in a new variable)
  2) not look for specially-formatted strings (starting with *)

Fix both these issues.

Fixes: 38f7e00959 ("Split system's network interface fields from system fields")
Signed-off-by: Nishanth Aravamudan <nacc@linux.vnet.ibm.com>