### PR TITLE
seperate profile template logic for grub and pxelinux

### DIFF
--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -681,21 +681,22 @@ class PXEGen:
                         template = os.path.join(self.settings.pxe_template_dir,"pxelocal.template")
         else:
             # not a system record, so this is a profile record or an image
-            if arch.startswith("s390"):
-                template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_s390x.template")
-            if arch.startswith("arm"):
-                template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_arm.template")
-            if arch == "ppc64le":
-                template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_ppc64le.template")
-            elif format == "grub":
+            if format == "grub":
                 template = os.path.join(self.settings.pxe_template_dir,"grubprofile.template")
-            elif distro and distro.os_version.startswith("esxi"):
-                # ESXi uses a very different pxe method, see comment above in the system section
-                template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_esxi.template")
-            elif 'nexenta' == format:
+            elif format == 'nexenta':
                 template = os.path.join(self.settings.pxe_template_dir, 'nexenta_profile.template')
             else:
-                template = os.path.join(self.settings.pxe_template_dir,"pxeprofile.template")
+                if arch.startswith("s390"):
+                    template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_s390x.template")
+                if arch.startswith("arm"):
+                    template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_arm.template")
+                if arch == "ppc64le":
+                    template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_ppc64le.template")
+                elif distro and distro.os_version.startswith("esxi"):
+                    # ESXi uses a very different pxe method, see comment above in the system section
+                    template = os.path.join(self.settings.pxe_template_dir,"pxeprofile_esxi.template")
+                else:
+                    template = os.path.join(self.settings.pxe_template_dir,"pxeprofile.template")
 
 
         if kernel_path is not None:


### PR DESCRIPTION
With the current code base the `./grub/efidefault` file would get entries that were generated with the pxeprofile_{arm,s390x,ppc64le} resulting in an invalid grub configuration file. This change ensures only the `grubprofile.template` is used when generating entries with the `grub` or `nexenta` format. This is similar logic that is used above for generating pxe files for systems.
