### PR TITLE
Pass the mgmt_parameters(ksmeta) to the DHCP template

### DIFF
--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -178,6 +178,7 @@ class IscManager(object):
                 interface["owner"] = blended_system["name"]
                 interface["enable_gpxe"] = blended_system["enable_gpxe"]
                 interface["name_servers"] = blended_system["name_servers"]
+                interface["mgmt_parameters"] = blended_system["mgmt_parameters"]
 
                 if not self.settings.always_write_dhcp_entries:
                     if not interface["netboot_enabled"] and interface['static']:


### PR DESCRIPTION
The commit adds the mgmt_parameters(which includes ksmeta) to the data passed to the DHCP templating. These values are already available in other templating, (e.g. PXE templates).
As this is only adds an extra dictionary to each "interface" entry, this should be backwards compatible.