### PR TITLE
Allow --profiles in buildiso --airgapped to limit the profiles included on the ISO

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -131,7 +131,7 @@ class BuildIso:
                 which_objs.append(obj)
 
         if not which_objs:
-            utils.die("No valid systems or profiles were specified.")
+            utils.die(self.logger, "No valid systems or profiles were specified.")
 
         return which_objs
 
@@ -431,7 +431,7 @@ class BuildIso:
         cfg.write("MENU END\n")
         cfg.close()
 
-    def generate_standalone_iso(self, imagesdir, isolinuxdir, distname, filesource, airgapped):
+    def generate_standalone_iso(self, imagesdir, isolinuxdir, distname, filesource, airgapped, profiles):
         """
         Create bootable CD image to be used for handsoff CD installtions
         """
@@ -576,15 +576,22 @@ class BuildIso:
         # the distro option is for stand-alone builds only
         if not standalone and distro is not None:
             utils.die(self.logger, "The --distro option should only be used when creating a standalone or airgapped ISO")
-        # if building standalone, we only want --distro,
-        # profiles/systems are disallowed
+        # if building standalone, we only want --distro and --profiles (optional),
+        # systems are disallowed
         if standalone:
-            if profiles is not None or systems is not None:
-                utils.die(self.logger, "When building a standalone ISO, use --distro only instead of --profiles/--systems")
+            if systems is not None:
+                utils.die(self.logger, "When building a standalone ISO, use --distro and --profiles only, not --systems")
             elif distro is None:
                 utils.die(self.logger, "When building a standalone ISO, you must specify a --distro")
             if source is not None and not os.path.exists(source):
                 utils.die(self.logger, "The source specified (%s) does not exist" % source)
+
+            # insure all profiles specified are children of the distro
+            if profiles is not None:
+                which_profiles = self.filter_systems_or_profiles(profiles, 'profile')
+                for profile in which_profiles:
+                    if profile.distro != distro:
+                        utils.die(self.logger, "When building a standalone ISO, all --profiles must be under --distro")
 
         # if iso is none, create it in . as "autoinst.iso"
         if iso is None:
@@ -641,7 +648,7 @@ class BuildIso:
                 utils.copyfile(f, os.path.join(isolinuxdir, os.path.basename(f)), self.api)
 
         if standalone or airgapped:
-            self.generate_standalone_iso(imagesdir, isolinuxdir, distro, source, airgapped)
+            self.generate_standalone_iso(imagesdir, isolinuxdir, distro, source, airgapped, profiles)
         else:
             self.generate_netboot_iso(imagesdir, isolinuxdir, profiles, systems, exclude_dns)
 

--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -116,7 +116,7 @@ class BuildIso:
         elif list_type == 'system':
             all_objs = [system for system in self.api.systems()]
         else:
-            utils.die("Invalid list_type argument: " + list_type)
+            utils.die(self.logger, "Invalid list_type argument: " + list_type)
 
         all_objs.sort(self.sort_name)
 

--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -442,6 +442,7 @@ class BuildIso:
         if distro is None:
             utils.die(self.logger, "distro %s was not found, aborting" % distname)
         descendants = distro.get_descendants(sort=True)
+        profiles = utils.input_string_or_list(profiles)
 
         if filesource is None:
             # Try to determine the source from the distro kernel path
@@ -471,12 +472,17 @@ class BuildIso:
             repo_names_to_copy = {}
 
         for descendant in descendants:
-            data = utils.blender(self.api, False, descendant)
+            # if a list of profiles was given, skip any others and their systems
+            if (profiles is not None
+              and ((descendant.COLLECTION_TYPE == 'profile' and descendant.name not in profiles)
+              or (descendant.COLLECTION_TYPE == 'system' and descendant.profile not in profiles))):
+                continue
 
-            # indent system menu items by four spaces
             menu_indent = 0
             if descendant.COLLECTION_TYPE == 'system':
                 menu_indent = 4
+
+            data = utils.blender(self.api, False, descendant)
 
             cfg.write("\n")
             cfg.write("LABEL %s\n" % descendant.name)

--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -473,7 +473,7 @@ class BuildIso:
 
         for descendant in descendants:
             # if a list of profiles was given, skip any others and their systems
