### PR TITLE
Fixes case where distro object is None

### DIFF
--- a/cobbler/action_buildiso.py
+++ b/cobbler/action_buildiso.py
@@ -156,7 +156,7 @@ class BuildIso:
 
              data = utils.blender(self.api, False, profile)
              # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-             utils.suse_kopts_textmode_overwrite(dist.breed, data['kernel_options'])
+             utils.suse_kopts_textmode_overwrite(dist, data['kernel_options'])
 
              if data["kickstart"].startswith("/"):
                  data["kickstart"] = "http://%s:%s/cblr/svc/op/ks/profile/%s" % (
@@ -460,7 +460,7 @@ class BuildIso:
         for descendant in descendants:
             data = utils.blender(self.api, False, descendant)
             # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-            utils.suse_kopts_textmode_overwrite(distro.breed, data['kernel_options'])
+            utils.suse_kopts_textmode_overwrite(distro, data['kernel_options'])
 
             cfg.write("\n")
             cfg.write("LABEL %s\n" % descendant.name)

--- a/cobbler/pxegen.py
+++ b/cobbler/pxegen.py
@@ -784,7 +784,7 @@ class PXEGen:
         kopts = blended.get("kernel_options", dict())
 
         # SUSE is not using 'text'. Instead 'textmode' is used as kernel option
-        utils.suse_kopts_textmode_overwrite(distro.breed, kopts)
+        utils.suse_kopts_textmode_overwrite(distro, kopts)
 
         # support additional initrd= entries in kernel options.
         if "initrd" in kopts:

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2304,9 +2304,9 @@ def find_distro_path(settings, distro):
     # directory in which the given distro's kernel is
     return os.path.dirname(distro.kernel)
 
-def suse_kopts_textmode_overwrite(distro_breed, kopts):
+def suse_kopts_textmode_overwrite(distro, kopts):
     """SUSE is not using 'text'. Instead 'textmode' is used as kernel option."""
-    if distro_breed == "suse":
+    if distro and distro.breed == "suse":
         if 'textmode' in kopts.keys():
             kopts.pop('text', None)
         elif 'text' in kopts.keys():


### PR DESCRIPTION
The distro or dist object can be None and therefore we have to gate this in suse_kopts_textmode_overwrite().

This is a backport of 99448337f39743c82e4e174f4132f245ab2cf0c8.