### PR TITLE
Manage genders file

### DIFF
--- a/cobbler/modules/manage_genders.py
+++ b/cobbler/modules/manage_genders.py
@@ -1,10 +1,10 @@
 import distutils.sysconfig
 import sys
 import os
-import templar
-from utils import _
-from cexceptions import CX
 import time
+import cobbler.templar
+from cobbler.utils import _
+from cobbler.cexceptions import CX
 
 plib = distutils.sysconfig.get_python_lib()
 mod_path = "%s/cobbler" % plib
@@ -24,7 +24,7 @@ def write_genders_file(config, profiles_genders, distros_genders, mgmtcls_gender
     /var/lib/cobbler/settings.
     """
 
-    templar_inst = templar.Templar(config)
+    templar_inst = cobbler.templar.Templar(config)
     try:
         f2 = open(template_file, "r")
     except:
@@ -46,7 +46,7 @@ def write_genders_file(config, profiles_genders, distros_genders, mgmtcls_gender
 def run(api, args, logger):
 
     # do not run if we are not enabled.
-    if(not api.settings.manage_genders):
+    if(not api.settings().manage_genders):
         return 0
 
     profiles_genders = dict()
@@ -99,5 +99,5 @@ def run(api, args, logger):
         logger.info("Please run: touch " + settings_file + " as root and try again.")
         return 1
 
-    write_genders_file(api._config, profiles_genders, distros_genders, mgmtcls_genders)
+    write_genders_file(api._collection_mgr, profiles_genders, distros_genders, mgmtcls_genders)
     return 0

--- a/cobbler/modules/manage_genders.py
+++ b/cobbler/modules/manage_genders.py
@@ -1,109 +1,103 @@
 import distutils.sysconfig
 import sys
 import os
-import cobbler.module_loader as module_loader
-import cobbler.utils as utils
 import templar
+from utils import _
 from cexceptions import CX
 import time
 
 plib = distutils.sysconfig.get_python_lib()
-mod_path="%s/cobbler" % plib
+mod_path = "%s/cobbler" % plib
 sys.path.insert(0, mod_path)
 template_file = "/etc/cobbler/genders.template"
 settings_file = "/etc/genders"
+
 
 def register():
     # we should run anytime something inside of cobbler changes.
     return "/var/lib/cobbler/triggers/change/*"
 
-def write_genders_file(config,profiles_genders, distros_genders, mgmtcls_genders):
+
+def write_genders_file(config, profiles_genders, distros_genders, mgmtcls_genders):
     """
     genders file is over-written when manage_genders is set in
     /var/lib/cobbler/settings.
     """
 
-    templar_inst       = templar.Templar(config)
-    blender_cache = {}
-
+    templar_inst = templar.Templar(config)
     try:
-        f2 = open(template_file,"r")
+        f2 = open(template_file, "r")
     except:
         raise CX(_("error reading template: %s") % template_file)
     template_data = ""
     template_data = f2.read()
     f2.close()
 
-
     metadata = {
-        "date"                  : time.asctime(time.gmtime()),
-        "profiles_genders"      : profiles_genders,
-        "distros_genders"       : distros_genders,
-        "mgmtcls_genders"       : mgmtcls_genders
-        
+        "date": time.asctime(time.gmtime()),
+        "profiles_genders": profiles_genders,
+        "distros_genders": distros_genders,
+        "mgmtcls_genders": mgmtcls_genders
     }
 
-
-
-    
     templar_inst.render(template_data, metadata, settings_file, None)
 
-def run(api,args,logger):
+
+def run(api, args, logger):
 
     # do not run if we are not enabled.
-    if( not api.settings.manage_genders ) :
+    if(not api.settings.manage_genders):
         return 0
 
-    profiles_genders=dict()
-    distros_genders=dict()
-    mgmtcls_genders=dict()
+    profiles_genders = dict()
+    distros_genders = dict()
+    mgmtcls_genders = dict()
 
     # let's populate our dicts
 
     # TODO: the lists that are created here are strictly comma separated.
-    # /etc/genders allows for host lists that are in the notation 
+    # /etc/genders allows for host lists that are in the notation
     # similar to: node00[01-07,08,09,70-71]
     # at some point, need to come up with code to generate these types of lists.
-    
+
     # profiles
     for prof in api.profiles():
         # create the key
         profiles_genders[prof.name] = ""
-        for sys in api.find_system(profile=prof.name, return_list=True):
-            profiles_genders[prof.name]+=sys.name + ","
+        for system in api.find_system(profile=prof.name, return_list=True):
+            profiles_genders[prof.name] += system.name + ","
         # remove a trailing comma
         profiles_genders[prof.name] = profiles_genders[prof.name][:-1]
         if(profiles_genders[prof.name] == ""):
-            profiles_genders.pop(prof.name, None);
-    
+            profiles_genders.pop(prof.name, None)
+
     # distros
     for dist in api.distros():
         # create the key
         distros_genders[dist.name] = ""
-        for sys in api.find_system(distro=dist.name, return_list=True):
-            distros_genders[dist.name]+=sys.name + ","
+        for system in api.find_system(distro=dist.name, return_list=True):
+            distros_genders[dist.name] += system.name + ","
         # remove a trailing comma
         distros_genders[dist.name] = distros_genders[dist.name][:-1]
         if(distros_genders[dist.name] == ""):
-            distros_genders.pop(dist.name, None);
+            distros_genders.pop(dist.name, None)
 
     # mgmtclasses
     for mgmtcls in api.mgmtclasses():
         # create the key
         mgmtcls_genders[mgmtcls.name] = ""
-        for sys in api.find_system(mgmt_classes=mgmtcls.name, return_list=True):
-            mgmtcls_genders[mgmtcls.name]+=sys.name + ","
+        for system in api.find_system(mgmt_classes=mgmtcls.name, return_list=True):
+            mgmtcls_genders[mgmtcls.name] += system.name + ","
         # remove a trailing comma
         mgmtcls_genders[mgmtcls.name] = mgmtcls_genders[mgmtcls.name][:-1]
         if(mgmtcls_genders[mgmtcls.name] == ""):
-            mgmtcls_genders.pop(mgmtcls.name, None);
-    # the file doesn't exist and for some reason the template engine 
+            mgmtcls_genders.pop(mgmtcls.name, None)
+    # the file doesn't exist and for some reason the template engine
     # won't create it, so spit out an error and tell the user what to do.
     if(not os.path.isfile(settings_file)):
         logger.info("Error: " + settings_file + " does not exist.")
-        logger.info("Please run: touch " + settings_file +  " as root and try again.")
+        logger.info("Please run: touch " + settings_file + " as root and try again.")
         return 1
-    
+
     write_genders_file(api._config, profiles_genders, distros_genders, mgmtcls_genders)
     return 0
-

--- a/cobbler/modules/manage_genders.py
+++ b/cobbler/modules/manage_genders.py
@@ -1,0 +1,109 @@
+import distutils.sysconfig
+import sys
+import os
+import cobbler.module_loader as module_loader
+import cobbler.utils as utils
+import templar
+from cexceptions import CX
+import time
+
+plib = distutils.sysconfig.get_python_lib()
+mod_path="%s/cobbler" % plib
+sys.path.insert(0, mod_path)
+template_file = "/etc/cobbler/genders.template"
+settings_file = "/etc/genders"
+
+def register():
+    # we should run anytime something inside of cobbler changes.
+    return "/var/lib/cobbler/triggers/change/*"
+
+def write_genders_file(config,profiles_genders, distros_genders, mgmtcls_genders):
+    """
+    genders file is over-written when manage_genders is set in
+    /var/lib/cobbler/settings.
+    """
+
+    templar_inst       = templar.Templar(config)
+    blender_cache = {}
+
+    try:
+        f2 = open(template_file,"r")
+    except:
+        raise CX(_("error reading template: %s") % template_file)
+    template_data = ""
+    template_data = f2.read()
+    f2.close()
+
+
+    metadata = {
+        "date"                  : time.asctime(time.gmtime()),
+        "profiles_genders"      : profiles_genders,
+        "distros_genders"       : distros_genders,
+        "mgmtcls_genders"       : mgmtcls_genders
+        
+    }
+
+
+
+    
+    templar_inst.render(template_data, metadata, settings_file, None)
+
+def run(api,args,logger):
+
+    # do not run if we are not enabled.
+    if( not api.settings.manage_genders ) :
+        return 0
+
+    profiles_genders=dict()
+    distros_genders=dict()
+    mgmtcls_genders=dict()
+
+    # let's populate our dicts
+
+    # TODO: the lists that are created here are strictly comma separated.
+    # /etc/genders allows for host lists that are in the notation 
+    # similar to: node00[01-07,08,09,70-71]
+    # at some point, need to come up with code to generate these types of lists.
+    
+    # profiles
+    for prof in api.profiles():
+        # create the key
+        profiles_genders[prof.name] = ""
+        for sys in api.find_system(profile=prof.name, return_list=True):
+            profiles_genders[prof.name]+=sys.name + ","
+        # remove a trailing comma
+        profiles_genders[prof.name] = profiles_genders[prof.name][:-1]
+        if(profiles_genders[prof.name] == ""):
+            profiles_genders.pop(prof.name, None);
+    
+    # distros
+    for dist in api.distros():
+        # create the key
+        distros_genders[dist.name] = ""
+        for sys in api.find_system(distro=dist.name, return_list=True):
+            distros_genders[dist.name]+=sys.name + ","
+        # remove a trailing comma
+        distros_genders[dist.name] = distros_genders[dist.name][:-1]
+        if(distros_genders[dist.name] == ""):
+            distros_genders.pop(dist.name, None);
+
+    # mgmtclasses
+    for mgmtcls in api.mgmtclasses():
+        # create the key
+        mgmtcls_genders[mgmtcls.name] = ""
+        for sys in api.find_system(mgmt_classes=mgmtcls.name, return_list=True):
+            mgmtcls_genders[mgmtcls.name]+=sys.name + ","
+        # remove a trailing comma
+        mgmtcls_genders[mgmtcls.name] = mgmtcls_genders[mgmtcls.name][:-1]
+        if(mgmtcls_genders[mgmtcls.name] == ""):
+            mgmtcls_genders.pop(mgmtcls.name, None);
+    # the file doesn't exist and for some reason the template engine 
+    # won't create it, so spit out an error and tell the user what to do.
+    if(not os.path.isfile(settings_file)):
+        logger.info("Error: " + settings_file + " does not exist.")
+        logger.info("Please run: touch " + settings_file +  " as root and try again.")
+        return 1
+    
+    write_genders_file(api._config, profiles_genders, distros_genders, mgmtcls_genders)
+    return 0
+

--- a/config/cobbler/settings.d/manage_genders.settings
+++ b/config/cobbler/settings.d/manage_genders.settings
@@ -1,0 +1,2 @@
+# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
+manage_genders: 1

--- a/templates/etc/genders.template
+++ b/templates/etc/genders.template
@@ -1,0 +1,25 @@
+# ******************************************************************
+# Cobbler managed genders file.
+#
+# generated from cobbler genders template ($date)
+# Do NOT make changes to /etc/genders. Instead, make your changes
+# in /etc/cobbler/genders.template, as /etc/genders will be
+# overwritten.
+#
+# Then run: cobbler sync
+# to apply your changes.
+#
+# ******************************************************************
+
+#for profile in $profiles_genders.keys():
+$profiles_genders[$profile]     profile=$profile
+#end for
+
+#for distro in $distros_genders.keys():
+$distros_genders[$distro]       distro=$distro
+#end for
+
+
+#for mgmtcls in $mgmtcls_genders.keys():
+$mgmtcls_genders[$mgmtcls]  $mgmtcls
+#end for


### PR DESCRIPTION
New feature to manage the /etc/genders file using cobbler.

A setting is added to enable or disable this behavior.  It's enabled through a module that is called on every change to re-generate the /etc/genders file.

Tested in my instance of 2.8 running from RPM on CentOS 7, all changes should work on current branch of cobbler, but should be tested.  