### PR TITLE
Add a new option to enable triggers when calling nopxe

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1306,6 +1306,11 @@ class CobblerXMLRPCInterface:
         if not self.api.settings().pxe_just_once:
             # feature disabled!
             return False
+        if str(self.api.settings().nopxe_with_triggers).upper() in ["1", "Y", "YES", "TRUE"]:
+            # triggers should be enabled when calling nopxe
+            triggers_enabled = True
+        else:
+            triggers_enabled = False
         systems = self.api.systems()
         obj = systems.find(name=name)
         if obj is None:
@@ -1313,7 +1318,7 @@ class CobblerXMLRPCInterface:
             return False
         obj.set_netboot_enabled(0)
         # disabling triggers and sync to make this extremely fast.
-        systems.add(obj, save=True, with_triggers=False, with_sync=False, quick_pxe_update=True)
+        systems.add(obj, save=True, with_triggers=triggers_enabled, with_sync=False, quick_pxe_update=True)
         # re-generate dhcp configuration
         self.api.sync_dhcp()
         return True

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -106,6 +106,7 @@ DEFAULTS = {
     "puppet_version": [2, "int"],
     "puppetca_path": ["/usr/bin/puppet", "str"],
     "pxe_just_once": [1, "bool"],
+    "nopxe_with_triggers": [1, "bool"],
     "redhat_management_permissive": [0, "bool"],
     "redhat_management_server": ["xmlrpc.rhn.redhat.com", "str"],
     "register_new_installs": [0, "bool"],

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -278,6 +278,10 @@ power_template_dir: "/etc/cobbler/power"
 # for --netboot-enabled.
 pxe_just_once: 1
 
+# if this setting is set to one, triggers will be executed when systems
+# will request to toggle the --netboot-enabled record at the end of their installation.
+nopxe_with_triggers: 1
+
 # This setting is only used by the code that supports using Spacewalk/Satellite
 # authentication within Cobbler Web and Cobbler XMLRPC.
 redhat_management_server: "xmlrpc.rhn.redhat.com"


### PR DESCRIPTION
It may be needed to execute triggers when calling nopxe
This patch adds a new option "nopxe_with_triggers" to use in conjunction with "pxe_just_once" to allow or not the execution of triggers