### PR TITLE
Use OrderedDict.  Okay in python 2.7+ and RHEL6.5+ with python-2.6.6-43.

### DIFF
--- a/cobbler/web/templatetags/site.py
+++ b/cobbler/web/templatetags/site.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict
 
 register = template.Library()
 
@@ -372,7 +372,7 @@ ifinlist = register.tag(smart_if)
 @register.filter(name='sort')
 def listsort(value):
     if isinstance(value, dict):
-        new_dict = SortedDict()
+        new_dict = OrderedDict()
         key_list = value.keys()
         key_list.sort()
         for key in key_list:


### PR DESCRIPTION
Would need to get backported to at least cobbler 2.8