### PR TITLE
die when signature file can't be parsed

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -136,7 +136,7 @@ class BootAPI:
 
             # import signatures
             if not utils.load_signatures(self.settings().signature_path):
-                return
+                utils.die(self.logger, 'failed to load signature file')
             else:
                 self.log("%d breeds and %d OS versions read from the signature file" % ( \
                          len(utils.get_valid_breeds()), \


### PR DESCRIPTION
When the signature file can't be parsed or loaded, cobbler dies with this message in the log. See Issue #641 

> Thu Jan 28 11:58:43 2016 - INFO | Exception value: BootAPI instance has no attribute 'authn'

This patch provides a slightly more helpful message
> Thu Jan 28 12:17:06 2016 - INFO | Exception value: 'failed to load signature file'

Things I don't know
  * Is die the right action? Should the code continue if it fails to load the signature file?
  * If die is *not* the right action, should `self.authn` and `self.authz` get set before trying to load the signatures?