### PR TITLE
Fixed proxy issue (#1569)

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -431,10 +431,10 @@ class RepoSync:
 
         # grab repomd.xml and use it to download any metadata we can use
         proxies = None
-        if repo.proxy == '<<inherit>>':
-	    proxies={ 'http' : self.settings.proxy_url_ext }
-	elif repo.proxy != '<<None>>' and repo.proxy != '':
-            proxies={ 'http' : repo.proxy , 'https': repo.proxy }
+        if repo.proxy == '<<inherit>>': 
+            proxies = { 'http' : self.settings.proxy_url_ext }
+	elif repo.proxy != '<<None>>' and repo.proxy != '': 
+            proxies = { 'http' : repo.proxy , 'https': repo.proxy }
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"
         try:

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -432,9 +432,9 @@ class RepoSync:
         # grab repomd.xml and use it to download any metadata we can use
         proxies = None
         if repo.proxy == '<<inherit>>':
-            proxies = {'http':self.settings.proxy_url_ext}
+            proxies = {'http': self.settings.proxy_url_ext}
         elif repo.proxy != '<<None>>' and repo.proxy != '':
-            proxies = {'http':repo.proxy, 'https':repo.proxy}
+            proxies = {'http': repo.proxy, 'https': repo.proxy}
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"
         try:

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -432,8 +432,8 @@ class RepoSync:
         # grab repomd.xml and use it to download any metadata we can use
         proxies = None
         if repo.proxy == '<<inherit>>':
-	        proxies={ 'http' : self.settings.proxy_url_ext }
-	    elif repo.proxy != '<<None>>' and repo.proxy != '':
+	    proxies={ 'http' : self.settings.proxy_url_ext }
+	elif repo.proxy != '<<None>>' and repo.proxy != '':
             proxies={ 'http' : repo.proxy , 'https': repo.proxy }
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -430,13 +430,11 @@ class RepoSync:
         repodata_path = os.path.join(dest_path, "repodata")
 
         # grab repomd.xml and use it to download any metadata we can use
-        proxies = {}
+        proxies = None
         if repo.proxy == '<<inherit>>':
-            proxies['http'] = self.settings.proxy_url_ext
-        elif repo.proxy != '<<None>>' and repo.proxy != '':
-            proxies['http'] = repo.proxy
-            proxies['https'] = repo.proxy
-
+	        proxies={ 'http' : self.settings.proxy_url_ext }
+	    elif repo.proxy != '<<None>>' and repo.proxy != '':
+            proxies={ 'http' : repo.proxy , 'https': repo.proxy }
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"
         try:

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -431,10 +431,10 @@ class RepoSync:
 
         # grab repomd.xml and use it to download any metadata we can use
         proxies = None
-        if repo.proxy == '<<inherit>>': 
-            proxies = { 'http' : self.settings.proxy_url_ext }
-	elif repo.proxy != '<<None>>' and repo.proxy != '': 
-            proxies = { 'http' : repo.proxy , 'https': repo.proxy }
+        if repo.proxy == '<<inherit>>':
+            proxies = {'http':self.settings.proxy_url_ext}
+        elif repo.proxy != '<<None>>' and repo.proxy != '':
+            proxies = {'http':repo.proxy, 'https':repo.proxy}
         src = repo_mirror + "/repodata/repomd.xml"
         dst = temp_path + "/repomd.xml"
         try:


### PR DESCRIPTION
The URLGrabber module starts using the environment variables when an empty dictionary is submitted. 
So we have to initialize it to None, in case we neither want to use the proxy_url_ext nor the repo.proxy.

Now you can define repo-specific proxies, which will override the global ones and there is no more confusion with urlgrabber and environment variables.