### PR TITLE
Avoid deprecated use of module set

### DIFF
--- a/cobbler/module_loader.py
+++ b/cobbler/module_loader.py
@@ -27,7 +27,10 @@ import clogger
 from utils import _, log_exc
 from cexceptions import CX
 import ConfigParser
-from sets import Set as set
+try:
+   set
+except NameError:
+   from sets import Set as set
 
 # add cobbler/modules to python path
 import cobbler


### PR DESCRIPTION
As seen in Apache logs:
..cobbler/module_loader.py:30: DeprecationWarning: the sets module is deprecated

According to (1), set is deprecated since python 2.6 but builtin set
exists since python 2.4

(1)
https://stackoverflow.com/questions/2040616/sets-module-deprecated-warning

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>