### PR TITLE
WIP: Adds SUSE Manager as a new SUSE distribution

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -692,7 +692,7 @@ class RepoSync(object):
         # all_path = os.path.join(repo_path, "*")
         owner = "root:apache"
         distribution = distro.linux_distribution()[0]
-        if distribution.lower() in ("sles", "opensuse leap", "opensuse tumbleweed"):
+        if distribution.lower() in ("sles", "opensuse leap", "opensuse tumbleweed", "suse-manager-server"):
             owner = "root:www"
         elif "debian" in distribution.lower():
             owner = "root:www-data"

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -895,7 +895,7 @@ def get_family():
             return "redhat"
     if "debian" in dist or "ubuntu" in dist:
         return "debian"
-    if dist in ("opensuse tumbleweed", "opensuse leap", "sles"):
+    if dist in ("opensuse tumbleweed", "opensuse leap", "sles", "suse-manager-server"):
         return "suse"
     return dist
 
@@ -946,7 +946,7 @@ def os_release():
     elif family == "suse":
         make = "suse"
         distribution, version = distro.linux_distribution()[:2]
-        if distribution.lower() not in ("sles", "opensuse leap", "opensuse tumbleweed"):
+        if distribution.lower() not in ("sles", "opensuse leap", "opensuse tumbleweed", "suse-manager-server"):
             make = "unknown"
         return (make, float(version))
 


### PR DESCRIPTION
SUSE Manager will soon ship as base product and therefore got its own entries in `/etc/os-release`.