### PR TITLE
Use django.shortcuts.render()

### DIFF
--- a/cobbler/web/views.py
+++ b/cobbler/web/views.py
@@ -1,8 +1,6 @@
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
-from django.template import RequestContext
-from django.template.loader import get_template
+from django.shortcuts import render
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 
@@ -37,11 +35,10 @@ def index(request):
     if not test_user_authenticated(request):
         return login(request, next="/cobbler_web", expired=True)
 
-    t = get_template('index.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'index.tmpl', {
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
-    }))
+    })
     return HttpResponse(html)
 
 # ========================================================================
@@ -53,11 +50,11 @@ def task_created(request):
     """
     if not test_user_authenticated(request):
         return login(request, next="/cobbler_web/task_created", expired=True)
-    t = get_template("task_created.tmpl")
-    html = t.render(RequestContext(request, {
+
+    html = render(request, "task_created.tmpl", {
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username
-    }))
+    })
     return HttpResponse(html)
 
 # ========================================================================
@@ -69,16 +66,17 @@ def error_page(request, message):
     """
     if not test_user_authenticated(request):
         return login(request, expired=True)
+
     # FIXME: test and make sure we use this rather than throwing lots of tracebacks for
     # field errors
-    t = get_template('error_page.tmpl')
     message = message.replace("<Fault 1: \"<class 'cobbler.cexceptions.CX'>:'", "Remote exception: ")
     message = message.replace("'\">", "")
-    html = t.render(RequestContext(request, {
+
+    html = render(request, 'error_page.tmpl', {
         'version': remote.extended_version(request.session['token'])['version'],
         'message': message,
         'username': username
-    }))
+    })
     return HttpResponse(html)
 
 # ==================================================================================
@@ -409,8 +407,7 @@ def genlist(request, what, page=None):
         columns = ["name"]
 
     # render the list
-    t = get_template('generic_list.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'generic_list.tmpl', {
         'what': what,
         'columns': __format_columns(columns, sort_field),
         'items': __format_items(pageditems["items"], columns),
@@ -421,7 +418,7 @@ def genlist(request, what, page=None):
         'limit': limit,
         'batchactions': batchactions,
         'profiles': profiles,
-    }))
+    })
     return HttpResponse(html)
 
 
@@ -652,11 +649,11 @@ def generic_domulti(request, what, multi_mode=None, multi_arg=None):
 def import_prompt(request):
     if not test_user_authenticated(request):
         return login(request, next="/cobbler_web/import/prompt", expired=True)
