### PR TITLE
Release28 - 

### DIFF
--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -12,6 +12,7 @@ You should have received a copy of the GNU General Public License along with thi
 """
 
 import time
+import copy
 
 import cobbler.utils as utils
 import cobbler.templar as templar
@@ -86,7 +87,11 @@ class IscManager:
             distro  = profile.get_conceptual_parent()
 
             # if distro is None then the profile is really an image record
-            for (name, interface) in system.interfaces.iteritems():
+            for (name, system_interface) in system.interfaces.iteritems():
+
+                # We make a copy because we may modify it before adding it to the dhcp_tags
+                # and we don't want to affect the master copy.
+                interface = copy.deepcopy(system_interface)
 
                 # this is really not a per-interface setting
                 # but we do this to make the templates work

--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -93,7 +93,7 @@ class IscManager:
                 # and we don't want to affect the master copy.
                 interface = copy.deepcopy(system_interface)
 
-                if "if_gateway" in interface:
+                if interface["if_gateway"]:
                     interface["gateway"] = interface["if_gateway"]
                 else:
                     interface["gateway"] = system.gateway

--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -93,10 +93,11 @@ class IscManager:
                 # and we don't want to affect the master copy.
                 interface = copy.deepcopy(system_interface)
 
-                # this is really not a per-interface setting
-                # but we do this to make the templates work
-                # without upgrade
-                interface["gateway"] = system.gateway
+                if "if_gateway" in interface:
+                    interface["gateway"] = interface["if_gateway"]
+                else:
+                    interface["gateway"] = system.gateway
+
                 mac  = interface["mac_address"]
 
                 if interface["interface_type"] in ("slave","bond_slave","bridge_slave","bonded_bridge_slave"):


### PR DESCRIPTION
I found that during the generation of the dhcpd.conf for slave interfaces the two lines:

  interface["ip_address"] = ip
  interface["netmask"] = netmask

updated the actual in memory interface configuration. This effectively adds the same IP to all the slaves as well as the bond master. If you then used the http://<>/cblr/svc/op/autodetect you get a "FAILED: multiple matches" error as the same IP found on all the interfaces.

So the first change makes a copy of the interface data so that any updates don't change the real config. It's the copy that is assigned to the temporary dhcp_tags object that is ultimately used to generate the dhcpd.conf.

The second change takes account of the per-interface gateway values (if_gateway) when generating the DHCP config.

I've tested that the resulting dhcp.conf is the same for a setup with about 180 hosts.
