### PR TITLE
In import_tree() check for zero-length mirror_name and _url

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -788,10 +788,10 @@ class CobblerAPI:
         self.log("import_tree", [mirror_url, mirror_name, network_root, autoinstall_file, rsync_flags])
 
         # both --path and --name are required arguments
-        if mirror_url is None:
+        if mirror_url is None or not mirror_url:
             self.log("import failed.  no --path specified")
             return False
-        if mirror_name is None:
+        if mirror_name is None or not mirror_name:
             self.log("import failed.  no --name specified")
             return False
 


### PR DESCRIPTION
The existing code checks for "None" in the mirror_name and mirror_url paths provided to import_tree(), but None is not the same as an empty string.

As a result, if a field is left blank in cobbler_web's interface, for example, an invalid path is constructed
such as: "/var/www/cobbler/ks_mirror-x86_64," and an exception is thrown from a mkdir call instead of getting an error message from import_tree().