### PR TITLE
Ipmi fixup 28

### DIFF
--- a/config/cobbler/settings.d/bind_manage_ipmi.settings
+++ b/config/cobbler/settings.d/bind_manage_ipmi.settings
@@ -1,2 +1,0 @@
-# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind is set.
-bind_manage_ipmi: 1

--- a/config/cobbler/settings.d/manage_genders.settings
+++ b/config/cobbler/settings.d/manage_genders.settings
@@ -1,2 +1,0 @@
-# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
-manage_genders: 1

--- a/config/settings
+++ b/config/settings
@@ -256,6 +256,9 @@ bind_master: 127.0.0.1
 # manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
 manage_genders: 0
 
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind is set.
+bind_manage_ipmi: 0
+
 # set to 1 to enable Cobbler's TFTP management features.
 # the choice of TFTP mangement engine is in /etc/cobbler/modules.conf
 manage_tftpd: 1

--- a/config/settings
+++ b/config/settings
@@ -253,6 +253,9 @@ bind_chroot_path: ""
 # bind configuration files
 bind_master: 127.0.0.1
 
+# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
+manage_genders: 0
+
 # set to 1 to enable Cobbler's TFTP management features.
 # the choice of TFTP mangement engine is in /etc/cobbler/modules.conf
 manage_tftpd: 1


### PR DESCRIPTION
There is currently a fedora/epel distro patch to revert the ipmi feature in 28 because (at least) is reliy on settings.d which is not available there.

Move the hook into the settings file and disable by default to keep the previous behaviour in the cobbler28 branch