### PR TITLE
Debian10 automated DEBs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.class
 dist
 rpm-build
+deb-build
 release
 build
 MANIFEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,9 @@ jobs:
     - stage: rpms
       name: "Build Fedora 31 RPMs"
       script: ./tests/build-and-install-rpms.sh fc31 dockerfiles/Fedora31.dockerfile
+    - stage: debs
+      name: "Build Debian 10 DEBs"
+      script: ./tests/build-and-install-debs.sh deb10 dockerfiles/Debian10.dockerfile
 notifications:
   webhooks:
     urls:

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -12,6 +12,9 @@
 # If it doesn't build on the Open Build Service (OBS) it's a bug.
 #
 
+# Force bash instead of Debian dash
+%global _buildshell /bin/bash
+
 # Work around quirk in OBS about handling defines...
 %if 0%{?el7}
 %{!?python3_pkgversion: %global python3_pkgversion 36}
@@ -132,6 +135,8 @@ BuildRequires:  python-rpm-macros
 %endif
 %if %{_vendor} == "debbuild"
 BuildRequires:  python3-deb-macros
+BuildRequires:  apache2-deb-macros
+
 %endif
 BuildRequires:  %{py3_module_coverage}
 BuildRequires:  python%{python3_pkgversion}-distro
@@ -261,14 +266,7 @@ mkdir -p %{buildroot}%{_sysconfdir}/logrotate.d
 mv %{buildroot}%{_sysconfdir}/cobbler/cobblerd_rotate %{buildroot}%{_sysconfdir}/logrotate.d/cobblerd
 
 # Create data directories in tftpboot_dir
-mkdir -p %{buildroot}%{tftpboot_dir}/boot
-mkdir %{buildroot}%{tftpboot_dir}/etc
-mkdir %{buildroot}%{tftpboot_dir}/grub
-mkdir %{buildroot}%{tftpboot_dir}/images
-mkdir %{buildroot}%{tftpboot_dir}/images2
-mkdir %{buildroot}%{tftpboot_dir}/ppc
-mkdir %{buildroot}%{tftpboot_dir}/pxelinux.cfg
-mkdir %{buildroot}%{tftpboot_dir}/s390x
+mkdir -p %{buildroot}%{tftpboot_dir}/{boot,etc,grub,images{,2},ppc,pxelinux.cfg,s390x}
 
 # systemd
 mkdir -p %{buildroot}%{_unitdir}
@@ -306,6 +304,7 @@ fi
 %post
 %{py3_bytecompile_post %{name}}
 %{systemd_post cobblerd.service}
+%{apache2_module_post proxy_http}
 
 %preun
 %{py3_bytecompile_preun %{name}}
@@ -403,6 +402,17 @@ sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler
 %config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf
 %config(noreplace) %{_sysconfdir}/cobbler/named.template
 %config(noreplace) %{_sysconfdir}/cobbler/ndjbdns.template
+%dir %{_sysconfdir}/cobbler/power
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_apc_snmp.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_bladecenter.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_bullpap.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_drac.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_ilo.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_ipmilan.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_lpar.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_rsa.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_virsh.template
+%config(noreplace) %{_sysconfdir}/cobbler/power/fence_wti.template
 %dir %{_sysconfdir}/cobbler/reporting
 %config(noreplace) %{_sysconfdir}/cobbler/reporting/build_report_email.template
 %config(noreplace) %{_sysconfdir}/cobbler/rsync.exclude
@@ -417,6 +427,8 @@ sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler
 %config(noreplace) %{_sysconfdir}/cobbler/users.digest
 %config(noreplace) %{_sysconfdir}/cobbler/version
 %config(noreplace) %{_sysconfdir}/cobbler/zone.template
+%dir %{_sysconfdir}/cobbler/zone_templates
+%config(noreplace) %{_sysconfdir}/cobbler/zone_templates/foo.example.com
 %config(noreplace) %{_sysconfdir}/logrotate.d/cobblerd
 %config(noreplace) %{apache_webconfigdir}/cobbler.conf
 %{_bindir}/cobbler

