### PR TITLE
Allow to override build date

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ def glob(*args, **kwargs):
 #####################################################################
 
 def gen_build_version():
-    builddate = time.asctime()
+    buildepoch = int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+    builddate = time.asctime(time.gmtime(buildepoch))
 
     gitloc = "/usr/bin/git"
     gitdate = "?"


### PR DESCRIPTION
Allow to override build date with SOURCE_DATE_EPOCH.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of the environment variable.

Also uses gmtime/UTC to be independent of timezones.

This PR was done as part of my work on reproducible builds for openSUSE.