### PR TITLE
Fixed errors preventing the startup of the cobbler deamon.

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -694,7 +694,7 @@ class RepoSync(object):
         distribution = distro.linux_distribution()[0]
         if distribution.lower() in ("sles", "opensuse leap", "opensuse tumbleweed"):
             owner = "root:www"
-        elif "debian" in distribution.lower()
+        elif "debian" in distribution.lower():
             owner = "root:www-data"
 
         cmd1 = "chown -R " + owner + " %s" % repo_path

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -950,12 +950,12 @@ def os_release():
         raise CX("failed to detect local OS version from /etc/redhat-release")
 
     elif family == "debian":
-        distro = check_dist()
-        if distro == "debian":
+        distribution = check_dist()
+        if distribution == "debian":
             import lsb_release
             release = lsb_release.get_distro_information()['RELEASE']
             return ("debian", release)
-        elif distro == "ubuntu":
+        elif distribution == "ubuntu":
             version = subprocess_get(None, "lsb_release --release --short").rstrip()
             make = "ubuntu"
             return (make, float(version))

--- a/setup.py
+++ b/setup.py
@@ -594,7 +594,7 @@ if __name__ == "__main__":
         url="https://cobbler.github.io",
         license="GPLv2+",
         requires=[
-            "mod_python",
+            "mod_wsgi",
             "requests",
             "future",
             "pyyaml",
@@ -605,6 +605,10 @@ if __name__ == "__main__":
             "Django",
             "pymongo",
             "distro",
+        ],
+        test_requires=[
+            "pytest",
+            "nose"
         ],
         packages=[
             "cobbler",


### PR DESCRIPTION
The cobbler deamon was not able to start and keep running. After refactoring the variable name `distro` to `distribution` the error was prevented because the naming conflicts were not anymore present.

Additionally I removed `mod_python` and added `mod_wsgi`.

Finally I added a colon which was a syntax error.