-    t = get_template('import.tmpl')
-    html = t.render(RequestContext(request, {
+
+    html = render(request, 'import.tmpl', {
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -668,13 +665,14 @@ def check(request):
     """
     if not test_user_authenticated(request):
         return login(request, next="/cobbler_web/check", expired=True)
+
     results = remote.check(request.session['token'])
-    t = get_template('check.tmpl')
-    html = t.render(RequestContext(request, {
+
+    html = render(request, 'check.tmpl', {
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
         'results': results
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -721,14 +719,13 @@ def aifile_list(request, page=None):
     for aifile in aifiles:
         aifile_list.append((aifile, 'editable'))
 
-    t = get_template('aifile_list.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'aifile_list.tmpl', {
         'what': 'aifile',
         'ai_files': aifile_list,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
         'item_count': len(aifile_list[0]),
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -752,8 +749,7 @@ def aifile_edit(request, aifile_name=None, editmode='edit'):
         deleteable = not remote.is_autoinstall_in_use(aifile_name, request.session['token'])
         aidata = remote.read_autoinstall_template(aifile_name, request.session['token'])
 
-    t = get_template('aifile_edit.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'aifile_edit.tmpl', {
         'aifile_name': aifile_name,
         'deleteable': deleteable,
         'aidata': aidata,
@@ -761,7 +757,7 @@ def aifile_edit(request, aifile_name=None, editmode='edit'):
         'editmode': editmode,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -808,13 +804,12 @@ def snippet_list(request, page=None):
     for snippet in snippets:
         snippet_list.append((snippet, 'editable'))
 
-    t = get_template('snippet_list.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'snippet_list.tmpl', {
         'what': 'snippet',
         'snippets': snippet_list,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -838,8 +833,7 @@ def snippet_edit(request, snippet_name=None, editmode='edit'):
         deleteable = True
         snippetdata = remote.read_autoinstall_snippet(snippet_name, request.session['token'])
 
-    t = get_template('snippet_edit.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'snippet_edit.tmpl', {
         'snippet_name': snippet_name,
         'deleteable': deleteable,
         'snippetdata': snippetdata,
@@ -847,7 +841,7 @@ def snippet_edit(request, snippet_name=None, editmode='edit'):
         'editmode': editmode,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -901,12 +895,11 @@ def setting_list(request):
     for k in skeys:
         results.append([k, settings[k]])
 
-    t = get_template('settings.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'settings.tmpl', {
         'settings': results,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
-    }))
+    })
     return HttpResponse(html)
 
 
@@ -932,8 +925,7 @@ def setting_edit(request, setting_name=None):
     sections_data = field_ui_info.SETTING_UI_FIELDS_MAPPING
     sections = _create_sections_metadata('setting', sections_data, fields)
 
-    t = get_template('generic_edit.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'generic_edit.tmpl', {
         'what': 'setting',
         'sections': sections,
         'subobject': False,
@@ -942,7 +934,7 @@ def setting_edit(request, setting_name=None):
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
         'name': setting_name,
-    }))
+    })
     return HttpResponse(html)
 
 
@@ -987,12 +979,11 @@ def events(request):
         return cmp(a[0], b[0])
     events2.sort(sorter)
 
-    t = get_template('events.tmpl')
-    html = t.render(RequestContext(request, {
+    html = render(request, 'events.tmpl', {
         'results': events2,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username
-    }))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -1014,8 +1005,7 @@ def eventlog(request, event=0):
     eventstate = data[2]
     eventlog = remote.get_event_log(event)
 
-    t = get_template('eventlog.tmpl')
-    vars = {
+    html = render(request, 'eventlog.tmpl', {
         'eventlog': eventlog,
         'eventname': eventname,
         'eventstate': eventstate,
@@ -1023,8 +1013,7 @@ def eventlog(request, event=0):
         'eventtime': eventtime,
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username
-    }
-    html = t.render(RequestContext(request, vars))
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -1221,10 +1210,10 @@ def generic_edit(request, what=None, obj_name=None, editmode="new"):
         sections_data = field_ui_info.SYSTEM_UI_FIELDS_MAPPING
     sections = _create_sections_metadata(what, sections_data, fields)
 
-    t = get_template('generic_edit.tmpl')
     inames = interfaces.keys()
     inames.sort()
-    html = t.render(RequestContext(request, {
+
+    html = render(request, 'generic_edit.tmpl', {
         'what': what,
         'sections': sections,
         'subobject': child,
@@ -1236,8 +1225,7 @@ def generic_edit(request, what=None, obj_name=None, editmode="new"):
         'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
         'name': obj_name
-    }))
-
+    })
     return HttpResponse(html)
 
 # ======================================================================
@@ -1411,7 +1399,7 @@ def login(request, next=None, message=None, expired=False):
 
     if expired and not message:
         message = "Sorry, either you need to login or your session expired."
-    return render_to_response('login.tmpl', RequestContext(request, {'next': next, 'message': message}))
+    return render(request, 'login.tmpl', {'next': next, 'message': message})
 
 
 def accept_remote_user(request, nextsite):


### PR DESCRIPTION
return get_template('file.tmpl').render(RequestContext(request, {})
is kinda cumbersome, and deprecated in django-2.0.

render_to_response() changed arguments/behaviour in django-1.10, and
is also deprecated in django-2.0.