### PR TITLE
fixing accidentally renamed 'collections' back

### DIFF
--- a/cobbler/web/templatetags/site.py
+++ b/cobbler/web/templatetags/site.py
@@ -1,6 +1,6 @@
 from builtins import object
 from django import template
-from cobbler_collections import OrderedDict
+from collections import OrderedDict
 
 register = template.Library()
 


### PR DESCRIPTION
When 'collections' in cobbler was renamed to 'cobbler_collections', a valid 'collections' import was accidentally renamed. It shouldn't have been - OrderedDict comes from 'collections', not 'cobbler_collections'.