### PR TITLE
Fixes whitespace before every log entry on the cli client.

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -712,7 +712,7 @@ class CobblerCLI(object):
             else:
                 if line.find(" | "):
                     line = line.split(" | ")[-1]
-                print(line, end=' ')         # already has newline
+                print(line)
 
     def print_object_help(self, object_type):
         """


### PR DESCRIPTION
Every logentry printed on the cli client was prefixed with a whitespace if it originates from a task. When removing the responsible argument in the print statement, every entry was printed correctly.