### PR TITLE
Exclude fix

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -605,7 +605,6 @@ class RepoSync:
                 self.logger.debug("excluding: %s" % repo.yumopts['exclude'])
                 config_file.write("exclude=%s\n" % repo.yumopts['exclude'])
 
-
         if not optenabled:
             config_file.write("enabled=1\n")
         config_file.write("priority=%s\n" % repo.priority)

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -560,8 +560,7 @@ class RepoSync:
         config_file = open(fname, "w+")
         config_file.write("[%s]\n" % repo.name)
         config_file.write("name=%s\n" % repo.name)
-        if 'exclude' in repo.yumopts.keys():
-            self.logger.debug("excluding: %s" % repo.yumopts['exclude'])
+
         optenabled = False
         optgpgcheck = False
         if output:

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -602,6 +602,10 @@ class RepoSync:
 
             if config_proxy is not None:
                 config_file.write("proxy=%s\n" % config_proxy)
+            if 'exclude' in repo.yumopts.keys():
+                self.logger.debug("excluding: %s" % repo.yumopts['exclude'])
+                config_file.write("exclude=%s\n" % repo.yumopts['exclude'])
+
 
         if not optenabled:
             config_file.write("enabled=1\n")


### PR DESCRIPTION
This patch includes the yum exclude option when writing the local .repo file for syncing with the upstream repository.  It avoids the problem from previous releases when two copies of the same line were written.