### PR TITLE
Add destination directory to copy_bootloaders() where to copy them

### DIFF
--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -142,7 +142,7 @@ class InTftpdManager(object):
         """
         self.tftpgen.verbose = verbose
         self.logger.info("copying bootloaders")
-        self.tftpgen.copy_bootloaders()
+        self.tftpgen.copy_bootloaders(self.bootloc)
 
         self.logger.info("copying distros to tftpboot")
 

--- a/cobbler/modules/managers/tftpd_py.py
+++ b/cobbler/modules/managers/tftpd_py.py
@@ -45,6 +45,7 @@ class TftpdPyManager(object):
             self.logger = clogger.Logger()
 
         self.collection_mgr = collection_mgr
+        self.bootloc = collection_mgr.settings().tftpboot_location
         self.templar = templar.Templar(collection_mgr)
 
     def regen_hosts(self):
@@ -75,7 +76,7 @@ class TftpdPyManager(object):
         Write out files to /tftpdboot.  Mostly unused for the python server
         """
         self.logger.info("copying bootloaders")
-        tftpgen.TFTPGen(self.collection_mgr, self.logger).copy_bootloaders()
+        tftpgen.TFTPGen(self.collection_mgr, self.logger).copy_bootloaders(self.bootloc)
 
     def update_netboot(self, name):
         """

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -53,7 +53,7 @@ class TFTPGen(object):
         self.templar = templar.Templar(collection_mgr)
         self.bootloc = self.settings.tftpboot_location
 
-    def copy_bootloaders(self):
+    def copy_bootloaders(self, dest):
         """
         Copy bootloaders to the configured tftpboot directory
         NOTE: we support different arch's if defined in


### PR DESCRIPTION
This is a first step to implement http(s) boot.
We need the bootloaders not only in tftpboot, but also in /srv/www
(or wherever tftp and webserver directories are in the end..)

This only adds the parameter to the function -> no functional change.