### PR TITLE
Fix apache code to not access /var/log/cobbler/...

### DIFF
--- a/cobbler/clogger.py
+++ b/cobbler/clogger.py
@@ -23,8 +23,15 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 import logging
 import logging.config
+import os
 
-logging.config.fileConfig('/etc/cobbler/logging_config.conf')
+# Temporary hack, a clean solution seems to be tricky
+# Defining a variable in our Apache startup code seem not to
+# it is still set later when this code is executed via cobbler
+
+# This is necessary to prevent apache to try to access the file
+if os.access("/var/log/cobbler/cobbler.log", os.W_OK):
+    logging.config.fileConfig('/etc/cobbler/logging_config.conf')
 
 
 class Logger(object):


### PR DESCRIPTION
This is really hard to understand...

My first approach was to define a global variable in
/srv/www/cobbler/svc/services.py
the apache startup code which cannot be issued by
code running in cobblerd context.

And then in clogger.py do:
try:
    global APACHE_CONTEXT
    print("We are in apache context")

except NameError:
    print ("We are in cobbler context")
    logging.config.fileConfig('/etc/cobbler/logging_config.conf')

But this only works until apache code got processed.
It looks like the variable is not stored in process context, no
idea yet why this does not work.

Next approach was to parse the config file to identify
the real log file. But this is very unfortunate put in brackets
for a constructor call, instead of a clean "logfile" statement:
/etc/cobbler/logging_config.conf
args=('/var/log/cobbler/cobbler.log', 'a')

I started, but ended up getting the bracket string:
import configparser

config = configparser.ConfigParser()
config.read('/etc/cobbler/logging_config.conf')
print (config.get("handler_FileLogger", "args")

This can certainly be done nicer, but it took me quite some
time to debug this that far already...