### PR TITLE
Small fixes for Debian 10 DEB package

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -259,7 +259,14 @@ mkdir -p %{buildroot}%{_sysconfdir}/logrotate.d
 mv %{buildroot}%{_sysconfdir}/cobbler/cobblerd_rotate %{buildroot}%{_sysconfdir}/logrotate.d/cobblerd
 
 # Create data directories in tftpboot_dir
-mkdir -p %{buildroot}%{tftpboot_dir}/{boot,etc,grub,images{,2},ppc,pxelinux.cfg,s390x}
+mkdir -p %{buildroot}%{tftpboot_dir}/boot
+mkdir %{buildroot}%{tftpboot_dir}/etc
+mkdir %{buildroot}%{tftpboot_dir}/grub
+mkdir %{buildroot}%{tftpboot_dir}/images
+mkdir %{buildroot}%{tftpboot_dir}/images2
+mkdir %{buildroot}%{tftpboot_dir}/ppc
+mkdir %{buildroot}%{tftpboot_dir}/pxelinux.cfg
+mkdir %{buildroot}%{tftpboot_dir}/s390x
 
 # systemd
 mkdir -p %{buildroot}%{_unitdir}
@@ -316,7 +323,8 @@ fi
 %post web
 # Change the SECRET_KEY option in the Django settings.py file
 # required for security reasons, should be unique on all systems
-RAND_SECRET=$(openssl rand -base64 40 | sed 's/\//\\\//g')
+# Choose from multiple characters, but without an ampersand (&).
+RAND_SECRET=$(head /dev/urandom | tr -dc 'A-Za-z0-9!"#$%'\''()*+,-./:;<=>?@[\]^_`{|}~' | head -c 57 ; echo '')
 sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler/web/settings.py
 
 

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -438,9 +438,9 @@ replicate_repo_rsync_options: "-avzH"
 always_write_dhcp_entries: 0
 
 # external proxy - used by: get-loaders, reposync, signature update
-proxy_url_ext:
-  #http: http://192.168.1.1:8080
-  #https: https://192.168.1.1:8443
+# eg: proxy_url_ext: "http://192.168.1.1:8080" (HTTP)
+# or: proxy_url_ext: "https://192.168.1.1:8443" (HTTPS)
+proxy_url_ext: ""
 
 # internal proxy - used by systems to reach cobbler for kickstarts
 # eg: proxy_url_int: "http://10.0.0.1:8080"


### PR DESCRIPTION
Small changes to make a more or less working Debian 10 "Buster" package.

- On Debain 10 `mkdir -p %{buildroot}%{tftpboot_dir}/{boot,etc,grub,images{,2},ppc,pxelinux.cfg,s390x}` would create one long-lined directory with curly brackets instead of multiple directories when the DEB package is actually installed.
- The `RAND_SECRET` would make the sed on the `SECRET_KEY` fail if it contains an ampersand (`&`) - which happens almost all the time.
- Fixed empty setting for `proxy_url_ext`. This would make the augeas lens [`cobblersetting`](https://github.com/hercules-team/augeas/blob/master/lenses/cobblersettings.aug) fail, eg. when using SaltStack states.

I was unable to fix the `self.root = "/usr/local"` to be set to `self.root = "/usr"`, so the systemd service file still points to files in `/usr/local`, which are not there.