### PR TITLE
Fixes field setting for rhn_management_key

### DIFF
--- a/cobbler/item_profile.py
+++ b/cobbler/item_profile.py
@@ -55,7 +55,7 @@ FIELDS = [
     ["owners", "SETTINGS:default_ownership", "SETTINGS:default_ownership", "Owners", True, "Owners list for authz_ownership (space delimited)", 0, "list"],
     ["parent", '', '', "Parent Profile", True, "", [], "str"],
     ["proxy", "SETTINGS:proxy_url_int", "<<inherit>>", "Proxy", True, "Proxy URL", 0, "str"],
-    ["redhat_management_key", "<<inherit>>", "<<inherit>>", "Redhat Management Key", True, 0, "str"],
+    ["redhat_management_key", "<<inherit>>", "<<inherit>>", "Red Hat Management Key", True, "Registration key for RHN, Spacewalk, or Satellite", 0, "str"],
     ["repos", [], '<<inherit>>', "Repos", True, "Repos to auto-assign to this profile", [], "list"],
     ["server", "<<inherit>>", '<<inherit>>', "Server Override", True, "See manpage or leave blank", 0, "str"],
     ["template_files", {}, '<<inherit>>', "Template Files", True, "File mappings for built-in config management", 0, "dict"],


### PR DESCRIPTION
One value was missing from the list and therefore cobbler bailed on profile rename.

This is a follow up of #2060.