### PR TITLE
Add watchfiles to waitlist

### DIFF
--- a/aux/anamon
+++ b/aux/anamon
@@ -197,10 +197,12 @@ def anamon_loop():
     if watchfiles:
         # Create WatchedFile objects for each requested file
         for watchfile in watchfiles:
+            watchfilebase = os.path.basename(watchfile)
+            watchlog = WatchedFile(watchfile, watchfilebase)
             if os.path.exists(watchfile):
-                watchfilebase = os.path.basename(watchfile)
-                watchlog = WatchedFile(watchfile, watchfilebase)
                 watchlist.append(watchlog)
+            else:
+                waitlist.append(watchlog)
 
     # Use the default watchlist and waitlist
     else:


### PR DESCRIPTION
Anamon currently won't wait on files that you specifically ask it to
watch for via the --watchfiles.  This allows it to do that.