### PR TITLE
Protect Kickstart "curl" from "url .*" change to "cdrom" in standalone

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -487,8 +487,8 @@ class BuildIso:
                 autoinstall_data = self.api.autoinstallgen.generate_autoinstall_for_system(descendant.name)
 
             if distro.breed == "redhat":
-                cdregex = re.compile("url .*\n", re.IGNORECASE)
-                autoinstall_data = cdregex.sub("cdrom\n", autoinstall_data)
+                cdregex = re.compile("^\s*url .*\n", re.IGNORECASE | re.MULTILINE)
+                autoinstall_data = cdregex.sub("cdrom\n", autoinstall_data, count=1)
 
             autoinstall_name = os.path.join(isolinuxdir, "%s.cfg" % descendant.name)
             autoinstall_file = open(autoinstall_name, "w+")


### PR DESCRIPTION
The Kickstart that's generated while building a Red Hat breed standalone ISO is modified by a regexp to change the "url http://cobbler-server/...etc..." line, which directs a network-based installation, to "cdrom" instead, directing a media-based installation.

The regexp used is overinclusive, also changing "curl -o" command lines later in the Kickstart to read "ccdrom." The issue is described in more detail in a note at 286 in the original commit, a389783b113ada0e3e33e8eb22e3b5a4b74db71e.

This commit modifies the regexp to anchor it to the beginning of the line (ignoring any leading spaces on the line) so that only the "url" directive will be modified, and adds a "count=1" option to only change the first such directive that is encountered in the Kickstart.