### PR TITLE
Fix bad import

### DIFF
--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -39,7 +39,6 @@ except:
 from cobbler.items import profile, distro
 from cobbler.cexceptions import CX
 
-import items.repo as item_repo
 import cobbler.templar as templar
 import cobbler.utils as utils
 


### PR DESCRIPTION
Fixes this backtrace/exception:
````
2019-09-13T08:33:04 - INFO | Exception raised when loading module managers.import_signatures
2019-09-13T08:33:04 - INFO | Exception occured: <class 'ModuleNotFoundError'>
2019-09-13T08:33:04 - INFO | Exception value: No module named 'items'
2019-09-13T08:33:04 - INFO | Exception Info:
  File "/usr/lib/python3.6/site-packages/cobbler/module_loader.py", line 82, in __import_module
    blip = __import__("cobbler.modules.%s" % modname, globals(), locals(), [modname])

  File "/usr/lib/python3.6/site-packages/cobbler/modules/managers/import_signatures.py", line 42, in <module>
    import items.repo as item_repo
````