### PR TITLE
Updated comment with path to  cobbler settings file

### DIFF
--- a/cobbler/modules/manage_dnsmasq.py
+++ b/cobbler/modules/manage_dnsmasq.py
@@ -67,7 +67,7 @@ class DnsmasqManager(object):
     def write_dhcp_file(self):
         """
         DHCP files are written when manage_dhcp is set in
-        /var/lib/cobbler/settings.
+        /etc/cobbler/settings.
         """
 
         settings_file = "/etc/dnsmasq.conf"


### PR DESCRIPTION
The cobbler/settings file is located in /etc/, not /var/lib/.