### PR TITLE
Fix for the issue with mangling kernel options (flags) with the --in-place key

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -651,6 +651,7 @@ class TFTPGen:
 
         append_line = ""
         kopts = blended.get("kernel_options", dict())
+        kopts = utils.revert_strip_none(kopts)
 
         # since network needs to be configured again (it was already in netboot) when kernel boots
         # and we choose to do it dinamically, we need to set 'ksdevice' to one of

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1947,6 +1947,28 @@ def strip_none(data, omit_none=False):
     return data
 
 # -------------------------------------------------------
+def revert_strip_none(data):
+    """
+    Does the opposite to strip_none
+    """
+    if isinstance(data, str) and data.strip() == '~':
+        return None
+
+    if isinstance(data, list):
+        data2 = []
+        for x in data:
+            data2.append(revert_strip_none(x))
+        return data2
+
+    if isinstance(data, dict):
+        data2 = {}
+        for key in data.keys():
+            data2[key] = revert_strip_none(data[key])
+        return data2
+
+    return data
+
+# -------------------------------------------------------
 
 
 def lod_to_dod(_list, indexkey):


### PR DESCRIPTION
Editing a cobbler profile kernel options with the key --in-place for the kernel option flags (which originally didn't have an assignment '=value') follows to the adding assignment with the '~' value.
It follows to the kernel crash for the kernel option 'toram' on the nodes.

For example, the original kernel options are (please put your attention to the 'toram' and 'debug' options):
initrd=/images/ubuntu_bootstrap/initrd.img ksdevice=bootif console=ttyS0,9600 console=tty0 toram debug

After executing the cobbler command:
cobbler profile edit --name ubuntu_bootstrap --kopts="console=tty0 console=ttyS0,115200 iommu=off" --in-place

The kernel options will be mangled to (please put attention to the 'toram' and 'debug' options):
initrd=/images/ubuntu_bootstrap/initrd.img ksdevice=bootif console=ttyS0,115200 console=tty0 iommu=off toram=~ debug=~

The kernel option toram=~ now is not a flag (downloading file system into the RAM), bug rather a file name '~', what actually follows to kernel panic.