### PR TITLE
Added check for git to gen_build_version in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,13 +64,18 @@ def glob(*args, **kwargs):
 
 def gen_build_version():
     builddate = time.asctime()
-    cmd = subprocess.Popen(["/usr/bin/git", "log", "--format=%h%n%ad", "-1"], stdout=subprocess.PIPE)
-    data = cmd.communicate()[0].strip()
-    if cmd.returncode == 0:
-        gitstamp, gitdate = data.split("\n")
+
+    gitloc = "/usr/bin/git"
+    gitdate = "?"
+    gitstamp = "?"
+    if not os.path.isfile(gitloc):
+        print("warning: " + gitloc + " not found")
     else:
-        gitdate = "?"
-        gitstamp = "?"
+        cmd = subprocess.Popen([gitloc, "log", "--format=%h%n%ad", "-1"],
+                               stdout=subprocess.PIPE)
+        data = cmd.communicate()[0].strip()
+        if cmd.returncode == 0:
+            gitstamp, gitdate = data.split("\n")
 
     fd = open(os.path.join(OUTPUT_DIR, "version"), "w+")
     config = ConfigParser()


### PR DESCRIPTION
When building cobbler on a machine without git installed, you would be greeted with the message "error: file not found", and the build would abort - which was a bit cryptic. This attempts to correct that issue. It should also now build successfully despite not having git installed.

EDIT: Perhaps I should instead print the "git not installed" warning message to stderr instead of stdout? Let me know what you think,