### PR TITLE
Added missing python modules to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -605,6 +605,8 @@ if __name__ == "__main__":
             "Django",
             "pymongo",
             "distro",
+            "ldap",
+            "dnspython3"
         ],
         test_requires=[
             "pytest",


### PR DESCRIPTION
For the cobbler module `authn_ldap.py` the pip package `ldap` was missing and for the module `nsupdate_add_system_post` was the pip package `dnspython3` required.