### PR TITLE
Changes return to float

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -195,7 +195,7 @@ class CobblerAPI(object):
             fd = open("/var/lib/cobbler/.mtime", 'w')
             fd.write("0")
             fd.close()
-            return 0
+            return float(0)
         fd = open("/var/lib/cobbler/.mtime", 'r')
         data = fd.read().strip()
         return float(data)

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -198,7 +198,7 @@ class CobblerAPI(object):
             return 0
         fd = open("/var/lib/cobbler/.mtime", 'r')
         data = fd.read().strip()
-        return data
+        return float(data)
 
     # ==========================================================
 


### PR DESCRIPTION
There is a timestamp `time.time()` in `.mtime` and we could return `float` instead of `str` to make parsing on the receivers end easier.