### PR TITLE
using general rule to name collections

### DIFF
--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -57,12 +57,11 @@ def serialize_item(collection, item):
     if not item.name:
         raise CX("name unset for item!")
 
-    # FIXME: Need a better way to support collections/items
-    # appending an 's' does not work in all cases
-    if collection.collection_type() in ['mgmtclass']:
-        filename = "/var/lib/cobbler/collections/%ses/%s" % (collection.collection_type(), item.name)
+    collection_type = collection.collection_type()
+    if collection_type[-1].lower() in ['h', 's', 'x', 'z']:
+        filename = "/var/lib/cobbler/collections/%ses/%s" % (collection_type, item.name)
     else:
-        filename = "/var/lib/cobbler/collections/%ss/%s" % (collection.collection_type(), item.name)
+        filename = "/var/lib/cobbler/collections/%ss/%s" % (collection_type, item.name)
 
     _dict = item.to_dict()
 
@@ -90,12 +89,11 @@ def serialize_delete(collection, item):
     @param item Item collection item
     """
 
-    # FIXME: Need a better way to support collections/items
-    # appending an 's' does not work in all cases
-    if collection.collection_type() in ['mgmtclass']:
-        filename = "/var/lib/cobbler/collections/%ses/%s" % (collection.collection_type(), item.name)
+    collection_type = collection.collection_type()
+    if collection_type[-1].lower() in ['h', 's', 'x', 'z']:
+        filename = "/var/lib/cobbler/collections/%ses/%s" % (collection_type, item.name)
     else:
-        filename = "/var/lib/cobbler/collections/%ss/%s" % (collection.collection_type(), item.name)
+        filename = "/var/lib/cobbler/collections/%ss/%s" % (collection_type, item.name)
 
     filename += ".json"
     if os.path.exists(filename):
@@ -134,9 +132,8 @@ def deserialize_raw(collection_type):
         return _dict
     else:
         results = []
-        # FIXME: Need a better way to support collections/items
-        # appending an 's' does not work in all cases
-        if collection_type in ['mgmtclass']:
+
+        if collection_type[-1].lower() in ['h', 's', 'x', 'z']:
             all_files = glob.glob("/var/lib/cobbler/collections/%ses/*" % collection_type)
         else:
             all_files = glob.glob("/var/lib/cobbler/collections/%ss/*" % collection_type)


### PR DESCRIPTION
single update to a single file (I came across while working on a larger set of code edits)
the fixme about collection names needing a general rule rather than psychically knowing about mgmclass collection and such.

General rule is that 'es' is usually for words ending with h, x, s, or z. Works most of the time.