### PR TITLE
Fix Travis build

### DIFF
--- a/bin/tftpd.py
+++ b/bin/tftpd.py
@@ -424,7 +424,7 @@ class Request(object):
         # Look for elements starting with ".", and blow up.
         try:
             if len(self.filename) == 0:
-                    raise RuntimeError("Empty Path: ")
+                raise RuntimeError("Empty Path: ")
             for elm in self.filename.split("/"):
                 if elm[0] == ".":
                     raise RuntimeError("Path includes '.': ")
@@ -881,8 +881,7 @@ def read_packet(data, local_sock, remote_addr):
 
     if REQUESTS[opcode][REQ_CLASS] is None:
         if opcode != TFTP_OPCODE_ERROR:
-                logging.warn("Unsupported request %d(%s) from %s" %
-                             (opcode, REQUESTS[opcode][REQ_NAME], remote_addr))
+            logging.warn("Unsupported request %d(%s) from %s" % (opcode, REQUESTS[opcode][REQ_NAME], remote_addr))
         local_sock.sendto(
             ERRORPacket(2, "Unsupported request").marshall(), remote_addr)
         return None

--- a/cobbler/modules/manage_bind.py
+++ b/cobbler/modules/manage_bind.py
@@ -21,19 +21,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-from builtins import str
-from builtins import range
-from builtins import object
 import re
+import socket
 import time
+from builtins import object
+from builtins import range
+from builtins import str
 
 import cobbler.clogger as clogger
 import cobbler.templar as templar
 import cobbler.utils as utils
-
-from cobbler.utils import _
 from cobbler.cexceptions import CX
-import socket
+from cobbler.utils import _
 
 
 def register():
@@ -99,7 +98,7 @@ class BindManager(object):
                 fullAddress = fullAddress[:-1]
         groups = fullAddress.split(":")
         for group in groups:
-            while(len(group) < validGroupSize):
+            while (len(group) < validGroupSize):
                 group = "0" + group
             expandedAddress += group + ":"
         if expandedAddress[-1] == ":":
@@ -166,7 +165,7 @@ class BindManager(object):
                         # if the power address is an IP, then add it to the DNS
                         # with the host suffix of "-ipmi"
                         # TODO: Perhpas the suffix can be configurable through settings?
-                        if(power_address_is_ip):
+                        if (power_address_is_ip):
                             ipmi_host = host + "-ipmi"
                             ipmi_ips = []
                             ipmi_ips.append(system.power_address)
@@ -280,13 +279,13 @@ class BindManager(object):
                     'zone_include': ''}
 
         for zone in metadata['forward_zones']:
-                txt = """
+            txt = """
 zone "%(zone)s." {
     type master;
     file "%(zone)s";
 };
 """ % {'zone': zone}
-                metadata['zone_include'] = metadata['zone_include'] + txt
+            metadata['zone_include'] = metadata['zone_include'] + txt
 
         for zone in list(self.__reverse_zones().keys()):
             # IPv6 zones are : delimited
@@ -338,7 +337,7 @@ zone "%(arpa)s." {
                     'zone_include': ''}
 
         for zone in metadata['forward_zones']:
-                txt = """
+            txt = """
 zone "%(zone)s." {
     type slave;
     masters {
@@ -347,7 +346,7 @@ zone "%(zone)s." {
     file "data/%(zone)s";
 };
 """ % {'zone': zone, 'master': self.settings.bind_master}
-                metadata['zone_include'] = metadata['zone_include'] + txt
+            metadata['zone_include'] = metadata['zone_include'] + txt
 
         for zone in list(self.__reverse_zones().keys()):
             # IPv6 zones are : delimited
@@ -426,11 +425,12 @@ zone "%(arpa)s." {
         for system in self.systems:
             for (name, interface) in list(system.interfaces.items()):
                 if interface["dns_name"] == "":
-                    self.logger.info(("Warning: dns_name unspecified in the system: %s, while writing host records") % system.name)
+                    self.logger.info(
+                        ("Warning: dns_name unspecified in the system: %s, while writing host records") % system.name)
 
         names = [k for k, v in list(hosts.items())]
         if not names:
-            return ''       # zones with no hosts
+            return ''  # zones with no hosts
 
         if rectype == 'PTR':
             names = self.__ip_sort(names)

--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -135,8 +135,8 @@ class IscManager(object):
                     if ip is None or ip == "":
                         for (nam2, int2) in list(system.interfaces.items()):
                             if (nam2.startswith(interface["interface_master"] + ".") and int2["ip_address"] is not None and int2["ip_address"] != ""):
-                                    ip = int2["ip_address"]
-                                    break
+                                ip = int2["ip_address"]
+                                break
 
                     interface["ip_address"] = ip
                     interface["netmask"] = netmask

--- a/cobbler/modules/manage_ndjbdns.py
+++ b/cobbler/modules/manage_ndjbdns.py
@@ -85,5 +85,5 @@ class NDjbDnsManager(object):
         p = subprocess.Popen(['/usr/bin/tinydns-data'], cwd=data_dir)
         p.communicate()
 
-        if p.returncode is not 0:
+        if p.returncode != 0:
             raise Exception('Could not regenerate tinydns data file.')

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -232,7 +232,7 @@ class TFTPGen(object):
         template_src.close()
 
         # Write the grub menu:
-        outfile = os.path.join(self.bootloc, "grub", "menu_items.cfg")        
+        outfile = os.path.join(self.bootloc, "grub", "menu_items.cfg")
         fd = open(outfile, "w+")
         fd.write(menu_items['grub'])
         fd.close()
@@ -475,7 +475,7 @@ class TFTPGen(object):
                 if format == "pxe":
                     buffer = "serial %d %d\n" % (serial_device, serial_baud_rate)
                 elif format == "grub":
-                    buffer = "set serial_console=true\nset serial_baud={baud}\nset serial_line={device}\n".format (baud=serial_baud_rate, device=serial_device)
+                    buffer = "set serial_console=true\nset serial_baud={baud}\nset serial_line={device}\n".format(baud=serial_baud_rate, device=serial_device)
 
         # get the template
         if kernel_path is not None:

--- a/setup.py
+++ b/setup.py
@@ -599,7 +599,7 @@ if __name__ == "__main__":
         author_email="cobbler@lists.fedorahosted.org",
         url="https://cobbler.github.io",
         license="GPLv2+",
-        requires=requires("requirements.txt"),
+        install_requires=requires("requirements.txt"),
         tests_require=requires("requirements-test.txt"),
         packages=[
             "cobbler",


### PR DESCRIPTION
Currently the Travis build fails due to errors in the a `-` in the package name. This can be resolved through using setuptools instead of distutils.