### PR TITLE
Use service instead of init.d so logrotate also works with systemd

### DIFF
--- a/config/rotate/cobblerd_rotate
+++ b/config/rotate/cobblerd_rotate
@@ -5,7 +5,7 @@
    weekly
    postrotate
       if [ -f /var/lock/subsys/cobblerd ]; then
-         /etc/init.d/cobblerd condrestart > /dev/null
+         /usr/sbin/service cobblerd condrestart > /dev/null
       fi
    endscript
 }


### PR DESCRIPTION
We discovered logrotate wasn't working on our EL7 boxes, this fixes that while preserving correct behavior on earlier OS versions.