### PR TITLE
Fixup man page location for cobbler.conf

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -372,7 +372,7 @@ fi
 %doc AUTHORS COPYING README
 %{_mandir}/man1/cobblerd.1.gz
 %{_mandir}/man1/cobbler-cli.1.gz
-%{_mandir}/man1/cobbler.conf.5.gz
+%{_mandir}/man5/cobbler.conf.5.gz
 
 
 #

--- a/setup.py
+++ b/setup.py
@@ -487,7 +487,7 @@ if __name__ == "__main__":
 
     # Trailing slashes on these vars is to allow for easy
     # later configuration of relative paths if desired.
-    docpath = "share/man/man1"
+    docpath = "share/man"
     etcpath = "/etc/cobbler/"
     libpath = "/var/lib/cobbler/"
     logpath = "/var/log/"
@@ -678,6 +678,7 @@ if __name__ == "__main__":
             ("%szone_templates" % etcpath, []),
             ("%s" % etcpath, ["config/cobbler/logging_config.conf"]),
             # man pages
-            (docpath, glob("build/sphinx/man/*")),
+            ("%s/man1" % docpath, glob("build/sphinx/man/*.1")),
+            ("%s/man5" % docpath, glob("build/sphinx/man/*.5")),
         ],
     )


### PR DESCRIPTION
As mentioned by @watologo1 at the end of #2185, this fixes the man page location for `cobbler.conf` and makes `docpath` more generic. Together with the previous merge, this closes #2173.