### PR TITLE
Fix grub menu

### DIFF
--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -185,6 +185,12 @@ class Distro(item.Item):
         """
         return utils.set_arch(self, arch)
 
+    def get_arch(self):
+        """
+        Return the architecture of the distribution
+        """
+        return self.arch
+
     def set_supported_boot_loaders(self, supported_boot_loaders):
         """
         Some distributions, particularly on powerpc, can only be netbooted using

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -276,5 +276,8 @@ class Profile(item.Item):
         return self.redhat_management_key
 
     def get_arch(self):
-        return self.get_parent().get_arch()
+        parent = self.get_parent()
+        if parent:
+            return parent.get_arch()
+        return None
 # EOF

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -275,4 +275,6 @@ class Profile(item.Item):
     def get_redhat_management_key(self):
         return self.redhat_management_key
 
+    def get_arch(self):
+        return self.get_parent().get_arch()
 # EOF

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -288,9 +288,7 @@ class TFTPGen(object):
         profile_list = [profile for profile in self.profiles]
         profile_list = sorted(profile_list, key=lambda profile: profile.name)
 
-        if arch:
-            profile_list = [
-                profile for profile in profile_list if profile.get_parent().get_arch() == arch]
+        profile_list = [profile for profile in profile_list if profile.get_arch() == arch]
 
         # sort the images
         image_list = [image for image in self.images]

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -272,18 +272,25 @@ class TFTPGen(object):
         template_src.close()
 
         # Write the grub menu:
-        outfile = os.path.join(self.bootloc, "grub", "menu_items.cfg")
-        fd = open(outfile, "w+")
-        fd.write(menu_items['grub'])
-        fd.close()
+        for arch in utils.get_valid_archs():
+            arch_menu_items = self.get_menu_items(arch)
+            if(arch_menu_items['grub']):
+                outfile = os.path.join(self.bootloc, "grub", "{0}_menu_items.cfg".format(arch))
+                fd = open(outfile, "w+")
+                fd.write(arch_menu_items['grub'])
+                fd.close()
 
-    def get_menu_items(self):
+    def get_menu_items(self, arch=None):
         """
         Generates menu items for pxe and grub
         """
         # sort the profiles
         profile_list = [profile for profile in self.profiles]
         profile_list = sorted(profile_list, key=lambda profile: profile.name)
+
+        if arch:
+            profile_list = [
+                profile for profile in profile_list if profile.get_parent().get_arch() == arch]
 
         # sort the images
         image_list = [image for image in self.images]

--- a/config/grub/grub/grub.cfg
+++ b/config/grub/grub/grub.cfg
@@ -36,6 +36,7 @@ elif [ "$grub_cpu" == "arm64" ]; then
   # Untested
   set arch='aarch64'
 else
+  echo "Warning: No architecture found for ${grub_cpu}"
   set arch='unknown'
 fi
 
@@ -121,9 +122,10 @@ else
   source "$prefix/local_legacy.cfg"
 fi
 
-if [ -s "$prefix/menu_items.cfg" ]; then
-  # ToDo: Provide architecture specific menus
-  source "$prefix/menu_items.cfg"
+if [ !"{$arch}" == "unknown" ]; then
+  echo "Warning: architecture is unknown, skipping menu items";
+  else
+  source "$prefix/${arch}_menu_items.cfg"
 fi
 
 # Trigger local boot setting (may alter grub.cfg) at the very end to avoid races


### PR DESCRIPTION
This PR creates architecture specific  menu_items.cfg files and sources the appropriate one in the grub.cfg
This prevents boot entries for other architectures from showing up in the grub menu