### PR TITLE
grub hangs on efi pxe installation

### DIFF
--- a/templates/boot_loader_conf/grubsystem.template
+++ b/templates/boot_loader_conf/grubsystem.template
@@ -1,3 +1,5 @@
+default=0
+timeout=0
 title $profile_name
     root (nd)
     kernel $kernel_path $kernel_options


### PR DESCRIPTION
There is no timeout/default in the grub menu for pxe using efi, thus
the installation hangs on boot in grub. This patch adds timeout and
default. Both values are set to zero.