--- a/config/apache/cobbler_web.conf
+++ b/config/apache/cobbler_web.conf
@@ -3,16 +3,22 @@
 
 Alias /cobbler_webui_content @@webroot@@/cobbler_webui_content
 
+# Let mod_wsgi know about the location block,
+# so it can access /cobbler_web
+<Location /cobbler_web>
+    Require all granted
+</Location>
+
 # Use separate process group for wsgi
 WSGISocketPrefix /var/run/wsgi
-WSGIScriptAlias /cobbler_web @@install_data@@/share/cobbler/web/cobbler.wsgi
+WSGIScriptAlias /cobbler_web /usr/share/cobbler/web/cobbler.wsgi
 WSGIDaemonProcess cobbler_web display-name=%{GROUP}
 WSGIProcessGroup cobbler_web
 WSGIPassAuthorization On
 
 <VirtualHost *:443>
 
-<Directory "@@install_data@@/share/cobbler/web/">
+<Directory "/usr/share/cobbler/web/">
         <IfModule mod_ssl.c>
             SSLRequireSSL
         </IfModule>
@@ -36,10 +42,5 @@ WSGIPassAuthorization On
         AllowOverride None
         Require all granted
 </Directory>
-
-
-<Location /cobbler_web>
-    Require all granted
-</Location>
 
 </VirtualHost>

