### PR TITLE
Fix: Login errors

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1845,7 +1845,7 @@ class CobblerXMLRPCInterface(object):
             return False
 
     def check_access(self, token, resource, arg1=None, arg2=None):
-        user = self.get_user_from_token(token.data)
+        user = self.get_user_from_token(token)
         if user == "<DIRECT>":
             self._log("CLI Authorized", debug=True)
             return True


### PR DESCRIPTION
The token was not correctly used in the login method. After removing the `.data` suffix the logs are now fine.