### PR TITLE
Adding a feature to allow manage_bind to manage ipmi A records

### DIFF
--- a/config/cobbler/settings.d/bind_manage_ipmi.settings
+++ b/config/cobbler/settings.d/bind_manage_ipmi.settings
@@ -1,0 +1,2 @@
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind is set.
+bind_manage_ipmi: 1


### PR DESCRIPTION
Feature to allow manage_bind module to manage IPMI A records if the power_address is an IP.  

Tested with latest master on CentOS 7.