--- a/config/bash/completion/cobbler
+++ b/config/bash/completion/cobbler
@@ -12,18 +12,18 @@ _cobbler_completions()
     TYPE="distro profile system repo image mgmtclass package file aclsetup buildiso import list replicate report reposync sync validateks version signature get-loaders hardlink"
     ACTION="add edit copy list remove rename report"
     opts=(
-        [distro]="--name --owners --kernel --initrd --kopts --kopts-post --ksmeta --arch --breed --os-version --source-repos --depth --comment --tree-build-time --mgmt-classes --boot-files --fetchable-files --template-files --redhat-management-key --redhat-management-server --clobber --in-place  --help"
-        [profile]="--name --owners --distro --enable-gpxe --enable-menu --kickstart --kopts --ksmeta --proxy --repos --comment --virt-file-size --virt-ram --virt-type --virt-cpus --virt-path --virt-bridge --depth --dhcp-tag --server --name-servers --name-servers-search --mgmt-classes --mgmt-parameters --boot-files --fetchable-files --template-files --redhat-management-key --redhat-management-server --template-remote-kickstarts --clobber --in-place --parent  --help"
-        [system]="--name --owners --profile --image --status --mac --ip-address --hostname --kopts --kopts-post --ksmeta --kickstart --enable-gpxe --proxy --netboot-enabled --comment --depth --server --virt-path --virt-type --virt-cpus --virt-file-size --virt-disk-driver --virt-ram --virt-auto-boot --virt-pxe-boot --virt-bridge --power-address --power-user --power-pass --power-id --gateway --dns-name --name-servers --name-servers-search --ipv6-default-device --ipv6-autoconfiguration --mgmt-classes --mgmt-parameters --boot-files --fetchable-files --template-files --redhat-management-key --redhat-management-server --template-remote-kickstarts --repos-enabled --ldap-enabled --ldap-type --monit-enabled --cnames --interface --delete-interface --rename-interface --interface-type --interface-master --bonding-opts --static-routes --static --netmask --clobber --in-place  --help"
-        [repo]="--mirror --name --owners --comment --parent --rpmlist --creatrepo-flags --yumopts --proxy --keep-updated --environment --priority --arch --mirror-locally --breed --apt-components --apt-dists --depth --clobber --in-place --help"
-        [image]="--name --arch --breed --comment --ctime --mtime --file --depth --image-type --network-count --os-version --owners --parent --kickstart --virt-auto-boot --virt-bridge --virt-cpus --virt-file-size --virt-disk-driver --virt-path --virt-ram --virt-type --clobber --in-place --help"
-        [mgmtclass]="--name --owners --comment --class-name --is-definition --params --packages --files --depth --clobber --in-place --help"
-        [package]="--uid --depth --comment --ctime --mtime --owners --name --action --installer --version --clobber --in-place --help"
-        [file]="--uid --depth --comment --ctime --mtime --owners --name --is-dir --action --group --mode --owner --path --template --clobber --in-place --help"
-        [import]="--arch --breed --os-version --path --name --available-as --kickstart --rsync-flags --help"
+        [distro]="--ctime --depth --mtime --source-repos --tree-build-time --uid --arch --autoinstall-meta --boot-files --boot-loader --breed --comment --fetchable-files --initrd --kernel --kernel-options --kernel-options-post --mgmt-classes --name --os-version --owners --redhat-management-key --template-files --in-place --help"
+        [profile]="--ctime --depth --mtime --uid --autoinstall --autoinstall-meta --boot-files --comment --dhcp-tag --distro --enable-gpxe --enable-menu --fetchable-files --kernel-options --kernel-options-post --mgmt-classes --mgmt-parameters --name --name-servers --name-servers-search --next-server --owners --parent --proxy --redhat-management-key --repos --server --template-files --virt-auto-boot --virt-bridge --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-ram --virt-type --in-place --help"
+        [system]="--ctime --depth --ipv6-autoconfiguration --mtime --repos-enabled --uid --autoinstall --autoinstall-meta --boot-files --boot-loader --comment --enable-gpxe --fetchable-files --gateway --hostname --image --ipv6-default-device --kernel-options --kernel-options-post --mgmt-classes --mgmt-parameters --name --name-servers --name-servers-search --netboot-enabled --next-server --owners --power-address --power-id --power-pass --power-type --power-user --power-options --power-identity-file --profile --proxy --redhat-management-key --server --status --template-files --virt-auto-boot --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-pxe-boot --virt-ram --virt-type --serial-device --serial-baud-rate --bonding-opts --bridge-opts --cnames --interface, --connected-mode --interface) --dhcp-tag --dns-name --if-gateway --interface) --interface-master --interface-type --ip-address --ipv6-address --ipv6-default-gateway --ipv6-mtu --ipv6-prefix --ipv6-secondaries --interface) --ipv6-static-routes --mac-address --management --mtu --netmask --static --interface) --static-routes --virt-bridge --interface --delete-interface --rename-interface --in-place --help"
+        [repo]="--ctime --depth --mtime --parent --uid --apt-components --apt-dists --arch --breed --comment --createrepo-flags --environment --keep-updated --mirror --mirror-locally --name --owners --priority --proxy --rpm-list --yumopts --in-place --help"
+        [image]="--ctime --depth --mtime --parent --uid --arch --autoinstall --breed --comment --file --image-type --name --network-count --os-version --owners --virt-auto-boot --virt-bridge --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-ram --virt-type --in-place --help"
+        [mgmtclass]="--ctime --depth --is-definition --mtime --uid --class-name --comment --files --name --owners --packages --params --in-place --help"
+        [package]="--ctime --depth --mtime --uid --action --comment --installer --name --owners --version --in-place --help"
+        [file]="--ctime --depth --mtime --uid --action --comment --group --is-dir --mode --name --owner --owners --path --template --in-place --help"
+        [import]="--arch --breed --os-version --path --name --available-as --autoinstall --rsync-flags --help"
         [buildiso]="--iso --profiles --systems --tempdir --distro --standalone --source --exclude-dns --mkisofs-opts --help"
     )
-    
+
     while :; do
         case "${prev}" in
             cobbler)
@@ -75,7 +75,7 @@ _cobbler_completions()
                 return 0
                 ;;
             *)
-               if [[ ${COMP_CWORD} > 2 ]]; then
+               if [[ ${COMP_CWORD} -gt 2 ]]; then
                    prev="${COMP_WORDS[2]}"
                else
                    return 0

--- a/config/service/cobblerd.service
+++ b/config/service/cobblerd.service
@@ -4,8 +4,8 @@ After=syslog.target network.target
 Wants=@@httpd_service@@
 
 [Service]
