### PR TITLE
Changes shebang to /bin/bash

### DIFF
--- a/tests/setup-test-docker.sh
+++ b/tests/setup-test-docker.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # SystemD stuff (needs insserv additionally)
 zypper -n install systemd insserv; zypper clean


### PR DESCRIPTION
The Bash executable is located at `/bin/bash` and not `/usr/bin/bash`.