### PR TITLE
Fix python setup.py bdist_rpm

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -692,6 +692,7 @@ if __name__ == "__main__":
             ("%scobbler/distro_mirror/config" % webroot, []),
             ("%scobbler/links" % webroot, []),
             ("%scobbler/misc" % webroot, []),
+            ("%scobbler/svc" % webroot, []),
             ("%scobbler/pub" % webroot, []),
             ("%scobbler/rendered" % webroot, []),
             ("%scobbler/images" % webroot, []),


### PR DESCRIPTION
This is an easy fix for python setup.py bdist_rpm

At this step the resulting rpm doesn't works for me for cobbler 2.9.0 on master...
I have :
ProtocolError: <ProtocolError for 127.0.0.1:80/cobbler_api: 503 Service Unavailable>