### PR TITLE
make access to "gateway" element depend on its presence

### DIFF
--- a/autoinstall_snippets/pre_install_network_config
+++ b/autoinstall_snippets/pre_install_network_config
@@ -60,7 +60,9 @@ get_ifname() {
         #set $static        = $idata["static"]
         #set $ip            = $idata["ip_address"]
         #set $netmask       = $idata["netmask"]
-        #set $gateway       = $idata["gateway"]
+        #if "gateway" in $idata
+            #set $gateway       = $idata["gateway"]
+        #end if
         #set $if_gateway    = $idata["if_gateway"]
         #set $iface_type    = $idata["interface_type"]
         #set $iface_master  = $idata["interface_master"]


### PR DESCRIPTION
With Cobbler updated from 2.6 to 3.0, I see profiles that have no "gateway" element, but rather "if_gateway". Simply accessing "gateway" produces an error, therefore the code was changed to access "gateway" only if that element is available.