### PR TITLE
[WIP] Cleans up distribution detection

### DIFF
--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -27,7 +27,6 @@ import os
 import os.path
 import pipes
 import stat
-import distro
 
 HAS_YUM = True
 try:
@@ -38,6 +37,7 @@ except:
 from . import clogger
 from . import utils
 from . import download_manager
+from .utils import os_release
 
 
 def repo_walker(top, func, arg):
@@ -691,10 +691,11 @@ class RepoSync(object):
         """
         # all_path = os.path.join(repo_path, "*")
         owner = "root:apache"
-        distribution = distro.linux_distribution()[0]
-        if distribution.lower() in ("sles", "opensuse leap", "opensuse tumbleweed"):
+
+        (dist, version) = os_release()
+        if dist == "suse":
             owner = "root:www"
-        elif "debian" in distribution.lower():
+        elif dist in ("debian", "ubuntu"):
             owner = "root:www-data"
 
         cmd1 = "chown -R " + owner + " %s" % repo_path

--- a/cobbler/action_reposync.py
+++ b/cobbler/action_reposync.py
@@ -692,7 +692,7 @@ class RepoSync(object):
         # all_path = os.path.join(repo_path, "*")
         owner = "root:apache"
 
-        (dist, version) = os_release()
+        (dist, _) = os_release()
         if dist == "suse":
             owner = "root:www"
         elif dist in ("debian", "ubuntu"):

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1052,8 +1052,3 @@ class CobblerAPI(object):
         Clears console and anamon logs for system
         """
         action_log.LogTool(self._collection_mgr, system, self, logger=logger).clear()
-
-    def get_os_details(self):
-        return (self.dist, self.os_version)
-
-# EOF

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1960,23 +1960,23 @@ def lod_sort_by_key(_list, indexkey):
 
 
 def dhcpconf_location(api):
-    (dist, ver) = api.get_os_details()
-    if dist in ["redhat", "centos"] and ver < 6:
+    (dist, version) = os_release()
+    if dist in ("redhat", "centos") and version < 6:
         return "/etc/dhcpd.conf"
-    elif dist in ["fedora"] and ver < 11:
+    elif dist == "fedora" and version < 11:
         return "/etc/dhcpd.conf"
     elif dist == "suse":
         return "/etc/dhcpd.conf"
-    elif dist == "debian" and int(ver.split('.')[0]) < 6:
+    elif dist == "debian" and int(version) < 6:
         return "/etc/dhcp3/dhcpd.conf"
-    elif dist == "ubuntu" and ver < 11.10:
+    elif dist == "ubuntu" and version < 11.10:
         return "/etc/dhcp3/dhcpd.conf"
     else:
         return "/etc/dhcp/dhcpd.conf"
 
 
 def namedconf_location(api):
-    (dist, ver) = api.get_os_details()
+    (dist, _) = os_release()
     if dist == "debian" or dist == "ubuntu":
         return "/etc/bind/named.conf"
     else:
@@ -1984,7 +1984,7 @@ def namedconf_location(api):
 
 
 def zonefile_base(api):
-    (dist, ver) = api.get_os_details()
+    (dist, _) = os_release()
     if dist == "debian" or dist == "ubuntu":
         return "/etc/bind/db."
     if dist == "suse":
@@ -1994,10 +1994,10 @@ def zonefile_base(api):
 
 
 def dhcp_service_name(api):
-    (dist, version) = api.get_os_details()
-    if dist == "debian" and int(version.split('.')[0]) < 6:
+    (dist, version) = os_release()
+    if dist == "debian" and int(version) < 6:
         return "dhcp3-server"
-    elif dist == "debian" and int(version.split('.')[0]) >= 6:
+    elif dist == "debian" and int(version) >= 6:
         return "isc-dhcp-server"
     elif dist == "ubuntu" and version < 11.10:
         return "dhcp3-server"
@@ -2008,7 +2008,7 @@ def dhcp_service_name(api):
 
 
 def named_service_name(api, logger=None):
-    (dist, ver) = api.get_os_details()
+    (dist, _) = os_release()
     if dist == "debian" or dist == "ubuntu":
         return "bind9"
     else:
@@ -2046,6 +2046,7 @@ def find_distro_path(settings, distro):
     # non-standard directory, assume it's the same as the
     # directory in which the given distro's kernel is
     return os.path.dirname(distro.kernel)
+
 
 
 def compare_versions_gt(ver1, ver2):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2048,7 +2048,6 @@ def find_distro_path(settings, distro):
     return os.path.dirname(distro.kernel)
 
 
-
 def compare_versions_gt(ver1, ver2):
     def versiontuple(v):
         return tuple(map(int, (v.split("."))))


### PR DESCRIPTION
`api.get_os_details()` was just a proxy function for `utils.os_release()`, so this is removed now. We are using `os_release()` now everywhere. Variable naming is also unified throughout the code.

This also fixes broken version detection for debian like distros.