### PR TITLE
Fixed documentation badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/cobbler/cobbler.svg)](https://travis-ci.org/cobbler/cobbler)
-[![Documentation Status](https://readthedocs.org/projects/cobbler/badge/?version=latest)](https://readthedocs.org/projects/cobbler/?badge=latest)
+[![Documentation Status](https://readthedocs.org/projects/cobbler/badge/?version=latest)](https://cobbler.readthedocs.io/en/latest/)
 [![Code Health](https://landscape.io/github/cobbler/cobbler/master/landscape.svg?style=flat)](https://landscape.io/github/cobbler/cobbler/master)
 
 Cobbler


### PR DESCRIPTION
Made it point at the docs and not an outdated endpoint