### PR TITLE
Refactor tftpbootlocation

### DIFF
--- a/bin/tftpd.py
+++ b/bin/tftpd.py
@@ -60,7 +60,8 @@ import xmlrpc.client
 
 from collections import deque
 from fnmatch import fnmatch
-from cobbler.utils import local_get_cobbler_api_url, tftpboot_location
+from cobbler.utils import local_get_cobbler_api_url
+from cobbler import settings
 
 import tornado.ioloop as ioloop
 import cobbler.templar
@@ -95,7 +96,7 @@ OPTIONS = {
     "cache-time": 5 * 300,
     "neg-cache-time": 10,
     "active": 0,
-    "prefix": tftpboot_location(),
+    "prefix": settings.Settings.tftpboot_location,
     "logger": "stream",
     "file_cmd": "/usr/bin/file",
     "user": "nobody",

--- a/cobbler/action_acl.py
+++ b/cobbler/action_acl.py
@@ -67,7 +67,7 @@ class AclConfig(object):
     def modacl(self, isadd, isuser, who):
 
         snipdir = self.settings.autoinstall_snippets_dir
-        tftpboot = utils.tftpboot_location()
+        tftpboot = self.collection_mgr.settings.tftpboot_location
 
         PROCESS_DIRS = {
             "/var/log/cobbler": "rwx",

--- a/cobbler/action_check.py
+++ b/cobbler/action_check.py
@@ -327,7 +327,7 @@ class CobblerCheck(object):
         if self.checked_family == "debian":
             return
 
-        bootloc = utils.tftpboot_location()
+        bootloc = self.settings.tftpboot_location
         if not os.path.exists(bootloc):
             status.append(_("please create directory: %(dirname)s") % {"dirname": bootloc})
 
@@ -365,7 +365,7 @@ class CobblerCheck(object):
         if self.checked_family == "debian":
             return
 
-        bootloc = utils.tftpboot_location()
+        bootloc = self.settings.tftpboot_location
         if not os.path.exists(bootloc):
             status.append(_("please create directory: %(dirname)s") % {"dirname": bootloc})
 

--- a/cobbler/action_litesync.py
+++ b/cobbler/action_litesync.py
@@ -55,6 +55,7 @@ class CobblerLiteSync(object):
         self.tftpd = module_loader.get_module_from_file("tftpd", "module", "in_tftpd").get_manager(collection_mgr, logger)
         self.sync = collection_mgr.api.get_sync(verbose, logger=self.logger)
         self.sync.make_tftpboot()
+        self.tftpbootloc = collection_mgr.settings.tftpboot_location
 
     def add_single_distro(self, name):
         # get the distro record
@@ -96,7 +97,7 @@ class CobblerLiteSync(object):
         self.sync.tftpgen.make_pxe_menu()
 
     def remove_single_distro(self, name):
-        bootloc = utils.tftpboot_location()
+        bootloc = self.tftpbootloc
         # delete contents of images/$name directory in webdir
         utils.rmtree(os.path.join(self.settings.webdir, "images", name))
         # delete contents of images/$name in tftpboot
@@ -105,7 +106,7 @@ class CobblerLiteSync(object):
         utils.rmfile(os.path.join(self.settings.webdir, "links", name))
 
     def remove_single_image(self, name):
-        bootloc = utils.tftpboot_location()
+        bootloc = self.tftpbootloc
         utils.rmfile(os.path.join(bootloc, "images2", name))
 
     def add_single_profile(self, name, rebuild_menu=True):
@@ -155,7 +156,7 @@ class CobblerLiteSync(object):
         self.tftpd.add_single_system(system)
 
     def remove_single_system(self, name):
-        bootloc = utils.tftpboot_location()
+        bootloc = self.tftpbootloc
         system_record = self.systems.find(name=name)
         # delete contents of autoinsts_sys/$name in webdir
         system_record = self.systems.find(name=name)

--- a/cobbler/action_sync.py
+++ b/cobbler/action_sync.py
@@ -60,7 +60,7 @@ class CobblerSync(object):
         self.dns = dns
         self.dhcp = dhcp
         self.tftpd = tftpd
-        self.bootloc = utils.tftpboot_location()
+        self.bootloc = collection_mgr.settings.tftpboot_location
         self.tftpgen.verbose = verbose
         self.dns.verbose = verbose
         self.dhcp.verbose = verbose

--- a/cobbler/modules/manage_in_tftpd.py
+++ b/cobbler/modules/manage_in_tftpd.py
@@ -56,7 +56,7 @@ class InTftpdManager(object):
         self.settings_file = "/etc/xinetd.d/tftp"
         self.tftpgen = tftpgen.TFTPGen(collection_mgr, self.logger)
         self.systems = collection_mgr.systems()
-        self.bootloc = utils.tftpboot_location()
+        self.bootloc = collection_mgr.settings.tftpboot_location
 
     def regen_hosts(self):
         pass        # not used
@@ -74,7 +74,7 @@ class InTftpdManager(object):
         # Right now, just using local_img_path, but adding more
         # cobbler variables here would probably be good
         metadata = {}
-        metadata["local_img_path"] = os.path.join(utils.tftpboot_location(), "images", distro.name)
+        metadata["local_img_path"] = os.path.join(self.bootloc, "images", distro.name)
         # Create the templar instance.  Used to template the target directory
         templater = templar.Templar(self.collection_mgr)
 

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -19,13 +19,14 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
-
+import sys
 from builtins import str
 from builtins import object
 import glob
 import os.path
 import re
 
+from cexceptions import CX
 from . import utils
 from .utils import _
 
@@ -129,6 +130,7 @@ DEFAULTS = {
     "sign_puppet_certs_automatically": [0, "bool"],
     "signature_path": ["/var/lib/cobbler/distro_signatures.json", "str"],
     "signature_url": ["https://cobbler.github.io/signatures/3.0.x/latest.json", "str"],
+    "tftpboot_location": ["/srv/tftpboot", "str"],
     "virt_auto_boot": [0, "bool"],
     "webdir": ["/var/www/cobbler", "str"],
     "webdir_whitelist": [".link_cache", "misc", "distro_mirror", "images", "links", "localmirror", "pub", "rendered", "repo_mirror", "repo_profile", "repo_system", "svc", "web", "webui"],
@@ -190,6 +192,9 @@ class Settings(object):
         Constructor.
         """
         self._clear()
+        if (self.manage_tftp or self.manage_tftpd) and not os.path.isdir(self.tftpboot_location):
+            # TODO: Logging of this.
+            sys.exit(1)
 
     def _clear(self):
         self.__dict__ = {}

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -52,7 +52,7 @@ class TFTPGen(object):
         self.repos = collection_mgr.repos()
         self.images = collection_mgr.images()
         self.templar = templar.Templar(collection_mgr)
-        self.bootloc = utils.tftpboot_location()
+        self.bootloc = collection_mgr.settings.tftpboot_location
 
     def copy_bootloaders(self):
         """
@@ -863,7 +863,7 @@ class TFTPGen(object):
         #        available to templates across the board
         if blended["distro_name"]:
             blended['img_path'] = os.path.join("/images", blended["distro_name"])
-            blended['local_img_path'] = os.path.join(utils.tftpboot_location(), "images", blended["distro_name"])
+            blended['local_img_path'] = os.path.join(self.bootloc, "images", blended["distro_name"])
 
         for template in list(templates.keys()):
             dest = templates[template]
@@ -888,8 +888,8 @@ class TFTPGen(object):
             # a user granted cobbler privileges via sudo can't overwrite
             # arbitrary system files (This also makes cleanup easier).
             if os.path.isabs(dest_dir) and write_file:
-                if dest_dir.find(utils.tftpboot_location()) != 0:
-                    raise CX(" warning: template destination (%s) is outside %s, skipping." % (dest_dir, utils.tftpboot_location()))
+                if dest_dir.find(self.bootloc) != 0:
+                    raise CX(" warning: template destination (%s) is outside %s, skipping." % (dest_dir, self.bootloc))
                     continue
             elif write_file:
                 dest_dir = os.path.join(self.settings.webdir, "rendered", dest_dir)

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -977,33 +977,6 @@ def os_release():
         return (make, float(version))
 
 
-def tftpboot_location():
-    """
-    Guesses the location of the tftpboot directory,
-    based on the distro on which cobblerd is running
-    """
-    (make, version) = os_release()
-    str_version = str(version)
-
-    if make in ("fedora", "redhat", "centos", "virtuozzo"):
-        return "/var/lib/tftpboot"
-    elif make == "suse":
-        return "/srv/tftpboot"
-    # As of Ubuntu 12.04, while they seem to have settled on sticking with
-    # /var/lib/tftpboot, they haven't scrubbed all of the packages that came
-    # from Debian that use /srv/tftp by default.
-    elif make == "ubuntu" and os.path.exists("/var/lib/tftpboot"):
-        return "/var/lib/tftpboot"
-    elif make == "ubuntu" and os.path.exists("/srv/tftp"):
-        return "/srv/tftp"
-    elif make == "debian" and int(str_version.split('.')[0]) < 6:
-        return "/var/lib/tftpboot"
-    elif make == "debian" and int(str_version.split('.')[0]) >= 6:
-        return "/srv/tftp"
-    else:
-        return "/tftpboot"
-
-
 def is_safe_to_hardlink(src, dst, api):
     (dev1, path1) = get_file_device_path(src)
     (dev2, path2) = get_file_device_path(dst)

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -244,6 +244,11 @@ bind_master: 127.0.0.1
 # the choice of TFTP mangement engine is in /etc/cobbler/modules.conf
 manage_tftpd: 1
 
+# This variable contains the location of the tftpboot directory. If this directory is not present cobbler does not
+# start.
+# Default: /srv/tftpboot
+tftpboot_location: "/srv/tftpboot"
+
 # set to 1 to enable Cobbler's RSYNC management features.
 manage_rsync: 0
 


### PR DESCRIPTION
Currently the tftpbootlocation was guessed by a function from `utils`. Now I removed that functions and am using a settings-option to read where the directory is. If the directory is not there and manage_tftp* is true then cobbler shuts itself down. Currently sadly with no explanation because there is no logger available.