### PR TITLE
Finish change to OrderedDict

### DIFF
--- a/web/cobbler_web/templatetags/site.py
+++ b/web/cobbler_web/templatetags/site.py
@@ -371,7 +371,7 @@ ifinlist = register.tag(smart_if)
 @register.filter(name='sort')
 def listsort(value):
         if isinstance(value, dict):
-            new_dict = SortedDict()
+            new_dict = OrderedDict()
             key_list = value.keys()
             key_list.sort()
             for key in key_list:


### PR DESCRIPTION
Finish port of #1686 to 2.8.  OrderedDict is the new standard, SortedDict is dead.