### PR TITLE
Re-create grub2 boot loaders from grub modules at install time

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -316,12 +316,27 @@ fi
 
 %else
 %post
+%if 0%{?suse_version}
+# Create bootloders into /var/lib/cobbler/loaders
+# Other distros might also want to do that
+%{_datadir}/%{name}/bin/mkgrub.sh >/dev/null 2>&1
+%endif
 %systemd_post cobblerd.service
 
 %preun
 %systemd_preun cobblerd.service
 
 %postun
+%if 0%{?suse_version}
+# This is mkgrub.sh cleanup (exeucted above in post):
+# remove linked and installed grub loader executables again
+if [ -e %{_localstatedir}/lib/cobbler/loaders/.cobbler_postun_cleanup ];then
+   for file in $(cat %{_localstatedir}/lib/cobbler/loaders/.cobbler_postun_cleanup);do
+       rm -f %{_localstatedir}/lib/cobbler/loaders/$file
+   done
+   rm -rf %{_localstatedir}/lib/cobbler/loaders/.cobbler_postun_cleanup
+fi
+%endif
 %systemd_postun_with_restart cobblerd.service
 %endif
 


### PR DESCRIPTION
mkgrub2 may have to be adopted to other distros, then the
if suse condition can be removed.