### PR TITLE
Add default 'manage_genders' setting

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -90,6 +90,7 @@ DEFAULTS = {
     "ldap_tls_certfile"                   : ["", "str"],
     "manage_dhcp"                         : [0,"bool"],
     "manage_dns"                          : [0,"bool"],
+    "manage_genders"                      : [0,"bool"],
     "manage_tftp"                         : [1,"bool"],
     "manage_tftpd"                        : [1,"bool"],
     "manage_rsync"                        : [0,"bool"],


### PR DESCRIPTION
Commit e1c6aa5 backported a feature to manage '/etc/genders', but does
not include a default setting for 'manage_genders' to be used when it is
not included in the config file.