### PR TITLE
Make anamon python 2/3 agnostic and run on EL8

### DIFF
--- a/autoinstall_snippets/pre_anamon
+++ b/autoinstall_snippets/pre_anamon
@@ -1,4 +1,7 @@
 #if $str($getVar('anamon_enabled','')) == "1"
 curl -o /tmp/anamon "http://$server:$http_port/cobbler/misc/anamon"
-python /tmp/anamon --name "$name" --server "$server" --port "$http_port"
+python=python
+[ -x /usr/libexec/platform-python ] && python=/usr/libexec/platform-python
+[ -x /usr/bin/python3 ] && python=/usr/bin/python3
+$python /tmp/anamon --name "$name" --server "$server" --port "$http_port"
 #end if

--- a/misc/anamon
+++ b/misc/anamon
@@ -30,7 +30,10 @@ import time
 import re
 import base64
 import shlex
-from xmlrpc import client
+try:
+    from xmlrpc.client import Server
+except ImportError:
+    from xmlrpclib import Server
 
 
 # shlex.split support arrived in python-2.3, the following will provide some
@@ -59,7 +62,7 @@ class WatchedFile:
         self.seen_line[pattern] = 0
 
     def seen(self,pattern):
-        if self.seen_line.has_key(pattern):
+        if pattern in self.seen_line:
             return self.seen_line[pattern]
         else:
             return 0
@@ -77,7 +80,7 @@ class WatchedFile:
     def uploadWrapper(self, blocksize = 262144):
         """upload a file in chunks using the uploadFile call"""
         retries = 3
-        fo = file(self.fn, "r")
+        fo = open(self.fn, "rb")
         totalsize = os.path.getsize(self.fn)
         ofs = 0
         while True:
@@ -95,7 +98,7 @@ class WatchedFile:
             tries = 0
             while tries <= retries:
                 debug("upload_log_data('%s', '%s', %s, %s, ...)\n" % (name, self.alias, sz, offset))
-                if session.upload_log_data(name, self.alias, sz, offset, data):
+                if session.upload_log_data(name, self.alias, sz, offset, data.decode()):
                     break
                 else:
                     tries = tries + 1
@@ -132,7 +135,7 @@ class MountWatcher:
                 line = fd.readline()
                 if not line:
                     break
-                parts = string.split(line)
+                parts = line.split()
                 mp = parts[1]
                 if mp == self.mountpoint:
                     found = 1
@@ -256,7 +259,7 @@ while n < len(sys.argv):
     n = n+1
 
 # Create an xmlrpc session handle
-session = client.Server("http://%s:%s/cobbler_api" % (server, port))
+session = Server("http://%s:%s/cobbler_api" % (server, port))
 
 # Fork and loop
 if daemon:

--- a/misc/anamon.init
+++ b/misc/anamon.init
@@ -47,8 +47,11 @@ if [ -z "$LOGFILES" ]; then
 fi
 
 start() {
+    python=python
+    [ -x /usr/libexec/platform-python ] && python=/usr/libexec/platform-python
+    [ -x /usr/bin/python3 ] && python=/usr/bin/python3
     echo -n $"Starting anamon: "
-    daemon /usr/local/sbin/anamon --watchfile \"$LOGFILES\" --name $COBBLER_NAME --server $COBBLER_SERVER --port ${COBBLER_PORT:-80} --exit
+    daemon $python /usr/local/sbin/anamon --watchfile \"$LOGFILES\" --name $COBBLER_NAME --server $COBBLER_SERVER --port ${COBBLER_PORT:-80} --exit
     RETVAL=$?
     [ $RETVAL -eq 0 ] && touch $LOCKFILE
     echo


### PR DESCRIPTION
This is much better than what we have now, but it still fails on EL8.
```
line 101 uploadWrapper:
                  if session.upload_log_data(name, self.alias, sz, offset, data):
```
ends with:
```
xmlrpc.client.Fault: <Fault 1: "<type 'exceptions.TypeError'>:must be string or buffer, not instance">
```
I think this has to do with the base64 encoding.