### PR TITLE
Fix `restartservice` failure for systemd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,11 @@ restartservices:
 			/sbin/service apache2 restart; \
 		fi; \
 	elif [ -x /bin/systemctl ]; then \
-		/bin/systemctl restart httpd.service; \
+		if [ -d /lib/systemd/system/apache2.service.d ]; then \
+			/bin/systemctl restart apache2.service; \
+		else \
+			/bin/systemctl restart httpd.service; \
+		fi \
 	else \
 		/usr/sbin/service cobblerd restart; \
 		/usr/sbin/service apache2 restart; \


### PR DESCRIPTION
Ubuntu 16.04 LTS service manager have been switched to systemd,
HTTP service name should be apache2 on Ubuntu, but not httpd.

Signed-off-by: guessi <guessi@gmail.com>