### PR TITLE
some SuSE autoyast improvements

### DIFF
--- a/kickstarts/sample_autoyast.xml
+++ b/kickstarts/sample_autoyast.xml
@@ -1,17 +1,4 @@
 <?xml version="1.0"?>
-<!--
-
- Copyright (c) 2011 Novell
- Uwe Gansert ug@suse.de
-
- This software is licensed to you under the GNU General Public License,
- version 2 (GPLv2). There is NO WARRANTY for this software, express or
- implied, including the implied warranties of MERCHANTABILITY or FITNESS
- FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
- along with this software; if not, see
- http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
-
--->
 <!DOCTYPE profile>
 <profile xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
   <deploy_image>
@@ -24,6 +11,7 @@
       <final_reboot config:type="boolean">true</final_reboot>	
     </mode>
   </general>
+  $SNIPPET('addons.xml')
   $SNIPPET('hosts.xml')
   $SNIPPET('kdump.xml')
   <keyboard>
@@ -61,6 +49,13 @@
   <scripts>
     ## we have to include the pre-scripts tag to get kickstart_start included
     <pre-scripts config:type="list">
+      ##
+      ## function 'generate_autoyast' must be disabled/removed first
+      ## from kickgen.py (line 295 to 297) to make this working properly
+      ## otherwise kickstart_start commands would be executed twice
+      ##
+      #set global $wrappedscript = 'kickstart_start'
+      ## $SNIPPET('suse_scriptwrapper.xml')
 	## SuSE has an annoying habit on ppc64 of changing the system
 	## boot order after installation. This makes it non-trivial to
 	## automatically re-install future OS.
@@ -68,7 +63,7 @@
 	$SNIPPET('suse_scriptwrapper.xml')
     </pre-scripts>
     <post-scripts config:type="list">
-
+	##
 	## This plugin wrapper provides the flexibility to call pure shell
 	## snippets which can be used directly on kickstart and with with
 	## wrapper on SuSE.
@@ -79,12 +74,22 @@
 	##
 	#set global $wrappedscript = 'name_of_pure_shell_snippet'
 	## $SNIPPET('suse_scriptwrapper.xml')
+
 	## SuSE has an annoying habit on ppc64 of changing the system
 	## boot order after installation. This makes it non-trivial to
 	## automatically re-install future OS.
 	#set global $wrappedscript = 'restore_boot_device'
 	$SNIPPET('suse_scriptwrapper.xml')
-
     </post-scripts>
+    ## we have to include the init-scripts tag to get kickstart_done included
+    <init-scripts config:type="list">
+      ##
+      ## function 'generate_autoyast' must be disabled/removed first
+      ## from kickgen.py (line 295 to 297) to make this working properly
+      ## otherwise kickstart_done commands would be executed twice
+      ##
+      #set global $wrappedscript = 'kickstart_done'
+      ## $SNIPPET('suse_scriptwrapper.xml')
+    </init-scripts>
   </scripts>
 </profile>

--- a/snippets/SuSE/addons.xml
+++ b/snippets/SuSE/addons.xml
@@ -1,0 +1,33 @@
+##
+## This snippet enables you to install additional and customized packages
+## by adding further software repositories.
+##
+<add-on>
+    <add_on_products config:type="list">
+##
+#for rkey in range(0 , len($repos))
+  #set rdata         = $repo_data[$rkey]
+  #set $repo_name    = $rdata.get("name", "")
+  #set $repo_arch    = $rdata.get("arch", "")
+  #set $repo_breed   = $rdata.get("breed", "")
+  #set $repo_mirror  = $rdata.get("mirror", "")
+  #set $repo_comment = $rdata.get("comment", "")
+  #if $repo_comment == ""
+    #set $repo_comment = $repo_name
+  #end if
+  #set $repo_proxy   = $rdata.get("proxy", "")
+  #set $repo_prio    = $rdata.get("priority", "")
+##
+      <listentry>
+        <media_url>$repo_mirror</media_url>
+        <product>$repo_comment</product>
+        <product_dir>/</product_dir>
+        <ask_on_error config:type="boolean">false</ask_on_error>
+        <!-- available since openSUSE 11.0/SLES 11 -->
+        <name>$repo_name</name>
+      </listentry>
+##
+#end for
+##
+    </add_on_products>
+  </add-on>

