### PR TITLE
Fixes typo for scm_push_script*s*

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -125,7 +125,7 @@ DEFAULTS = {
     "scm_track_enabled": [0, "bool"],
     "scm_track_mode": ["git", "str"],
     "scm_track_author": ["cobbler <cobbler@localhost>", "str"],
-    "scm_push_scripts": ["/bin/true", "str"],
+    "scm_push_script": ["/bin/true", "str"],
     "serializer_pretty_json": [0, "bool"],
     "server": ["127.0.0.1", "str"],
     "sign_puppet_certs_automatically": [0, "bool"],


### PR DESCRIPTION
This PR is related to PR #2100. 

I can see three two usages of `scm_push_script` (singular) and one for `scm_push_scripts`. So I guess this was a typo. Switching to `scm_push_script` in settings.py.