### PR TITLE
Allow autodetection from machines with multiple NICs where the interf…

### DIFF
--- a/bin/services.py
+++ b/bin/services.py
@@ -63,7 +63,15 @@ def application(environ, start_response):
     # This MAC header is set by anaconda during a kickstart booted with the
     # kssendmac kernel option. The field will appear here as something
     # like: eth0 XX:XX:XX:XX:XX:XX
-    form["REMOTE_MAC"] = environ.get("HTTP_X_RHN_PROVISIONING_MAC_0", None)
+    mac_counter = 0
+    remote_macs = []
+    mac_header = "HTTP_X_RHN_PROVISIONING_MAC_%d" % mac_counter
+    while environ.get(mac_header, None):
+        remote_macs.append(environ[mac_header])
+        mac_counter = mac_counter + 1
+        mac_header = "HTTP_X_RHN_PROVISIONING_MAC_%d" % mac_counter
+    
+    form["REMOTE_MACS"] = remote_macs
 
     # REMOTE_ADDR isn't a required wsgi attribute so it may be naive to assume
     # it's always present in this context.

--- a/bin/services.py
+++ b/bin/services.py
@@ -70,7 +70,7 @@ def application(environ, start_response):
         remote_macs.append(environ[mac_header])
         mac_counter = mac_counter + 1
         mac_header = "HTTP_X_RHN_PROVISIONING_MAC_%d" % mac_counter
-    
+
     form["REMOTE_MACS"] = remote_macs
 
     # REMOTE_ADDR isn't a required wsgi attribute so it may be naive to assume

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -197,12 +197,7 @@ class CobblerSvc(object):
         # if a system can be found matching the MAC address.  This
         # is more specific than an IP match.
 
-        macinput = rest["REMOTE_MAC"]
-        if macinput is not None:
-            # FIXME: will not key off other NICs, problem?
-            mac = macinput.split()[1].strip()
-        else:
-            mac = "None"
+        macinput = [mac.split(' ').lower() for mac in rest["REMOTE_MACS"]]
 
         ip = rest["REMOTE_ADDR"]
 
@@ -210,7 +205,7 @@ class CobblerSvc(object):
 
         for x in systems:
             for y in x["interfaces"]:
-                if x["interfaces"][y]["mac_address"].lower() == mac.lower():
+                if x["interfaces"][y]["mac_address"].lower() in macinput:
                     candidates.append(x)
 
         if len(candidates) == 0:


### PR DESCRIPTION
…ace recorded is not eth0.

This really is only applicable for people who use external PXE boot menu generation. The general idea is "loop through all the X-RHN-Provisioning-MAC-<N> headers, collect the values" then "compare all configured system MACs to the set of MACs passed from the machine".