### PR TITLE
Futurize distro platform fix

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -27,6 +27,7 @@ import os
 import os.path
 import pipes
 import stat
+import distro
 
 HAS_YUM = True
 try:
@@ -690,9 +691,10 @@ class RepoSync(object):
         """
         # all_path = os.path.join(repo_path, "*")
         owner = "root:apache"
-        if os.path.exists("/etc/SuSE-release"):
+        distribution = distro.linux_distribution()[0]
+        if distribution.lower() in ("sles", "opensuse leap", "opensuse tumbleweed"):
             owner = "root:www"
-        elif os.path.exists("/etc/debian_version"):
+        elif "debian" in distribution.lower()
             owner = "root:www-data"
 
         cmd1 = "chown -R " + owner + " %s" % repo_path

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -910,9 +910,9 @@ def get_family():
     for item in redhat_list:
         if item in dist:
             return "redhat"
-    if dist in ("debian", "ubuntu"):
+    if "debian" in dist or "ubuntu" in dist:
         return "debian"
-    if "suse" in dist:
+    if dist in ("opensuse tumbleweed", "opensuse leap", "sles"):
         return "suse"
     return dist
 

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -47,6 +47,7 @@ import urllib.request
 import urllib.error
 import urllib.parse
 import yaml
+import distro
 
 from .cexceptions import FileNotFoundException, CX
 from cobbler import clogger
@@ -920,11 +921,7 @@ def check_dist():
     """
     Determines what distro we're running under.
     """
-    import platform
-    try:
-        return platform.linux_distribution()[0].lower().strip()
-    except AttributeError:
-        return platform.dist()[0].lower().strip()
+    return distro.linux_distribution()[0].lower().strip()
 
 
 def os_release():

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -925,7 +925,6 @@ def check_dist():
 
 
 def os_release():
-
     family = get_family()
     if family == "redhat":
         fh = open("/etc/redhat-release")
@@ -962,16 +961,11 @@ def os_release():
             return (make, float(version))
 
     elif family == "suse":
-        fd = open("/etc/SuSE-release")
-        for line in fd.read().split("\n"):
-            if line.find("VERSION") != -1:
-                version = line.replace("VERSION = ", "")
-            if line.find("PATCHLEVEL") != -1:
-                rest = line.replace("PATCHLEVEL = ", "")
         make = "suse"
+        distribution, version = distro.linux_distribution()[:2]
+        if distribution.lower() not in ("sles", "opensuse leap", "opensuse tumbleweed"):
+            make = "unknown"
         return (make, float(version))
-    else:
-        return ("unknown", 0)
 
 
 def tftpboot_location():

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -121,7 +121,7 @@ def log_exc(logger):
     (t, v, tb) = sys.exc_info()
     logger.info("Exception occured: %s" % t)
     logger.info("Exception value: %s" % v)
-    logger.info("Exception Info:\n%s" % string.join(traceback.format_list(traceback.extract_tb(tb))))
+    logger.info("Exception Info:\n%s" % "\n".join(traceback.format_list(traceback.extract_tb(tb))))
 
 
 def get_exc(exc, full=True):

--- a/setup.py
+++ b/setup.py
@@ -603,7 +603,8 @@ if __name__ == "__main__":
             "Cheetah3",
             "coverage",
             "Django",
-            "pymongo"
+            "pymongo",
+            "distro",
         ],
         packages=[
             "cobbler",


### PR DESCRIPTION
Distributions like openSUSE are not correctly detected by the
platform module. This change leverages the distro library
instead and also fixes Kerberos auth.

Fixes #1957 