### PR TITLE
Some versions of virt-install respond to --version on stderr. Adapt.

### DIFF
--- a/koan/app.py
+++ b/koan/app.py
@@ -631,9 +631,12 @@ class Koan:
                 if not os.path.exists("/usr/bin/qemu-img"):
                     raise InfoException("qemu package needs to be installed")
                 # is libvirt new enough?
-                rc, version_str = utils.subprocess_get_response(shlex.split('/usr/bin/virt-install --version'), True)
-                version_str = version_str.strip()
-                if len(version_str) == 0 and not utils.check_version_greater_or_equal(version_str.strip(), "0.2.0"):
+                rc, response, stderr_response = utils.sub_process_get_response(shlex.split('/usr/bin/virt-install --version'), True, True)
+                if response:
+                    version_str = response.strip()
+                else:
+                    version_str = stderr_response.strip()
+                if len(version_str) == 0 and not utils.check_version_greater_or_equal(version_str, "0.2.0"):
                     raise InfoException("need python-virtinst >= 0.2 or virt-install package to do installs for qemu/kvm (depending on your OS)")
 
             # for vmware

--- a/koan/utils.py
+++ b/koan/utils.py
@@ -173,7 +173,7 @@ def subprocess_call(cmd,ignore_rc=0):
         raise InfoException, "command failed (%s)" % rc
     return rc
 
-def subprocess_get_response(cmd, ignore_rc=False):
+def subprocess_get_response(cmd, ignore_rc=False, get_stderr=False):
     """
     Wrapper around subprocess.check_output(...)
     """
@@ -181,8 +181,12 @@ def subprocess_get_response(cmd, ignore_rc=False):
     rc = 0
     result = ""
     if not ANCIENT_PYTHON:
-        p = sub_process.Popen(cmd, stdout=sub_process.PIPE)
-        result = p.communicate()[0]
+        if get_stderr:
+            p = sub_process.Popen(cmd, stdout=sub_process.PIPE,
+                    stderr=sub_process.PIPE)
+        else:
+            p = sub_process.Popen(cmd, stdout=sub_process.PIPE)
+        result, stderr_result = p.communicate()
         rc = p.wait()
     else:
         cmd = string.join(cmd, " ")
@@ -190,6 +194,8 @@ def subprocess_get_response(cmd, ignore_rc=False):
         rc = os.system(cmd)
     if not ignore_rc and rc != 0:
         raise InfoException, "command failed (%s)" % rc
+    if get_stderr:
+        return rc, result, stderr_result
     return rc, result
 
 def input_string_or_hash(options,delim=None,allow_multiples=True):

--- a/koan/virtinstall.py
+++ b/koan/virtinstall.py
@@ -38,10 +38,14 @@ import utils
 # command line tool. This should work on both old and new variants,
 # as the virt-install command line tool has always been provided by
 # python-virtinst (and now the new virt-install rpm).
-rc, response = utils.subprocess_get_response(
-        shlex.split('virt-install --version'), True)
+# virt-install 1.0.1 responds to --version on stderr. WTF? Check both.
+rc, response, stderr_response = utils.subprocess_get_response(
+    shlex.split('virt-install --version'), True, True)
 if rc == 0:
-    virtinst_version = response
+    if response:
+        virtinst_version = response
+    else:
+        virtinst_version = stderr_response
 else:
     virtinst_version = None
 


### PR DESCRIPTION
Backport stderr handling to 2.6.