### PR TITLE
SUSE texmode fix for futurize

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -164,6 +164,10 @@ class BuildIso(object):
             cfg.write("  kernel %s.krn\n" % distname)
 
             data = utils.blender(self.api, False, profile)
+
+            # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
+            utils.suse_kopts_textmode_overwrite(dist.breed, data['kernel_options'])
+
             if not re.match("[a-z]+://.*", data["autoinstall"]):
                 data["autoinstall"] = "http://%s:%s/cblr/svc/op/autoinstall/profile/%s" % (
                     data["server"], self.api.settings().http_port, profile.name
@@ -488,6 +492,9 @@ class BuildIso(object):
                 menu_indent = 4
 
             data = utils.blender(self.api, False, descendant)
+
+            # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
+            utils.suse_kopts_textmode_overwrite(distro.breed, data['kernel_options'])
 
             cfg.write("\n")
             cfg.write("LABEL %s\n" % descendant.name)

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -675,6 +675,9 @@ class TFTPGen(object):
         kopts = blended.get("kernel_options", dict())
         kopts = utils.revert_strip_none(kopts)
 
+        # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
+        utils.suse_kopts_textmode_overwrite(distro.breed, kopts)
+
         # since network needs to be configured again (it was already in netboot) when kernel boots
         # and we choose to do it dinamically, we need to set 'ksdevice' to one of
         # the interfaces' MAC addresses in ppc systems.

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2125,5 +2125,16 @@ def compare_versions_gt(ver1, ver2):
         return tuple(map(int, (v.split("."))))
     return versiontuple(ver1) > versiontuple(ver2)
 
+
+def suse_kopts_textmode_overwrite(distro_breed, kopts):
+    """SUSE is not using 'text'. Instead 'textmode' is used as kernel option."""
+    if distro_breed == "suse":
+        if 'textmode' in kopts.keys():
+            kopts.pop('text', None)
+        elif 'text' in kopts.keys():
+            kopts.pop('text', None)
+            kopts['textmode'] = ['1']
+
+
 if __name__ == "__main__":
     print(os_release())  # returns 2, not 3


### PR DESCRIPTION
SUSE distributions are not using text as a kernel option. Instead we've got `textmode=0` or `textmode=1`. These changes would change that according to what was defined, while a textmode setting would always overrule text.