### PR TITLE
Fix CI pipeline - #2252

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,8 @@ clean:
 	@rm -rf buildiso
 	@rm -f *.tmp
 	@rm -f *.log
+
+cleandoc:
 	@echo "cleaning: documentation"
 	@cd docs; make clean > /dev/null 2>&1
 
@@ -83,7 +85,7 @@ sdist: readme authors
 	@echo "creating: sdist"
 	@${PYTHON} setup.py sdist > /dev/null
 
-release: clean qa readme authors sdist doc
+release: clean qa readme authors sdist
 	@echo "creating: release artifacts"
 	@mkdir release
 	@cp dist/*.gz release/
@@ -203,5 +205,5 @@ eraseconfig:
 	-rm /var/lib/cobbler/collections/packages/*
 
 .PHONY: tags
-tags: 
+tags:
 	find . \( -name build -o -name .git \) -prune -o -type f -name '*.py' -print | xargs etags -o TAGS --

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -328,8 +328,8 @@ fi
 %post web
 # Change the SECRET_KEY option in the Django settings.py file
 # required for security reasons, should be unique on all systems
-# Choose from multiple characters, but without an ampersand (&).
-RAND_SECRET=$(head /dev/urandom | tr -dc 'A-Za-z0-9!"#$%'\''()*+,-./:;<=>?@[\]^_`{|}~' | head -c 57 ; echo '')
+# Choose from letters and numbers only, so no special chars like ampersand (&).
+RAND_SECRET=$(head /dev/urandom | tr -dc 'A-Za-z0-9!' | head -c 50 ; echo '')
 sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler/web/settings.py
 
 

--- a/dockerfiles/CentOS7.dockerfile
+++ b/dockerfiles/CentOS7.dockerfile
@@ -29,10 +29,6 @@ RUN yum install -y          \
     python36-sphinx         \
     rpm-build
 
-# TEMPORARY !! This package is in EPEL testing since 20200127
-# These lines can be deleted once the package has passed.
-RUN rpm -ihv https://kojipkgs.fedoraproject.org/packages/python3-cheetah/3.2.4/1.el7/x86_64/python36-cheetah-3.2.4-1.el7.x86_64.rpm
-
 RUN yum install -y          \
 # Runtime dependencies
     httpd                   \

--- a/dockerfiles/CentOS7.dockerfile
+++ b/dockerfiles/CentOS7.dockerfile
@@ -13,7 +13,10 @@ RUN yum install -y          \
     git                     \
     rsync                   \
     make                    \
+    dnf-plugins-core        \
+    epel-rpm-macros         \
     openssl                 \
+    mod_ssl                 \
     python-sphinx           \
     python36-coverage       \
     python36-devel          \
@@ -26,10 +29,15 @@ RUN yum install -y          \
     python36-sphinx         \
     rpm-build
 
+# TEMPORARY !! This package is in EPEL testing since 20200127
+# These lines can be deleted once the package has passed.
+RUN rpm -ihv https://kojipkgs.fedoraproject.org/packages/python3-cheetah/3.2.4/1.el7/x86_64/python36-cheetah-3.2.4-1.el7.x86_64.rpm
+
 RUN yum install -y          \
 # Runtime dependencies
     httpd                   \
     python36-mod_wsgi       \
+    python36-pymongo        \
     python36-PyYAML         \
     python36-netaddr        \
     python36-simplejson     \
@@ -37,6 +45,7 @@ RUN yum install -y          \
     python36-django         \
     python36-dns            \
     python36-ldap3          \
+    python36-cheetah        \
     createrepo              \
     xorriso                 \
     grub2-efi-ia32-modules  \

--- a/dockerfiles/CentOS8.dockerfile
+++ b/dockerfiles/CentOS8.dockerfile
@@ -21,6 +21,8 @@ RUN touch /var/lib/rpm/* &&   \
     rsync                     \
     make                      \
     openssl                   \
+    mod_ssl                   \
+    initscripts               \
     python3-sphinx            \
     platform-python-coverage  \
     python3-devel             \
@@ -30,6 +32,7 @@ RUN touch /var/lib/rpm/* &&   \
     python3-pycodestyle       \
     python3-setuptools        \
     python3-sphinx            \
+    epel-rpm-macros           \
     rpm-build
 
 # Runtime dependencies
@@ -44,6 +47,8 @@ RUN touch /var/lib/rpm/* &&   \
     python3-tornado           \
     python3-django            \
     python3-dns               \
+    python3-ldap3             \
+    python3-pymongo           \
     createrepo                \
     dnf-plugins-core          \
     xorriso                   \
@@ -53,7 +58,6 @@ RUN touch /var/lib/rpm/* &&   \
     syslinux                  \
     tftp-server               \
     fence-agents
-
 
 COPY . /usr/src/cobbler
 WORKDIR /usr/src/cobbler

--- a/dockerfiles/Fedora29.dockerfile
+++ b/dockerfiles/Fedora29.dockerfile
@@ -10,6 +10,8 @@ RUN dnf install -y          \
     rsync                   \
     make                    \
     openssl                 \
+    mod_ssl                 \
+    initscripts             \
     python-sphinx           \
     python3-coverage        \
     python3-devel           \
@@ -19,7 +21,7 @@ RUN dnf install -y          \
     python3-pyflakes        \
     python3-pycodestyle     \
     python3-setuptools      \
-    python3-sphinx         \
+    python3-sphinx          \
     rpm-build
 
 # Runtime dependencies

--- a/dockerfiles/Fedora30.dockerfile
+++ b/dockerfiles/Fedora30.dockerfile
@@ -10,6 +10,8 @@ RUN dnf install -y          \
     rsync                   \
     make                    \
     openssl                 \
+    mod_ssl                 \
+    initscripts             \
     python-sphinx           \
     python3-coverage        \
     python3-devel           \
@@ -19,7 +21,7 @@ RUN dnf install -y          \
     python3-pyflakes        \
     python3-pycodestyle     \
     python3-setuptools      \
-    python3-sphinx         \
+    python3-sphinx          \
     rpm-build
 
 # Runtime dependencies

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,7 +47,6 @@ extensions = [
     'sphinx.ext.mathjax',
     'sphinx.ext.ifconfig',
     'sphinx.ext.viewcode',
-    'sphinx.ext.githubpages',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
**Changes**:

- `tests/build-and-install-rpms.sh`: add `set -eo pipefail` to fail early; fix Cobbler startup
- Dockerfiles: added missing packages to make builds not fail
- `docs/conf.py`: removed `sphinx.ext.githubpages`
- `Makefile`: shuffled doc section

**Added:**

- `tests/install-rpms.sh `: to test RPMs when they are already build locally

**TODO:**

~Documents build `continuous-documentation/read-the-docs ` will probably still fail.~