### PR TITLE
Force IPv4 connection to cobblerd

### DIFF
--- a/config/apache/cobbler.conf
+++ b/config/apache/cobbler.conf
@@ -23,8 +23,8 @@ WSGIScriptAliasMatch ^/cblr/svc/([^/]*) @@webroot@@/cobbler/svc/services.py
 
 ProxyRequests off
 
-ProxyPass /cobbler_api http://localhost:25151/
-ProxyPassReverse /cobbler_api http://localhost:25151/
+ProxyPass /cobbler_api http://127.0.0.1:25151/
+ProxyPassReverse /cobbler_api http://127.0.0.1:25151/
 
 BrowserMatch "MSIE" AuthDigestEnableQueryStringHack=On
 


### PR DESCRIPTION
On Fedora 23 (and probably elsewhere), apache can decide to use the IPv6 address '[::1]' to connect to the cobbler server.  However, the cobbler server currently only listens to the IPv4 localhost address 127.0.0.1.  This is a stop-gap fix until we can get the cobbler daemon listening on both IPv4 and IPv6 addresses.