### PR TITLE
Allow repo.proxy to be null, and <<inherit>> settings proxy

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -431,10 +431,11 @@ class RepoSync:
 
         # grab repomd.xml and use it to download any metadata we can use
         proxies = {}
-        if repo.proxy is not None and repo.proxy:
-            proxies['http'] = repo.proxy
-        else:
+        if repo.proxy == '<<inherit>>':
             proxies['http'] = self.settings.proxy_url_ext
+        elif repo.proxy != '<<None>>' and repo.proxy != '':
+            proxies['http'] = repo.proxy
+            proxies['https'] = repo.proxy
 
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"
@@ -595,8 +596,14 @@ class RepoSync:
             line = line.replace("@@server@@", http_server)
             config_file.write(line)
 
-            if repo.proxy != '':
-                config_file.write("proxy=%s\n" % repo.proxy)
+            config_proxy = None
+            if repo.proxy == '<<inherit>>':
+                config_proxy = self.settings.proxy_url_ext
+            elif repo.proxy != '' and repo.proxy != '<<None>>':
+                config_proxy = repo.proxy
+
+            if config_proxy is not None:
+                config_file.write("proxy=%s\n" % config_proxy)
 
         if not optenabled:
             config_file.write("enabled=1\n")

--- a/cobbler/item_repo.py
+++ b/cobbler/item_repo.py
@@ -48,7 +48,7 @@ FIELDS = [
     ["name", "", 0, "Name", True, "Ex: f10-i386-updates", 0, "str"],
     ["owners", "SETTINGS:default_ownership", 0, "Owners", True, "Owners list for authz_ownership (space delimited)", [], "list"],
     ["priority", 99, 0, "Priority", True, "Value for yum priorities plugin, if installed", 0, "int"],
-    ["proxy", "SETTINGS:proxy_url_ext", "<<inherit>>", "Proxy information", True, "ex: http://example.com:8080", [], "str"],
+    ["proxy", "<<inherit>>", 0, "Proxy information", True, "http://example.com:8080, or <<inherit>> to use proxy_url_ext from settings, blank or <<None>> for no proxy", [], "str"],
     ["rpm_list", [], 0, "RPM List", True, "Mirror just these RPMs (yum only)", 0, "list"],
     ["yumopts", {}, 0, "Yum Options", True, "Options to write to yum config file", 0, "dict"],
 ]


### PR DESCRIPTION
When the proxy setting in the repo was blank, it used the settings.proxy_url_ext value, but this prevented a repo from overriding that to use no proxy at all, as might be necessary if one of your repos is on an internal server and your default proxy, as configured in settings, doesn't serve internal URLs.

The repo default proxy setting is now ```<<inherit>>``` which pulls the value from settings.proxy_url_ext, and if the proxy box is blank or ```<<None>>``` it will provide urlgrabber with an empty proxy list.

If a proxy is specified, it sets both the http and https proxies for urlgrabber, allowing the use of an https:// mirror URL provided that a valid proxy for https is specified in repo.proxy.