-ExecStart=@@install_scripts@@/cobblerd -F
-ExecStartPost=-/usr/bin/touch @@install_data@@/share/cobbler/web/cobbler.wsgi
+ExecStart=/usr/bin/cobblerd -F
+ExecStartPost=-/usr/bin/touch /usr/share/cobbler/web/cobbler.wsgi
 PrivateTmp=yes
 KillMode=process
 

--- a/dockerfiles/CentOS7.dockerfile
+++ b/dockerfiles/CentOS7.dockerfile
@@ -42,7 +42,7 @@ RUN yum install -y          \
     python36-dns            \
     python36-ldap3          \
     python36-cheetah        \
-    createrepo_c              \
+    createrepo_c            \
     xorriso                 \
     grub2-efi-ia32-modules  \
     grub2-efi-x64-modules   \

--- a/dockerfiles/Debian10.dockerfile
+++ b/dockerfiles/Debian10.dockerfile
@@ -1,0 +1,74 @@
+# vim: ft=dockerfile
+
+FROM debian:10
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# TERM=screen is fairly neutral and works with xterm for example, for others
+# you might need to pass -e TERM=<terminal>, like rxvt-unicode.
+ENV TERM screen
+ENV OSCODENAME buster
+
+# Add repo for debbuild and install all packages required
+# hadolint ignore=DL3008,DL3015,DL4006
+RUN apt-get update -qq && \
+    apt-get install -qqy gnupg curl && \
+    /bin/sh -c "echo 'deb http://download.opensuse.org/repositories/Debian:/debbuild/Debian_10/ /' > /etc/apt/sources.list.d/debbuild.list" && \
+    curl -sL http://download.opensuse.org/repositories/Debian:/debbuild/Debian_10/Release.key | apt-key add - && \
+    apt-get update -qq && \
+    apt-get install -qqy \
+    debbuild \
+    debbuild-macros \
+    wget \
+    pycodestyle \
+    pyflakes3 \
+    python-django-common \
+    python3-cheetah  \
+    python3-coverage \
+    python3-distro \
+    python3-distutils \
+    python3-django \
+    python3-dnspython \
+    python3-dns  \
+    python3-dnsq  \
+    python3-future \
+    python3-ldap3 \
+    python3-netaddr \
+    python3-pip \
+    python3-pycodestyle \
+    python3-pytest \
+    python3-setuptools \
+    python3-simplejson  \
+    python3-sphinx \
+    python3-tornado \
+    python3-tz \
+    python3-yaml \
+    liblocale-gettext-perl \
+    lsb-release \
+    xz-utils \
+    bzip2 \
+    dpkg-dev \
+    tftpd-hpa \
+    createrepo \
+    rsync \
+    xorriso\
+    fakeroot \
+    patch \
+    pax \
+    git \
+    apache2 \
+    libapache2-mod-wsgi-py3 \
+    systemd && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Make /bin/sh point to bash, not dash
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
+
+COPY . /usr/src/cobbler
+WORKDIR /usr/src/cobbler
+
+VOLUME /usr/src/cobbler/deb-build
+
+CMD ["/bin/bash", "-c", "make debs"]

--- a/setup.py
+++ b/setup.py
@@ -331,7 +331,7 @@ class install(_install):
             raise Exception("libpath is not absolute.")
         # libpath is hardcoded in the code everywhere
         # therefor cant relocate using self.root
-        path = os.path.join(libpath, 'webui_sessions')
+        path = os.path.join(self.root + libpath, 'webui_sessions')
         try:
             self.change_owner(path, http_user)
         except Exception as e:
@@ -488,6 +488,7 @@ if __name__ == "__main__":
         webconfig = "/etc/apache2/conf-available"
         webroot = "/var/www/"
         http_user = "www-data"
+        httpd_service = "apache2.service"
         defaultpath = "/etc/default/"
     else:
         webconfig = "/etc/httpd/conf.d"
