### PR TITLE
Update installation-guide URL for 16.04

### DIFF
--- a/autoinstall_templates/sample.seed
+++ b/autoinstall_templates/sample.seed
@@ -1,5 +1,5 @@
 # Mostly based on the Ubuntu installation guide
-# https://help.ubuntu.com/12.04/installation-guide/
+# https://help.ubuntu.com/16.04/installation-guide/
 
 # Preseeding only locale sets language, country and locale.
 d-i debian-installer/locale string en_US


### PR DESCRIPTION
Trivial update URL as the last is 404
(also verify that the travis failure isn't caused by my previous PR).