### PR TITLE
template engine selection fix

### DIFF
--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -109,7 +109,7 @@ class Templar(object):
             # it and rejoin them to pass to the template language
             template_type = lines[0].split("=")[1].strip().lower()
             del lines[0]
-            raw_data = string.join(lines, "\n")
+            raw_data = "\n".join(lines)
 
         if template_type == "cheetah":
             data_out = self.render_cheetah(raw_data, search_table, subject)

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -29,7 +29,6 @@ import functools
 import os
 import os.path
 import pprint
-import string
 
 jinja2_available = False
 try:


### PR DESCRIPTION
When explicitly selecting a templating engine, the raw template code is re-written to exclude the selection statement, by splitting the raw data into lines, deleting the first line and then re-joining to new raw data.

The original code to join does not work with at least Python 3. This diff fixes that.