### PR TITLE
Fix for issue #1693

### DIFF
--- a/cobbler/web/templatetags/site.py
+++ b/cobbler/web/templatetags/site.py
@@ -1,5 +1,5 @@
 from django import template
-from django.utils.datastructures import SortedDict
+from collections import OrderedDict as SortedDict
 
 register = template.Library()
 


### PR DESCRIPTION
Source: https://github.com/aljosa/django-tinymce/issues/114#issuecomment-122861883

https://code.djangoproject.com/wiki/SortedDict:
SortedDict is deprecated as of Django 1.7 and will be removed in Django 1.9. Use ​collections.OrderedDict instead. Available in Python 2.7 and 3.1+.