### PR TITLE
Fixed ldap dependency.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,6 @@ coverage
 Django
 pymongo
 distro
-ldap
+python-ldap
 dnspython
 tornado


### PR DESCRIPTION
When you try to install the ldap module from pip you get an error because this is only a placeholder package. The equivalent we need is `python-ldap`.