@@ -598,7 +599,15 @@ if __name__ == "__main__":
                               "config/rsync/import_rsync_whitelist",
                               "config/rsync/rsync.exclude",
                               "config/version"]),
-            ("%s" % etcpath, glob("templates/etc/*")),
+            ("%s" % etcpath, glob("cobbler/etc/*")),
+            ("%s" % etcpath, ["templates/etc/named.template",
+                              "templates/etc/genders.template",
+                              "templates/etc/secondary.template",
+                              "templates/etc/zone.template",
+                              "templates/etc/dnsmasq.template",
+                              "templates/etc/rsync.template",
+                              "templates/etc/dhcp.template",
+                              "templates/etc/ndjbdns.template"]),
             ("%siso" % etcpath, glob("templates/iso/*")),
             ("%sboot_loader_conf" % etcpath, glob("templates/boot_loader_conf/*")),
             # completion_file
@@ -692,7 +701,7 @@ if __name__ == "__main__":
             # A script that isn't really data, wsgi script
             ("share/cobbler/web/", ["cobbler/web/settings.py"]),
             # zone-specific templates directory
-            ("%szone_templates" % etcpath, []),
+            ("%szone_templates" % etcpath, glob("templates/zone_templates/*")),
             ("%s" % etcpath, ["config/cobbler/logging_config.conf"]),
             # man pages
             ("%s/man1" % docpath, glob("build/sphinx/man/*.1")),

--- a/templates/power/fence_apc_snmp.template
+++ b/templates/power/fence_apc_snmp.template
@@ -1,0 +1,3 @@
+action=$power_mode
+ipaddr=$power_address
+port=$power_id

--- a/templates/power/fence_bladecenter.template
+++ b/templates/power/fence_bladecenter.template
@@ -1,0 +1,6 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass
+port=$power_id
+secure

--- a/templates/power/fence_bullpap.template
+++ b/templates/power/fence_bullpap.template
@@ -1,0 +1,5 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass
+port=$power_id

--- a/templates/power/fence_drac.template
+++ b/templates/power/fence_drac.template
@@ -1,0 +1,4 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass

--- a/templates/power/fence_ilo.template
+++ b/templates/power/fence_ilo.template
@@ -1,0 +1,4 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass

--- a/templates/power/fence_ipmilan.template
+++ b/templates/power/fence_ipmilan.template
@@ -1,0 +1,4 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass

--- a/templates/power/fence_lpar.template
+++ b/templates/power/fence_lpar.template
@@ -1,0 +1,9 @@
+#set ($power_sys, $power_lpar) = $power_id.split(':')
+
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+managed=$power_sys
+port=$power_lpar
+passwd=$power_pass
+secure

--- a/templates/power/fence_rsa.template
+++ b/templates/power/fence_rsa.template
@@ -1,0 +1,4 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass

--- a/templates/power/fence_virsh.template
+++ b/templates/power/fence_virsh.template
@@ -1,0 +1,5 @@
+action=$power_mode
+ipaddr=$power_address
+login=$power_user
+passwd=$power_pass
+port=$power_id

--- a/templates/power/fence_wti.template
+++ b/templates/power/fence_wti.template
@@ -1,0 +1,4 @@
+action=$power_mode
+ipaddr=$power_address
+passwd=$power_pass
+port=$power_id

