### PR TITLE
Bring back power_system method in the XML-RPC API

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1040,11 +1040,12 @@ class CobblerAPI(object):
         elif power_operation == "off":
             self.power_mgr.power_off(system, user=user, password=password, logger=logger)
         elif power_operation == "status":
-            self.power_mgr.get_power_status(system, user=user, password=password, logger=logger)
+            return self.power_mgr.get_power_status(system, user=user, password=password, logger=logger)
         elif power_operation == "reboot":
             self.power_mgr.reboot(system, user=user, password=password, logger=logger)
         else:
             utils.die(self.logger, "invalid power operation '%s', expected on/off/status/reboot" % power_operation)
+        return None
 
     # ==========================================================================
 

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -165,7 +165,8 @@ class PowerManager(object):
         # Some power switches are flakey
         for x in range(0, 5):
             output, rc = utils.subprocess_sp(logger, power_command, shell=False, input=template_data)
-            if rc == 0:
+            # fencing agent returns 2 if the system is powered off
+            if rc == 0 or (rc == 2 and power_operation == 'status'):
                 # If the desired state is actually a query for the status
                 # return different information than command return code
                 if power_operation == 'status':

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -271,6 +271,20 @@ class CobblerXMLRPCInterface(object):
         self.check_access(token, "power_system")
         return self.__start_task(runner, token, "power", "Power management (%s)" % options.get("power", ""), options)
 
+    def power_system(self, system_id, power, token):
+        """
+        Execute power task synchronously.
+             system_id      -- system handle
+             power          -- power operation (on/off/status/reboot)
+             token          -- token from login() call, all tasks require tokens
+        Returns true if the operation succeeded or if the system is powered on (in case of status).
+        False otherwise.
+        """
+        system = self.__get_object(system_id)
+        self.check_access(token, "power_system", system)
+        result = self.api.power_system(system, power, logger=self.logger)
+        return True if result is None else result
+
     def background_signature_update(self, options, token):
         def runner(self):
             self.remote.api.signature_update(self.logger)


### PR DESCRIPTION
Add synchronous `power_system` to the XML-RPC API. Method existed in previous versions.