### PR TITLE
remove check for httpd from action_check.py

### DIFF
--- a/cobbler/action_check.py
+++ b/cobbler/action_check.py
@@ -89,7 +89,6 @@ class CobblerCheck(object):
         self.check_bootloaders(status)
         self.check_for_wget_curl(status)
         self.check_rsync_conf(status)
-        self.check_httpd(status)
         self.check_iptables(status)
         self.check_yum(status)
         self.check_debmirror(status)
@@ -232,19 +231,6 @@ class CobblerCheck(object):
                     need_sync.append(r.name)
         if len(need_sync) > 0:
             status.append(_("One or more repos need to be processed by cobbler reposync for the first time before automating installations using them: %s") % ", ".join(need_sync))
-
-    def check_httpd(self, status):
-        """
-        Check if Apache is installed.
-        """
-        if self.checked_family == "redhat":
-            rc = utils.subprocess_get(self.logger, "httpd -v")
-        elif self.checked_family == "suse":
-            rc = utils.subprocess_get(self.logger, "httpd2 -v")
-        else:
-            rc = utils.subprocess_get(self.logger, "apache2 -v")
-        if rc.find("Server") == -1:
-            status.append("Apache (httpd) is not installed and/or in path")
 
     def check_dhcpd_bin(self, status):
         """

--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -64,6 +64,7 @@ FIELDS = [
     ["power_pass", "", 0, "Power Management Password", True, "", 0, "str"],
     ["power_type", "SETTINGS:power_management_default_type", 0, "Power Management Type", True, "Power management script to use", power_manager.get_power_types(), "str"],
     ["power_user", "", 0, "Power Management Username", True, "", 0, "str"],
+    ["power_options","", 0,"Power Management Options", True, "Additional options, to be passed to the fencing agent",0 ,"str"],
     ["profile", None, 0, "Profile", True, "Parent profile", [], "str"],
     ["proxy", "<<inherit>>", 0, "Internal Proxy", True, "Internal proxy URL", 0, "str"],
     ["redhat_management_key", "<<inherit>>", 0, "Redhat Management Key", True, "Registration key for RHN, Spacewalk, or Satellite", 0, "str"],
@@ -646,6 +647,12 @@ class System(item.Item):
         utils.safe_filter(power_user)
         self.power_user = power_user
 
+    def set_power_options(self, power_options):
+        if power_options is None:
+            power_options = ""
+        utils.safe_filter(power_options)
+        self.power_options = power_options
+        
     def set_power_pass(self, power_pass):
         if power_pass is None:
             power_pass = ""

--- a/cobbler/item_system.py
+++ b/cobbler/item_system.py
@@ -64,7 +64,8 @@ FIELDS = [
     ["power_pass", "", 0, "Power Management Password", True, "", 0, "str"],
     ["power_type", "SETTINGS:power_management_default_type", 0, "Power Management Type", True, "Power management script to use", power_manager.get_power_types(), "str"],
     ["power_user", "", 0, "Power Management Username", True, "", 0, "str"],
-    ["power_options","", 0,"Power Management Options", True, "Additional options, to be passed to the fencing agent",0 ,"str"],
+    ["power_options", "", 0, "Power Management Options", True, "Additional options, to be passed to the fencing agent", 0, "str"],
+    ["power_identity_file", "", 0, "Power Identity File", True, "Identity file to be passed to the fencing agent (ssh key)", 0, "str"],
     ["profile", None, 0, "Profile", True, "Parent profile", [], "str"],
     ["proxy", "<<inherit>>", 0, "Internal Proxy", True, "Internal proxy URL", 0, "str"],
     ["redhat_management_key", "<<inherit>>", 0, "Redhat Management Key", True, "Registration key for RHN, Spacewalk, or Satellite", 0, "str"],
@@ -640,6 +641,12 @@ class System(item.Item):
             power_type = ""
         power_manager.validate_power_type(power_type)
         self.power_type = power_type
+
+    def set_power_identity_file(self, power_identity_file):
+        if power_identity_file is None:
+            power_identity_file = ""
+        utils.safe_filter(power_identity_file)
+        self.power_identity_file = power_identity_file
 
     def set_power_user(self, power_user):
         if power_user is None:

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -110,25 +110,33 @@ class PowerManager(object):
 
     @staticmethod
     def _get_power_input(system, power_operation):
-        power_input=""
-        if system.power_type == "virsh":
-            try:
-                power_input += "action=" + power_operation + "\n"
-                power_input += "ipaddr=" + system.power_address + "\n"
-                power_input += "login="  + system.power_user + "\n"
-                power_input += "plug=" + system.power_id + "\n"
-                if system.power_pass is not None and  not system.power_pass == "":
-                    power_input += "password" + system.power_pass + "\n"
-                if system.power_identity_file is not None and not system.power_identity_file == "":
-                    power_input += "identity-file=" + system.power_identity_file                
-                if system.power_options is not None:
-                    power_input += system.power_options+"\n"
-                return power_input
-            except TypeError:
-                raise CX("one of power_address, power_user and power_id was not set")
+        """
+        Creats an option string for the fence agent from the system data
+        Internal method
 
