### PR TITLE
Create grubcfg in buildiso for grub2 mkrescue UEFI - do not blindly merge

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -222,7 +222,7 @@ class BuildIso:
             gcfg.write("menuentry 'LEGACY %s' {\n" % profile.name)
             gcfg.write("  linux %s.krn %s\n" % (
                     distname,
-                    append_line.replace(grub_prefix_to_remove_later, ''
+                    append_line.replace(grub_prefix_to_remove_later, '')
                     )
             )
             gcfg.write("  initrd %s.img\n" % distname)
@@ -477,7 +477,7 @@ class BuildIso:
             gcfg.write("menuentry 'LEGACY %s' {\n" % system.name)
             gcfg.write("  linux %s.krn %s\n" % (
                     distname,
-                    append_line.replace(grub_prefix_to_remove_later, ''
+                    append_line.replace(grub_prefix_to_remove_later, '')
                     )
             )
             gcfg.write("  initrd %s.img\n" % distname)


### PR DESCRIPTION
Hi @jmaas,

this is the PR I told you I would create to give you a hint, how to get one step further into getting a UEFI bootable ISO.

This is an ugly patch. Also, this one is not really tested (with this latest version). I was only able to create a patch for an 2.6.xx release on the system at the customer site. This is a re-write of the patch I did (and also includes a second entry for each profile or system to also be able to use the same ISO even I you do not use UEFI)

It basically just creates a ```boot/grub/grub.cfg``` file within the ```buildisodir```, that will be used, if you run
```
grub2-mkrescue -o <output.iso> /var/cache/cobbler/buildiso
```
after creating the ```normal``` ISO with ```cobbler buildiso```.

If you already have installed the corresponding grub-efi package (on my x86_64 SLES test machine, this is ```grub2-x86_64-efi```), the ```grub2-mkrescue``` command will copy the necessary EFI files and create a bootable ```grub``` ISO.

The ```normal``` ISO still uses the ISOLINUX, whereas the ISO created by ```grub2-mkrescue``` uses ```grub2```.

So this might just give you hint, how this might be done in future. I'm sorry. I'm unable to test this on other hardware. Maybe someone else can use this information.

