### PR TITLE
get_system_for_koan() does no longer exits

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1576,7 +1576,7 @@ class CobblerXMLRPCInterface(object):
         if system is None:
             return {}
         else:
-            return self.get_system_for_koan(system.name)
+            return self.get_system_as_rendered(system.name)
 
     def get_distro_as_rendered(self, name, token=None, **rest):
         """


### PR DESCRIPTION
At some point of time that function was removed, but the function doc claims that it's the same as `get_system_as_rendered()` and the two function look indeed very similar. So I'm replacing the function call.