### PR TITLE
Coding style: Ignore W504, Allow line break after binary operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ qa:
 		cobbler/web/*.py cobbler/web/templatetags/*.py \
 		bin/cobbler* bin/*.py web/cobbler.wsgi
 	@echo "checking: pycodestyle"
-	@${PYCODESTYLE} -r --ignore E501,E402,E722 \
+	@${PYCODESTYLE} -r --ignore E501,E402,E722,W504 \
         *.py \
         cobbler/*.py \
         cobbler/modules/*.py \


### PR DESCRIPTION
Either W503 or W504 should be allowed to avoid too long lines and
a proper line break.
We allow a binary operator at end of line like:
print("Line break after binary operator allowed " +
      "to be able to do proper line breaks")