### PR TITLE
esxi65 signature regex update

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -930,7 +930,7 @@
    "esxi65": {
     "signatures":["tboot.b00"],
     "version_file":"vmware-esx-base-osl\\.txt",
-    "version_file_regex":"^ESXi v6\\.5\\.0.*$",
+    "version_file_regex":"^(VMware )?ESXi (v)?6\\.5.*$",
     "kernel_arch":"tools\\.t00",
     "kernel_arch_regex":"^.*(x86_64).*$",
     "supported_arches":["x86_64"],


### PR DESCRIPTION
Hello!

When using cobbler with ESXi 6.5 - the signature regex does not seem to align with the various ISO's available for download. I've checked this against vmware/dell/hp versions of 6.5 and 6.5 U1, which use the following strings:

- VMware ESXi 6.5U1 GA
- VMware ESXi 6.5.0c GA

I modified this regex with some optional values to maintain compatibility with the existing regex, as well as support the strings referenced above.

Thanks!