### PR TITLE
Django 1.10 v3

### DIFF
--- a/cobbler/web/manage.py
+++ b/cobbler/web/manage.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings  # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+import os
+import sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/cobbler/web/settings.py
+++ b/cobbler/web/settings.py
@@ -5,7 +5,6 @@
 ALLOWED_HOSTS = ['*']
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -40,10 +39,23 @@ SECRET_KEY = ''
 
 # code config
 
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            '/usr/share/cobbler/web/templates',
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
 MIDDLEWARE_CLASSES = (
     'django.middleware.common.CommonMiddleware',
@@ -54,21 +66,12 @@ MIDDLEWARE_CLASSES = (
 
 ROOT_URLCONF = 'cobbler.web.urls'
 
-TEMPLATE_DIRS = (
-    '/usr/share/cobbler/web/templates',
-)
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
     'cobbler.web',
-)
-
-from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
-
-TEMPLATE_CONTEXT_PROCESSORS += (
-    'django.core.context_processors.request',
 )
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.file'

--- a/cobbler/web/urls.py
+++ b/cobbler/web/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls import patterns
+from django.conf.urls import url
 
 import views
 
@@ -6,50 +6,49 @@ import views
 # from cobbler_web.contrib import admin
 # admin.autodiscover()
 
-urlpatterns = patterns(
-    '',
-    (r'^$', views.index),
+urlpatterns = [
+    url(r'^$', views.index),
 
-    (r'^setting/list$', views.setting_list),
-    (r'^setting/edit/(?P<setting_name>.+)$', views.setting_edit),
-    (r'^setting/save$', views.setting_save),
+    url(r'^setting/list$', views.setting_list),
+    url(r'^setting/edit/(?P<setting_name>.+)$', views.setting_edit),
+    url(r'^setting/save$', views.setting_save),
 
-    (r'^aifile/list(/(?P<page>\d+))?$', views.aifile_list),
-    (r'^aifile/edit$', views.aifile_edit, {'editmode': 'new'}),
-    (r'^aifile/edit/file:(?P<aifile_name>.+)$', views.aifile_edit, {'editmode': 'edit'}),
-    (r'^aifile/save$', views.aifile_save),
+    url(r'^aifile/list(/(?P<page>\d+))?$', views.aifile_list),
+    url(r'^aifile/edit$', views.aifile_edit, {'editmode': 'new'}),
+    url(r'^aifile/edit/file:(?P<aifile_name>.+)$', views.aifile_edit, {'editmode': 'edit'}),
+    url(r'^aifile/save$', views.aifile_save),
 
-    (r'^snippet/list(/(?P<page>\d+))?$', views.snippet_list),
-    (r'^snippet/edit$', views.snippet_edit, {'editmode': 'new'}),
-    (r'^snippet/edit/file:(?P<snippet_name>.+)$', views.snippet_edit, {'editmode': 'edit'}),
-    (r'^snippet/save$', views.snippet_save),
+    url(r'^snippet/list(/(?P<page>\d+))?$', views.snippet_list),
+    url(r'^snippet/edit$', views.snippet_edit, {'editmode': 'new'}),
+    url(r'^snippet/edit/file:(?P<snippet_name>.+)$', views.snippet_edit, {'editmode': 'edit'}),
+    url(r'^snippet/save$', views.snippet_save),
 
-    (r'^(?P<what>\w+)/list(/(?P<page>\d+))?', views.genlist),
-    (r'^(?P<what>\w+)/modifylist/(?P<pref>[!\w]+)/(?P<value>.+)$', views.modify_list),
-    (r'^(?P<what>\w+)/edit/(?P<obj_name>.+)$', views.generic_edit, {'editmode': 'edit'}),
-    (r'^(?P<what>\w+)/edit$', views.generic_edit, {'editmode': 'new'}),
+    url(r'^(?P<what>\w+)/list(/(?P<page>\d+))?', views.genlist),
+    url(r'^(?P<what>\w+)/modifylist/(?P<pref>[!\w]+)/(?P<value>.+)$', views.modify_list),
+    url(r'^(?P<what>\w+)/edit/(?P<obj_name>.+)$', views.generic_edit, {'editmode': 'edit'}),
+    url(r'^(?P<what>\w+)/edit$', views.generic_edit, {'editmode': 'new'}),
 
-    (r'^(?P<what>\w+)/rename/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_rename),
-    (r'^(?P<what>\w+)/copy/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_copy),
-    (r'^(?P<what>\w+)/delete/(?P<obj_name>.+)$', views.generic_delete),
+    url(r'^(?P<what>\w+)/rename/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_rename),
+    url(r'^(?P<what>\w+)/copy/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_copy),
+    url(r'^(?P<what>\w+)/delete/(?P<obj_name>.+)$', views.generic_delete),
 
-    (r'^(?P<what>\w+)/multi/(?P<multi_mode>.+)/(?P<multi_arg>.+)$', views.generic_domulti),
-    (r'^utils/random_mac$', views.random_mac),
-    (r'^utils/random_mac/virttype/(?P<virttype>.+)$', views.random_mac),
-    (r'^events$', views.events),
-    (r'^eventlog/(?P<event>.+)$', views.eventlog),
-    (r'^task_created$', views.task_created),
-    (r'^sync$', views.sync),
-    (r'^reposync$', views.reposync),
-    (r'^replicate$', views.replicate),
-    (r'^hardlink', views.hardlink),
-    (r'^(?P<what>\w+)/save$', views.generic_save),
-    (r'^import/prompt$', views.import_prompt),
-    (r'^import/run$', views.import_run),
-    (r'^buildiso$', views.buildiso),
-    (r'^check$', views.check),
+    url(r'^(?P<what>\w+)/multi/(?P<multi_mode>.+)/(?P<multi_arg>.+)$', views.generic_domulti),
+    url(r'^utils/random_mac$', views.random_mac),
+    url(r'^utils/random_mac/virttype/(?P<virttype>.+)$', views.random_mac),
+    url(r'^events$', views.events),
+    url(r'^eventlog/(?P<event>.+)$', views.eventlog),
+    url(r'^task_created$', views.task_created),
+    url(r'^sync$', views.sync),
+    url(r'^reposync$', views.reposync),
+    url(r'^replicate$', views.replicate),
+    url(r'^hardlink', views.hardlink),
+    url(r'^(?P<what>\w+)/save$', views.generic_save),
+    url(r'^import/prompt$', views.import_prompt),
+    url(r'^import/run$', views.import_run),
+    url(r'^buildiso$', views.buildiso),
+    url(r'^check$', views.check),
 
-    (r'^login$', views.login),
-    (r'^do_login$', views.do_login),
-    (r'^logout$', views.do_logout),
-)
+    url(r'^login$', views.login),
+    url(r'^do_login$', views.do_login),
+    url(r'^logout$', views.do_logout),
+]


### PR DESCRIPTION
Please review. With this changes, I don't have the csrf issue anymore.
This changes bump the requirement to django 1.8
(el7 users: you can get python-django >= 1.8 from fedora-infra repository from
https://kojipkgs.fedoraproject.org/repos-dist/epel7-infra/latest/x86_64/ )

I've attempted to merge the dvandok views.py patch as he made it right (I've reversed the arguments order, which lead to the csrf issue I've experienced previously). but it didn't passed pep8 review, so I've dropped it for now.
The settings.py TEMPLATE has been cleanup to the minimal and old options are removed.
I've also turn the urlpatterns into a list as it's the default in the django-admin startproject 1.10.
