### PR TITLE
Fixes a template rendering error

### DIFF
--- a/autoinstall_snippets/pre_install_network_config
+++ b/autoinstall_snippets/pre_install_network_config
@@ -60,7 +60,7 @@ get_ifname() {
         #set $static        = $idata["static"]
         #set $ip            = $idata["ip_address"]
         #set $netmask       = $idata["netmask"]
-        #set $gateway       = $idata["gateway"]
+        #set $gateway       = $getVar("gateway","")
         #set $if_gateway    = $idata["if_gateway"]
         #set $iface_type    = $idata["interface_type"]
         #set $iface_master  = $idata["interface_master"]


### PR DESCRIPTION
Some parts of the code that generate the interface dictionaries must have
changed since it no longer contains `gateway` as a key. Since this is a system
property anyway, get it directly using `$getVar("gateway", "")`.

Fixes #2175