### PR TITLE
Add testing in multiple containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,18 @@ test:
 	make restorestate prefix=test
 	/sbin/service cobblerd restart
 
+test-centos7:
+	./tests/build-and-install-rpms.sh --with-tests el7 dockerfiles/CentOS7.dockerfile
+
+test-centos8:
+	./tests/build-and-install-rpms.sh --with-tests el8 dockerfiles/CentOS8.dockerfile
+
+test-fedora29:
+	./tests/build-and-install-rpms.sh --with-tests f29 dockerfiles/Fedora29.dockerfile
+
+test-fedora30:
+	./tests/build-and-install-rpms.sh --with-tests f30 dockerfiles/Fedora30.dockerfile
+
 nosetests:
 	PYTHONPATH=./cobbler/ nosetests -v -w tests/cli/ 2>&1 | tee test.log
 

--- a/dockerfiles/CentOS7.dockerfile
+++ b/dockerfiles/CentOS7.dockerfile
@@ -44,7 +44,8 @@ RUN yum install -y          \
     logrotate               \
     syslinux                \
     systemd-sysv            \
-    tftp-server
+    tftp-server             \
+    fence-agents
 
 COPY . /usr/src/cobbler
 WORKDIR /usr/src/cobbler

--- a/dockerfiles/CentOS8.dockerfile
+++ b/dockerfiles/CentOS8.dockerfile
@@ -51,7 +51,8 @@ RUN touch /var/lib/rpm/* &&   \
     grub2-efi-x64-modules     \
     logrotate                 \
     syslinux                  \
-    tftp-server
+    tftp-server               \
+    fence-agents
 
 
 COPY . /usr/src/cobbler

--- a/dockerfiles/Fedora29.dockerfile
+++ b/dockerfiles/Fedora29.dockerfile
@@ -42,7 +42,8 @@ RUN yum install -y          \
     grub2-efi-x64-modules   \
     logrotate               \
     syslinux                \
-    tftp-server
+    tftp-server             \
+    fence-agents
 
 COPY . /usr/src/cobbler
 WORKDIR /usr/src/cobbler

--- a/dockerfiles/Fedora30.dockerfile
+++ b/dockerfiles/Fedora30.dockerfile
@@ -43,7 +43,8 @@ RUN yum install -y          \
     logrotate               \
     rsync                   \
     syslinux                \
-    tftp-server
+    tftp-server             \
+    fence-agents
 
 COPY . /usr/src/cobbler
 WORKDIR /usr/src/cobbler

--- a/tests/build-and-install-rpms.sh
+++ b/tests/build-and-install-rpms.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 # Utility script to build RPMs in a Docker container and then install them
 
+if [ "$1" == "--with-tests" ]
+then
+    RUN_TESTS=true
+    shift
+else
+    RUN_TESTS=false
+fi
+
 TAG=$1
 DOCKERFILE=$2
 
@@ -18,6 +26,12 @@ docker run -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name cobbler -v
 docker logs cobbler
 docker exec -it cobbler bash -c 'rpm -Uvh rpm-build/cobbler-*.noarch.rpm'
 docker exec -it cobbler bash -c 'cobbler --version'
+
+if $RUN_TESTS
+then
+    docker exec -it cobbler bash -c 'pip3 install -r requirements-test.txt'
+    docker exec -it cobbler bash -c 'pytest'
+fi
 
 # Clean up
 docker stop cobbler


### PR DESCRIPTION
* Add missing `fence-agents` package needed for tests (note, CentOS doesn't have `fence-agents-lpar` in x86_64 repos, which seems to fail a test case for both CentOS 7 and CentOS 8)

* modifies `build-and-install-rpms.sh` to allow running the test suite inside of the containers when adding the `--with-tests` option. This could be added to the Travis run once the test cases have been fixed.

* Adds the following targets to the Makefile:
  - test-centos7
  - test-centos8
  - test-fedora29
  - test-fedora30

  Each of these runs the `build-and-install-rpms.sh` script to generate a container, builds and installs the RPMs, and then executes the test suite inside of the container using this installation. This should simplify local development and testing.
