### PR TITLE
Make parsing users.conf case sensitive to handle Kerboros users

### DIFF
--- a/cobbler/modules/authz_ownership.py
+++ b/cobbler/modules/authz_ownership.py
@@ -43,6 +43,8 @@ def __parse_config():
     if not os.path.exists(etcfile):
         raise CX(_("/etc/cobbler/users.conf does not exist"))
     config = ConfigParser.ConfigParser()
+    # Make users case sensitive to handle kerberos
+    config.optionxform = str
     config.read(etcfile)
     alldata = {}
     sections = config.sections()


### PR DESCRIPTION
When logging in with GSSAPI, users are of the form user@REALM with realm in upper case.  Authorization then fails because it compares the string from the browser to the lower cased key from users.conf.  The other alternative is to lowercase the browser string, but this seems more correct.