### PR TITLE
Drop support for older ubuntu

### DIFF
--- a/autoinstall_templates/sample.seed
+++ b/autoinstall_templates/sample.seed
@@ -38,8 +38,8 @@ d-i mirror/http/directory string $install_source_directory
 d-i mirror/http/proxy string
 
 #set $os_v = $getVar('os_version','')
-#if $breed == "ubuntu" and $os_v and ($os_v.lower()[0] > 'p' or $os_v.lower()[0] < 'd')
-# Required at least for ubuntu 12.10+ , so test os_v is higher than precise and lower than drapper
+#if $breed == "ubuntu" and $os_v and $os_v.lower() != 'precise'
+# Required at least for ubuntu 12.10+ , so test os_v is not precise. Olders versions are not supported anymore
 d-i live-installer/net-image string http://$http_server/cobbler/links/$distro_name/install/filesystem.squashfs
 #end if
 


### PR DESCRIPTION
Since ubuntu 19.04 this check isn't accurate anymore since dapper drake
is Ubuntu 6.04

FYI
Ubuntu 19.04 Disco Dingo
Ubuntu 19.10 Eoan Ermine

Support of older ubuntu can still be added with a dedicated preseed.

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>