### PR TITLE
Quote kernel options, if they contain whitespaces

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -68,9 +68,17 @@ class BuildIso:
             else:
                 if isinstance(v, list):
                     for i in v:
-                        append_line += " %s=%s" % (k, i)
+                        _i = str(i).strip()
+                        if ' ' in _i:
+                            append_line += " %s='%s'" % (k, _i)
+                        else:
+                            append_line += " %s=%s" % (k, _i)
                 else:
-                    append_line += " %s=%s" % (k, v)
+                    _v = str(v).strip()
+                    if ' ' in _v:
+                        append_line += " %s='%s'" % (k, _v)
+                    else:
+                        append_line += " %s=%s" % (k, _v)
         append_line += "\n"
         return append_line
 

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -782,9 +782,18 @@ def dict_to_string(_dict):
             # this value is an array, so we print out every
             # key=value
             for item in value:
-                buffer += str(key) + "=" + str(item) + " "
+                # strip possible leading and trailing whitespaces
+                _item = str(item).strip()
+                if ' ' in _item:
+                    buffer += str(key) + "='" + _item + "' "
+                else:
+                    buffer += str(key) + "=" + _item + " "
         else:
-            buffer += str(key) + "=" + str(value) + " "
+            _value = str(value).strip()
+            if ' ' in _value:
+                buffer += str(key) + "='" + _value + "' "
+            else:
+                buffer += str(key) + "=" + _value + " "
     return buffer
 
 


### PR DESCRIPTION
Kernel options containing whitespaces, even when given quoted are reparsed
and added unquoted, resulting in wrong options