### PR TITLE
Fix: Typo in services.py

### DIFF
--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -45,7 +45,7 @@ class CobblerSvc(object):
         self.req = req
         self.collection_mgr = collection_manager.CollectionManager(self)
         self.logger = None
-        self.dlmgr = download_manager.DownloadManager(self.collection_manager, self.logger)
+        self.dlmgr = download_manager.DownloadManager(self.collection_mgr, self.logger)
 
     def __xmlrpc_setup(self):
         """


### PR DESCRIPTION
Just a small typo error. This should also fix some not detected bugs.