### PR TITLE
Update prune to remove objects that don't match patterns

### DIFF
--- a/cobbler/action_replicate.py
+++ b/cobbler/action_replicate.py
@@ -63,14 +63,14 @@ class Replicate:
         locals = utils.lod_to_dod(self.local_data[obj_type], "uid")
         remotes = utils.lod_to_dod(self.remote_data[obj_type], "uid")
 
-        obj_pattern = getattr(self,"%s_patterns" % obj_type)
+        obj_pattern = getattr(self, "%s_patterns" % obj_type)
         if obj_pattern and self.prune:
             self.logger.info("Found pattern for %s. Pruning non-matching items" % obj_type)
             keep_obj = {}
-            remote_names = utils.loh_to_hoh(self.remote_data[obj_type],"name")
+            remote_names = utils.loh_to_hoh(self.remote_data[obj_type], "name")
             for name in remote_names.keys():
-                if name in self.must_include[obj_type] and remotes.has_key(remote_names[name]["uid"]):
-                    self.logger.info("Adding %s:%s to keep list" % (name,remote_names[name]["uid"]))
+                if name in self.must_include[obj_type] and remote_names[name]["uid"] in remotes:
+                    self.logger.info("Adding %s:%s to keep list" % (name, remote_names[name]["uid"]))
                     keep_obj[remote_names[name]["uid"]] = remotes[remote_names[name]["uid"]]
             remotes = keep_obj
 

--- a/cobbler/action_replicate.py
+++ b/cobbler/action_replicate.py
@@ -63,6 +63,17 @@ class Replicate:
         locals = utils.lod_to_dod(self.local_data[obj_type], "uid")
         remotes = utils.lod_to_dod(self.remote_data[obj_type], "uid")
 
+        obj_pattern = getattr(self,"%s_patterns" % obj_type)
+        if obj_pattern and self.prune:
+            self.logger.info("Found pattern for %s. Pruning non-matching items" % obj_type)
+            keep_obj = {}
+            remote_names = utils.loh_to_hoh(self.remote_data[obj_type],"name")
+            for name in remote_names.keys():
+                if name in self.must_include[obj_type] and remotes.has_key(remote_names[name]["uid"]):
+                    self.logger.info("Adding %s:%s to keep list" % (name,remote_names[name]["uid"]))
+                    keep_obj[remote_names[name]["uid"]] = remotes[remote_names[name]["uid"]]
+            remotes = keep_obj
+
         for (luid, ldata) in locals.iteritems():
             if luid not in remotes:
                 try:


### PR DESCRIPTION
I use this patch in my production instances due to overlapping private IP spaces. I can add a secondary flag for this functionality if you don't want to change existing functionality.

This will just cause --prune to match the patterns provided. If there are extra systems, prune will remove them. It does act a bit funny if you have a system that requires a profile that didn't match your patterns. This alone might be a reason to add another flag.
