### PR TITLE
Disables nsupdate_enabled by default

### DIFF
--- a/config/cobbler/settings.d/nsupdate.settings
+++ b/config/cobbler/settings.d/nsupdate.settings
@@ -1,6 +1,6 @@
 
 # set to 1 to enable Cobbler's dynamic DNS updates.
-nsupdate_enabled: 1
+nsupdate_enabled: 0
 
 # define tsig key
 # please don't use this one, instead generate your own:


### PR DESCRIPTION
Flipping the switch to disabled by default, since this is not popular among enterprise users.

Closes #2047 