### PR TITLE
Add optional serial configuration to grub and pxe files

### DIFF
--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -77,6 +77,8 @@ FIELDS = [
     ["virt_pxe_boot", 0, 0, "Virt PXE Boot", True, "Use PXE to build this VM?", 0, "bool"],
     ["virt_ram", "<<inherit>>", 0, "Virt RAM (MB)", True, "", 0, "int"],
     ["virt_type", "<<inherit>>", 0, "Virt Type", True, "Virtualization technology to use", validate.VIRT_TYPES, "str"],
+    ["serial_device", "", 0, "Serial Device #", True, "Serial Device Number", 0, "int"],
+    ["serial_baud_rate", "", 0, "Serial Baud Rate", True, "Serial Baud Rate", ["", "2400", "4800", "9600", "19200", "38400", "57600", "115200"], "int"],
 ]
 
 # network interface fields are in a separate list because a system may contain
@@ -733,5 +735,11 @@ class System(item.Item):
 
     def set_repos_enabled(self, repos_enabled):
         self.repos_enabled = utils.input_boolean(repos_enabled)
+
+    def set_serial_device(self, device_number):
+        return utils.set_serial_device(self, device_number)
+
+    def set_serial_baud_rate(self, baud_rate):
+        return utils.set_serial_baud_rate(self, baud_rate)
 
 # EOF

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1566,6 +1566,32 @@ def get_mtab(mtab="/etc/mtab", vfstype=None):
     return mtab_map
 
 
+def set_serial_device(self, device_number):
+    if device_number == "" or device_number is None:
+        device_number = None
+    else:
+        try:
+            device_number = int(str(device_number))
+        except:
+            raise CX(_("invalid value for serial device (%s)" % device_number))
+
+    self.serial_device = device_number
+    return True
+
+
+def set_serial_baud_rate(self, baud_rate):
+    if baud_rate == "" or baud_rate is None:
+        baud_rate = None
+    else:
+        try:
+            baud_rate = int(str(baud_rate))
+        except:
+            raise CX(_("invalid value for serial baud (%s)" % baud_rate))
+
+    self.serial_baud_rate = baud_rate
+    return True
+
+
 def __cache_mtab__(mtab="/etc/mtab"):
     f = open(mtab)
     mtab = [MntEntObj(line) for line in f.read().split('\n') if len(line) > 0]


### PR DESCRIPTION
Systems can now have an optional serial device number and/or serial baud
rate. If one of the two values are given, the other will be set to a
default value (unit: 0, baud rate: 115200). If so, a leading 'serial'
line gets added to grub/pxe files for the specific system.

If none of the values is set, nothing changes.