### PR TITLE
Changes detection to distro.like() for SUSE distributions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -542,8 +542,7 @@ if __name__ == "__main__":
     logpath = "/var/log/"
     statepath = "/tmp/cobbler_settings/devinstall"
     httpd_service = "httpd.service"
-    os_release = distro.linux_distribution()[0].lower().strip()
-    suse_release = ("suse" in os_release)
+    suse_release = "suse" in distro.like()
 
     if suse_release:
         webconfig = "/etc/apache2/conf.d"


### PR DESCRIPTION
SLES does not have SUSE in the name field in os-release. Therefore we've switched to the like() function call, which is using id_like.