### PR TITLE
Fix for issue #2288; fix for tftpboot error

### DIFF
--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -18,7 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-from past.builtins import str
+from past.builtins import str as oldstr
 from cobbler.items import item
 from cobbler import utils
 from cobbler.cexceptions import CX
@@ -93,7 +93,7 @@ class Mgmtclass(item.Item):
         self.is_definition = utils.input_boolean(isdef)
 
     def set_class_name(self, name):
-        if not isinstance(name, str):
+        if not isinstance(name, str) and not isinstance(name, oldstr):
             raise CX(_("class name must be a string"))
         for x in name:
             if not x.isalnum() and x not in ["_", "-", ".", ":", "+"]:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -26,7 +26,6 @@ import os
 import os.path
 import re
 import socket
-#import string
 
 from cobbler.cexceptions import CX
 from cobbler import templar

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -26,7 +26,7 @@ import os
 import os.path
 import re
 import socket
-import string
+#import string
 
 from cobbler.cexceptions import CX
 from cobbler import templar
@@ -886,7 +886,7 @@ class TFTPGen(object):
         # URL passed in, so all of the files need to be at this location
         # (which is why we can't use the images link, which just contains
         # the kernel and initrd).
-        distro_mirror_name = string.join(distro.kernel.split('/')[-2:-1], '')
+        distro_mirror_name = str.join('', distro.kernel.split('/')[-2:-1])
 
         blended = utils.blender(self.api, False, obj)
 
@@ -962,7 +962,7 @@ class TFTPGen(object):
         # URL passed in, so all of the files need to be at this location
         # (which is why we can't use the images link, which just contains
         # the kernel and initrd).
-        distro_mirror_name = string.join(distro.kernel.split('/')[-2:-1], '')
+        distro_mirror_name = str.join('', distro.kernel.split('/')[-2:-1])
 
         blended = utils.blender(self.api, False, obj)
 


### PR DESCRIPTION
First commit is a fix for issue #2288 (simply changing the import str and comparison command)
Second commit is to fix an error I'm getting from cobbler script:

When dhcp server's pxe boot (gpxe) tries to curl `http://<my cobbler server>/cblr/svc/op/gpxe/system/<system name>`

2020-03-23T14:46:46 - INFO | Exception value: module 'string' has no attribute 'join'
2020-03-23T14:46:46 - INFO | Exception Info:
  File "/usr/lib/python3.6/site-packages/cobbler/remote.py", line 2246, in _dispatch
    return method_handle(*params)

  File "/usr/lib/python3.6/site-packages/cobbler/remote.py", line 1128, in generate_gpxe
    return self.api.generate_gpxe(profile, system)

  File "/usr/lib/python3.6/site-packages/cobbler/api.py", line 650, in generate_gpxe
    return self.tftpgen.generate_gpxe("system", system)

  File "/usr/lib/python3.6/site-packages/cobbler/tftpgen.py", line 889, in generate_gpxe
    distro_mirror_name = string.join(distro.kernel.split('/')[-2:-1], '')

the 'string' module doesn't have an attribute join in python 3.6. str has an atrtibute join - however the arguments are reversed. str.join( list, str) rather than string.join(str, list)
I've changed both of the string.join(list, '') lines to str.join('', list) format