### PR TITLE
Codacy: Fix README.md style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Cobbler
 
 Cobbler is a Linux installation server that allows for rapid setup of network installation environments. It glues together and automates many associated Linux tasks so you do not have to hop between lots of various commands and applications when rolling out new systems, and, in some cases, changing existing ones. It can help with installation, DNS, DHCP, package updates, power management, configuration management orchestration, and much more.
 
-Read more at https://cobbler.github.io
+Read more at [https://cobbler.github.io](https://cobbler.github.io)
 
-To view the manpages, install the RPM and run "man cobbler" or run "perldoc cobbler.pod" from a source checkout.
+To view the manpages, install the RPM and run `man cobbler` or run `perldoc cobbler.pod` from a source checkout.
 
-To build the RPM, run "make rpms".   Developers, try "make webtest" to do a local "make install" that preserves your configuration.
+To build the RPM, run `make rpms`. Developers, try `make webtest` to do a local `make install` that preserves your configuration.


### PR DESCRIPTION
Just a quick fix, to make sure the markdown of the `README.md` is valid.