### PR TITLE
Make debuild Work on Ubuntu 14.04 With 2.8.2 Tag 

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,50 @@
-cobbler (2.6.0-1.3) unstable; urgency=low
+cobbler (2.8.2-1) unstable; urgency=low
 
-  * Package "cobbler-nsupdate" for nsupdate module
+  * Maintenance release in the Cobbler 2.8 series
 
- --  Adrian Brzezinski <adrbxx@gmail.com>  Wed, 14 May 2014 08:23:38 +0200
+ --  Jeremy Brown <jwbrown77@yahoo.com>  Wed, 21 Sep 2017 09:30:00 -0700
+
+cobbler (2.6.7-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Wed, 31 Dec 2014 00:19:50 +0200
+
+cobbler (2.6.6-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Sun, 19 Oct 2014 00:19:50 +0200
+
+cobbler (2.6.5-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Fri, 15 Aug 2014 00:19:50 +0200
+
+cobbler (2.6.4-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Fri, 08 Aug 2014 00:19:50 +0200
+
+cobbler (2.6.3-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Fri, 18 Jul 2014 00:19:50 +0200
+
+cobbler (2.6.2-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Thu, 15 Jul 2014 00:19:50 +0200
+
+cobbler (2.6.1-1) unstable; urgency=low
+
+  * Maintenance release in the Cobbler 2.6 series
+
+ --  Jorgen Maas <jorgen.maas@gmail.com>  Thu, 22 May 2014 00:19:50 +0200
 
 cobbler (2.6.0-1.2) unstable; urgency=low
 
@@ -21,4 +63,5 @@ cobbler (2.6.0-1) unstable; urgency=low
   * Initial release. Orginal package splitted into two: cobbler and koan.
 
  -- Adrian Brzezinski <adrbxx@gmail.com>  Fri, 18 Apr 2014 18:24:22 +0200
+
 

--- a/debian/cobbler.docs
+++ b/debian/cobbler.docs
@@ -1,1 +1,1 @@
-README
+README.md

--- a/debian/cobbler.install
+++ b/debian/cobbler.install
@@ -8,7 +8,7 @@ usr/share/cobbler/*
 var/lib/cobbler/*
 usr/share/man/man1/cobbler.1.gz
 etc/cobbler/*
-etc/apache2/conf.d/*
+etc/apache2/conf-available/*
 etc/init.d/cobblerd
 srv/www/cobbler/*
 srv/www/cobbler_webui_content/*


### PR DESCRIPTION
@jmaas 

Since you had mentioned in #1825 that you were struggling to get contributions on the Debian/Ubuntu build, I figured I'd send you the minor changes needed to make debuild work.

Here is what I did to make the package:

- Clone cobbler repo and checkout tag v2.8.2
- In the same directory where the parent cobbler repo is cloned, download https://github.com/cobbler/cobbler/archive/v2.8.2.tar.gz and rename it to ```cobbler_2.8.2.orig.tar.gz```
- Make the edits in this pull request (note that I'm actually bringing the master version of the changelog more in line with the newer version that was in the v2.8.2 tag)
- In the root of the cobbler checkout, run ```debuild -us -uc```
- Install resulting deb package: ```dpkg -i cobbler_2.8.2-1_all.deb```

Everything so far in my testing seems to work fine with this installed package, including cobbler_web.

Hope it helps.  Thanks for your work on this project.