### PR TITLE
Cobbler wsgi django api

### DIFF
--- a/web/cobbler.wsgi
+++ b/web/cobbler.wsgi
@@ -24,8 +24,5 @@ def application(environ, start_response):
         # Now all modules are available even under a virtualenv
 
     import django.core.handlers.wsgi
-    import django
-    if hasattr(django, 'setup'):
-        django.setup()
     _application = django.core.handlers.wsgi.WSGIHandler()
     return _application(environ, start_response)

--- a/web/cobbler.wsgi
+++ b/web/cobbler.wsgi
@@ -23,6 +23,6 @@ def application(environ, start_response):
         site.addsitedir(distutils.sysconfig.get_python_lib(prefix=environ['VIRTUALENV']))
         # Now all modules are available even under a virtualenv
 
-    import django.core.handlers.wsgi
-    _application = django.core.handlers.wsgi.WSGIHandler()
+    from django.core.wsgi import get_wsgi_application
+    _application = get_wsgi_application()
     return _application(environ, start_response)


### PR DESCRIPTION
According to the Django documentation the API break was between 1.3 and 1.4

The correct fix for wsgi scripts such as cobbler.wsgi was to use this over django.setup() that is reserved for standalone applications.

This bump the requirements for django >= 1.4, but others part might be tested against a newer django anyway. So I also would like this to be backported to cobbler26 branch.

This was tested on django 1.8 on CentOS 7
