### PR TITLE
Add fence_ipmitool wrapper calling fence_impilan with lanplus enabled

### DIFF
--- a/bin/fence_ipmitool
+++ b/bin/fence_ipmitool
@@ -1,0 +1,17 @@
+#!/bin/bash -x
+
+# fence_ipmitool wrapper script to call fence_ipmilan with -P parameter
+# fence_ipmilan will then use IPMIv2.0 -I lanplus interface which should
+# be used by all modern IPMI driven BMCs out there
+
+# An issue is open for fence-agents project to use IPMIv2.0 by default:
+# https://github.com/ClusterLabs/fence-agents/issues/314
+
+# Clarification:
+# fence_ipmilan "$@" --lanplus
+# does not work. cobbler passes options via stdin and fence_ipmilan
+# does either recognise opions from stdin or via commandline.
+# Therefore below line adds lanplus=1\n to incomming stdin (cobbler passed fence
+# options)
+
+cat <(echo "lanplus=1") - | fence_ipmilan "$@"

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -331,6 +331,7 @@ sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler
 %{_bindir}/cobbler-ext-nodes
 %{_bindir}/cobblerd
 %{_sbindir}/tftpd.py
+%{_sbindir}/fence_ipmitool
 %dir %{_datadir}/cobbler
 %{_datadir}/cobbler/bin
 %{_mandir}/man1/cobbler.1*

--- a/setup.py
+++ b/setup.py
@@ -569,6 +569,7 @@ if __name__ == "__main__":
         data_files=[
             # tftpd, hide in /usr/sbin
             ("sbin", ["bin/tftpd.py"]),
+            ("sbin", ["bin/fence_ipmitool"]),
             ("%s" % webconfig, ["build/config/apache/cobbler.conf"]),
             ("%s" % webconfig, ["build/config/apache/cobbler_web.conf"]),
             ("%stemplates" % libpath, glob("autoinstall_templates/*")),


### PR DESCRIPTION
This fixes:
https://github.com/cobbler/cobbler/issues/2230

fence_ipmitool is the default cobbler fence agent.
For whatever reason this fence does not exist (anymore?) in the mainline
fence-agent project.
Instead there is fence_ipmilan which takes --lanplus (or via stdin lanplus=1)
parameter to work exactly like ipmitool is exepcted to work.

This patch adds /sbin/fence_ipmitool which calls /sbin/fence_ipmitool with
exactly the same parameters and stdin, only lanplus=1\n is additionally
added to stdin.