### PR TITLE
Fix /etc/cobbler/pxe/pxesystem_esxi.template file about boot.cfg issue.

### DIFF
--- a/templates/boot_loader_conf/pxesystem_esxi.template
+++ b/templates/boot_loader_conf/pxesystem_esxi.template
@@ -4,5 +4,5 @@ timeout 1
 label linux
         kernel $kernel_path
         ipappend 2
-        append $img_path/vmkboot.gz $append_line --- $img_path/vmkernel.gz --- $img_path/sys.vgz --- $img_path/cim.vgz --- $img_path/ienviron.vgz --- $img_path/install.vgz
+        append -c $img_path/cobbler-boot.cfg $img_path/vmkboot.gz $append_line --- $img_path/vmkernel.gz --- $img_path/sys.vgz --- $img_path/cim.vgz --- $img_path/ienviron.vgz --- $img_path/install.vgz
 


### PR DESCRIPTION
In esxi provisioning, I used system file that created "cobbler system add".
But esxi has been unable to boot with the message that "Configuration error while parsing /boot.cfg".
This issue is due to boot.cfg path does not exist in the system file.

I have fixed this issue.