### PR TITLE
Add "sorted" option to get_descendants for a grouped listing

### DIFF
--- a/cobbler/item.py
+++ b/cobbler/item.py
@@ -218,16 +218,21 @@ class Item(object):
             results.append(self.children[k])
         return results
 
-    def get_descendants(self):
+    def get_descendants(self, sorted=False):
         """
         Get objects that depend on this object, i.e. those that
         would be affected by a cascading delete, etc.
+        With sorted=True the list will be a walk of the tree,
+        e.g., distro -> [profile, sys, sys, profile, sys, sys]
         """
         results = []
-        kids = self.get_children(sorted=False)
-        results.extend(kids)
+        kids = self.get_children(sorted=sorted)
+        if not sorted:
+            results.extend(kids)
         for kid in kids:
-            grandkids = kid.get_descendants()
+            if sorted:
+                results.append(kid)
+            grandkids = kid.get_descendants(sorted=sorted)
             results.extend(grandkids)
         return results
 


### PR DESCRIPTION
Similar to the "sorted" keyword option in get_children, when this is set to True in get_descendants, the list returned will be organized as a sorted heirarchy, like so:

```
distro.get.descendants(sorted=True) =
   profile1
     subprofile1
       system11A
       system11B
     system1A
   profile2
     system2A
     system2B
```

Coupled with the object's COLLECTION_TYPE attribute, this will allow the isolinux.cfg menu to present an indented heirarchical list of profiles and systems, and open the possibility for easily reporting an organized representation of the server's distro/profile/sub-profile/system tree to the user.