--- a/tests/build-and-install-debs.sh
+++ b/tests/build-and-install-debs.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Utility script to build DEBs in a Docker container and then install them
+
+set -euo pipefail
+
+if [ "$1" == "--with-tests" ]
+then
+    RUN_TESTS=true
+    shift
+else
+    RUN_TESTS=false
+fi
+
+TAG=$1
+DOCKERFILE=$2
+
+IMAGE=cobbler:$TAG
+
+# Build container
+echo "==> Build container ..."
+docker build -t "$IMAGE" -f "$DOCKERFILE" .
+
+# Build DEBs
+echo "==> Build packages ..."
+mkdir -p deb-build tmp
+docker run -ti -v "$PWD/deb-build:/usr/src/cobbler/deb-build" -v "$PWD/tmp:/var/tmp" "$IMAGE"
+
+# Launch container and install cobbler
+echo "==> Start privileged container with systemd ..."
+docker run -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name cobbler -v "$PWD/deb-build:/usr/src/cobbler/deb-build" "$IMAGE" /lib/systemd/systemd --system
+
+echo "==> Install fresh packages ..."
+docker exec -it cobbler bash -c 'dpkg -i deb-build/DEBS/all/cobbler*.deb'
+
+echo "==> Restart Apache and Cobbler daemon ..."
+docker exec -it cobbler bash -c 'a2enconf cobbler cobbler_web && systemctl daemon-reload && systemctl restart apache2 cobblerd'
+
+echo "==> Wait 3 sec. and show Cobbler version ..."
+docker exec -it cobbler bash -c 'sleep 3 && cobbler --version'
+
+if $RUN_TESTS
+then
+    # Almost all of these requirement are already satisfied in the Dockerfiles!
+    # Also on Debian mod_wsgi is installed as "libapache2-mod-wsgi-py3"
+    echo "==> Running tests ..."
+    docker exec -it cobbler bash -c 'pip3 install coverage distro future setuptools sphinx requests future'
+    docker exec -it cobbler bash -c 'pip3 install pyyaml simplejson netaddr Cheetah3 Django pymongo distro ldap3'
+    docker exec -it cobbler bash -c 'pip3 install dnspython tornado pyflakes pycodestyle pytest pytest-cov codecov'
+    docker exec -it cobbler bash -c 'pytest-3'
+fi
+
+# Clean up
+echo "==> Stop Cobbler container ..."
+docker stop cobbler
+echo "==> Delete Cobbler container ..."
+docker rm cobbler
+rm -rf ./tmp

--- a/tests/install-debs.sh
+++ b/tests/install-debs.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Utility script to run Docker container without building the DEBs,
+# just install them. So make sure they are in deb-build dir!
+
+if [ "$1" == "--with-tests" ]
+then
+    RUN_TESTS=true
+    shift
+else
+    RUN_TESTS=false
+fi
+
+TAG=$1
+IMAGE=cobbler:$TAG
+
+# Launch container and install cobbler
+docker run -d --privileged -v /sys/fs/cgroup:/sys/fs/cgroup:ro --name cobbler -v "$PWD/deb-build:/usr/src/cobbler/deb-build" "$IMAGE" /lib/systemd/systemd --system
+
+docker exec -it cobbler bash -c 'dpkg -i deb-build/DEBS/all/cobbler*.deb'
+docker exec -it cobbler bash -c 'a2enmod proxy proxy_http wsgi && a2enconf cobbler cobbler_web'
+docker exec -it cobbler bash -c 'systemctl daemon-reload && systemctl restart apache2 cobblerd'
+docker exec -it cobbler bash -c 'sleep 3 && cobbler --version'
+
+if $RUN_TESTS
+then
+    # Most of these requirement are already satisfied in the Dockerfiles!
+    # Also on Debian mod_wsgi is installed as "libapache2-mod-wsgi-py3"
+    docker exec -it cobbler bash -c 'pip3 install coverage distro future setuptools sphinx requests future'
+    docker exec -it cobbler bash -c 'pip3 install pyyaml simplejson netaddr Cheetah3 Django pymongo distro ldap3'
+    docker exec -it cobbler bash -c 'pip3 install dnspython tornado pyflakes pycodestyle pytest pytest-cov codecov'
+    docker exec -it cobbler bash -c 'pytest-3'
+fi
+
+# Entering the running container
+docker exec -ti cobbler bash


### PR DESCRIPTION
This will add automated Debian 10 "Buster" DEB package builds to the CI pipeline.
Far from perfect due to issues in multiple places, eg. in `setup.py`; the `cobbler.spec`; etc.
Look at ` tests/build-and-install-debs.sh` and in the Travis buildlogs for where to improve.