--- a/snippets/SuSE/networking.xml
+++ b/snippets/SuSE/networking.xml
@@ -1,3 +1,4 @@
+#set $osversion = $getVar("os_version","")
 #set $hostname = $getVar("hostname","")
 #if $hostname == ""
 #set $hostname = $getVar("system_name","cobbler")
@@ -38,59 +39,107 @@
     </dns>
     <interfaces config:type="list">
     #if $getVar("system_name","") != ""
+    #import re
+    #set $vlanpattern = $re.compile("[a-zA-Z0-9]+[\.][0-9]+")
     #set $ikeys = $interfaces.keys()
     #for $iface in $ikeys
-      #set $idata         = $interfaces[$iface]
-      #set $mac           = $idata["mac_address"]
-      #set $ip            = $idata["ip_address"]
-      #set $netmask       = $idata["netmask"]
-      #set $iface_type    = $idata["interface_type"]
-      #set $bonding_opts  = $idata["bonding_opts"]
-      #if $iface_type.lower() == "bond"
+      #set $idata                = $interfaces[$iface]
+      #set $mac                  = $idata.get("mac_address", "").lower()
+      #set $static               = $idata.get("static", "")
+      #set $ip                   = $idata.get("ip_address", "")
+      #set $netmask              = $idata.get("netmask", "")
+      #set $static_routes        = $idata.get("static_routes", "")
+      #set $iface_type           = $idata.get("interface_type", "").lower()
+      #set $iface_master         = $idata.get("interface_master", "")
+      #set $bonding_opts         = $idata.get("bonding_opts", "").lower()
+      #set $ipv6_address         = $idata.get("ipv6_address", "")
+      #set $ipv6_secondaries     = $idata.get("ipv6_secondaries", "")
+      #set $ipv6_mtu             = $idata.get("ipv6_mtu", "")
+      #set $ipv6_default_gateway = $idata.get("ipv6_default_gateway", "")
+      #set $ipv6_static_routes   = $idata.get("ipv6_static_routes", "")
+      ## start of interface section
       <interface>
+      #if $iface_type in ("bond", "master")
         <bonding_master>yes</bonding_master>
-        <bonding_module_opts>$bonding_opts.lower()</bonding_module_opts>
+        <bonding_module_opts>$bonding_opts</bonding_module_opts>
         #set $loop_ikeys = $interfaces.keys()
         #set $loop_counter = 0
         #for $loop_iface in $loop_ikeys
           #set $loop_idata          = $interfaces[$loop_iface]
-          #set $loop_interface_type = $loop_idata["interface_type"]
-          #if $loop_interface_type.lower == "bond_slave"
+          #set $loop_interface_type = $loop_idata.get("interface_type", "").lower()
+          #if $loop_interface_type in ("slave","bond_slave")
              #if $loop_idata["interface_master"] != ""
                 #if $loop_idata["interface_master"].lower() == $iface.lower()
-                   <bonding_slave$loop_counter>$loop_iface</bonding_slave$loop_counter>
+        <bonding_slave$loop_counter>$loop_iface</bonding_slave$loop_counter>
                    #set $loop_counter += 1
                 #end if
              #end if
           #end if
         #end for
+        #if $static
         <bootproto>static</bootproto>
+        #else
+        <bootproto>dhcp</bootproto>
+        #end if
         <device>$iface</device>
         <ipaddr>$ip</ipaddr>
         <netmask>$netmask</netmask>
         <startmode>auto</startmode>
         <usercontrol>no</usercontrol>
-      </interface>
-      #end if
-      #if $iface_type.lower() in ["bond_slave","bridge_slave"]
-      <interface>
+      #elif $iface_type in ("slave","bond_slave","bridge_slave")
         <bootproto>none</bootproto>
         <device>$iface</device>
+        #if $osversion == "sles12" or re.match('^sles12sp[1234]$', $osversion)
+        <startmode>hotplug</startmode>
+        #else
         <startmode>off</startmode>
+        #end if
         <usercontrol>no</usercontrol>
-      </interface>
-      #end if
-      #if $iface_type.lower() in ["","na"]
-      <interface>
+      #elif $iface_type in ("","na")
+        #if $static
         <bootproto>static</bootproto>
