### PR TITLE
When reposyncing, ignore the default repo config directory and support multiple bonded interfaces

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -564,6 +564,7 @@ class RepoSync:
         if not os.path.exists(dest_path):
             utils.mkdir(dest_path)
         config_file = open(fname, "w+")
+        if not output: config_file.write("[main]\nreposdir=/dev/null\n")
         config_file.write("[%s]\n" % repo.name)
         config_file.write("name=%s\n" % repo.name)
         if 'exclude' in repo.yumopts.keys():

--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -106,11 +106,13 @@ class IscManager:
                     if interface["interface_master"] not in system.interfaces:
                         continue
 
-                    if not system.name in ding:
-                        ding[system.name] = {interface["interface_master"]: []}
+                    # We may have multiple bonded interfaces, so we need a composite index into ding.
+                    name_master="%s-%s" % (system.name, interface["interface_master"])
+                    if not name_master in ding:
+                      ding[name_master] = {interface["interface_master"]: []}
 
-                    if len(ding[system.name][interface["interface_master"]]) == 0:
-                        ding[system.name][interface["interface_master"]].append(mac)
+                    if len(ding[name_master][interface["interface_master"]]) == 0:
+                        ding[name_master][interface["interface_master"]].append(mac)
                     else:
                         ignore_macs.append(mac)
 


### PR DESCRIPTION
Change 1:
This avoids the issue where the cobbler server is subscribed to its own
cobbler synced repos, but the cobbler synced repos have been cleaned/deleted.

This is similar to:
https://unix.stackexchange.com/questions/63138/make-reposync-ignore-etc-yum-conf

In situations where I clean out a mirror to force a full re-sync, then the "cobbler reposync" fails with a 404 error because the reposync command tries to check that the repos the server is subscribed to are up-to-date, i.e. it tries to pull the repodata I've just deleted.

Change 2:
If multiple bonded interfaces are defined, cobbler sync failes with:
```
rendering DHCP files
Exception occured: <type 'exceptions.KeyError'>
Exception value: 'bond1'
Exception Info:
  File "/usr/lib/python2.7/site-packages/cobbler/remote.py", line 82, in run
    rc = self._run(self)
   File "/usr/lib/python2.7/site-packages/cobbler/remote.py", line 181, in runner
    return self.remote.api.sync(self.options.get("verbose",False),logger=self.logger)
   File "/usr/lib/python2.7/site-packages/cobbler/api.py", line 763, in sync
    return sync.run()
   File "/usr/lib/python2.7/site-packages/cobbler/action_sync.py", line 122, in run
    self.write_dhcp()
   File "/usr/lib/python2.7/site-packages/cobbler/action_sync.py", line 208, in write_dhcp
    self.dhcp.write_dhcp_file()
   File "/usr/lib/python2.7/site-packages/cobbler/modules/manage_isc.py", line 112, in write_dhcp_file
    if len(ding[system.name][interface["interface_master"]]) == 0:

!!! TASK FAILED !!!
```
An example system definition:
```
cobbler system add --name myhost --profile rhel7-x86_64 --hostname myhost --name-servers "10.32.4.5" --gateway "10.21.132.254"
cobbler system edit --name myhost --interface eth0 --mac 52:54:00:90:00:26 --ip-address 10.32.4.38 --subnet 10.32.4.0 --netmask 255.255.255.0 --static y
cobbler system edit --name myhost --interface ens6 --mac 52:54:00:91:01:0b --interface-type bond_slave --interface-master bond0
cobbler system edit --name myhost --interface ens7 --mac 52:54:00:92:01:0b --interface-type bond_slave --interface-master bond1
cobbler system edit --name myhost --interface ens8 --mac 52:54:00:91:02:0b --interface-type bond_slave --interface-master bond0
cobbler system edit --name myhost --interface ens9 --mac 52:54:00:92:02:0b --interface-type bond_slave --interface-master bond1
cobbler system edit --name myhost --interface bond0 --interface-type bond --bonding-opts "miimon=100 mode=active-backup fail_over_mac=active" --ip-address 10.21.132.11 --subnet 10.21.132.0 --netmask 255.255.255.0 --static y
cobbler system edit --name myhost --interface bond1 --interface-type bond --bonding-opts "miimon=100 mode=active-backup fail_over_mac=active" --ip-address 10.31.132.11 --subnet 10.31.132.0 --netmask 255.255.255.0 --static y
```