### PR TITLE
28 django 1.8+

### DIFF
--- a/web/cobbler_web/urls.py
+++ b/web/cobbler_web/urls.py
@@ -1,54 +1,55 @@
-from django.conf.urls import patterns
+from django.conf.urls import url
+
 import views
 
 # Uncomment the next two lines to enable the admin:
 # from cobbler_web.contrib import admin
 # admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^$', views.index),
+urlpatterns = [
+    url(r'^$', views.index),
 
-    (r'^setting/list$', views.setting_list),
-    (r'^setting/edit/(?P<setting_name>.+)$', views.setting_edit),
-    (r'^setting/save$', views.setting_save),
+    url(r'^setting/list$', views.setting_list),
+    url(r'^setting/edit/(?P<setting_name>.+)$', views.setting_edit),
+    url(r'^setting/save$', views.setting_save),
 
-    (r'^ksfile/list(/(?P<page>\d+))?$', views.ksfile_list),
-    (r'^ksfile/edit$', views.ksfile_edit, {'editmode':'new'}),
-    (r'^ksfile/edit/file:(?P<ksfile_name>.+)$', views.ksfile_edit, {'editmode':'edit'}),
-    (r'^ksfile/save$', views.ksfile_save),
+    url(r'^ksfile/list(/(?P<page>\d+))?$', views.ksfile_list),
+    url(r'^ksfile/edit$', views.ksfile_edit, {'editmode':'new'}),
+    url(r'^ksfile/edit/file:(?P<ksfile_name>.+)$', views.ksfile_edit, {'editmode':'edit'}),
+    url(r'^ksfile/save$', views.ksfile_save),
 
-    (r'^snippet/list(/(?P<page>\d+))?$', views.snippet_list),
-    (r'^snippet/edit$', views.snippet_edit, {'editmode':'new'}),
-    (r'^snippet/edit/file:(?P<snippet_name>.+)$', views.snippet_edit, {'editmode':'edit'}),
-    (r'^snippet/save$', views.snippet_save),
+    url(r'^snippet/list(/(?P<page>\d+))?$', views.snippet_list),
+    url(r'^snippet/edit$', views.snippet_edit, {'editmode':'new'}),
+    url(r'^snippet/edit/file:(?P<snippet_name>.+)$', views.snippet_edit, {'editmode':'edit'}),
+    url(r'^snippet/save$', views.snippet_save),
 
-    (r'^(?P<what>\w+)/list(/(?P<page>\d+))?', views.genlist),
-    (r'^(?P<what>\w+)/modifylist/(?P<pref>[!\w]+)/(?P<value>.+)$', views.modify_list),
-    (r'^(?P<what>\w+)/edit/(?P<obj_name>.+)$', views.generic_edit, {'editmode': 'edit'}),
-    (r'^(?P<what>\w+)/edit$', views.generic_edit, {'editmode': 'new'}),
+    url(r'^(?P<what>\w+)/list(/(?P<page>\d+))?', views.genlist),
+    url(r'^(?P<what>\w+)/modifylist/(?P<pref>[!\w]+)/(?P<value>.+)$', views.modify_list),
+    url(r'^(?P<what>\w+)/edit/(?P<obj_name>.+)$', views.generic_edit, {'editmode': 'edit'}),
+    url(r'^(?P<what>\w+)/edit$', views.generic_edit, {'editmode': 'new'}),
 
-    (r'^(?P<what>\w+)/rename/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_rename),
-    (r'^(?P<what>\w+)/copy/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_copy),
-    (r'^(?P<what>\w+)/delete/(?P<obj_name>.+)$', views.generic_delete),
+    url(r'^(?P<what>\w+)/rename/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_rename),
+    url(r'^(?P<what>\w+)/copy/(?P<obj_name>.+)/(?P<obj_newname>.+)$', views.generic_copy),
+    url(r'^(?P<what>\w+)/delete/(?P<obj_name>.+)$', views.generic_delete),
 
-    (r'^(?P<what>\w+)/multi/(?P<multi_mode>.+)/(?P<multi_arg>.+)$', views.generic_domulti),
-    (r'^utils/random_mac$', views.random_mac),
-    (r'^utils/random_mac/virttype/(?P<virttype>.+)$', views.random_mac),
-    (r'^events$', views.events),
-    (r'^eventlog/(?P<event>.+)$', views.eventlog),
-    (r'^iplist$', views.iplist),
-    (r'^task_created$', views.task_created),
-    (r'^sync$', views.sync),
-    (r'^reposync$',views.reposync),
-    (r'^replicate$',views.replicate),
-    (r'^hardlink', views.hardlink),
-    (r'^(?P<what>\w+)/save$', views.generic_save),
-    (r'^import/prompt$', views.import_prompt),
-    (r'^import/run$', views.import_run),
-    (r'^buildiso$', views.buildiso),
-    (r'^check$', views.check),
+    url(r'^(?P<what>\w+)/multi/(?P<multi_mode>.+)/(?P<multi_arg>.+)$', views.generic_domulti),
+    url(r'^utils/random_mac$', views.random_mac),
+    url(r'^utils/random_mac/virttype/(?P<virttype>.+)$', views.random_mac),
+    url(r'^events$', views.events),
+    url(r'^eventlog/(?P<event>.+)$', views.eventlog),
+    url(r'^iplist$', views.iplist),
+    url(r'^task_created$', views.task_created),
+    url(r'^sync$', views.sync),
+    url(r'^reposync$',views.reposync),
+    url(r'^replicate$',views.replicate),
+    url(r'^hardlink', views.hardlink),
+    url(r'^(?P<what>\w+)/save$', views.generic_save),
+    url(r'^import/prompt$', views.import_prompt),
+    url(r'^import/run$', views.import_run),
+    url(r'^buildiso$', views.buildiso),
+    url(r'^check$', views.check),
 
-    (r'^login$', views.login),
-    (r'^do_login$', views.do_login),
-    (r'^logout$', views.do_logout),
-)
+    url(r'^login$', views.login),
+    url(r'^do_login$', views.do_login),
+    url(r'^logout$', views.do_logout),
+]

--- a/web/cobbler_web/views.py
+++ b/web/cobbler_web/views.py
@@ -1,8 +1,7 @@
-from django.template.loader import get_template
-from django.template import RequestContext
+
 from django.http import HttpResponse
 from django.http import HttpResponseRedirect
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from django.views.decorators.http import require_POST
 from django.views.decorators.csrf import csrf_protect
 
@@ -36,11 +35,10 @@ def index(request):
    """
    if not test_user_authenticated(request): return login(request,next="/cobbler_web", expired=True)
 
-   t = get_template('index.tmpl')
-   html = t.render(RequestContext(request,{
-        'version' : remote.extended_version(request.session['token'])['version'],
+   html = render(request, 'index.tmpl', {
+        'version': remote.extended_version(request.session['token'])['version'],
         'username': username,
-   }))
+   })
    return HttpResponse(html)
 
 #========================================================================
@@ -50,11 +48,11 @@ def task_created(request):
    Let's the user know what to expect for event updates.
    """
    if not test_user_authenticated(request): return login(request, next="/cobbler_web/task_created", expired=True)
-   t = get_template("task_created.tmpl")
-   html = t.render(RequestContext(request,{
+
+   html = render(request, "task_created.tmpl", {
        'version'  : remote.extended_version(request.session['token'])['version'],
        'username' : username
-   }))
+   })
    return HttpResponse(html)
 
 #========================================================================
@@ -66,14 +64,13 @@ def error_page(request,message):
    if not test_user_authenticated(request): return login(request,expired=True)
    # FIXME: test and make sure we use this rather than throwing lots of tracebacks for
    # field errors
-   t = get_template('error_page.tmpl')
    message = message.replace("<Fault 1: \"<class 'cobbler.cexceptions.CX'>:'","Remote exception: ")
    message = message.replace("'\">","")
-   html = t.render(RequestContext(request,{
+   html = render(request, 'error_page.tmpl', {
        'version' : remote.extended_version(request.session['token'])['version'],
        'message' : message,
        'username': username
-   }))
+   })
    return HttpResponse(html)
 
 #==================================================================================
@@ -333,8 +330,7 @@ def genlist(request, what, page=None):
         columns = [ "name" ]
 
     # render the list
-    t = get_template('generic_list.tmpl')
-    html = t.render(RequestContext(request,{
+    html = render(request, 'generic_list.tmpl', {
         'what'           : what,
         'columns'        : __format_columns(columns,sort_field),
         'items'          : __format_items(pageditems["items"],columns),
@@ -344,7 +340,7 @@ def genlist(request, what, page=None):
         'username'       : username,
         'limit'          : limit,
         'batchactions'   : batchactions,
-    }))
+    })
     return HttpResponse(html)
 
 @require_POST
@@ -567,11 +563,11 @@ def generic_domulti(request, what, multi_mode=None, multi_arg=None):
 
 def import_prompt(request):
    if not test_user_authenticated(request): return login(request, next="/cobbler_web/import/prompt", expired=True)
-   t = get_template('import.tmpl')
-   html = t.render(RequestContext(request,{
+
+   html = render(request, 'import.tmpl', {
        'version'  : remote.extended_version(request.session['token'])['version'],
        'username' : username,
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -582,12 +578,12 @@ def check(request):
    """
    if not test_user_authenticated(request): return login(request, next="/cobbler_web/check", expired=True)
    results = remote.check(request.session['token'])
-   t = get_template('check.tmpl')
-   html = t.render(RequestContext(request,{
+
+   html = render(request, 'check.tmpl', {
        'version': remote.extended_version(request.session['token'])['version'],
        'username' : username,
        'results'  : results
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -629,14 +625,13 @@ def ksfile_list(request, page=None):
        if ksfile not in ["", "<<inherit>>"]:
            ksfile_list.append((ksfile, ksfile, 'editable'))
 
-   t = get_template('ksfile_list.tmpl')
-   html = t.render(RequestContext(request,{
+   html = render(request, 'ksfile_list.tmpl', {
        'what':'ksfile',
        'ksfiles': ksfile_list,
        'version': remote.extended_version(request.session['token'])['version'],
        'username': username,
        'item_count': len(ksfile_list[0]),
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -658,8 +653,7 @@ def ksfile_edit(request, ksfile_name=None, editmode='edit'):
       deleteable = not remote.is_kickstart_in_use(ksfile_name, request.session['token'])
       ksdata = remote.read_or_write_kickstart_template(ksfile_name, True, "", request.session['token'])
 
-   t = get_template('ksfile_edit.tmpl')
-   html = t.render(RequestContext(request,{
+   html = render(request, 'ksfile_edit.tmpl', {
        'ksfile_name' : ksfile_name,
        'deleteable'  : deleteable,
        'ksdata'      : ksdata,
@@ -667,7 +661,7 @@ def ksfile_edit(request, ksfile_name=None, editmode='edit'):
        'editmode'    : editmode,
        'version'     : remote.extended_version(request.session['token'])['version'],
        'username'    : username
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -717,13 +711,12 @@ def snippet_list(request, page=None):
        else:
            return error_page(request, "Invalid snippet at %s, outside %s" % (snippet, base_dir))
 
-   t = get_template('snippet_list.tmpl')
-   html = t.render(RequestContext(request,{
+   html = render(request, 'snippet_list.tmpl', {
        'what'     : 'snippet',
        'snippets' : snippet_list,
        'version'  : remote.extended_version(request.session['token'])['version'],
        'username' : username
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -745,8 +738,7 @@ def snippet_edit(request, snippet_name=None, editmode='edit'):
       deleteable = True
       snippetdata = remote.read_or_write_snippet(snippet_name, True, "", request.session['token'])
 
-   t = get_template('snippet_edit.tmpl')
-   html = t.render(RequestContext(request,{
+   html = render(request, 'snippet_edit.tmpl', {
        'snippet_name' : snippet_name,
        'deleteable'   : deleteable,
        'snippetdata'  : snippetdata,
@@ -754,7 +746,7 @@ def snippet_edit(request, snippet_name=None, editmode='edit'):
        'editmode'     : editmode,
        'version'      : remote.extended_version(request.session['token'])['version'],
        'username'     : username
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -803,12 +795,11 @@ def setting_list(request):
     for k in skeys:
         results.append([k,settings[k]])
 
-    t = get_template('settings.tmpl')
-    html = t.render(RequestContext(request,{
+    html = render(request, 'settings.tmpl', {
          'settings' : results,
          'version'  : remote.extended_version(request.session['token'])['version'],
          'username' : username,
-    }))
+    })
     return HttpResponse(html)
 
 @csrf_protect
@@ -837,8 +828,7 @@ def setting_edit(request, setting_name=None):
             sections[fkey]['fields'] = []
         sections[fkey]['fields'].append(field)
 
-    t = get_template('generic_edit.tmpl')
-    html = t.render(RequestContext(request,{
+    html = render(request, 'generic_edit.tmpl', {
         'what'            : 'setting',
         #'fields'          : fields,
         'sections'        : sections,
@@ -848,7 +838,7 @@ def setting_edit(request, setting_name=None):
         'version'         : remote.extended_version(request.session['token'])['version'],
         'username'        : username,
         'name'            : setting_name,
-    }))
+    })
     return HttpResponse(html)
 
 @csrf_protect
@@ -889,12 +879,11 @@ def events(request):
       return cmp(a[0],b[0])
    events2.sort(sorter)
 
-   t = get_template('events.tmpl')
-   html = t.render(RequestContext(request,{
+   html = render(request, 'events.tmpl', {
        'results'  : events2,
        'version'  : remote.extended_version(request.session['token'])['version'],
        'username' : username
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -918,12 +907,11 @@ def iplist(request):
       return cmp(ipaddress.ip_address(unicode(a[0])),ipaddress.ip_address(unicode(b[0])))
    iplist.sort(sorter)
 
-   t = get_template('iplist.tmpl')
-   html = t.render(RequestContext(request,{
+   html = render(request, 'iplist.tmpl', {
        'results'  : iplist,
        'version'  : remote.extended_version(request.session['token'])['version'],
        'username' : username
-   }))
+   })
    return HttpResponse(html)
 
 # ======================================================================
@@ -943,8 +931,7 @@ def eventlog(request, event=0):
    eventstate = data[2]
    eventlog   = remote.get_event_log(event)
 
-   t = get_template('eventlog.tmpl')
-   vars = {
+   html = render(request, 'eventlog.tmpl', {
       'eventlog'   : eventlog,
       'eventname'  : eventname,
       'eventstate' : eventstate,
@@ -952,8 +939,8 @@ def eventlog(request, event=0):
       'eventtime'  : eventtime,
       'version'    : remote.extended_version(request.session['token'])['version'],
       'username'  : username
-   }
-   html = t.render(RequestContext(request,vars))
+   })
+
    return HttpResponse(html)
 
 # ======================================================================
@@ -1112,10 +1099,10 @@ def generic_edit(request, what=None, obj_name=None, editmode="new"):
            sections[fkey]['fields'] = []
        sections[fkey]['fields'].append(field)
 
-   t = get_template('generic_edit.tmpl')
    inames = interfaces.keys()
    inames.sort()
-   html = t.render(RequestContext(request,{
+
+   html = render(request, 'generic_edit.tmpl', {
        'what'            : what,
        #'fields'          : fields,
        'sections'        : sections,
@@ -1128,7 +1115,7 @@ def generic_edit(request, what=None, obj_name=None, editmode="new"):
        'version'         : remote.extended_version(request.session['token'])['version'],
        'username'        : username,
        'name'            : obj_name
-   }))
+   })
 
    return HttpResponse(html)
 
@@ -1298,7 +1285,8 @@ def login(request, next=None, message=None, expired=False):
 
     if expired and not message:
         message = "Sorry, either you need to login or your session expired."
-    return render_to_response('login.tmpl', RequestContext(request,{'next':next,'message':message}))
+    return render(request, 'login.tmpl', {'next': next, 'message': message})
+
 
 def accept_remote_user(request, nextsite):
     global username

--- a/web/manage.py
+++ b/web/manage.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
-from django.core.management import execute_manager
-try:
-    import settings # Assumed to be in the same directory.
-except ImportError:
-    import sys
-    sys.stderr.write("Error: Can't find the file 'settings.py' in the directory containing %r. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
-    sys.exit(1)
+
+import os
+import sys
 
 if __name__ == "__main__":
-    execute_manager(settings)
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+
+    from django.core.management import execute_from_command_line
+
+    execute_from_command_line(sys.argv)

--- a/web/settings.py
+++ b/web/settings.py
@@ -1,12 +1,10 @@
 # Django settings for cobbler-web project.
-import django
 
 # This is the list of http server request names the site is allowed to serve for
 # Added for CVE-2016-9014
 ALLOWED_HOSTS = ['*']
 
 DEBUG = True
-TEMPLATE_DEBUG = DEBUG
 
 ADMINS = (
     # ('Your Name', 'your_email@domain.com'),
@@ -35,61 +33,45 @@ SITE_ID = 1
 MEDIA_ROOT = ''
 MEDIA_URL = ''
 
-if django.VERSION[0] == 1 and django.VERSION[1] < 4:
-    ADMIN_MEDIA_PREFIX = '/media/'
-else:
-    STATIC_URL = '/media/'
+STATIC_URL = '/media/'
 
 SECRET_KEY = ''
 
 # code config
 
-if django.VERSION[0] == 1 and django.VERSION[1] < 4:
-    TEMPLATE_LOADERS = (
-        'django.template.loaders.filesystem.load_template_source',
-        'django.template.loaders.app_directories.load_template_source',
-    )
-else:
-    TEMPLATE_LOADERS = (
-        'django.template.loaders.filesystem.Loader',
-        'django.template.loaders.app_directories.Loader',
-    )
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [
+            '/usr/share/cobbler/web/cobbler_web/templates',
+        ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]
 
-if django.VERSION[0] == 1 and django.VERSION[1] < 2:
-    # Legacy django had a different CSRF method, which also had
-    # different middleware. We check the vesion here so we bring in
-    # the correct one.
-    MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-        'django.contrib.csrf.middleware.CsrfMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-    )
-else:
-    MIDDLEWARE_CLASSES = (
-        'django.middleware.common.CommonMiddleware',
-        'django.middleware.csrf.CsrfViewMiddleware',
-        'django.contrib.sessions.middleware.SessionMiddleware',
-        'django.contrib.auth.middleware.AuthenticationMiddleware',
-    )
+MIDDLEWARE = (
+    'django.middleware.common.CommonMiddleware',
+    'django.middleware.csrf.CsrfViewMiddleware',
+    'django.contrib.sessions.middleware.SessionMiddleware',
+    'django.contrib.auth.middleware.AuthenticationMiddleware',
+)
 
 ROOT_URLCONF = 'urls'
 
-TEMPLATE_DIRS = (
-    '/usr/share/cobbler/web/cobbler_web/templates',
-)
 INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.sites',
     'cobbler_web',
-)
-
-from django.conf.global_settings import TEMPLATE_CONTEXT_PROCESSORS
-
-TEMPLATE_CONTEXT_PROCESSORS += (
-     'django.core.context_processors.request',
 )
 
 SESSION_ENGINE = 'django.contrib.sessions.backends.file'

--- a/web/urls.py
+++ b/web/urls.py
@@ -1,10 +1,10 @@
-from django.conf.urls import patterns, include
+from django.conf.urls import url, include
 
 # Uncomment the next two lines to enable the admin:
 #from django.contrib import admin
 #admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^', include('cobbler_web.urls')),
-)
+urlpatterns = [
+    url(r'^', include('cobbler_web.urls')),
+]
 


### PR DESCRIPTION
This patch update django to support 1.8+ in cobbler28 branch
It was tested against current django 1.11 which is the last version to support python2
(tested on Fedora29)

Unfortunately, it seems too complex to support older django (1.6 is what was previously used in CentOS 7, but 1.11 is the default for many components already).
