### PR TITLE
Change buildiso --iso description to use "file" instead of "path"

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -520,7 +520,7 @@ class CobblerCLI:
         if action_name == "buildiso":
 
             defaultiso = os.path.join(os.getcwd(), "generated.iso")
-            self.parser.add_option("--iso", dest="iso", default=defaultiso, help="(OPTIONAL) output ISO to this path")
+            self.parser.add_option("--iso", dest="iso", default=defaultiso, help="(OPTIONAL) output ISO to this file")
             self.parser.add_option("--profiles", dest="profiles", help="(OPTIONAL) use these profiles only")
             self.parser.add_option("--systems", dest="systems", help="(OPTIONAL) use these systems only")
             self.parser.add_option("--tempdir", dest="buildisodir", help="(OPTIONAL) working directory")


### PR DESCRIPTION
The --iso option specifies the name of a file into which the ISO image is written. The term "path" used in the description of this argument could be interpreted as referring to either a directory or a file. Changing it to "file" eliminates that ambiguity.