### PR TITLE
Revert unneeded fence templates again

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -402,17 +402,6 @@ sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler
 %config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf
 %config(noreplace) %{_sysconfdir}/cobbler/named.template
 %config(noreplace) %{_sysconfdir}/cobbler/ndjbdns.template
-%dir %{_sysconfdir}/cobbler/power
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_apc_snmp.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_bladecenter.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_bullpap.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_drac.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_ilo.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_ipmilan.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_lpar.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_rsa.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_virsh.template
-%config(noreplace) %{_sysconfdir}/cobbler/power/fence_wti.template
 %dir %{_sysconfdir}/cobbler/reporting
 %config(noreplace) %{_sysconfdir}/cobbler/reporting/build_report_email.template
 %config(noreplace) %{_sysconfdir}/cobbler/rsync.exclude

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -50,12 +50,11 @@ def get_power_types():
     """
 
     power_types = []
-    power_template = re.compile(r'fence_(.*)')
     fence_files = glob.glob("/usr/sbin/fence_*") + glob.glob("/sbin/fence_*")
     for x in fence_files:
-        templated_x = power_template.search(x).group(1)
-        if templated_x not in power_types:
-            power_types.append(templated_x)
+        fence_name = os.path.basename(x).replace("fence_", "")
+        if fence_name not in power_types:
+            power_types.append(fence_name)
     power_types.sort()
     return power_types
 

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -101,7 +101,6 @@ DEFAULTS = {
     "next_server": ["127.0.0.1", "str"],
     "nsupdate_enabled": [0, "bool"],
     "power_management_default_type": ["ipmitool", "str"],
-    "power_template_dir": ["/etc/cobbler/power", "str"],
     "proxy_url_ext": ["", "str"],
     "proxy_url_int": ["", "str"],
     "puppet_auto_setup": [0, "bool"],

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -270,10 +270,6 @@ next_server: 127.0.0.1
 #    ipmilan ipmitool lpar rsa virsh wti
 power_management_default_type: 'ipmitool'
 
-# the commands used by the power management module are sourced
-# from what directory?
-power_template_dir: "/etc/cobbler/power"
-
 # if this setting is set to 1, cobbler systems that pxe boot
 # will request at the end of their installation to toggle the 
 # --netboot-enabled record in the cobbler system record.  This eliminates

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -399,12 +399,6 @@ Choices (refer to codes.py):
 
 default: ``ipmitool``
 
-power_template_dir
-==================
-The commands used by the power management module are sourced from what directory?
-
-default: ``"/etc/cobbler/power"``
-
 pxe_just_once
 =============
 If this setting is set to 1, cobbler systems that pxe boot will request at the end of their installation to toggle the

--- a/templates/power/fence_apc_snmp.template
+++ b/templates/power/fence_apc_snmp.template
@@ -1,3 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-port=$power_id

--- a/templates/power/fence_bladecenter.template
+++ b/templates/power/fence_bladecenter.template
@@ -1,6 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-port=$power_id
-secure

--- a/templates/power/fence_bullpap.template
+++ b/templates/power/fence_bullpap.template
@@ -1,5 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-port=$power_id

--- a/templates/power/fence_drac.template
+++ b/templates/power/fence_drac.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_ilo.template
+++ b/templates/power/fence_ilo.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_ipmilan.template
+++ b/templates/power/fence_ipmilan.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_lpar.template
+++ b/templates/power/fence_lpar.template
@@ -1,9 +1,0 @@
-#set ($power_sys, $power_lpar) = $power_id.split(':')
-
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-managed=$power_sys
-port=$power_lpar
-passwd=$power_pass
-secure

--- a/templates/power/fence_rsa.template
+++ b/templates/power/fence_rsa.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass

--- a/templates/power/fence_virsh.template
+++ b/templates/power/fence_virsh.template
@@ -1,5 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-login=$power_user
-passwd=$power_pass
-port=$power_id

--- a/templates/power/fence_wti.template
+++ b/templates/power/fence_wti.template
@@ -1,4 +1,0 @@
-action=$power_mode
-ipaddr=$power_address
-passwd=$power_pass
-port=$power_id


### PR DESCRIPTION
These are not used anymore and slipped in again wrongly with
last commit eda635ffb86bf81e56fb845070f798e5ea9e441f.