### PR TITLE
Fix cobbler hardlink on suse distributions.

### DIFF
--- a/cobbler/action_hardlink.py
+++ b/cobbler/action_hardlink.py
@@ -43,6 +43,9 @@ class HardLinker(object):
         if self.family == "debian":
             self.hardlink = "/usr/bin/hardlink"
             self.hardlink_args = "-f -p -o -t -v /var/www/cobbler/distro_mirror /var/www/cobbler/repo_mirror"
+        elif self.family == "suse":
+            self.hardlink = "/usr/bin/hardlink"
+            self.hardlink_args = "-f -v /var/www/cobbler/distro_mirror /var/www/cobbler/repo_mirror"
         else:
             self.hardlink = "/usr/sbin/hardlink"
             self.hardlink_args = "-c -v /var/www/cobbler/distro_mirror /var/www/cobbler/repo_mirror"
@@ -69,6 +72,6 @@ class HardLinker(object):
         if os.path.exists("/srv/www"):
             webdir = "/srv/www/cobbler"
 
-        rc = utils.subprocess_call(self.logger, "/usr/sbin/hardlink -c -v " + webdir + "/distro_mirror /var/www/cobbler/repo_mirror", shell=True)
+        rc = utils.subprocess_call(self.logger, self.hardlink + " -c -v " + webdir + "/distro_mirror /var/www/cobbler/repo_mirror", shell=True)
 
         return rc


### PR DESCRIPTION
On Suse distributions `hardlink` is under `/usr/bin/hardlink` and removing options which are not available under Suse distros.

Additionally I fixed the hardcoded `hardlink` path at the second subprocess call.