### PR TITLE
String import cleanup

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1032,7 +1032,7 @@ def hashfile(fn, lcache=None, logger=None):
 
     if os.path.exists(fn):
         cmd = '/usr/bin/sha1sum %s' % fn
-        key = subprocess_get(logger, cmd).split(' ')[0]
+        key = str(subprocess_get(logger, cmd), 'utf-8').split(' ')[0]
         if lcache is not None:
             db[fn] = (mtime, key)
             simplejson.dump(db, open(dbfile, 'w'))

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -17,7 +17,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-from past.builtins import str
 import netaddr
 import re
 import shlex


### PR DESCRIPTION
While adding a system to cobbler the `past.builtins` import prevented the `instanceof` to work. Without the import and the adjustment of the split in `utils.py` the `cobbler system add` now works.