### PR TITLE
Building on Debian 9 and higher fails, here is why (don't just merge this)

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1003,9 +1003,10 @@ def tftpboot_location():
         return "/var/lib/tftpboot"
     elif make == "ubuntu" and os.path.exists("/srv/tftp"):
         return "/srv/tftp"
-    elif make == "debian" and int(str_version.split('.')[0]) < 6:
-        return "/var/lib/tftpboot"
-    elif make == "debian" and int(str_version.split('.')[0]) >= 6:
+    #elif make == "debian" and int(str_version.split('.')[0]) < 6:
+    #    return "/var/lib/tftpboot"
+    #elif make == "debian" and int(str_version.split('.')[0]) >= 6:
+    elif make == "debian":
         return "/srv/tftp"
     else:
         return "/tftpboot"
@@ -2018,8 +2019,8 @@ def dhcpconf_location(api):
         return "/etc/dhcpd.conf"
     elif dist == "suse":
         return "/etc/dhcpd.conf"
-    elif dist == "debian" and int(version[1].split('.')[0]) < 6:
-        return "/etc/dhcp3/dhcpd.conf"
+    #elif dist == "debian" and int(version[1].split('.')[0]) < 6:
+    #    return "/etc/dhcp3/dhcpd.conf"
     elif dist == "ubuntu" and version[1] < 11.10:
         return "/etc/dhcp3/dhcpd.conf"
     else:

--- a/setup.py
+++ b/setup.py
@@ -304,7 +304,7 @@ class build_man(Command):
                 # It is. Configure it
                 self.build_one_file(infile, outfile)
 
-    _COMMAND = 'pod2man --center="%s" --release="" %s | gzip -c > %s'
+    _COMMAND = 'pod2man --center="%s" --release="unreleased" %s | gzip -c > %s'
 
     def build_one_file(self, infile, outfile):
         man = os.path.splitext(os.path.splitext(os.path.basename(infile))[0])[0]


### PR DESCRIPTION
Trying out the 2.8.2 release on Debian testing failed to build, and after a quick fix failed to run.

The first problem is the call to pod2man which leaves the release string empty. For some reason that resulted in an empty manpage and a subsequent failure of dh_installman. I fixed that with a blunt fixed 'unreleased' string but a placeholder would be much nicer.

The second problem is with the OS detection algorithm. It assumes that the Debian version is numeric, but on my system it was 'testing' (I suppose it could also be 'stable' or even a codename such as 'stretch'). I simply pruned the offending code. The code tries to be clever about the location of pxeboot scripts for older Debian systems, but Debian 6 is now so old it may as well be dropped from support.

Anyway the pull request should not be taken literally. I originally made the changes to the 2.8.2 release but when I tried to apply them to master I found that there were too many differences to do an automatic patch so I did the work again manually.