+        #else
+        <bootproto>dhcp</bootproto>
+        #end if
         <device>$iface</device>
-        <lladdr>$mac.lower()</lladdr>
+        <lladdr>$mac</lladdr>
         <ipaddr>$ip</ipaddr>
         <netmask>$netmask</netmask>
         <startmode>auto</startmode>
         <usercontrol>no</usercontrol>
-      </interface>
       #end if
+      ## ===================================================================
+      ## VLAN configuration
+      ## ===================================================================
+      #if $vlanpattern.match($iface)
+        #set [$etherdevice, $vlanid] = $iface.split(".")
+        <etherdevice>$etherdevice</etherdevice>
+        <vlan_id>$vlanid</vlan_id>
+      #end if
+      ## ===================================================================
+      ## IPv6 support
+      ## ===================================================================
+      #if $ipv6_address != ""
+        <aliases>
+          <alias0>
+            <IPADDR>$ipv6_address</IPADDR>
+            <LABEL>a0</LABEL>
+            <PREFIXLEN>64</PREFIXLEN>
+          </alias0>
+        #if $ipv6_secondaries != ""
+          #set $s = 1
+          #for $alias in $ipv6_secondaries
+          <alias${s}>
+            <IPADDR>$alias</IPADDR>
+            <LABEL>a${s}</LABEL>
+            <PREFIXLEN>64</PREFIXLEN>
+          </alias${s}>
+            #set $s += 1
+          #end for
+        #end if
+        </aliases>
+      #end if
+      </interface>
     #end for
     #end if
     </interfaces>
@@ -117,7 +166,6 @@
     <routing>
       <ip_forward config:type="boolean">false</ip_forward>
       #if $getVar("system_name","") != ""
-      ## TODO: add in static routes here
       <routes config:type="list">
         <route>
           <destination>default</destination>
@@ -125,6 +173,55 @@
           <device>-</device>
           <gateway>$gateway</gateway>
         </route>
+        ## ===================================================================
+        ## IPv4 static route setup
+        ## ===================================================================
+        #for $iface in $ikeys
+          #set $idata         = $interfaces[$iface]
+          #set $static_routes = $idata.get("static_routes", "")
+          #for $route in $static_routes
+            #set routepattern = $re.compile("[0-9/.]+:[0-9.]+")
+            #if $routepattern.match($route)
+              #set $routebits = $route.split(":")
+              #set [$network, $router] = $route.split(":")
+        <route>
+          <destination>$network</destination>
+          <netmask>-</netmask>
+          <device>$iface</device>
+          <gateway>$router</gateway>
+        </route>
+            #end if
+          #end for
+        #end for
+        ## ===================================================================
+        ## IPv6 routing setup
+        ## ===================================================================
+        #for $iface in $ikeys
+          #set $idata                = $interfaces[$iface]
+          #set $ipv6_static_routes   = $idata.get("ipv6_static_routes", "")
+          #set $ipv6_default_gateway = $idata.get("ipv6_default_gateway", "")
+          #if $ipv6_default_gateway != ""
+        <route>
+          <destination>default</destination>
+          <netmask>-</netmask>
+          <device>$iface</device>
+          <gateway>$ipv6_default_gateway</gateway>
+        </route>
+          #end if
+          #for $route in $ipv6_static_routes
+            #set routepattern = $re.compile("[0-9a-fA-F:/]+,[0-9a-fA-F:]+")
+            #if $routepattern.match($route)
+              #set $routebits = $route.split(",")
+              #set [$network, $router] = $route.split(",")
+        <route>
+          <destination>$network</destination>
+          <netmask>-</netmask>
+          <device>$iface</device>
+          <gateway>$router</gateway>
+        </route>
+            #end if
+          #end for
+        #end for
       </routes>
       #end if
     </routing>

--- a/snippets/SuSE/suse_scriptwrapper.xml
+++ b/snippets/SuSE/suse_scriptwrapper.xml
@@ -1,12 +1,12 @@
-      <script>
+<script>
 ##        <debug config:type="boolean">true</debug>
 ##        <feedback config:type="boolean">false</feedback>
 ##        <location></location>
