### PR TITLE
Add Debian Buster in distro_signatures

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -430,6 +430,22 @@
     "kernel_options":"",
     "kernel_options_post":"",
     "boot_files":[]
+   },
+   "buster": {
+    "signatures":["dists"],
+    "version_file":"Release",
+    "version_file_regex":"Codename: buster",
+    "kernel_arch":"linux-headers-(.*)\\.deb",
+    "kernel_arch_regex":null,
+    "supported_arches":["i386","amd64"],
+    "supported_repo_breeds":["apt"],
+    "kernel_file":"vmlinuz(.*)",
+    "initrd_file":"initrd(.*)\\.gz",
+    "isolinux_ok":false,
+    "default_kickstart":"sample.seed",
+    "kernel_options":"",
+    "kernel_options_post":"",
+    "boot_files":[]
    }
   },
   "ubuntu": {


### PR DESCRIPTION
This will fix #2081.
But sadly only for Cobbler 2.8.x I guess, since @jmaas statement: https://github.com/cobbler/cobbler/pull/1730#issuecomment-268970018