-        else:
-            raise CX("powser type %s not yet implemented in template free version" % system.power_type)
+        @param System system Cobbler system
+        @param str power_operation power operation. Valid values: on, off, status.
+                Rebooting is implemented as a set of 2 operations (off and on) in
+                a higher level method.
+        """
+        
+        power_input=""
+        if power_operation == None or power_operation not in ['on', 'off', 'status']:
+            raise CX("invalid power operation")
+        power_input += "action=" + power_operation + "\n"
+        if system.power_address is not None and not system.power_address == "":
+            power_input += "ipaddr=" + system.power_address + "\n"
+        if system.power_user is not None and not system.power_user == "":    
+            power_input += "login="  + system.power_user + "\n"
+        if system.power_id is not None and not system.power_id == "":
+            power_input += "plug=" + system.power_id + "\n"
+        if system.power_pass is not None and  not system.power_pass == "":
+            power_input += "password" + system.power_pass + "\n"
+        if system.power_identity_file is not None and not system.power_identity_file == "":
+            power_input += "identity-file=" + system.power_identity_file                
+        if system.power_options is not None:
+            power_input += system.power_options+"\n"
+        return power_input
 
     def _power(self, system, power_operation, user=None, password=None, logger=None):
         """

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -119,21 +119,21 @@ class PowerManager(object):
                 Rebooting is implemented as a set of 2 operations (off and on) in
                 a higher level method.
         """
-        
-        power_input=""
+
+        power_input = ""
         if power_operation == None or power_operation not in ['on', 'off', 'status']:
             raise CX("invalid power operation")
         power_input += "action=" + power_operation + "\n"
         if system.power_address is not None and not system.power_address == "":
             power_input += "ipaddr=" + system.power_address + "\n"
-        if system.power_user is not None and not system.power_user == "":    
-            power_input += "login="  + system.power_user + "\n"
+        if system.power_user is not None and not system.power_user == "":
+            power_input += "login=" + system.power_user + "\n"
         if system.power_id is not None and not system.power_id == "":
             power_input += "plug=" + system.power_id + "\n"
-        if system.power_pass is not None and  not system.power_pass == "":
+        if system.power_pass is not None and not system.power_pass == "":
             power_input += "password" + system.power_pass + "\n"
         if system.power_identity_file is not None and not system.power_identity_file == "":
-            power_input += "identity-file=" + system.power_identity_file                
+            power_input += "identity-file=" + system.power_identity_file
         if system.power_options is not None:
             power_input += system.power_options+"\n"
         return power_input


### PR DESCRIPTION
The naming convention of the http daemon seems to be pretty unstable, so this check is prone to give false positives. Also the installation of an http server is enforced by the spec file.