### PR TITLE
Fixes case where distro object is None

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -167,7 +167,7 @@ class BuildIso(object):
             data = utils.blender(self.api, False, profile)
 
             # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-            utils.suse_kopts_textmode_overwrite(dist.breed, data['kernel_options'])
+            utils.suse_kopts_textmode_overwrite(dist, data['kernel_options'])
 
             if not re.match(r"[a-z]+://.*", data["autoinstall"]):
                 data["autoinstall"] = "http://%s:%s/cblr/svc/op/autoinstall/profile/%s" % (
@@ -495,7 +495,7 @@ class BuildIso(object):
             data = utils.blender(self.api, False, descendant)
 
             # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-            utils.suse_kopts_textmode_overwrite(distro.breed, data['kernel_options'])
+            utils.suse_kopts_textmode_overwrite(distro, data['kernel_options'])
 
             cfg.write("\n")
             cfg.write("LABEL %s\n" % descendant.name)

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -527,7 +527,7 @@ class TFTPGen(object):
         kopts = utils.revert_strip_none(kopts)
 
         # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-        utils.suse_kopts_textmode_overwrite(distro.breed, kopts)
+        utils.suse_kopts_textmode_overwrite(distro, kopts)
 
         # since network needs to be configured again (it was already in netboot) when kernel boots
         # and we choose to do it dinamically, we need to set 'ksdevice' to one of

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2074,9 +2074,9 @@ def compare_versions_gt(ver1, ver2):
     return versiontuple(ver1) > versiontuple(ver2)
 
 
-def suse_kopts_textmode_overwrite(distro_breed, kopts):
+def suse_kopts_textmode_overwrite(distro, kopts):
     """SUSE is not using 'text'. Instead 'textmode' is used as kernel option."""
-    if distro_breed == "suse":
+    if distro and distro.breed == "suse":
         if 'textmode' in list(kopts.keys()):
             kopts.pop('text', None)
         elif 'text' in list(kopts.keys()):


### PR DESCRIPTION
The `distro` or `dist` object can be `None` and therefore we have to gate this in `suse_kopts_textmode_overwrite()`.