### PR TITLE
include bind_master in metadata passed to secondary.template

### DIFF
--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -347,6 +347,7 @@ zone "%(arpa)s." {
 };
 """ % {'arpa': arpa, 'zone': zone, 'master': self.settings.bind_master}
             metadata['zone_include'] = metadata['zone_include'] + txt
+            metadata['bind_master'] = self.settings.bind_master
 
         try:
             f2 = open(template_file, "r")


### PR DESCRIPTION
The commit in #1720 corrected a hardcoded master IP address for the secondary.template, however $bind_master is not passed to the template engine via the metadata and rendering fails with the following cobbler.log entries:

`{'code': u'VFFSL(SL,"bind_master",True)',
  'exc_val': NotFound(u"cannot find 'bind_master'",),
  'lineCol': (23, 9),
  'rawCode': u'$bind_master',
  'time': 'Tue Jan 24 12:27:24 2017'},`

This PR adds $bind_master to the metadata passed to the template correcting this.

As a side note, it looks like the original code from https://github.com/cobbler/cobbler/commit/87907cd5829fae2e7d8510fe3b34fef0bf3b3917 correctly adds bind_master to the zone_include metadata, but that's not what gets used for the secondary.template file.