### PR TITLE
Fixed typo in the repo_url when creating yum repo files.

### DIFF
--- a/cobbler/modules/manage_import_signatures.py
+++ b/cobbler/modules/manage_import_signatures.py
@@ -587,7 +587,7 @@ class ImportSignatureManager:
 
             fname = os.path.join(self.settings.webdir, "ks_mirror", "config", "%s" % (dotrepo))
 
-            repo_url = "http://@@http_server@@/cobbler/ks_mirror/config/%s-%s.repo" % (distro.name, counter)
+            repo_url = "http://@@http_server@@/cobbler/ks_mirror/config/%s" % (dotrepo)
             repo_url2 = "http://@@http_server@@/cobbler/ks_mirror/%s" % (urlseg)
 
             distro.source_repos.append([repo_url,repo_url2])


### PR DESCRIPTION
Fixed typo in the repo_url when creating yum repo files when importing rhel distros.

This fixes issue #1818.

This has been tested against import off RHEL6/7 and CentOS6/7.