### PR TITLE
Build ISO: Support for syslinux 6

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -562,7 +562,19 @@ class BuildIso:
         if not os.path.exists(chain):
             chain = "/usr/lib/syslinux/chain.c32"
 
-        files = [isolinuxbin, menu, chain]
+        ldlinux = "/usr/share/syslinux/ldlinux.c32"
+        if not os.path.exists(ldlinux):
+            ldlinux = "/usr/lib/syslinux/ldlinux.c32"
+
+        libcom32 = "/usr/share/syslinux/libcom32.c32"
+        if not os.path.exists(libcom32):
+            ldlinux = "/usr/lib/syslinux/libcom32.c32"
+
+        libutil = "/usr/share/syslinux/libutil.c32"
+        if not os.path.exists(libutil):
+            ldlinux = "/usr/lib/syslinux/libutil.c32"
+
+        files = [ isolinuxbin, menu, chain, ldlinux, libcom32, libutil ]
         for f in files:
             if not os.path.exists(f):
                 utils.die(self.logger, "Required file not found: %s" % f)

--- a/templates/iso/buildiso.template
+++ b/templates/iso/buildiso.template
@@ -1,4 +1,4 @@
-DEFAULT MENU
+DEFAULT menu
 PROMPT 0
 MENU TITLE Cobbler | https://cobbler.github.io
 TIMEOUT 200


### PR DESCRIPTION
Fedora ships a much newer syslinux than what cobbler originally supported. Building an ISO using the current Fedora packages results in an ISO that does not boot. There are missing modules and the boot menu template needs to be fixed to find the menu module.

These changes create a bootable ISO file.
