### PR TITLE
Provide old name aliases for renamed methods part 2

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -575,9 +575,19 @@ class CobblerXMLRPCInterface(object):
         what is the name of a cobbler object type, as described for get_item.
         Individual list elements are the same for get_item.
         """
-        # FIXME: is the xmlrpc_hacks method still required ?
-        item = [x.to_dict() for x in self.api.get_items(what)]
-        return self.xmlrpc_hacks(item)
+        items = [x.to_dict() for x in self.api.get_items(what)]
+
+        for item in items:
+            if "autoinstall" in item:
+                self._log("autoinstall legacy field added as kickstart")
+                kick_dict = {"kickstart": item.get("autoinstall")}
+                item.update(kick_dict)
+            if "autoinstall_meta" in item:
+                self._log("autoinstall_meta legacy field added as ks_meta")
+                kick_meta_dict = {"ks_meta": item.get("autoinstall_meta")}
+                item.update(kick_meta_dict)
+
+        return self.xmlrpc_hacks(items)
 
     def get_item_names(self, what):
         """
@@ -1721,30 +1731,158 @@ class CobblerXMLRPCInterface(object):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
         return self.xmlrpc_hacks({})
 
-    # provide renamed methods under old name for compatibility
     def get_distro_for_koan(self, name, token=None, **rest):
-        return self.get_distro_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: The name of the distro to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired distro or '~'.
+        """
+        self._log("get_distro_for_koan", name=name, token=token)
+        obj = self.api.find_distro(name=name)
+        if obj is not None:
+            _dict = utils.blender(self.api, True, obj)
+            _dict["ks_meta"] = _dict["autoinstall_meta"]
+            return self.xmlrpc_hacks(_dict)
+        return self.xmlrpc_hacks({})
 
     def get_profile_for_koan(self, name, token=None, **rest):
-        return self.get_profile_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: The name of the profile to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired profile or '~'.
+        """
+        self._log("get_profile_for_koan", name=name, token=token)
+        obj = self.api.find_profile(name=name)
+        if obj is not None:
+            _dict = utils.blender(self.api, True, obj)
+            _dict["kickstart"] = _dict["autoinstall"]
+            _dict["ks_meta"] = _dict["autoinstall_meta"]
+            return self.xmlrpc_hacks(_dict)
+        return self.xmlrpc_hacks({})
 
     def get_system_for_koan(self, name, token=None, **rest):
-        return self.get_system_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: The name of the system to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired system or '~'.
+        """
+        self._log("get_system_as_rendered", name=name, token=token)
+        obj = self.api.find_system(name=name)
+        if obj is not None:
+            _dict = utils.blender(self.api, True, obj)
+
+            # Generate a pxelinux.cfg?
+            image_based = False
+            profile = obj.get_conceptual_parent()
+            distro = profile.get_conceptual_parent()
+
+            # the management classes stored in the system are just a list
+            # of names, so we need to turn it into a full list of dictionaries
+            # (right now we just use the params field)
+            mcs = _dict["mgmt_classes"]
+            _dict["mgmt_classes"] = {}
+            for m in mcs:
+                c = self.api.find_mgmtclass(name=m)
+                if c:
+                    _dict["mgmt_classes"][m] = c.to_dict()
+
+            arch = None
+            if distro is None and profile.COLLECTION_TYPE == "image":
+                image_based = True
+                arch = profile.arch
+            else:
+                arch = distro.arch
+
+            if obj.is_management_supported():
+                if not image_based:
+                    _dict["pxelinux.cfg"] = self.tftpgen.write_pxe_file(
+                        None, obj, profile, distro, arch)
+                else:
+                    _dict["pxelinux.cfg"] = self.tftpgen.write_pxe_file(
+                        None, obj, None, None, arch, image=profile)
+
+            # Add legacy fields to the system
+            _dict["kickstart"] = _dict["autoinstall"]
+            _dict["ks_meta"] = _dict["autoinstall_meta"]
+
+            return self.xmlrpc_hacks(_dict)
+        return self.xmlrpc_hacks({})
 
     def get_repo_for_koan(self, name, token=None, **rest):
-        return self.get_repo_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: The name of the repo to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired repo or '~'.
+        """
+        self._log("get_repo_for_koan", name=name, token=token)
+        obj = self.api.find_repo(name=name)
+        if obj is not None:
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
+        return self.xmlrpc_hacks({})
 
     def get_image_for_koan(self, name, token=None, **rest):
