### PR TITLE
Make web event log box readonly and properly sized

### DIFF
--- a/web/templates/eventlog.tmpl
+++ b/web/templates/eventlog.tmpl
@@ -3,9 +3,11 @@
 
 <h1>{{ eventid }} : {{ eventname }} :: {{ eventstate }}</h1>
 <hr />
-<textarea rows="40" cols="120" name="eventlog" id="eventlog">
+<pre>
+<textarea readonly rows="40" cols="120" name="eventlog" id="eventlog">
 {{ eventlog }}
 </textarea>
+</pre>
 <br />
 <a href="javascript:location.reload(true)">Refresh log</a>
 


### PR DESCRIPTION
The textarea for the eventlog was subject to mangling by misdirected typing or cutting; the "readonly" attribute was added to protect the contents of the event log's textarea from inadvertent modification.

The style.css sheet defines a "textarea" size as 8em x 25em, but a "pre textarea" has a size of 30em x 60em. The eventlog was using the former instead of the latter, resulting in a very small event log viewing box that was only about 45 columns wide.

Adding the pre tags around the textarea selects the latter style to provide enough width and height to comfortably display the event log.