### PR TITLE
create system directory at the correct place

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -661,8 +661,8 @@ if __name__ == "__main__":
             # files
             ("%sgrub_config/grub" % libpath, glob("config/grub/grub/*")),
             # dirs
-            ("%sgrub_config/grub/grub/system" % libpath, []),
-            ("%sgrub_config/grub/grub/system_link" % libpath, []),
+            ("%sgrub_config/grub/system" % libpath, []),
+            ("%sgrub_config/grub/system_link" % libpath, []),
             ("%sreporting" % etcpath, glob("templates/reporting/*")),
             ("%spower" % etcpath, glob("templates/power/*")),
             # Build empty directories to hold triggers


### PR DESCRIPTION
On cobbler sync I get:
```
Exception value: [Errno 2] No such file or directory: '/srv/tftpboot/grub/system/00:22:22:77:ee:cc'
```

The directory "system" is missing as it is again inside a second "grub" directory:

```
/srv/tftpboot/grub/grub/system/
```

@watologo1 - I am not sure what structure the grub.cfg files expect. Maybe you want to check.