### PR TITLE
Prefer Liberation Sans over ORW Gothic

### DIFF
--- a/web/static/style.css
+++ b/web/static/style.css
@@ -173,7 +173,7 @@ span.context-tip:hover {
   font-weight: bold;
 }
 .ui-widget {
-  font-family: "URW Gothic", "Liberation Sans", "Helvetica", "Luxi Sans", "Bitstream Vera Sans", arial,helvetica,clean,sans-serif;
+  font-family: "Liberation Sans", "URW Gothic", "Helvetica", "Luxi Sans", "Bitstream Vera Sans", arial,helvetica,clean,sans-serif;
   font-size: 0.85em;
   font-weight: normal;
 }


### PR DESCRIPTION
There is a rendering issue with the latter on Fedora clients

Signed-off-by: Nicolas Chauvet <kwizart@gmail.com>