### PR TITLE
Cope with the dhcp_tag being undefined rather than just blank.

### DIFF
--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -174,7 +174,7 @@ class IscManager:
                         interface["filename"] = yaboot
 
                 if dhcp_tag == "":
-                    dhcp_tag = blended_system["dhcp_tag"]
+                    dhcp_tag = blended_system.get("dhcp_tag", "")
                     if dhcp_tag == "":
                         dhcp_tag = "default"
 


### PR DESCRIPTION
Cope with the dhcp_tag being undefined rather than just being blank, as images cannot have dhcp_tags.

We can define "--dhcp-tag default" on every system affected, but this patch does this as a default.

We have an edge-case which can be reproduced with the following setup:
```
cobbler image add --clobber --name testimage

cobbler system add --clobber --name test --hostname test --image testimage
cobbler system edit --name test --interface eth0 --mac 01:02:03:04:05:06  --ip-address 10.0.0.1 --netmask 255.255.255.0 --static y
```
This produces the following error:
```
cobbler sync
task started: 2019-07-03_061159_sync
task started (id=Sync, time=Wed Jul  3 06:11:59 2019)
running pre-sync triggers
cleaning trees
removing: /var/lib/tftpboot/pxelinux.cfg/default
removing: /var/lib/tftpboot/grub/images
removing: /var/lib/tftpboot/grub/grub-x86_64.efi
removing: /var/lib/tftpboot/grub/efidefault
removing: /var/lib/tftpboot/s390x/profile_list
copying bootloaders
trying hardlink /var/lib/cobbler/loaders/grub-x86_64.efi -> /var/lib/tftpboot/grub/grub-x86_64.efi
copying distros to tftpboot
copying images
generating PXE configuration files
generating PXE menu structure
rendering DHCP files
Exception occured: <type 'exceptions.KeyError'>
Exception value: 'dhcp_tag'
Exception Info:
  File "/usr/lib/python2.7/site-packages/cobbler/remote.py", line 82, in run
    rc = self._run(self)
   File "/usr/lib/python2.7/site-packages/cobbler/remote.py", line 181, in runner
    return self.remote.api.sync(self.options.get("verbose",False),logger=self.logger)
   File "/usr/lib/python2.7/site-packages/cobbler/api.py", line 763, in sync
    return sync.run()
   File "/usr/lib/python2.7/site-packages/cobbler/action_sync.py", line 122, in run
    self.write_dhcp()
   File "/usr/lib/python2.7/site-packages/cobbler/action_sync.py", line 208, in write_dhcp
    self.dhcp.write_dhcp_file()
   File "/usr/lib/python2.7/site-packages/cobbler/modules/manage_isc.py", line 177, in write_dhcp_file
    dhcp_tag = blended_system["dhcp_tag"]

!!! TASK FAILED !!!
```