### PR TITLE
Added support for fixed DHCP IPs when using vlan over bond.

### DIFF
--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -106,6 +106,14 @@ class IscManager:
                         # exist
                         continue
                     ip = system.interfaces[interface["interface_master"]]["ip_address"]
+                    if ip is None or ip == "":
+                        for (nam2, int2) in system.interfaces.iteritems():
+                            if (nam2.startswith(interface["interface_master"] + ".")
+                                and int2["ip_address"] is not None
+                                and int2["ip_address"] != ""):
+                                    ip = int2["ip_address"]
+                                    break
+
                     interface["ip_address"] = ip
                     host = system.interfaces[interface["interface_master"]]["dns_name"]
                     interface["if_gateway"] = system.interfaces[interface["interface_master"]]["if_gateway"]


### PR DESCRIPTION
In my server config I use em1+em2 -> bond0 -> bond0.XXX vlan setup.
Additional bond0.YYY are created later on with puppet. Them main
problem is that some vlans have MTU 9000 and therefore they need bond0
(and em1 and em2) to have MTU 9000 as well. The system/installation
vlan XXX is, however, with MTU 1500 only so I cannot put the IP on the
bond0 interface directly.

So far cobbler did not create fixed address entries in DHCP
("fixed-address X.X.X.X;") if there was no IP on emX or bond0 but
only on bond0.XXX. This fix adds the fixed address from the 'first'
vlan interface on top of the bond device, if the bond device itself
does not have an IP.

I tested the change with cobbler-2.4.4.1-el6 and cobbler-2.6.11-1.el6 rhel/epel RPMs on centos 6 with python-2.6.6-52.el6.x86_64
 