### PR TITLE
Extend support for Ubuntu 16.04 LTS (Xenial)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,11 @@ restartservices:
 			/sbin/service apache2 restart; \
 		fi; \
 	elif [ -x /bin/systemctl ]; then \
-		/bin/systemctl restart httpd.service; \
+		if [ -d /lib/systemd/system/apache2.service.d ]; then \
+			/bin/systemctl restart apache2.service; \
+		else \
+			/bin/systemctl restart httpd.service; \
+		fi \
 	else \
 		/usr/sbin/service cobblerd restart; \
 		/usr/sbin/service apache2 restart; \

--- a/config/distro_signatures.json
+++ b/config/distro_signatures.json
@@ -420,6 +420,22 @@
     "kernel_options":"",
     "kernel_options_post":"",
     "boot_files":[]
+   },
+   "xenial": {
+    "signatures":["dists", ".disk"],
+    "version_file":"Release|mini-info",
+    "version_file_regex":"Codename: xenial|Ubuntu 16.04",
+    "kernel_arch":"linux-headers-(.*)\\.deb",
+    "kernel_arch_regex":null,
+    "supported_arches":["i386","amd64"],
+    "supported_repo_breeds":["apt"],
+    "kernel_file":"linux(.*)",
+    "initrd_file":"initrd(.*)\\.gz",
+    "isolinux_ok":false,
+    "default_kickstart":"/var/lib/cobbler/kickstarts/sample.seed",
+    "kernel_options":"",
+    "kernel_options_post":"",
+    "boot_files":[]
    }
   },
   "suse": {


### PR DESCRIPTION
Make it possible to run on Ubuntu 16.04 LTS (Xenial) with following changes (branch: release26)

1. extend signature for `xenial`
2. fix error when executing `make devinstall` or `make restartservices`