### PR TITLE
Recent fixes

### DIFF
--- a/cobbler/download_manager.py
+++ b/cobbler/download_manager.py
@@ -32,8 +32,6 @@ class DownloadManager(object):
         """
         self.collection_mgr = collection_mgr
         self.settings = collection_mgr.settings()
-        if logger is None:
-            logger = clogger.Logger()
         self.logger = logger
         self.cert = ()
         if self.settings.proxy_url_ext:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -671,7 +671,6 @@ class TFTPGen(object):
 
                 append_line = "%s console=ttyS%s,%s" % (append_line, serial_device, serial_baud_rate)
 
-
         # FIXME - the append_line length limit is architecture specific
         if len(append_line) >= 1023:
             self.logger.warning("warning: kernel option length exceeds 1023")

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -654,6 +654,24 @@ class TFTPGen(object):
             blended.update(blended["autoinstall_meta"])
         append_line = self.templar.render(append_line, utils.flatten(blended), None)
 
+        # For now console=ttySx,BAUDRATE are only set for systems
+        # This could get enhanced for profile/distro via utils.blender (inheritance)
+        # This also is architecture specific. E.g: Some ARM consoles need: console=ttyAMAx,BAUDRATE
+        # I guess we need a serial_kernel_dev = param, that can be set to "ttyAMA" if needed.
+        if system:
+            if (system.serial_device is not None) or (system.serial_baud_rate is not None):
+                if system.serial_device:
+                    serial_device = system.serial_device
+                else:
+                    serial_device = 0
+                if system.serial_baud_rate:
+                    serial_baud_rate = system.serial_baud_rate
+                else:
+                    serial_baud_rate = 115200
+
+                append_line = "%s console=ttyS%s,%s" % (append_line, serial_device, serial_baud_rate)
+
+
         # FIXME - the append_line length limit is architecture specific
         if len(append_line) >= 1023:
             self.logger.warning("warning: kernel option length exceeds 1023")

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1972,7 +1972,7 @@ def dhcpconf_location(api):
     elif dist == "ubuntu" and version < 11.10:
         return "/etc/dhcp3/dhcpd.conf"
     else:
-        return "/etc/dhcpd.conf"
+        return "/etc/dhcp/dhcpd.conf"
 
 
 def namedconf_location(api):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1972,7 +1972,7 @@ def dhcpconf_location(api):
     elif dist == "ubuntu" and version < 11.10:
         return "/etc/dhcp3/dhcpd.conf"
     else:
-        return "/etc/dhcp/dhcpd.conf"
+        return "/etc/dhcpd.conf"
 
 
 def namedconf_location(api):

--- a/templates/etc/dhcp.template
+++ b/templates/etc/dhcp.template
@@ -18,7 +18,7 @@ allow bootp;
 ignore client-updates;
 set vendorclass = option vendor-class-identifier;
 
-option pxe-system-type code 93 = unsigned integer 16;
+option system-arch code 93 = unsigned integer 16;
 
 subnet 192.168.1.0 netmask 255.255.255.0 {
      option routers             192.168.1.5;
@@ -30,17 +30,60 @@ subnet 192.168.1.0 netmask 255.255.255.0 {
      next-server                $next_server;
      class "pxeclients" {
           match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
-          if option pxe-system-type = 00:06 {
-                  filename "grub/grub2-x86.efi";
-          } else if option pxe-system-type = 00:07 {
+
+          # Legacy
+          if option system-arch = 00:00 {
+              filename "grub/grub.0";
+          }
+          # UEFI-32-1
+          if option system-arch = 00:06 {
+               # Not supported, no 32 bit UEFI grub executable
+              filename "";
+          }
+          # UEFI-32-2
+          if option system-arch = 00:02 {
+              # Not supported, no 32 bit UEFI grub executable
+              filename "";
+          }
+          # UEFI-64-1
+          else if option system-arch = 00:07 {
+		      filename "grub/grubx64.efi";
+          }
+          # UEFI-64-2
+          else if option system-arch = 00:08 {
+              filename "grub/grub64.efi";
+          }
+          # UEFI-64-3
+          else if option system-arch = 00:09 {
                   filename "grub/grub2-x86_64.efi";
-          } else if option pxe-system-type = 00:09 {
-                  filename "grub/grub2-x86_64.efi";
-          } else {
+          }
+          # armv7   (aka arm 32 bit)
+          else if option system-arch = 00:10 {
+              filename "grub/armv7/armv7.efi";
+          }
+          # aarch64 (aka arm 64 bit)
+          else if option system-arch = 00:11 {
+              filename "grub/aarch64/grub.efi";
+          }
+          # RiskV 32 bit
+          else if option system-arch = 00:25 {
+	          #ToDo petitboot loader
+              filename "";
+          }
+          #RiskV 32 bit
+          else if option system-arch = 00:27 {
+	          #ToDo petitboot loader
+              filename "";
+          }
+          else if option system-arch = 00:0e {
+              filename "grub.ppc64le";
+          }
+          else
+          {
                   filename "pxelinux.0";
           }
-     }
 
+}
 }
 
 #for dhcp_tag in $dhcp_tags.keys():


### PR DESCRIPTION
These commits fix some issues we encountered during the integration of cobbler into orthos:

tftpgen should use a sensible default for serial_device or serial_baudrate iff only the other is present.

The dhcp.template did not work for legacy x86 systems

The new default location for the dhcpd.conf seems to be more sensible.

