### PR TITLE
Change find_system_by_dns_name() to use the find API

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1539,16 +1539,13 @@ class CobblerXMLRPCInterface:
 
     # this is used by the puppet external nodes feature
     def find_system_by_dns_name(self, dns_name):
-        # FIXME: implement using api.py's find API
-        # and expose generic finds for other methods
+        # FIXME: expose generic finds for other methods
         # WARNING: this function is /not/ expected to stay in cobbler long term
-        systems = self.get_systems()
-        for x in systems:
-            for y in x["interfaces"]:
-                if x["interfaces"][y]["dns_name"] == dns_name:
-                    name = x["name"]
-                    return self.get_system_for_koan(name)
-        return {}
+        system = self.api.find_system(dns_name=dns_name)
+        if system is None:
+            return {}
+        else:
+            return self.get_system_for_koan(system.name)
 
     def get_distro_as_rendered(self, name, token=None, **rest):
         """


### PR DESCRIPTION
cobbler-ext-nodes uses find_system_by_dns_name(). This patch changes the function to use the find API, instead of iterating through the list of systems.

For a site with more nodes and frequent puppet runs, this may speed things up slightly and reduce cobblerd memory usage.

In my limited testing, it appears to work OK.