### PR TITLE
Fix create & delete snippets with XMLRPC

### DIFF
--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -208,7 +208,9 @@ class AutoInstallationManager(object):
     def remove_autoinstall_snippet(self, file_path):
 
         file_path = self.validate_autoinstall_snippet_file_path(file_path)
-        os.remove(file_path)
+
+        file_full_path = "%s/%s" % (self.snippets_base_dir, file_path)
+        os.remove(file_full_path)
 
         return True
 

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2189,7 +2189,7 @@ class CobblerXMLRPCInterface(object):
         @return bool if operation was successful
         """
 
-        what = "write_autoinstall_snippet"
+        what = "remove_autoinstall_snippet"
         self._log(what, name=file_path, token=token)
         self.check_access(token, what, file_path, True)
 

--- a/contrib/api-examples/API_test.py
+++ b/contrib/api-examples/API_test.py
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+
+import xmlrpc.client
+server = xmlrpc.client.Server("http://127.0.0.1/cobbler_api")
+print(server.get_distros())
+print(server.get_profiles())
+print(server.get_systems())
+print(server.get_images())
+print(server.get_repos())

--- a/contrib/api-examples/create_snippet.py
+++ b/contrib/api-examples/create_snippet.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+from xmlrpc.client import ServerProxy
+import optparse
+
+p = optparse.OptionParser()
+p.add_option("-u","--user",dest="user",default="test")
+p.add_option("-p","--pass",dest="password",default="test")
+
+sp =  ServerProxy("http://127.0.0.1/cobbler_api")
+(options, args) = p.parse_args()
+token = sp.login(options.user,options.password)
+
+sp.write_autoinstall_snippet("some-snippet","some content\n",token)

--- a/contrib/api-examples/demo_connect.py
+++ b/contrib/api-examples/demo_connect.py
@@ -20,7 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-from xmlrpclib import ServerProxy
+from xmlrpc.client import ServerProxy
 import optparse
 
 if __name__ == "__main__":
@@ -28,7 +28,7 @@ if __name__ == "__main__":
     p.add_option("-u","--user",dest="user",default="test")
     p.add_option("-p","--pass",dest="password",default="test")
 
-    # NOTE: if you've changed your xmlrpc_rw port or 
+    # NOTE: if you've changed your xmlrpc_rw port or
     # disabled xmlrpc_rw this test probably won't work
 
     sp = ServerProxy("http://127.0.0.1:25151")
@@ -39,6 +39,3 @@ if __name__ == "__main__":
     print("- authenticated ok, now seeing if user is authorized")
     check = sp.check_access(token,"imaginary_method_name")
     print("- access ok? %s" % check)
-
-
-

--- a/contrib/api-examples/read_snippet.py
+++ b/contrib/api-examples/read_snippet.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+from xmlrpc.client import ServerProxy
+import optparse
+
+p = optparse.OptionParser()
+p.add_option("-u","--user",dest="user",default="test")
+p.add_option("-p","--pass",dest="password",default="test")
+
+sp =  ServerProxy("http://127.0.0.1/cobbler_api")
+(options, args) = p.parse_args()
+token = sp.login(options.user,options.password)
+
+sp.read_autoinstall_snippet("some-snippet",token)

--- a/contrib/api-examples/remove_snippet.py
+++ b/contrib/api-examples/remove_snippet.py
@@ -1,0 +1,14 @@
+#!/usr/bin/python3
+
+from xmlrpc.client import ServerProxy
+import optparse
+
+p = optparse.OptionParser()
+p.add_option("-u","--user",dest="user",default="test")
+p.add_option("-p","--pass",dest="password",default="test")
+
+sp =  ServerProxy("http://127.0.0.1/cobbler_api")
+(options, args) = p.parse_args()
+token = sp.login(options.user,options.password)
+
+sp.remove_autoinstall_snippet("some-snippet",token)

--- a/web/templates/snippet_edit.tmpl
+++ b/web/templates/snippet_edit.tmpl
@@ -20,7 +20,7 @@ if you need to resolve this.
       <label for="snippetdata">{% if snippet_name %}Snippet: {{ snippet_name }}{% else %}Filename:{% endif %}</label>
 {% ifnotequal editmode 'edit' %}
       <input type="text" name="snippet_name" id="snippet_name" />
-      <span class="context-tip">Example:  foo.ks (to be saved in /var/lib/cobbler/snippets/)</span>
+      <span class="context-tip">Example:  some-snippet (to be saved in /var/lib/cobbler/snippets/)</span>
 {% else %}
       <input type="hidden" name="snippet_name" value="{{ snippet_name }}" />
 {% endifnotequal %}


### PR DESCRIPTION
## Changes
- fix deletion of snippets with XMLRPC and in the webUI, in `cobbler/autoinstall_manager.py`
- correction for `remove_autoinstall_snippet` in `cobbler/remote.py`
- fixed `demo_connect.py` to properly work with Python3
- added API example to test create / delete snippets

## NOTE
This will work on #2243 **BUT ONLY** using XMLRPC calls!!
After hours of investigating, I couldn't find where the webUI is causing the `snippet_path` to be added to the `snippet_file`.
So this PR is not a full fix.

### Logging
Create snippet in the webUI (http://cobblerhost/cobbler_web/snippet/edit)
```
2020-01-21T14:46:48 - INFO | REMOTE write_autoinstall_snippet; user(cobbler); name(/var/lib/cobbler/snippets/some-snippet)
2020-01-21T14:46:48 - DEBUG | authorize; ['cobbler', 'write_autoinstall_snippet', '/var/lib/cobbler/snippets/some-snippet', True, True]
2020-01-21T14:46:48 - DEBUG | REMOTE cobbler authorization result: True; user(?)
```

Create snippet with XMLRPC:
```
2020-01-21T14:46:00 - INFO | REMOTE write_autoinstall_snippet; user(cobbler); name(some-snippet)
2020-01-21T14:46:00 - DEBUG | authorize; ['cobbler', 'write_autoinstall_snippet', 'some-snippet', True, True]
2020-01-21T14:46:00 - DEBUG | REMOTE cobbler authorization result: True; user(?)
```