### PR TITLE
Show cause of failed urlgrabber fetch in reposync log

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -437,8 +437,8 @@ class RepoSync:
         dst = temp_path + "/repomd.xml"
         try:
             urlgrabber.grabber.urlgrab(src, filename=dst, proxies=proxies)
-        except:
-            utils.die(self.logger, "failed to fetch %s" % src)
+        except Exception as e:
+            utils.die(self.logger, "failed to fetch " + src + " " + e.args)
 
         # create our repodata directory now, as any extra metadata we're
         # about to download probably lives there
@@ -453,8 +453,8 @@ class RepoSync:
                 dst = dest_path + "/" + mdfile
                 try:
                     urlgrabber.grabber.urlgrab(src, filename=dst, proxies=proxies)
-                except:
-                    utils.die(self.logger, "failed to fetch %s" % src)
+                except Exception as e:
+                    utils.die(self.logger, "failed to fetch " + src + " " + e.args)
 
         # now run createrepo to rebuild the index
         if repo.mirror_locally:


### PR DESCRIPTION
The reposync operation attempts to grab the xml metadata and other items from the remote repo server, and if this fails, the reposync fails and reports "failed to fetch <url>" with no detail as to the cause of the failure. Adding the exception args indicates to the user the cause of the failure, increasing their ability to diagnose and correct it:

failed to fetch http://server/repo/repomd.xml (14, 'PYCURL ERROR 52 - "Empty reply from server"')