### PR TITLE
Refactor get config filename

### DIFF
--- a/cobbler/action_litesync.py
+++ b/cobbler/action_litesync.py
@@ -156,11 +156,10 @@ class CobblerLiteSync(object):
 
     def remove_single_system(self, name):
         bootloc = utils.tftpboot_location()
-        system_record = self.systems.find(name=name)
         # delete contents of autoinsts_sys/$name in webdir
         system_record = self.systems.find(name=name)
 
         for (name, interface) in list(system_record.interfaces.items()):
-            filename = utils.get_config_filename(system_record, interface=name)
+            filename = system_record.get_config_filename(interface=name)
             utils.rmfile(os.path.join(bootloc, "pxelinux.cfg", filename))
             utils.rmfile(os.path.join(bootloc, "grub", filename.upper()))

--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -742,4 +742,39 @@ class System(item.Item):
     def set_serial_baud_rate(self, baud_rate):
         return utils.set_serial_baud_rate(self, baud_rate)
 
+    def get_config_filename(self, interface, loader=None):
+        """
+        The configuration file for each system pxe uses is either
+        a form of the MAC address of the hex version of the IP.  If none
+        of that is available, just use the given name, though the name
+        given will be unsuitable for PXE configuration (For this, check
+        system.is_management_supported()). This same file is used to store
+        system config information in the Apache tree, so it's still relevant.
+
+        :param loader: Bootloader type.
+        :type loader: str
+        :param interface: Name of the interface.
+        :type interface: str
+        """
+
+        if loader is None:
+            loader = self.boot_loader
+
+        if interface not in self.interfaces:
+            return None
+
+        if self.name == "default":
+            return "default"
+        mac = self.get_mac_address(interface)
+        ip = self.get_ip_address(interface)
+        if mac is not None and mac != "":
+            if loader in ("grub2", "grub"):
+                return "grub.cfg-01-" + "-".join(mac.split(":")).lower()
+            else:
+                return "01-" + "-".join(mac.split(":")).lower()
+        elif ip is not None and ip != "":
+            return utils.get_host_ip(ip)
+        else:
+            return self.name
+
 # EOF

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -233,7 +233,7 @@ class TFTPGen(object):
         # generate one record for each described NIC ..
         for (name, interface) in list(system.interfaces.items()):
 
-            f1 = utils.get_config_filename(system, interface=name)
+            f1 = system.get_config_filename(interface=name)
             if f1 is None:
                 self.logger.warning("invalid interface recorded for system (%s,%s)" % (system.name, name))
                 continue
@@ -257,7 +257,7 @@ class TFTPGen(object):
 
             elif working_arch.startswith("ppc"):
                 # Determine filename for system-specific bootloader config
-                filename = "%s" % utils.get_config_filename(system, interface=name).lower()
+                filename = "%s" % system.get_config_filename(interface=name).lower()
                 # to inherit the distro and system's boot_loader values correctly
                 blended_system = utils.blender(self.api, False, system)
                 if blended_system["boot_loader"] == "pxelinux":
@@ -536,7 +536,7 @@ class TFTPGen(object):
                         # Disable yaboot network booting for all interfaces on the system
                         for (name, interface) in list(system.interfaces.items()):
 
-                            filename = "%s" % utils.get_config_filename(system, interface=name).lower()
+                            filename = "%s" % system.get_config_filename(interface=name).lower()
 
                             # Remove symlink to the yaboot binary
                             f3 = os.path.join(self.bootloc, "ppc", filename)

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -191,32 +191,6 @@ def _IP(ip):
         return ip_class(ip)
 
 
-def get_config_filename(sys, interface):
-    """
-    The configuration file for each system pxe uses is either
-    a form of the MAC address of the hex version of the IP.  If none
-    of that is available, just use the given name, though the name
-    given will be unsuitable for PXE configuration (For this, check
-    system.is_management_supported()).  This same file is used to store
-    system config information in the Apache tree, so it's still relevant.
-    """
-
-    interface = str(interface)
-    if interface not in sys.interfaces:
-        return None
-
-    if sys.name == "default":
-        return "default"
-    mac = sys.get_mac_address(interface)
-    ip = sys.get_ip_address(interface)
-    if mac is not None and mac != "":
-        return "grub.cfg-01-" + "-".join(mac.split(":")).lower()
-    elif ip is not None and ip != "":
-        return get_host_ip(ip)
-    else:
-        return sys.name
-
-
 def is_ip(strdata):
     """
     Return whether the argument is an IP address.


### PR DESCRIPTION
Moved a function from `utils` to the corresponding `item_system`. And removed a tailcall.