### PR TITLE
Feature multi arch grub 2

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -173,6 +173,8 @@ if (( $1 == 1 )); then
     sysconf_addword /etc/sysconfig/apache2 APACHE_MODULES wsgi > /dev/null 2>&1
     %service_add_post cobblerd.service
 fi
+# Create bootloders into /var/lib/cobbler/loaders                                                                                                                           
+%{_prefix}/lib/%{name}/bin/mkgrub.sh
 %preun
 # last package removal
 if (( $1 == 0 )); then
@@ -183,6 +185,12 @@ fi
 if (( $1 == 0 )); then
     %service_del_postun cobblerd.service
 fi
+if [ -e /var/lib/cobbler/loaders/.cobbler_postun_cleanup ];then                                                                                                             
+    for file in $(cat /var/lib/cobbler/loaders/.cobbler_postun_cleanup);do
+        rm /var/lib/cobbler/loaders/$file
+    done
+    rm -rf /var/lib/cobbler/loaders/.cobbler_postun_cleanup
+fi 
 %endif
 
 

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -174,7 +174,7 @@ if (( $1 == 1 )); then
     %service_add_post cobblerd.service
 fi
 # Create bootloders into /var/lib/cobbler/loaders                                                                                                                           
-%{_prefix}/lib/%{name}/bin/mkgrub.sh
+%{_prefix}/share/%{name}/bin/mkgrub.sh
 %preun
 # last package removal
 if (( $1 == 0 )); then

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -46,6 +46,7 @@ DEFAULTS = {
     "bind_chroot_path": ["", "str"],
     "bind_master": ["127.0.0.1", "str"],
     "boot_loader_conf_template_dir": ["/etc/cobbler/boot_loader_conf", "str"],
+    "bootloaders_dir": ["/var/lib/cobbler/loaders", "str"],
     "build_reporting_enabled": [0, "bool"],
     "build_reporting_ignorelist": ["", "str"],
     "build_reporting_sender": ["", "str"],

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -22,6 +22,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 
 from builtins import object
+from distutils import dir_util
 import os
 import os.path
 import re
@@ -60,71 +61,11 @@ class TFTPGen(object):
         NOTE: we support different arch's if defined in
         /etc/cobbler/settings.
         """
-        dst = self.bootloc
-        grub_dst = os.path.join(dst, "grub")
-        boot_dst = os.path.join(dst, "boot/grub")
+        src = self.settings.bootloaders_dir
+        dir_util.copy_tree(src, utils.tftpboot_location())
 
-        # copy pxelinux from one of two locations
-        try:
-            try:
-                utils.copyfile_pattern(
-                    '/var/lib/cobbler/loaders/pxelinux.0',
-                    dst, api=self.api, cache=False, logger=self.logger)
-                utils.copyfile_pattern(
-                    '/var/lib/cobbler/loaders/menu.c32',
-                    dst, api=self.api, cache=False, logger=self.logger)
-                utils.copyfile_pattern(
-                    '/var/lib/cobbler/loaders/ldlinux.c32',
-                    dst, require_match=False, api=self.api, cache=False, logger=self.logger)
-            except:
-                utils.copyfile_pattern(
-                    '/usr/share/syslinux/pxelinux.0',
-                    dst, api=self.api, cache=False, logger=self.logger)
-                utils.copyfile_pattern(
-                    '/usr/share/syslinux/menu.c32',
-                    dst, api=self.api, cache=False, logger=self.logger)
-                utils.copyfile_pattern(
-                    '/usr/share/syslinux/ldlinux.c32',
-                    dst, require_match=False, api=self.api, cache=False, logger=self.logger)
-        except:
-            utils.copyfile_pattern(
-                '/usr/lib/syslinux/pxelinux.0',
-                dst, api=self.api, cache=False, logger=self.logger)
-            utils.copyfile_pattern(
-                '/usr/lib/syslinux/menu.c32',
-                dst, api=self.api, cache=False, logger=self.logger)
-            utils.copyfile_pattern(
-                '/usr/lib/syslinux/ldlinux.c32',
-                dst, require_match=False, api=self.api, cache=False, logger=self.logger)
-
-        # copy yaboot which we include for PowerPC targets
-        utils.copyfile_pattern(
-            '/var/lib/cobbler/loaders/yaboot', dst,
-            require_match=False, api=self.api, cache=False, logger=self.logger)
-
-        utils.copyfile_pattern(
-            '/var/lib/cobbler/loaders/boot/grub/*', boot_dst,
-            require_match=False, api=self.api, cache=False, logger=self.logger)
-
-        try:
-            utils.copyfile_pattern(
-                '/usr/lib/syslinux/memdisk',
-                dst, api=self.api, cache=False, logger=self.logger)
-        except:
-            utils.copyfile_pattern(
-                '/usr/share/syslinux/memdisk', dst,
-                require_match=False, api=self.api, cache=False, logger=self.logger)
-
-        # Copy gPXE/iPXE bootloader if it exists
-        utils.copyfile_pattern(
-            '/usr/share/*pxe/undionly.kpxe', dst,
-            require_match=False, api=self.api, cache=False, logger=self.logger)
-
-        # Copy grub EFI bootloaders if possible:
-        utils.copyfile_pattern(
-            '/var/lib/cobbler/loaders/grub*.efi', grub_dst,
-            require_match=False, api=self.api, cache=False, logger=self.logger)
-
+        # This looks rather intrusive.
+        # ToDo: How can nexenta be better integrated?
         pxegrub_imported = False
         for i in self.distros:
             if 'nexenta' == i.breed and not pxegrub_imported:

--- a/scripts/mkgrub.sh
+++ b/scripts/mkgrub.sh
@@ -5,7 +5,7 @@
 [[ -z "$SYSLINUX_DIR" ]] && SYSLINUX_DIR="/usr/share/syslinux"
 
 BOOTLOADERS_DIR="/var/lib/cobbler/loaders"
-TARGETS="arm64-efi i386-pc powerpc-ieee1275 x86_64-efi"
+TARGETS="arm64-efi i386-pc-pxe powerpc-ieee1275 x86_64-efi"
 
 rm -rf "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
 
@@ -32,7 +32,7 @@ GRUB_MODULES="${CD_MODULES} ${FS_MODULES} ${PXE_MODULES} ${CRYPTO_MODULES} mdrai
 mkdir -p "${BOOTLOADERS_DIR}/grub/"
 for TARGET in $TARGETS;do
     case $TARGET in
-	i386-pc)
+	i386-pc-pxe)
 	    PXE_MODULES="${PXE_MODULES} pxe biosdisk"
 	    BINARY="grub.0"
 	    CD_MODULES="${CD_MODULES} chain"
@@ -58,17 +58,17 @@ for TARGET in $TARGETS;do
 done
 
     # ToDo: Use shim_dir and grub_dir variables for other distros to pass them in
-    if [[ -e /usr/share/efi/x86_64/shim.efi ]] && [[ ! -e "${BOOTLOADERS_DIR}/grub2/shim.efi" ]];then
-        ln -s /usr/share/efi/x86_64/shim.efi "${BOOTLOADERS_DIR}/grub2/shim.efi"
-        echo "grub2/shim.efi" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    if [[ -e /usr/share/efi/x86_64/shim.efi ]] && [[ ! -e "${BOOTLOADERS_DIR}/grub/shim.efi" ]];then
+        ln -s /usr/share/efi/x86_64/shim.efi "${BOOTLOADERS_DIR}/grub/shim.efi"
+        echo "grub/shim.efi" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
     fi
-    if [[ -e /usr/share/efi/grub.efi ]] && [[ ! -e "${BOOTLOADERS_DIR}/grub2/grub.efi" ]];then
-	    ln -s /usr/share/efi/grub.efi "${BOOTLOADERS_DIR}/grub2/grub.efi"
-	    echo "grub2/grub.efi" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    if [[ -e /usr/share/efi/grub.efi ]] && [[ ! -e "${BOOTLOADERS_DIR}/grub/grub.efi" ]];then
+	    ln -s /usr/share/efi/grub.efi "${BOOTLOADERS_DIR}/grub/grub.efi"
+	    echo "grub/grub.efi" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
     fi
     if [[ -e "$SYSLINUX_DIR"/pxelinux.0 ]] && [[ ! -e "${BOOTLOADERS_DIR}/pxelinux.0" ]];then
         ln -s "$SYSLINUX_DIR"/pxelinux.0 "${BOOTLOADERS_DIR}/pxelinux.0"
-        echo "grub2/${BINARY}" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+        echo "grub/${BINARY}" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
     fi
     if [[ -e "$SYSLINUX_DIR"/pxelinux.0 ]] && [[ ! -e "${BOOTLOADERS_DIR}/pxelinux.0" ]];then
         ln -s "$SYSLINUX_DIR"/pxelinux.0 "${BOOTLOADERS_DIR}/pxelinux.0"

--- a/scripts/mkgrub.sh
+++ b/scripts/mkgrub.sh
@@ -29,8 +29,8 @@ CD_MODULES="${CD_MODULES} linux"
 
 GRUB_MODULES="${CD_MODULES} ${FS_MODULES} ${PXE_MODULES} ${CRYPTO_MODULES} mdraid09 mdraid1x lvm serial regexp tr"
 
+mkdir -p "${BOOTLOADERS_DIR}/grub/"
 for TARGET in $TARGETS;do
-    mkdir -p "${BOOTLOADERS_DIR}/grub2/${TARGET}"
     case $TARGET in
 	i386-pc)
 	    PXE_MODULES="${PXE_MODULES} pxe biosdisk"
@@ -39,16 +39,12 @@ for TARGET in $TARGETS;do
 	    ;;
 	x86_64-efi)
 	    PXE_MODULES="${PXE_MODULES} efinet"
-	    BINARY="grubx64.efi"
+	    BINARY="grub2-x86_64.efi"
 	    CD_MODULES="${CD_MODULES} chain"
-	    ARCH="x86_64"
-	    HAVE_SIGNED_GRUB=1
 	    ;;
 	arm64-efi)
 	    PXE_MODULES="${PXE_MODULES} efinet"
 	    BINARY="grubaa64.efi"
-	    ARCH="aarch64"
-	    # HAVE_SIGNED_GRUB=1
 	    ;;
 	powerpc-ieee1275)
 	    PXE_MODULES="${PXE_MODULES} net ofnet"
@@ -56,7 +52,7 @@ for TARGET in $TARGETS;do
 	    ;;
     esac
     set -x
-    grub2-mkimage -O ${TARGET} -o "${BOOTLOADERS_DIR}/grub2/${BINARY}" --prefix= ${GRUB_MODULES}
+    grub2-mkimage -O ${TARGET} -o "${BOOTLOADERS_DIR}/grub/${BINARY}" --prefix= ${GRUB_MODULES}
     set +x
     echo "grub2/${BINARY}" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
 done
@@ -94,5 +90,3 @@ done
         ln -s "/usr/share/*pxe/undionly.kpxe" "${BOOTLOADERS_DIR}/undionly.kpxe"
         echo "undionly.kpxe" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
     fi
-    
-    

--- a/scripts/mkgrub.sh
+++ b/scripts/mkgrub.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# DISTRO directory overrides. Pass these vars in from outside:
+# export SYSLINUX_DIR=/usr/share/...;./mkgrub.sh
+[[ -z "$SYSLINUX_DIR" ]] && SYSLINUX_DIR="/usr/share/syslinux"
+
+BOOTLOADERS_DIR="/var/lib/cobbler/loaders"
+TARGETS="arm64-efi i386-pc powerpc-ieee1275 x86_64-efi"
+
+rm -rf "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+
+# grub2 internal executable naming
+# aarch64 => grubaa64.efi
+# x86_64 => grubx64.efi
+# i386/i686 => bootia32.efi
+# IA64 => bootia64.efi
+# arm => bootarm.efi
+
+FS_MODULES="btrfs ext2 xfs jfs reiserfs"
+CD_MODULES=" all_video boot cat configfile echo true \
+		font gfxmenu gfxterm gzio halt iso9660 \
+		jpeg minicmd normal part_apple part_msdos part_gpt \
+		password_pbkdf2 png reboot search search_fs_uuid \
+		search_fs_file search_label sleep test video fat loadenv"
+PXE_MODULES="tftp http"
+CRYPTO_MODULES="luks gcry_rijndael gcry_sha1 gcry_sha256"
+
+CD_MODULES="${CD_MODULES} linux"
+
+GRUB_MODULES="${CD_MODULES} ${FS_MODULES} ${PXE_MODULES} ${CRYPTO_MODULES} mdraid09 mdraid1x lvm serial regexp tr"
+
+for TARGET in $TARGETS;do
+    mkdir -p "${BOOTLOADERS_DIR}/grub2/${TARGET}"
+    case $TARGET in
+	i386-pc)
+	    PXE_MODULES="${PXE_MODULES} pxe biosdisk"
+	    BINARY="grub.0"
+	    CD_MODULES="${CD_MODULES} chain"
+	    ;;
+	x86_64-efi)
+	    PXE_MODULES="${PXE_MODULES} efinet"
+	    BINARY="grubx64.efi"
+	    CD_MODULES="${CD_MODULES} chain"
+	    ARCH="x86_64"
+	    HAVE_SIGNED_GRUB=1
+	    ;;
+	arm64-efi)
+	    PXE_MODULES="${PXE_MODULES} efinet"
+	    BINARY="grubaa64.efi"
+	    ARCH="aarch64"
+	    # HAVE_SIGNED_GRUB=1
+	    ;;
+	powerpc-ieee1275)
+	    PXE_MODULES="${PXE_MODULES} net ofnet"
+	    BINARY="grub.ppc64le"
+	    ;;
+    esac
+    set -x
+    grub2-mkimage -O ${TARGET} -o "${BOOTLOADERS_DIR}/grub2/${BINARY}" --prefix= ${GRUB_MODULES}
+    set +x
+    echo "grub2/${BINARY}" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+done
+
+    # ToDo: Use shim_dir and grub_dir variables for other distros to pass them in
+    if [[ -e /usr/share/efi/x86_64/shim.efi ]] && [[ ! -e "${BOOTLOADERS_DIR}/grub2/shim.efi" ]];then
+        ln -s /usr/share/efi/x86_64/shim.efi "${BOOTLOADERS_DIR}/grub2/shim.efi"
+        echo "grub2/shim.efi" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e /usr/share/efi/grub.efi ]] && [[ ! -e "${BOOTLOADERS_DIR}/grub2/grub.efi" ]];then
+	    ln -s /usr/share/efi/grub.efi "${BOOTLOADERS_DIR}/grub2/grub.efi"
+	    echo "grub2/grub.efi" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e "$SYSLINUX_DIR"/pxelinux.0 ]] && [[ ! -e "${BOOTLOADERS_DIR}/pxelinux.0" ]];then
+        ln -s "$SYSLINUX_DIR"/pxelinux.0 "${BOOTLOADERS_DIR}/pxelinux.0"
+        echo "grub2/${BINARY}" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e "$SYSLINUX_DIR"/pxelinux.0 ]] && [[ ! -e "${BOOTLOADERS_DIR}/pxelinux.0" ]];then
+        ln -s "$SYSLINUX_DIR"/pxelinux.0 "${BOOTLOADERS_DIR}/pxelinux.0"
+        echo "pxelinux.0" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e "$SYSLINUX_DIR"/menu.c32 ]] && [[ ! -e "${BOOTLOADERS_DIR}/menu.c32" ]];then
+        ln -s "$SYSLINUX_DIR"/menu.c32 "${BOOTLOADERS_DIR}/menu.c32"
+        echo "menu.c32" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e "$SYSLINUX_DIR"/ldlinux.c32 ]] && [[ ! -e "${BOOTLOADERS_DIR}/ldlinux.c32" ]];then
+        ln -s "$SYSLINUX_DIR"/ldlinux.c32 "${BOOTLOADERS_DIR}/ldlinux.c32"
+        echo "ldlinux.c32" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e "$SYSLINUX_DIR"/memdisk ]] && [[ ! -e "${BOOTLOADERS_DIR}/memdisk" ]];then
+        ln -s "$SYSLINUX_DIR"/memdisk "${BOOTLOADERS_DIR}/memdisk"
+        echo "memdisk" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    if [[ -e "/usr/share/*pxe/undionly.kpxe" ]] && [[ ! -e "${BOOTLOADERS_DIR}/undionly.kpxe" ]];then
+        ln -s "/usr/share/*pxe/undionly.kpxe" "${BOOTLOADERS_DIR}/undionly.kpxe"
+        echo "undionly.kpxe" >> "${BOOTLOADERS_DIR}/.cobbler_postun_cleanup"
+    fi
+    
+    

--- a/setup.py
+++ b/setup.py
@@ -641,6 +641,7 @@ if __name__ == "__main__":
             ("share/cobbler/web", glob("web/*.*")),
             ("%s" % webcontent, glob("web/static/*")),
             ("%s" % webimages, glob("web/static/images/*")),
+            ("share/cobbler/bin", glob("scripts/*.sh")),
             ("share/cobbler/web/templates", glob("web/templates/*")),
             ("%swebui_sessions" % libpath, []),
             ("%sloaders" % libpath, []),


### PR DESCRIPTION
This patch introduces some fundamental changes concerning /var/lib/cobbler/loaders:
- always sync the whole content of this directory to the tftp root
  this has several advantages:
  - You can manually add files to the tftp dir (this will get handsome for grub configs)
  - The distro specific code trying to find all installed boot loaders was an unmaintainable nightmare
    The path and logic where bootloaders are found is now into the .spec file where it should be by:
- Linking boot loaders into the directory instead of copying them
  This additionally has the advantage that you get up-to-date with updated boot loaders on your 
  system by syncing the directory
- grub.efi (afaik signed with the Microsoft key) is linked in there together with shim for later secure boot support. Other distros would need to introduce a shim/efi directory variable which can be overridden in the *.spec file via export.

Different architecture specific grub images are created using grub2-image.
This results in a smaller file footprint compared to grub2-mkstandalone. Also there is no need
to do explicit insmod xy calls in the grub.cfg
I could successfully boot grub-x86_64.efi and grub.0 (x86 legacy and efi). The grub config structure and pxelinux config structure still need further work (the latter does not work anymore correctly since latest grub2 patches?).