### PR TITLE
scm_tracker shouldn't read additional settings when disabled

### DIFF
--- a/cobbler/modules/scm_track.py
+++ b/cobbler/modules/scm_track.py
@@ -37,13 +37,14 @@ def run(api, args, logger):
 
     settings = api.settings()
     scm_track_enabled = str(settings.scm_track_enabled).lower()
-    mode = str(settings.scm_track_mode).lower()
-    author = str(settings.scm_track_author)
-    push_script = str(settings.scm_push_script)
 
     if scm_track_enabled not in ["y", "yes", "1", "true"]:
         # feature disabled
         return 0
+
+    mode = str(settings.scm_track_mode).lower()
+    author = str(settings.scm_track_author)
+    push_script = str(settings.scm_push_script)
 
     if mode == "git":
         old_dir = os.getcwd()


### PR DESCRIPTION
Seems like it might happen that we don't have a setting for push_script. I guess this would be fine, if scm_tracker is disabled anyway. But I don't know the the settings needs to be there otherwise.

With moving the check for scm_tracker_enabled above reading the rest of the settings, exceptions can be prevented when a settings for scm_push_script is not there.