-        return self.get_image_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: The name of the image to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired image or '~'
+        """
+        self._log("get_image_for_koan", name=name, token=token)
+        obj = self.api.find_image(name=name)
+        if obj is not None:
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
+        return self.xmlrpc_hacks({})
 
     def get_mgmtclass_for_koan(self, name, token=None, **rest):
-        return self.get_mgmtclass_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: Name of the mgmtclass to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired mgmtclass or `~`.
+        """
+        self._log("get_mgmtclass_for_koan", name=name, token=token)
+        obj = self.api.find_mgmtclass(name=name)
+        if obj is not None:
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
+        return self.xmlrpc_hacks({})
 
     def get_package_for_koan(self, name, token=None, **rest):
-        return self.get_package_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: Name of the package to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired package or '~'.
+        """
+        self._log("get_package_for_koan", name=name, token=token)
+        obj = self.api.find_package(name=name)
+        if obj is not None:
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
+        return self.xmlrpc_hacks({})
 
     def get_file_for_koan(self, name, token=None, **rest):
-        return self.get_file_as_rendered(name)
+        """
+        This is a legacy function for 2.6.6 releases.
+        :param name: Name of the file to get.
+        :param token: Auth token to authenticate against the api.
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: The desired file or '~'.
+        """
+        self._log("get_file_for_koan", name=name, token=token)
+        obj = self.api.find_file(name=name)
+        if obj is not None:
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
+        return self.xmlrpc_hacks({})
 
     def get_random_mac(self, virt_type="xenpv", token=None, **rest):
         """

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1839,7 +1839,9 @@ class CobblerXMLRPCInterface(object):
         self._log("get_image_for_koan", name=name, token=token)
         obj = self.api.find_image(name=name)
         if obj is not None:
-            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
+            _dict = utils.blender(self.api, True, obj)
+            _dict["kickstart"] = _dict["autoinstall"]
+            return self.xmlrpc_hacks(_dict)
         return self.xmlrpc_hacks({})
 
     def get_mgmtclass_for_koan(self, name, token=None, **rest):

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -72,6 +72,21 @@ class CobblerSvc(object):
         data = self.remote.generate_autoinstall(profile, system, REMOTE_ADDR, REMOTE_MAC)
         return "%s" % data
 
