### PR TITLE
Let repo.proxy override SETTINGS:proxy_url_ext for urlgrabber

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -431,7 +431,10 @@ class RepoSync:
 
         # grab repomd.xml and use it to download any metadata we can use
         proxies = {}
-        proxies['http'] = self.settings.proxy_url_ext
+        if repo.proxy is not None and repo.proxy:
+            proxies['http'] = repo.proxy
+        else:
+            proxies['http'] = self.settings.proxy_url_ext
 
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"


### PR DESCRIPTION
A proxy set in in repo.proxy was ignored, leaving this feature unimplemented and causing confusing failure of the attempt to fetch the repomd.xml file from the remote repository - and thus failure of the reposync operation - when the settings.proxy_url_ext was not set, or not set correctly, even though the repo.proxy was set.

This commit lets a repo-specific proxy setting take precedence over the global proxy_url_ext setting.