### PR TITLE
Python 3: Compatibility

### DIFF
--- a/contrib/api-examples/demo_connect.py
+++ b/contrib/api-examples/demo_connect.py
@@ -33,12 +33,12 @@ if __name__ == "__main__":
 
     sp = ServerProxy("http://127.0.0.1:25151")
     (options, args) = p.parse_args()
-    print "- trying to login with user=%s" % options.user
+    print("- trying to login with user=%s" % options.user)
     token = sp.login(options.user,options.password)
-    print "- token: %s" % token
-    print "- authenticated ok, now seeing if user is authorized"
+    print("- token: %s" % token)
+    print("- authenticated ok, now seeing if user is authorized")
     check = sp.check_access(token,"imaginary_method_name")
-    print "- access ok? %s" % check
+    print("- access ok? %s" % check)
 
 
 

--- a/tests/cli/imports/import_base.py
+++ b/tests/cli/imports/import_base.py
@@ -18,28 +18,28 @@ class CobblerImportTest(unittest.TestCase):
          try:
              (data,rc) = utils.subprocess_sp(None,["cobbler","distro","remove","--recursive","--name=%s" % d],shell=False)
          except:
-             print "Failed to remove distro '%s' during cleanup" % d
+             print("Failed to remove distro '%s' during cleanup" % d)
 
 def create_import_func(data):
    name = data["name"]
    desc = data["desc"]
    path = data["path"]
    def do_import(self):
-      print "doing import, name=%s, desc=%s, path=%s" % (name,desc,path)
+      print("doing import, name=%s, desc=%s, path=%s" % (name,desc,path))
       (data,rc) = utils.subprocess_sp(None,["cobbler","import","--name=test-%s" % name,"--path=%s" % path],shell=False)
-      print data
+      print(data)
       self.assertEqual(rc,0)
       # TODO: scan output of import to build list of imported distros/profiles
       #       and compare to expected list. Then use that list to run reports 
       #       and for later cleanup
       (data,rc) = utils.subprocess_sp(None,["cobbler","distro","report","--name=test-%s" % name],shell=False)
-      print data
+      print(data)
       self.assertEqual(rc,0)
       (data,rc) = utils.subprocess_sp(None,["cobbler","profile","report","--name=test-%s" % name],shell=False)
-      print data
+      print(data)
       self.assertEqual(rc,0)
       (data,rc) = utils.subprocess_sp(None,["cobbler","distro","remove","--recursive","--name=test-%s" % name],shell=False)
-      print data
+      print (data)
       self.assertEqual(rc,0)
    return do_import
 


### PR DESCRIPTION
To enable cobbler to work with Python 3 I prepared a fix which is compatible with Python 2 also.

The fix adds brackets to the print functions to match the Python 3 syntax.