### PR TITLE
powerpc64 little endian (ppc64le) support

### DIFF
--- a/cobbler/item_distro.py
+++ b/cobbler/item_distro.py
@@ -103,7 +103,7 @@ FIELDS = [
    [ "kernel_options",{},0,"Kernel Options",True,"Ex: selinux=permissive",0,"dict"],
    [ "kernel_options_post",{},0,"Kernel Options (Post Install)",True,"Ex: clocksource=pit noapic",0,"dict"],
    [ "ks_meta",{},0,"Kickstart Metadata",True,"Ex: dog=fang agent=86", 0,"dict"],
-   [ "arch",'i386',0,"Architecture",True,"", ['i386','x86_64','ia64','ppc','ppc64','s390', 'arm'],"str"],
+   [ "arch",'i386',0,"Architecture",True,"", ['i386','x86_64','ia64','ppc','ppc64','ppc64le','s390', 'arm'],"str"],
    [ "breed",'redhat',0,"Breed",True,"What is the type of distribution?",utils.get_valid_breeds(),"str"],
    [ "os_version","generic26",0,"OS Version",True,"Needed for some virtualization optimizations",utils.get_valid_os_versions(),"str"],
    [ "source_repos",[],0,"Source Repos", False,"",0,"list"],

--- a/cobbler/item_image.py
+++ b/cobbler/item_image.py
@@ -32,7 +32,7 @@ from utils import _
 
 FIELDS = [
   ['name','',0,"Name",True,"",0,"str"],
-  ['arch','i386',0,"Architecture",True,"",["i386","x86_64","ia64","s390","ppc","ppc64", "arm"],"str"],
+  ['arch','i386',0,"Architecture",True,"",["i386","x86_64","ia64","s390","ppc","ppc64","ppc64le", "arm"],"str"],
   ['breed','redhat',0,"Breed",True,"",utils.get_valid_breeds(),"str"],
   ['comment','',0,"Comment",True,"Free form text description",0,"str"],
   ['ctime',0,0,"",False,"",0,"float"],

--- a/cobbler/item_repo.py
+++ b/cobbler/item_repo.py
@@ -32,7 +32,7 @@ import codes
 FIELDS = [
   ["apt_components","",0,"Apt Components (apt only)",True,"ex: main restricted universe",[],"list"],
   ["apt_dists","",0,"Apt Dist Names (apt only)",True,"ex: precise precise-updates",[],"list"],
-  ["arch","",0,"Arch",True,"ex: i386, x86_64",['i386','x86_64','ia64','ppc','ppc64','s390', "arm", 'noarch', 'src'],"str"],
+  ["arch","",0,"Arch",True,"ex: i386, x86_64",['i386','x86_64','ia64','ppc','ppc64','ppc64le','s390', "arm", 'noarch', 'src'],"str"],
   ["breed","",0,"Breed",True,"",codes.VALID_REPO_BREEDS,"str"],
   ["comment","",0,"Comment",True,"Free form text description",0,"str"],
   ["ctime",0,0,"",False,"",0,"float"],

--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -282,7 +282,7 @@ class PXEGen:
 
             # for tftp only ...
             grub_path = None
-            if working_arch in [ "i386", "x86", "x86_64", "arm", "standard"]:
+            if working_arch in [ "i386", "x86", "x86_64", "arm", "ppc64le", "standard"]:
                 # pxelinux wants a file named $name under pxelinux.cfg
                 f2 = os.path.join(self.bootloc, "pxelinux.cfg", f1)
 
@@ -298,7 +298,7 @@ class PXEGen:
                 filename = "%s.conf" % utils.get_config_filename(system,interface=name)
                 f2 = os.path.join(self.bootloc, filename)
 
-            elif working_arch.startswith("ppc"):
+            elif working_arch in [ "ppc", "ppc64" ]:
                 # Determine filename for system-specific yaboot.conf
                 filename = "%s" % utils.get_config_filename(system, interface=name).lower()
                 f2 = os.path.join(self.bootloc, "etc", filename)
@@ -638,8 +638,10 @@ class PXEGen:
                         template = os.path.join(self.settings.pxe_template_dir,"pxesystem_s390x.template")
                     elif arch == "ia64":
                         template = os.path.join(self.settings.pxe_template_dir,"pxesystem_ia64.template")
-                    elif arch.startswith("ppc"):
+                    elif arch in ["ppc", "ppc64"]:
                         template = os.path.join(self.settings.pxe_template_dir,"pxesystem_ppc.template")
+                    elif arch == "ppc64le":
+                        template = os.path.join(self.settings.pxe_template_dir,"pxesystem_ppc64le.template")
                     elif arch.startswith("arm"):
                         template = os.path.join(self.settings.pxe_template_dir,"pxesystem_arm.template")
                     elif distro and distro.os_version.startswith("esxi"):
@@ -650,7 +652,7 @@ class PXEGen:
                         template = os.path.join(self.settings.pxe_template_dir,"pxesystem_esxi.template")
                 else:
                     # local booting on ppc requires removing the system-specific dhcpd.conf filename
-                    if arch is not None and arch.startswith("ppc"):
+                    if arch is not None and arch in ["ppc", "ppc64"]:
                         # Disable yaboot network booting for all interfaces on the system
                         for (name,interface) in system.interfaces.iteritems():
 
@@ -673,6 +675,8 @@ class PXEGen:
                         template = os.path.join(self.settings.pxe_template_dir,"pxelocal_s390x.template")
                     elif arch is not None and arch.startswith("ia64"):
                         template = os.path.join(self.settings.pxe_template_dir,"pxelocal_ia64.template")
+                    elif arch is not None and arch == "ppc64le":
+                        template = os.path.join(self.settings.pxe_template_dir,"pxelocal_ppc64le.template")
                     else:
                         template = os.path.join(self.settings.pxe_template_dir,"pxelocal.template")
         else:
@@ -681,6 +685,8 @@ class PXEGen:
                 template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_s390x.template")
             if arch.startswith("arm"):
                 template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_arm.template")
+            if arch == "ppc64le":
+                template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_ppc64le.template")
             elif format == "grub":
                 template = os.path.join(self.settings.pxe_template_dir,"grubprofile.template")
             elif distro and distro.os_version.startswith("esxi"):
@@ -704,7 +710,7 @@ class PXEGen:
 
         if distro and distro.os_version.startswith("esxi") and filename is not None:
             append_line = "BOOTIF=%s" % (os.path.basename(filename))
-        elif metadata.has_key("initrd_path") and (not arch or arch not in ["ia64", "ppc", "ppc64", "arm"]):
+        elif metadata.has_key("initrd_path") and (not arch or arch not in ["ia64", "ppc", "ppc64", "ppc64le", "arm"]):
             append_line = "append initrd=%s" % (metadata["initrd_path"])
         else:
             append_line = "append "

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1331,9 +1331,9 @@ def set_arch(self,arch,repo=False):
        arch = "i386"
 
    if repo:
-       valids = [ "i386", "x86_64", "ia64", "ppc", "ppc64", "s390", "s390x", "noarch", "src", "arm" ]
+       valids = [ "i386", "x86_64", "ia64", "ppc", "ppc64", "ppc64le", "s390", "s390x", "noarch", "src", "arm" ]
    else:
-       valids = [ "i386", "x86_64", "ia64", "ppc", "ppc64", "s390", "s390x", "arm" ]
+       valids = [ "i386", "x86_64", "ia64", "ppc", "ppc64", "ppc64le", "s390", "s390x", "arm" ]
 
    if arch in valids:
        self.arch = arch

--- a/config/distro_signatures.json
+++ b/config/distro_signatures.json
@@ -55,7 +55,7 @@
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*).rpm",
     "kernel_arch_regex":null,
-    "supported_arches":["i386","x86_64","ppc","ppc64"],
+    "supported_arches":["i386","x86_64","ppc","ppc64","ppc64le"],
     "supported_repo_breeds":["rsync", "rhn", "yum"],
     "kernel_file":"vmlinuz(.*)",
     "initrd_file":"initrd(.*)\\.img",

--- a/templates/pxe/pxeprofile_ppc64le.template
+++ b/templates/pxe/pxeprofile_ppc64le.template
@@ -1,0 +1,6 @@
+LABEL $profile_name
+        kernel http://$server/cobbler$kernel_path
+        initrd http://$server/cobbler$initrd_path
+        ipappend 2
+        append $append_line
+

--- a/templates/pxe/pxesystem_ppc64le.template
+++ b/templates/pxe/pxesystem_ppc64le.template
@@ -1,0 +1,8 @@
+default linux
+
+label linux
+        kernel http://$server/cobbler$kernel_path
+        initrd http://$server/cobbler$initrd_path
+        ipappend 2
+        append $append_line
+

--- a/web/cobbler_web/templates/import.tmpl
+++ b/web/cobbler_web/templates/import.tmpl
@@ -20,6 +20,7 @@
         <option value="ia64">ia64</option>
         <option value="ppc">ppc</option>
         <option value="ppc64">ppc64</option>
+        <option value="ppc64le">ppc64le</option>
         <option value="s390">s390</option>
         <option value="s390x">s390x</option>
         <option value="arm">arm</option>


### PR DESCRIPTION
IBM's new Power 8 systems (ppc64le) uses the [petiboot](https://www.kernel.org/pub/linux/kernel/people/geoff/petitboot/petitboot.html) boot manager.

> Petitboot supports configuration files based on the syslinux configuration format. However, not all keywords are parsed, as some relate to functionality that isn't relevant in a petitboot environment. Currently, petitboot supports the DEFAULT, KERNEL, INITRD and APPEND keywords. Keywords are case-insensitive.

Netbooting with petiboot documented here: http://jk.ozlabs.org/blog/post/158/netbooting-petitboot/

