### PR TITLE
OpenVZ7 fixes

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -51,7 +51,7 @@
    },
    "rhel7": {
     "signatures":["Packages"],
-    "version_file":"(redhat|sl|slf|centos|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*7(Server)*[\\.-]+(.*)\\.rpm",
+    "version_file":"(redhat|sl|slf|centos|oraclelinux)-release-(?!notes)([\\w]*-)*7(Server)*[\\.-]+(.*)\\.rpm",
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*).rpm",
     "kernel_arch_regex":null,
@@ -68,7 +68,7 @@
    },
    "rhel8": {
     "signatures":["BaseOS"],
-    "version_file":"(redhat|sl|slf|centos|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
+    "version_file":"(redhat|sl|slf|centos|oraclelinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
     "version_file_regex":null,
     "kernel_arch":"kernel-(.*).rpm",
     "kernel_arch_regex":null,
@@ -84,7 +84,7 @@
    },
    "ovz7": {
     "signatures":["Packages"],
-    "version_file":"(openvz)-release-7(.*)\\.rpm",
+    "version_file":"(openvz|vzlinux)-release-7(.*)\\.rpm",
     "version_file_regex":null,
     "kernel_arch":"vzkernel-(.*).rpm",
     "kernel_arch_regex":null,


### PR DESCRIPTION
Fixes detection of OpenVZ..  I removed 'vzlinux' from the other rhel* distros because they're not necessary for Rhel detection and cause a conflict with openvz detection.