### PR TITLE
Do not set interface["filename"] to /pxelinux.0 in manage_isc.py

### DIFF
--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -150,8 +150,6 @@ class IscManager:
                     if not interface["netboot_enabled"] and interface['static']:
                         continue
 
-                interface["filename"] = "/pxelinux.0"
-                # can't use pxelinux.0 anymore
                 if distro is not None:
                     if distro.arch.startswith("ppc"):
                         if blended_system["boot_loader"] == "pxelinux":


### PR DESCRIPTION
Do not set interface["filename"] to /pxelinux.0 in manage_isc.py, default is handled in dhcpd.template

This is a start towards fixing #1558.  However, we're still stuck with existing systems having a default filename set and no way to modify it in the web interface.  Is there a way to modify existing systems in an upgrade?