+    def ks(self, profile=None, system=None, REMOTE_ADDR=None, REMOTE_MAC=None, **rest):
+        """
+        Generate automatic installation files. This is a legacy function for part backward compability to 2.6.6
+        releases.
+        :param profile:
+        :param system:
+        :param REMOTE_ADDR:
+        :param REMOTE_MAC:
+        :param rest:
+        :return:
+        """
+        self.__xmlrpc_setup()
+        data = self.remote.generate_autoinstall(profile, system, REMOTE_ADDR, REMOTE_MAC)
+        return "%s" % data
+
     def gpxe(self, profile=None, system=None, mac=None, **rest):
         """
         Generate a gPXE config
@@ -251,6 +266,36 @@ class CobblerSvc(object):
             return self.dlmgr.urlread(url)
         except:
             return "# automatic installation file retrieval failed (%s)" % url
+
+    def findks(self, system=None, profile=None, **rest):
+        """
+        This is a legacy function which enabled cobbler partly to be backward compatible to 2.6.6 releases.
+
+        It should be only be used if you must. Please use find_autoinstall if possible!
+        :param system: If you wish to find a system please set this parameter to not null. Hand over the name of it.
+        :param profile: If you wish to find a system please set this parameter to not null. Hand over the name of it.
+        :param rest: If you wish you can try to let cobbler autodetect the system with the MAC address.
+        :return: Returns the autoinstall/kickstart profile.
+        """
+        self.__xmlrpc_setup()
+
+        serverseg = "http://%s" % self.collection_mgr._settings.server
+
+        name = "?"
+        if system is not None:
+            url = "%s/cblr/svc/op/ks/system/%s" % (serverseg, name)
+        elif profile is not None:
+            url = "%s/cblr/svc/op/ks/profile/%s" % (serverseg, name)
+        else:
+            name = self.autodetect(**rest)
+            if name.startswith("FAILED"):
+                return "# autodetection %s" % name
+            url = "%s/cblr/svc/op/ks/system/%s" % (serverseg, name)
+
+        try:
+            return self.dlmgr.urlread(url)
+        except:
+            return "# kickstart retrieval failed (%s)" % url
 
     def puppet(self, hostname=None, **rest):
         self.__xmlrpc_setup()

--- a/tests/xmlrpcapi/distro_profile_system_test.py
+++ b/tests/xmlrpcapi/distro_profile_system_test.py
@@ -714,6 +714,105 @@ class TestDistroProfileSystem:
         # Assert
         assert system is "~"
 
+    @pytest.mark.usefixtures("create_testdistro", "create_profile", "create_testsystem", "remove_testdistro",
+                             "remove_testprofile", "remove_testsystem")
+    def test_get_systems_koan(self, remote):
+        # Arrange
+
+        # Act
+        systems = remote.get_systems()
+
+        # Assert
+        for system in systems:
+            assert "ks_meta" in system
+            assert "kickstart" in system
+            assert system.get("kickstart") == system.get("autoinstall")
+            assert system.get("ks_meta") == system.get("autoinstall_meta")
+
+    @pytest.mark.usefixtures("create_testdistro", "create_profile", "create_testsystem", "remove_testdistro",
+                             "remove_testprofile", "remove_testsystem")
+    def test_get_system_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        system = remote.get_system_for_koan("testsystem0")
+
+        # Assert
+        assert "ks_meta" in system
+        assert "kickstart" in system
+
+    @pytest.mark.usefixtures("create_testdistro", "create_profile", "remove_testdistro", "remove_testprofile")
+    def test_get_profile_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        profile = remote.get_profile_for_koan("testprofile0")
+
+        # Assert
+        assert "ks_meta" in profile
+        assert "kickstart" in profile
+
+    @pytest.mark.usefixtures("create_testdistro", "remove_testdistro")
+    def test_get_distro_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        distro = remote.get_distro_for_koan("testdistro0")
+
+        # Assert
+        assert "ks_meta" in distro
+        assert "kickstart" not in distro
+
+    def test_get_repo_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        repo = remote.get_repo_for_koan()
+
+        # Assert
+        assert "ks_meta" in repo
+        assert "kickstart" not in repo
+
+    def test_get_image_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        image = remote.get_image_for_koan()
+
+        # Assert
+        assert "ks_meta" in image
+        assert "kickstart" in image
+
+    def test_get_mgmtclass_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        mgmt_class = remote.get_mgmtclass_for_koan()
+
+        # Assert
+        assert "ks_meta" in mgmt_class
+        assert "kickstart" not in mgmt_class
+
+    def test_get_package_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        package = remote.get_package_for_koan()
+
+        # Assert
+        assert "ks_meta" in package
+        assert "kickstart" not in package
+
+    def test_get_file_for_koan(self, remote):
+        # Arrange
+
+        # Act
+        file = remote.get_file_for_koan()
+
+        # Assert
+        assert "ks_meta" in file
+        assert "kickstart" not in file
+
     def test_find_distro(self, remote, token):
         """
         Test: find a distro object

--- a/tests/xmlrpcapi/distro_profile_system_test.py
+++ b/tests/xmlrpcapi/distro_profile_system_test.py
@@ -414,6 +414,136 @@ def remove_testsystem(remote, token):
     remote.remove_system("testsystem0", token, False)
 
 
