### PR TITLE
When adding records and there are 1000+ records and uniqueness checks…

### DIFF
--- a/cobbler/collection.py
+++ b/cobbler/collection.py
@@ -25,6 +25,7 @@ import os
 from threading import Lock
 
 from cobbler import action_litesync
+import item as item_base
 from cobbler import item_system
 from cobbler import item_profile
 from cobbler import item_distro
@@ -293,6 +294,7 @@ class Collection:
         during deserialization, in which case extra semantics around the add don't really apply.
         So, in that case, don't run any triggers and don't deal with any actual files.
         """
+        item_base.Item.remove_from_cache(ref)
         if ref is None:
             raise CX("Unable to add a None object")
         if ref.name is None:

--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -20,10 +20,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import glob
 import os.path
 import shutil
-import tftpgen
 
 import cobbler.clogger as clogger
 import cobbler.templar as templar
+import cobbler.tftpgen as tftpgen
 import cobbler.utils as utils
 
 from cobbler.utils import _


### PR DESCRIPTION
When adding records and there are 1000+ records and uniqueness checks  are turned on, it can take many seconds (5-60+) to add records.

This is fixed by doing two things:

1. Adding a cache to keep converted records in memory to make checking them faster.  This helps with other use cases like writing out the records also.

2. fnmatch is actually quite slow and not needed when it's a simple string match.  So do the simple string match when no special characters are used (which is the case for the uniqueness checks).

These two changes cause an add to be done with check to be about 33 times faster when there are 1000 records and 58 times faster when there are 5000 records.  The improvements will get greater the larger the number of records.  This will be a huge improvement for our environment since we build hundreds of server at a time with thousands of records already existing.  This delay is our biggest bottleneck in server building.

I ran make qa, but could not determine how to run the unit tests.  The directions seem to be out of date.  I will happily run them and make any adjustments from failures or other suggestions you have.