### PR TITLE
Re-order keyboard configuration

### DIFF
--- a/autoinstall_templates/sample.seed
+++ b/autoinstall_templates/sample.seed
@@ -7,16 +7,12 @@
 d-i debian-installer/locale string en_US
 
 # Keyboard selection.
-d-i keyboard-configuration/xkb-keymap select us
-d-i keyboard-configuration/xkb-keymap select us
 # Disable automatic (interactive) keymap detection.
 d-i console-setup/ask_detect boolean false
+d-i keyboard-configuration/xkb-keymap select us
+d-i keyboard-configuration/toggle select No toggling
 d-i keyboard-configuration/layoutcode string us
 d-i keyboard-configuration/variantcode string
-
-# Keyboard selection.
-d-i keyboard-configuration/xkb-keymap select us
-# d-i keyboard-configuration/toggle select No toggling
 
 # netcfg will choose an interface that has link if possible. This makes it
 # skip displaying a list if there is more than one interface.


### PR DESCRIPTION
This PR is for the master branch and will re-order directives here.

keyboard-configuration/toggle is disabled again because we expect a sane default to set one locale
toggling is probably more relevant for desktop installation (where the sample.preseed targets minimal/server).

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>