### PR TITLE
Fix config folder does not exist, can not be written to the file

### DIFF
--- a/cobbler/modules/manage_import_signatures.py
+++ b/cobbler/modules/manage_import_signatures.py
@@ -602,7 +602,11 @@ class ImportSignatureManager:
             repo_url2 = "http://@@http_server@@/cobbler/distro_mirror/%s" % (urlseg)
 
             distro.source_repos.append([repo_url, repo_url2])
-
+            
+            config_dir = os.path.dirname(fname)
+            if not os.path.exists(config_dir):
+                os.makedirs(config_dir)
+                
             # NOTE: the following file is now a Cheetah template, so it can be remapped
             # during sync, that's why we have the @@http_server@@ left as templating magic.
             # repo_url2 is actually no longer used. (?)


### PR DESCRIPTION
Sun Dec 27 18:39:41 2015 - INFO | need to process repo/comps: /var/www/cobbler/ks_mirror/ddd5
Sun Dec 27 18:39:41 2015 - INFO | looking for /var/www/cobbler/ks_mirror/ddd5/repodata/*comps*.xml
Sun Dec 27 18:39:41 2015 - ERROR | error launching createrepo (not installed?), ignoring
Sun Dec 27 18:39:41 2015 - INFO | Exception occured: <type 'exceptions.IOError'>
Sun Dec 27 18:39:41 2015 - INFO | Exception value: [Errno 2] No file or directory: '/var/www/cobbler/ks_mirror/config/ddd5-x86_64-0.repo'
Sun Dec 27 18:39:41 2015 - INFO | Exception Info:
  File "/usr/lib/python2.7/site-packages/cobbler/modules/manage_import_signatures.py", line 606, in yum_process_comps_file