### PR TITLE
CVE-2018-10931 - forbid exposure of private methods in the API

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2053,6 +2053,9 @@ class ProxiedXMLRPCInterface:
 
     def _dispatch(self, method, params, **rest):
 
+        if method.startswith('_'):
+            raise CX("forbidden method")
+
         if not hasattr(self.proxied, method):
             raise CX("unknown remote method")
 


### PR DESCRIPTION
Fixes https://access.redhat.com/security/cve/cve-2018-10931 which has been rated critical.