### PR TITLE
Make grub-image smaller by removing locales and compressing it. 

### DIFF
--- a/loaders/Makefile
+++ b/loaders/Makefile
@@ -2,9 +2,8 @@ installdep:
 	yum install -y grub2-efi-ia32-modules grub2-efi-x64-modules
 
 buildloaders:
-	grub2-mkstandalone -d /usr/lib/grub/i386-efi/ -O i386-efi --modules="tftp net efinet linux part_gpt efifwsetup" -o grub2-x86.efi
-	grub2-mkstandalone -d /usr/lib/grub/x86_64-efi/ -O x86_64-efi --modules="tftp net efinet linux part_gpt efifwsetup" -o grub2-x86_64.efi
-
+	grub2-mkstandalone -d /usr/lib/grub/i386-efi/ --compress=xz -O i386-efi --modules="tftp net efinet linux part_gpt efifwsetup" --locales= -o grub2-x86.efi
+	grub2-mkstandalone -d /usr/lib/grub/x86_64-efi/ --compress=xz -O x86_64-efi --modules="tftp net efinet linux part_gpt efifwsetup" --locales= -o grubx64.efi
 copyloaders:
 	cp grub2-x86.efi /var/lib/cobbler/loaders/
 	cp grub2-x86_64.efi /var/lib/cobbler/loaders/grub2-x86_64.efi

--- a/templates/boot_loader_conf/grub2system.template
+++ b/templates/boot_loader_conf/grub2system.template
@@ -1,4 +1,4 @@
-set default="0"
+set default="2"
 set timeout=5
 
 function load_video {
@@ -17,7 +17,18 @@ insmod gzio
 insmod part_gpt
 insmod ext2
 
+menuentry "Cobbler Provisioning Service - Grub2 EFI:" {
+    echo "Fake just to get a menu-record"
+}
+
+menuentry "The automatic provisioning will start shortly." {
+    echo "Fake entry to get a menu-record."
+}
+
 menuentry "$system_name" {
+    echo "Loading install kernel..."
     linuxefi (tftp)$kernel_path $kernel_options
+    echo "Loading initrd..."
     initrdefi (tftp)$initrd_path
+    echo "Starting automated provisioning..."
 }


### PR DESCRIPTION
CentOS 7 grubx64.efi -image is 1.1M, so we don't want ours to be that much bigger.
By using compression - and removing extra locales (but still all modules) we are down to 2.2MB instead of 8.6MB.
Grub2 System output modified to contain some useful info as grub2 is otherwise really quiet. (to xfer progress)

