### PR TITLE
get-loaders URL changes from http to https

### DIFF
--- a/cobbler/action_dlcontent.py
+++ b/cobbler/action_dlcontent.py
@@ -47,7 +47,7 @@ class ContentDownloader:
         they can still source their cross-arch bootloader content manually.
         """
 
-        content_server = "http://cobbler.github.io/loaders"
+        content_server = "https://cobbler.github.io/loaders"
         dest = "/var/lib/cobbler/loaders"
 
         files = (


### PR DESCRIPTION
Connection to http://cobbler.github.io is not allowed which causes `cobbler get-loaders` fail. Change proxy from http to https can fix it.