-            if (profiles is not None
+            if (profiles
                 and ((descendant.COLLECTION_TYPE == 'profile' and descendant.name not in profiles)
                      or (descendant.COLLECTION_TYPE == 'system' and descendant.profile not in profiles))):
                 continue
@@ -552,7 +552,7 @@ class BuildIso:
 
         if airgapped:
             # copy any repos found in profiles or systems to the iso build
-            repodir = os.path.abspath(isolinuxdir, "..", "repo_mirror")
+            repodir = os.path.abspath(os.path.join(isolinuxdir, "..", "repo_mirror"))
             if not os.path.exists(repodir):
                 os.makedirs(repodir)
 
@@ -593,7 +593,7 @@ class BuildIso:
                 utils.die(self.logger, "The source specified (%s) does not exist" % source)
 
             # insure all profiles specified are children of the distro
-            if profiles is not None:
+            if profiles:
                 which_profiles = self.filter_systems_or_profiles(profiles, 'profile')
                 for profile in which_profiles:
                     if profile.distro != distro:

--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -474,8 +474,8 @@ class BuildIso:
         for descendant in descendants:
             # if a list of profiles was given, skip any others and their systems
             if (profiles is not None
-              and ((descendant.COLLECTION_TYPE == 'profile' and descendant.name not in profiles)
-              or (descendant.COLLECTION_TYPE == 'system' and descendant.profile not in profiles))):
+                and ((descendant.COLLECTION_TYPE == 'profile' and descendant.name not in profiles)
+                     or (descendant.COLLECTION_TYPE == 'system' and descendant.profile not in profiles))):
                 continue
 
             menu_indent = 0

--- a/cobbler/item.py
+++ b/cobbler/item.py
@@ -222,7 +222,7 @@ class Item(object):
         """
         Get objects that depend on this object, i.e. those that
         would be affected by a cascading delete, etc.
-        With sorted=True the list will be a walk of the tree,
+        With sort=True the list will be a walk of the tree,
         e.g., distro -> [profile, sys, sys, profile, sys, sys]
         """
         results = []

--- a/cobbler/item.py
+++ b/cobbler/item.py
@@ -218,16 +218,21 @@ class Item(object):
             results.append(self.children[k])
         return results
 
-    def get_descendants(self):
+    def get_descendants(self, sorted=False):
         """
         Get objects that depend on this object, i.e. those that
         would be affected by a cascading delete, etc.
+        With sorted=True the list will be a walk of the tree,
+        e.g., distro -> [profile, sys, sys, profile, sys, sys]
         """
         results = []
-        kids = self.get_children(sorted=False)
-        results.extend(kids)
+        kids = self.get_children(sorted=sorted)
+        if not sorted:
+            results.extend(kids)
         for kid in kids:
-            grandkids = kid.get_descendants()
+            if sorted:
+                results.append(kid)
+            grandkids = kid.get_descendants(sorted=sorted)
             results.extend(grandkids)
         return results
 

--- a/cobbler/item.py
+++ b/cobbler/item.py
@@ -218,7 +218,7 @@ class Item(object):
             results.append(self.children[k])
         return results
 
-    def get_descendants(self, sorted=False):
+    def get_descendants(self, sort=False):
         """
         Get objects that depend on this object, i.e. those that
         would be affected by a cascading delete, etc.
@@ -226,13 +226,13 @@ class Item(object):
         e.g., distro -> [profile, sys, sys, profile, sys, sys]
         """
         results = []
-        kids = self.get_children(sorted=sorted)
-        if not sorted:
+        kids = self.get_children(sorted=sort)
+        if not sort:
             results.extend(kids)
         for kid in kids:
-            if sorted:
+            if sort:
                 results.append(kid)
-            grandkids = kid.get_descendants(sorted=sorted)
+            grandkids = kid.get_descendants(sort=sort)
             results.extend(grandkids)
         return results
 


### PR DESCRIPTION
Previously, the buildiso --airgapped command would include every profile and system associated with the specified distro.

With the introduction of the --airgapped option, which includes copies of the repos on the ISO, this poses a problem because if you have a variety of profiles which reference different repositories, you'd get every repo associated with every profile in that distro. If you're building an airgapped ISO aimed at systems which only need a specific profile and its systems, you may wind up with an ISO too big to fit on a DVD due to the inclusion of unneeded repos. Additionally, you may wish to segregate your profiles and repos into internal vs. external categories, so that you can build an ISO for an external site which does not include internal-only repos.

This commit allows you to use a "buildiso --distro=distro1 --airgapped --profiles=profile1" command line, so that the ISO image includes only profile1 and its systems and repos, and no other profiles associated with distro1.

It does not accept the --systems option as before, since this got a bit hairy to implement since systems would have to be processed to identify and include the profile under which they exist as well as verifying that they also fall within the distro specified. Profiles are easy enough to create, so if someone wants only a specific system on their ISO they can create a new profile that contains only that system.

In addition, the format of the isolinux menu is reorganized to sort the list of profiles and systems into an indented heirarchy, like so:

```
profile1
    system1
    system2
profile2
    system1
    system2
```

This uses the isolinux MENU INDENT option to indent systems but not profiles, coupled with a new "sort" keyword argument to get_descendants which returns the list of descendants ordered as shown above. This makes the installation menu more easily understood and improves the user experience.

The diff below looks rather daunting only because of a one-level indentation reduction when the profile and system filtering operation was factored out to its own function thus eliminating the need for the "if system_name in systems..." statement, and multiple matching "if suse" statements confusing the diff parser as to where the sections should be broken out. A patience diff makes it more legible.
