### PR TITLE
Virtual disk type field fixes

### DIFF
--- a/cobbler/field_info.py
+++ b/cobbler/field_info.py
@@ -51,6 +51,7 @@ USES_SELECT = [
    "kickstart",
    "image_type",
    "virt_type",
+   "virt_disk_driver",
    "arch",
    "*interface_type",
    "parent",

--- a/cobbler/item_profile.py
+++ b/cobbler/item_profile.py
@@ -46,7 +46,7 @@ FIELDS = [
   ["virt_auto_boot","SETTINGS:virt_auto_boot",'<<inherit>>',"Virt Auto Boot",True,"Auto boot this VM?",0,"bool"],
   ["virt_cpus",1,'<<inherit>>',"Virt CPUs",True,"integer",0,"int"],
   ["virt_file_size","SETTINGS:default_virt_file_size",'<<inherit>>',"Virt File Size(GB)",True,"",0,"int"],
-  ["virt_disk_driver","SETTINGS:default_virt_disk_driver",'<<inherit>>',"Virt Disk Driver Type",True,"The on-disk format for the virtualization disk","raw","str"],
+  ["virt_disk_driver","SETTINGS:default_virt_disk_driver",'<<inherit>>',"Virt Disk Driver Type",True,"The on-disk format for the virtualization disk",[ "raw", "qcow", "qcow2", "aio", "vmdk", "qed" ],"str"],
   ["virt_ram","SETTINGS:default_virt_ram",'<<inherit>>',"Virt RAM (MB)",True,"",0,"int"],
   ["depth",1,1,"",False,"",0,"int"],
   ["virt_type","SETTINGS:default_virt_type",'<<inherit>>',"Virt Type",True,"Virtualization technology to use",["xenpv","xenfv","qemu", "kvm", "vmware", "openvz"],"str"],

--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -48,7 +48,7 @@ FIELDS = [
   ["virt_type","<<inherit>>",0,"Virt Type",True,"Virtualization technology to use",["xenpv","xenfv","qemu","kvm","vmware","openvz"],"str"],
   ["virt_cpus","<<inherit>>",0,"Virt CPUs",True,"",0,"int"],
   ["virt_file_size","<<inherit>>",0,"Virt File Size(GB)",True,"",0,"float"],
-  ["virt_disk_driver","<<inherit>>",0,"Virt Disk Driver Type",True,"The on-disk format for the virtualization disk",["<<inherit>>","raw"],"str"],
+  ["virt_disk_driver","<<inherit>>",0,"Virt Disk Driver Type",True,"The on-disk format for the virtualization disk",["<<inherit>>","raw", "qcow", "qcow2", "aio", "vmdk", "qed"],"str"],
   ["virt_ram","<<inherit>>",0,"Virt RAM (MB)",True,"",0,"int"],
   ["virt_auto_boot","<<inherit>>",0,"Virt Auto Boot",True,"Auto boot this VM?",0,"bool"],
   ["virt_pxe_boot",0,0,"Virt PXE Boot",True,"Use PXE to build this VM?",0,"bool"],


### PR DESCRIPTION
Updates the virtual disk driver field to include the various disk types as choice items to avoid invalid entries.

The update (to release28) fixes the virt_disk_driver field to a selection dropdown on the WUI, and similarly changes the CLI, making sure that the only values permitted match koan's concept of valid disk drivers. 