+@pytest.fixture()
+def create_testrepo(remote, token):
+    """
+    Create a testrepository with the name "testrepo0"
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    repo = remote.new_repo(token)
+    remote.modify_repo(repo, "name", "testrepo0", token)
+    remote.modify_repo(repo, "arch", "x86_64", token)
+    remote.modify_repo(repo, "mirror", "http://something", token)
+    remote.save_repo(repo, token)
+    remote.background_sync([], token)
+
+
+@pytest.fixture()
+def remove_testrepo(remote, token):
+    """
+    Remove a repo "testrepo0".
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    yield
+    remote.remove_repo("testrepo0", token, False)
+
+
+@pytest.fixture()
+def create_testimage(remote, token):
+    """
+    Create a testrepository with the name "testimage0"
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    image = remote.new_image(token)
+    remote.modify_image(image, "name", "testimage0", token)
+    remote.save_image(image, token)
+    remote.background_sync([], token)
+
+
+@pytest.fixture()
+def remove_testimage(remote, token):
+    """
+    Remove the image "testimage0".
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    yield
+    remote.remove_image("testimage0", token, False)
+
+
+@pytest.fixture()
+def create_testpackage(remote, token):
+    """
+    Create a testpackage with the name "testpackage0"
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    package = remote.new_package(token)
+    remote.modify_package(package, "name", "testpackage0", token)
+    remote.save_package(package, token)
+    remote.background_sync([], token)
+
+
+@pytest.fixture()
+def remove_testpackage(remote, token):
+    """
+    Remove a package "testpackage0".
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+
+    yield
+    remote.remove_package("testpackage0", token, False)
+
+
+@pytest.fixture()
+def create_testfile(remote, token):
+    """
+    Create a testfile with the name "testfile0"
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+
+    mfile = remote.new_file(token)
+    remote.modify_file(mfile, "name", "testfile0", token)
+    remote.modify_file(mfile, "path", "/dev/shm/", token)
+    remote.modify_file(mfile, "group", "root", token)
+    remote.modify_file(mfile, "owner", "root", token)
+    remote.modify_file(mfile, "mode", "0600", token)
+    remote.modify_file(mfile, "is_dir", "True", token)
+    remote.save_file(mfile, token)
+    remote.background_sync([], token)
+
+
+@pytest.fixture()
+def remove_testfile(remote, token):
+    """
+    Remove a file "testfile0".
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    yield
+    remote.remove_file("testfile0", token, False)
+
+
+@pytest.fixture()
+def create_mgmtclass(remote, token):
+    """
+    Create a mgmtclass with the name "mgmtclass0"
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+
+    mgmtclass0 = remote.new_mgmtclass(token)
+    remote.modify_mgmtclass(mgmtclass0, "name", "mgmtclass0", token)
+    remote.save_mgmtclass(mgmtclass0, token)
+    remote.background_sync([], token)
+
+
+@pytest.fixture()
+def remove_mgmtclass(remote, token):
+    """
+    Remove a mgmtclass "mgmtclass0".
+    :param remote: See the corresponding fixture.
+    :param token: See the corresponding fixture.
+    """
+    yield
+    remote.remove_mgmtclass("mgmtclass0", token, False)
+
+
 @pytest.mark.usefixtures("cobbler_xmlrpc_base", "remove_fakefiles")
 class TestDistroProfileSystem:
     """
@@ -763,54 +893,59 @@ class TestDistroProfileSystem:
         assert "ks_meta" in distro
         assert "kickstart" not in distro
 
+    @pytest.mark.usefixtures("create_testrepo", "remove_testrepo")
     def test_get_repo_for_koan(self, remote):
         # Arrange
 
         # Act
-        repo = remote.get_repo_for_koan()
+        repo = remote.get_repo_for_koan("testrepo0")
 
         # Assert
-        assert "ks_meta" in repo
+        assert "ks_meta" not in repo
         assert "kickstart" not in repo
 
+    @pytest.mark.usefixtures("create_testimage", "remove_testimage")
     def test_get_image_for_koan(self, remote):
         # Arrange
 
         # Act
-        image = remote.get_image_for_koan()
+        image = remote.get_image_for_koan("testimage0")
 
         # Assert
-        assert "ks_meta" in image
+        assert "ks_meta" not in image
         assert "kickstart" in image
 
+    @pytest.mark.usefixtures("create_mgmtclass", "remove_mgmtclass")
     def test_get_mgmtclass_for_koan(self, remote):
         # Arrange
 
         # Act
-        mgmt_class = remote.get_mgmtclass_for_koan()
+        mgmt_class = remote.get_mgmtclass_for_koan("mgmtclass0")
 
         # Assert
-        assert "ks_meta" in mgmt_class
+        assert "ks_meta" not in mgmt_class
         assert "kickstart" not in mgmt_class
 
+    @pytest.mark.usefixtures("create_testpackage", "remove_testpackage")
     def test_get_package_for_koan(self, remote):
         # Arrange
 
         # Act
-        package = remote.get_package_for_koan()
+        package = remote.get_package_for_koan("package0")
 
         # Assert
-        assert "ks_meta" in package
+        assert "ks_meta" not in package
         assert "kickstart" not in package
 
+    @pytest.mark.usefixtures("create_testfile", "remove_testfile")
     def test_get_file_for_koan(self, remote):
         # Arrange
 
         # Act
-        file = remote.get_file_for_koan()
+        file = remote.get_file_for_koan("file0")
 
         # Assert
-        assert "ks_meta" in file
+        assert "ks_meta" not in file
         assert "kickstart" not in file
 
     def test_find_distro(self, remote, token):


### PR DESCRIPTION
This is basically part two of this PR: #2054 

For an old Koan version we would not only need the old methods in place, but also compatible responses.