### PR TITLE
Only the first kopts for install should be used

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -179,7 +179,10 @@ class BuildIso(object):
                 if "proxy" in data and data["proxy"] != "":
                     append_line += " proxy=%s" % data["proxy"]
                 if "install" in data["kernel_options"] and data["kernel_options"]["install"] != "":
-                    append_line += " install=%s" % data["kernel_options"]["install"]
+                    v = data["kernel_options"]["install"]
+                    if isinstance(v, list):
+                        v = v[0]
+                        append_line += " install=%s" % v
                     del data["kernel_options"]["install"]
                 else:
                     append_line += " install=http://%s:%s/cblr/links/%s" % (


### PR DESCRIPTION
If we've got a list in the kernel options for install, only the first element of the list is added to the append_line.