-##        <network_needed config:type="boolean">true</network_needed>
+        <network_needed config:type="boolean">true</network_needed>
         <interpreter>shell</interpreter>
 #set $filename = $wrappedscript.replace('/', '_')
         <filename>$filename</filename>
         <source><![CDATA[
 $SNIPPET($wrappedscript)
-]]></source>
+        ]]></source>
       </script>

--- a/snippets/kickstart_done
+++ b/snippets/kickstart_done
@@ -14,6 +14,8 @@
     #if $pxe_just_once in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
+        #else if $breed == 'suse'
+            #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'vmware'
@@ -22,13 +24,15 @@
             #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
         #else
             ## default to wget
-            #set nopxe = "wget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null;" % (srv, system_name)
+            #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
         #end if
     #end if
     ## SAVE KICKSTART
     #if $kickstart != ''
         #if $breed == 'redhat'
             #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.ks" % (srv, "system", system_name)
+        #else if $breed == 'suse'
+            #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.xml" % (srv, "system", system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.ks" % (srv, "system", system_name)
         #else if $breed == 'vmware'
@@ -40,6 +44,8 @@
     ## RUN POST TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
+            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
+        #else if $breed == 'suse'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
@@ -54,6 +60,8 @@
     #if $kickstart != ''
         #if $breed == 'redhat'
             #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.ks" % (srv, "profile", profile_name)
+        #else if $breed == 'suse'
+            #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.xml" % (srv, "profile", profile_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set saveks = "\ncurl \"http://%s/cblr/svc/op/ks/%s/%s\" -o /root/cobbler.ks" % (srv, "profile", profile_name)
         #else if $breed == 'vmware'
@@ -65,6 +73,8 @@
     ## RUN POST TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
+            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
+        #else if $breed == 'suse'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)

--- a/snippets/kickstart_start
+++ b/snippets/kickstart_start
@@ -9,18 +9,22 @@
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "system", system_name)
+        #else if $breed == 'suse'
+            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "system", system_name)
         #else if $breed == 'vmware'
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #else if $breed == 'debian' or $breed == 'ubuntu'
-            #set runpre = "wget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
+            #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #else if $breed == 'vmware'
-            #set runpre = "wget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
+            #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #end if
     #end if
 #else if $profile_name != ''
     ## RUN PRE TRIGGER
     #if $run_install_triggers in [ "1", "true", "yes", "y" ]
         #if $breed == 'redhat'
+            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
+        #else if $breed == 'suse'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
         #else if $breed == 'vmware'
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)

--- a/snippets/post_install_network_config
+++ b/snippets/post_install_network_config
@@ -77,9 +77,6 @@ mv /etc/sysconfig/network.cobbler /etc/sysconfig/network
 # Also set the hostname now, some applications require it
 # (e.g.: if we're connecting to Puppet before a reboot).
 /bin/hostname $hostname
-        #if $osversion == "rhel7"
-echo $hostname > /etc/hostname
-        #end if
     #end if
     #if $enableipv6 == True
 grep -v NETWORKING_IPV6 /etc/sysconfig/network > /etc/sysconfig/network.cobbler

--- a/snippets/post_install_network_config
+++ b/snippets/post_install_network_config
@@ -77,6 +77,9 @@ mv /etc/sysconfig/network.cobbler /etc/sysconfig/network
 # Also set the hostname now, some applications require it
 # (e.g.: if we're connecting to Puppet before a reboot).
 /bin/hostname $hostname
+        #if $osversion == "rhel7"
+echo $hostname > /etc/hostname
+        #end if
     #end if
     #if $enableipv6 == True
 grep -v NETWORKING_IPV6 /etc/sysconfig/network > /etc/sysconfig/network.cobbler


### PR DESCRIPTION
I would like to contribute to your great project by adding some SuSE autoyast code for network configuration and repository addon.

- repo addon (addon.xml) is working in the same way as for RHEL
- improved networking (adding VLAN support, static routing IPv4 and IPv6)
- some code cleanup

**To be discussed:**
- the way how kickstart_start and kickstart_done should work

From my point of view it should be done in the same way as for RHEL by including kickstart_* to autoyast template. While doing that I realized that the curl/wget commands are executed always twice. I found some code (function 'generate_autoyast') in kickgen.py which is also doing it. I think this should be removed there.