### PR TITLE
cobbler: fix get-autoinstall cli interface

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -468,9 +468,9 @@ class CobblerCLI:
                     sys.exit(1)
             elif object_action == "get-autoinstall":
                 if object_type == "profile":
-                    data = self.remote.generate_autoinstall(profile=options.name)
+                    data = self.remote.generate_profile_autoinstall(options.name)
                 elif object_type == "system":
-                    data = self.remote.generate_autoinstall(system=options.name)
+                    data = self.remote.generate_system_autoinstall(options.name)
                 print data
             elif object_action == "dumpvars":
                 if object_type == "profile":

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1083,6 +1083,12 @@ class CobblerXMLRPCInterface:
             utils.log_exc(self.logger)
             return "# This automatic OS installation file had errors that prevented it from being rendered correctly.\n# The cobbler.log should have information relating to this failure."
 
+    def generate_profile_autoinstall(self, profile):
+        return self.generate_autoinstall(profile=profile)
+
+    def generate_system_autoinstall(self, system):
+        return self.generate_autoinstall(system=system)
+
     def generate_gpxe(self, profile=None, system=None, **rest):
         self._log("generate_gpxe")
         return self.api.generate_gpxe(profile, system)


### PR DESCRIPTION
Because the CLI is proxied via the RPC interface, we cannot use named
parameters to the remote APIs. We have to either pass empty strings in
the right position, which is both fraught with likelihood of breakage,
but also breaks expectations about the default values (e.g., None), or
introduce helper APIs that are clear and simple. In this case, add a
simple helper interface that calls generate_autoinstall() with the named
parameter. Currently, `cobbler {profile,system} getks` throws an error: 

Traceback (most recent call last):
  File "/usr/bin/cobbler", line 36, in <module>
    sys.exit(app.main())
  File "/usr/lib/python2.7/site-packages/cobbler/cli.py", line 732, in main
    rc = cli.run(sys.argv)
  File "/usr/lib/python2.7/site-packages/cobbler/cli.py", line 354, in run
    self.object_command(object_type, object_action)
  File "/usr/lib/python2.7/site-packages/cobbler/cli.py", line 474, in object_command
    data = self.remote.generate_autoinstall(system=options.name)
TypeError: __call__() got an unexpected keyword argument 'system'

Fixes: 7ef12d1b ('Create automatic installation files manager')
Signed-off-by: Nishanth Aravamudan <nacc@linux.vnet.ibm.com>

---

Note that if the mentioned commit simply did one thing, instead of many
things, there would not have been a regression. E.g., if it had just
reorganized the code instead of changing any callers of APIs.