### PR TITLE
Pass the mgmt_parameters(ksmeta) to the DHCP template

### DIFF
--- a/cobbler/modules/manage_isc.py
+++ b/cobbler/modules/manage_isc.py
@@ -160,6 +160,7 @@ class IscManager:
                 interface["hostname"] = blended_system["hostname"]
                 interface["owner"] = blended_system["name"]
                 interface["enable_gpxe"] = blended_system["enable_gpxe"]
+                interface["mgmt_parameters"] = blended_system["mgmt_parameters"]
 
                 if not self.settings.always_write_dhcp_entries:
                     if not interface["netboot_enabled"] and interface['static']:


### PR DESCRIPTION
The commit adds the mgmt_parameters(which includes ksmeta) to the data passed to the DHCP templating. These values are already available in other templating, (e.g. PXE templates).
As this is only adds an extra dictionary to each "interface" entry, this should be backwards compatible.

FYI - we're using this to set a "filename" value to allow us to support UEFI Secure Boot. We set this though the ksmeta at various levels in the distro/profile/system hierarchy. I'll describe how we've achieved this in feature request #1766 .