### PR TITLE
Pass distro variables to setup.py via environment variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,8 @@ authors: ## Creates the AUTHORS file.
 
 sdist: authors ## Creates the sdist for release preparation.
 	@echo "creating: sdist"
-	@${PYTHON} setup.py sdist bdist_wheel
+	@source distro_build_configs.sh; \
+	${PYTHON} setup.py sdist bdist_wheel
 
 release: clean qa authors sdist ## Creates the full release.
 	@echo "creating: release artifacts"
@@ -106,11 +107,13 @@ test-debian10: ## Executes the testscript for testing cobbler in a docker contai
 	./tests/build-and-install-debs.sh --with-tests deb10 dockerfiles/Debian10.dockerfile
 
 build: ## Runs the Python Build.
+	@source distro_build_configs.sh; \
 	${PYTHON} setup.py build -f
 
 install: build ## Runs the build target and then installs via setup.py
 	# Debian/Ubuntu requires an additional parameter in setup.py
-	@${PYTHON} setup.py install --root $(DESTDIR) -f
+	@source distro_build_configs.sh; \
+	${PYTHON} setup.py install --root $(DESTDIR) -f
 
 devinstall: ## This deletes the /usr/share/cobbler directory and then runs the targets savestate, install and restorestate.
 	-rm -rf $(DESTDIR)/usr/share/cobbler
@@ -119,12 +122,14 @@ devinstall: ## This deletes the /usr/share/cobbler directory and then runs the t
 	make restorestate
 
 savestate: ## This runs the setup.py task savestate.
-	@${PYTHON} setup.py -v savestate --root $(DESTDIR); \
+	@source distro_build_configs.sh; \
+	${PYTHON} setup.py -v savestate --root $(DESTDIR); \
 
 
 restorestate: ## This restores a state which was previously saved via the target savestate. (Also run via setup.py)
 	# Check if we are on Red Hat, Suse or Debian based distribution
-	@${PYTHON} setup.py -v restorestate --root $(DESTDIR); \
+	@source distro_build_configs.sh; \
+	${PYTHON} setup.py -v restorestate --root $(DESTDIR); \
 	find $(DESTDIR)/var/lib/cobbler/triggers | xargs chmod +x
 	if [ -n "`getent passwd apache`" ] ; then \
 		chown -R apache $(DESTDIR)/var/www/cobbler; \

--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -1,0 +1,54 @@
+export DOCPATH="share/man"
+export ETCPATH="/etc/cobbler"
+export LIBPATH="/var/lib/cobbler"
+export LOGPATH="/var/log"
+export COMPLETION_PATH="/usr/share/bash-completion/completions"
+export STATEPATH="/tmp/cobbler_settings/devinstall"
+
+export HTTPD_SERVICE="apache2.service"
+export WEBROOT="/srv/www";
+export WEBCONFIG="/etc/apache2/vhosts.d";
+export WEBROOTCONFIG="/etc/apache2";
+export TFTPROOT="/srv/tftpboot"
+export DEFAULTPATH="etc/sysconfig"
+
+# First parameter is DISTRO if provided
+[ $# -ge 2 ] && DISTRO="$1"
+
+if [ "$DISTRO" = "" ] && [ -r /etc/os-release ];then
+    source /etc/os-release
+    case $ID in
+	sle*|*suse*)
+	    DISTRO="SUSE"
+	    ;;
+	fedora*|centos*)
+	    DISTRO="FEDORA"
+	    ;;
+	ubuntu*|debian*)
+	    DISTRO="UBUNTU"
+	    ;;
+    esac
+fi
+
+if [ "$DISTRO" = "SUSE" ];then
+    export APACHE_USER="wwwrun"
+    export APACHE_GROUP="www"
+elif [ "$DISTRO" = "UBUNTU" ];then
+    export APACHE_USER="www-data"
+    export APACHE_GROUP="www-data"
+
+    export WEBCONFIG="/etc/apache2/conf-available";
+    export DEFAULTPATH="etc/default"
+elif [ "$DISTRO" = "FEDORA" ];then
+    export APACHE_USER="apache"
+    export APACHE_GROUP="apache"
+
+    export HTTPD_SERVICE="httpd.service"
+    export WEBROOT="/var/www";
+    export WEBCONFIG="/etc/httpd/conf.d";
+    export WEBROOTCONFIG="/etc/httpd";
+    export TFTPROOT="/var/lib/tftpboot"
+else
+    echo "ERROR, unknown distro $DISTRO"
+    # ToDo: Should we loudly warn here?
+fi

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ import sys
 import time
 import logging
 import glob as _glob
-import distro
 
 from builtins import str
 from setuptools import setup
@@ -33,6 +32,22 @@ VERSION = "3.2.0"
 OUTPUT_DIR = "config"
 
 log = logging.getLogger("setup.py")
+
+# # Configurable installation roots for various data files.
+docpath = os.environ.get('DOCPATH', "share/man")
+etcpath = os.environ.get('ETCPATH', "/etc/cobbler")
+libpath = os.environ.get('LIBPATH', "/var/lib/cobbler")
+logpath = os.environ.get('LOG_PATH', "/var/log")
+completion_path = os.environ.get('COMPLETION_PATH', "/usr/share/bash-completion/completions")
+statepath = os.environ.get('STATEPATH', "/tmp/cobbler_settings/devinstall")
+http_user = os.environ.get('HTTP_USER', "wwwrun")
+httpd_service = os.environ.get('HTTPD_SERVICE', "apache2.service")
+webconfig = os.environ.get('WEBCONFIG', "/etc/apache2/vhosts.d")
+webroot = os.environ.get('WEBROOT', "/srv/www")
+tftproot = os.environ.get('TFTPROOT', "/srv/tftpboot")
+
+webcontent = webroot + "/cobbler_webui_content"
+webimages = webcontent + "/images"
 
 
 #####################################################################
@@ -465,38 +480,6 @@ class savestate(statebase):
 
 
 if __name__ == "__main__":
-    # # Configurable installation roots for various data files.
-
-    # Trailing slashes on these vars is to allow for easy later configuration of relative paths if desired.
-    docpath = "share/man"
-    etcpath = "/etc/cobbler/"
-    libpath = "/var/lib/cobbler/"
-    logpath = "/var/log/"
-    completion_path = "/usr/share/bash-completion/completions"
-    statepath = "/tmp/cobbler_settings/devinstall"
-    httpd_service = "httpd.service"
-    suse_release = "suse" in distro.like()
-
-    if suse_release:
-        webconfig = "/etc/apache2/vhosts.d"
-        webroot = "/srv/www/"
-        http_user = "wwwrun"
-        httpd_service = "apache2.service"
-        defaultpath = "/etc/sysconfig/"
-    elif distro.id() in ("debian", "ubuntu"):
-        webconfig = "/etc/apache2/conf-available"
-        webroot = "/var/www/"
-        http_user = "www-data"
-        httpd_service = "apache2.service"
-        defaultpath = "/etc/default/"
-    else:
-        webconfig = "/etc/httpd/conf.d"
-        webroot = "/var/www/"
-        http_user = "apache"
-        defaultpath = "/etc/sysconfig/"
-
-    webcontent = webroot + "cobbler_webui_content/"
-    webimages = webcontent + "/images"
 
     setup(
         distclass=Distribution,
@@ -554,7 +537,7 @@ if __name__ == "__main__":
         ],
         configure_values={
             'webroot': os.path.normpath(webroot),
-            'defaultpath': os.path.normpath(defaultpath),
+            'tftproot': os.path.normpath(tftproot),
             'httpd_service': httpd_service,
         },
         configure_files=[
@@ -574,25 +557,25 @@ if __name__ == "__main__":
             ("sbin", ["bin/fence_ipmitool"]),
             ("%s" % webconfig, ["build/config/apache/cobbler.conf"]),
             ("%s" % webconfig, ["build/config/apache/cobbler_web.conf"]),
-            ("%stemplates" % libpath, glob("autoinstall_templates/*")),
-            ("%stemplates/install_profiles" % libpath, glob("autoinstall_templates/install_profiles/*")),
-            ("%ssnippets" % libpath, glob("autoinstall_snippets/*", recursive=True)),
-            ("%sscripts" % libpath, glob("autoinstall_scripts/*")),
+            ("%s/templates" % libpath, glob("autoinstall_templates/*")),
+            ("%s/templates/install_profiles" % libpath, glob("autoinstall_templates/install_profiles/*")),
+            ("%s/snippets" % libpath, glob("autoinstall_snippets/*", recursive=True)),
+            ("%s/scripts" % libpath, glob("autoinstall_scripts/*")),
             ("%s" % libpath, ["config/cobbler/distro_signatures.json"]),
             ("share/cobbler/web", glob("web/*.*")),
             ("%s" % webcontent, glob("web/static/*")),
             ("%s" % webimages, glob("web/static/images/*")),
             ("share/cobbler/bin", glob("scripts/*.sh")),
             ("share/cobbler/web/templates", glob("web/templates/*")),
-            ("%swebui_sessions" % libpath, []),
-            ("%sloaders" % libpath, []),
-            ("%scobbler/misc" % webroot, glob("misc/*")),
+            ("%s/webui_sessions" % libpath, []),
+            ("%s/loaders" % libpath, []),
+            ("%s/cobbler/misc" % webroot, glob("misc/*")),
             # Configuration
             ("%s" % etcpath, ["build/config/apache/cobbler.conf",
                               "build/config/apache/cobbler_web.conf",
                               "build/config/service/cobblerd.service",
                               "build/config/cobbler/settings"]),
-            ("%ssettings.d" % etcpath, glob("config/cobbler/settings.d/*")),
+            ("%s/settings.d" % etcpath, glob("config/cobbler/settings.d/*")),
             ("%s" % etcpath, ["config/cobbler/auth.conf",
                               "config/cobbler/modules.conf",
                               "config/cobbler/mongodb.conf",
@@ -612,99 +595,99 @@ if __name__ == "__main__":
                               "templates/etc/rsync.template",
                               "templates/etc/dhcp.template",
                               "templates/etc/ndjbdns.template"]),
-            ("%siso" % etcpath, glob("templates/iso/*")),
-            ("%sboot_loader_conf" % etcpath, glob("templates/boot_loader_conf/*")),
+            ("%s/iso" % etcpath, glob("templates/iso/*")),
+            ("%s/boot_loader_conf" % etcpath, glob("templates/boot_loader_conf/*")),
             # completion_file
             ("%s" % completion_path, ["config/bash/completion/cobbler"]),
-            ("%sgrub_config" % libpath, glob("config/grub/*")),
+            ("%s/grub_config" % libpath, glob("config/grub/*")),
             # ToDo: Find a nice way to copy whole config/grub structure recursively
             # files
-            ("%sgrub_config/grub" % libpath, glob("config/grub/grub/*")),
+            ("%s/grub_config/grub" % libpath, glob("config/grub/grub/*")),
             # dirs
-            ("%sgrub_config/grub/system" % libpath, []),
-            ("%sgrub_config/grub/system_link" % libpath, []),
-            ("%sreporting" % etcpath, glob("templates/reporting/*")),
+            ("%s/grub_config/grub/system" % libpath, []),
+            ("%s/grub_config/grub/system_link" % libpath, []),
+            ("%s/reporting" % etcpath, glob("templates/reporting/*")),
             # Build empty directories to hold triggers
-            ("%striggers/add/distro/pre" % libpath, []),
-            ("%striggers/add/distro/post" % libpath, []),
-            ("%striggers/add/profile/pre" % libpath, []),
-            ("%striggers/add/profile/post" % libpath, []),
-            ("%striggers/add/system/pre" % libpath, []),
-            ("%striggers/add/system/post" % libpath, []),
-            ("%striggers/add/repo/pre" % libpath, []),
-            ("%striggers/add/repo/post" % libpath, []),
-            ("%striggers/add/mgmtclass/pre" % libpath, []),
-            ("%striggers/add/mgmtclass/post" % libpath, []),
-            ("%striggers/add/package/pre" % libpath, []),
-            ("%striggers/add/package/post" % libpath, []),
-            ("%striggers/add/file/pre" % libpath, []),
-            ("%striggers/add/file/post" % libpath, []),
-            ("%striggers/delete/distro/pre" % libpath, []),
-            ("%striggers/delete/distro/post" % libpath, []),
-            ("%striggers/delete/profile/pre" % libpath, []),
-            ("%striggers/delete/profile/post" % libpath, []),
-            ("%striggers/delete/system/pre" % libpath, []),
-            ("%striggers/delete/system/post" % libpath, []),
-            ("%striggers/delete/repo/pre" % libpath, []),
-            ("%striggers/delete/repo/post" % libpath, []),
-            ("%striggers/delete/mgmtclass/pre" % libpath, []),
-            ("%striggers/delete/mgmtclass/post" % libpath, []),
-            ("%striggers/delete/package/pre" % libpath, []),
-            ("%striggers/delete/package/post" % libpath, []),
-            ("%striggers/delete/file/pre" % libpath, []),
-            ("%striggers/delete/file/post" % libpath, []),
-            ("%striggers/install/pre" % libpath, []),
-            ("%striggers/install/post" % libpath, []),
-            ("%striggers/install/firstboot" % libpath, []),
-            ("%striggers/sync/pre" % libpath, []),
-            ("%striggers/sync/post" % libpath, []),
-            ("%striggers/change" % libpath, []),
-            ("%striggers/task/distro/pre" % libpath, []),
-            ("%striggers/task/distro/post" % libpath, []),
-            ("%striggers/task/profile/pre" % libpath, []),
-            ("%striggers/task/profile/post" % libpath, []),
-            ("%striggers/task/system/pre" % libpath, []),
-            ("%striggers/task/system/post" % libpath, []),
-            ("%striggers/task/repo/pre" % libpath, []),
-            ("%striggers/task/repo/post" % libpath, []),
-            ("%striggers/task/mgmtclass/pre" % libpath, []),
-            ("%striggers/task/mgmtclass/post" % libpath, []),
-            ("%striggers/task/package/pre" % libpath, []),
-            ("%striggers/task/package/post" % libpath, []),
-            ("%striggers/task/file/pre" % libpath, []),
-            ("%striggers/task/file/post" % libpath, []),
+            ("%s/triggers/add/distro/pre" % libpath, []),
+            ("%s/triggers/add/distro/post" % libpath, []),
+            ("%s/triggers/add/profile/pre" % libpath, []),
+            ("%s/triggers/add/profile/post" % libpath, []),
+            ("%s/triggers/add/system/pre" % libpath, []),
+            ("%s/triggers/add/system/post" % libpath, []),
+            ("%s/triggers/add/repo/pre" % libpath, []),
+            ("%s/triggers/add/repo/post" % libpath, []),
+            ("%s/triggers/add/mgmtclass/pre" % libpath, []),
+            ("%s/triggers/add/mgmtclass/post" % libpath, []),
+            ("%s/triggers/add/package/pre" % libpath, []),
+            ("%s/triggers/add/package/post" % libpath, []),
+            ("%s/triggers/add/file/pre" % libpath, []),
+            ("%s/triggers/add/file/post" % libpath, []),
+            ("%s/triggers/delete/distro/pre" % libpath, []),
+            ("%s/triggers/delete/distro/post" % libpath, []),
+            ("%s/triggers/delete/profile/pre" % libpath, []),
+            ("%s/triggers/delete/profile/post" % libpath, []),
+            ("%s/triggers/delete/system/pre" % libpath, []),
+            ("%s/triggers/delete/system/post" % libpath, []),
+            ("%s/triggers/delete/repo/pre" % libpath, []),
+            ("%s/triggers/delete/repo/post" % libpath, []),
+            ("%s/triggers/delete/mgmtclass/pre" % libpath, []),
+            ("%s/triggers/delete/mgmtclass/post" % libpath, []),
+            ("%s/triggers/delete/package/pre" % libpath, []),
+            ("%s/triggers/delete/package/post" % libpath, []),
+            ("%s/triggers/delete/file/pre" % libpath, []),
+            ("%s/triggers/delete/file/post" % libpath, []),
+            ("%s/triggers/install/pre" % libpath, []),
+            ("%s/triggers/install/post" % libpath, []),
+            ("%s/triggers/install/firstboot" % libpath, []),
+            ("%s/triggers/sync/pre" % libpath, []),
+            ("%s/triggers/sync/post" % libpath, []),
+            ("%s/triggers/change" % libpath, []),
+            ("%s/triggers/task/distro/pre" % libpath, []),
+            ("%s/triggers/task/distro/post" % libpath, []),
+            ("%s/triggers/task/profile/pre" % libpath, []),
+            ("%s/triggers/task/profile/post" % libpath, []),
+            ("%s/triggers/task/system/pre" % libpath, []),
+            ("%s/triggers/task/system/post" % libpath, []),
+            ("%s/triggers/task/repo/pre" % libpath, []),
+            ("%s/triggers/task/repo/post" % libpath, []),
+            ("%s/triggers/task/mgmtclass/pre" % libpath, []),
+            ("%s/triggers/task/mgmtclass/post" % libpath, []),
+            ("%s/triggers/task/package/pre" % libpath, []),
+            ("%s/triggers/task/package/post" % libpath, []),
+            ("%s/triggers/task/file/pre" % libpath, []),
+            ("%s/triggers/task/file/post" % libpath, []),
             # Build empty directories to hold the database
-            ("%scollections" % libpath, []),
-            ("%scollections/distros" % libpath, []),
-            ("%scollections/images" % libpath, []),
-            ("%scollections/profiles" % libpath, []),
-            ("%scollections/repos" % libpath, []),
-            ("%scollections/systems" % libpath, []),
-            ("%scollections/mgmtclasses" % libpath, []),
-            ("%scollections/packages" % libpath, []),
-            ("%scollections/files" % libpath, []),
+            ("%s/collections" % libpath, []),
+            ("%s/collections/distros" % libpath, []),
+            ("%s/collections/images" % libpath, []),
+            ("%s/collections/profiles" % libpath, []),
+            ("%s/collections/repos" % libpath, []),
+            ("%s/collections/systems" % libpath, []),
+            ("%s/collections/mgmtclasses" % libpath, []),
+            ("%s/collections/packages" % libpath, []),
+            ("%s/collections/files" % libpath, []),
             # logfiles
-            ("%scobbler/kicklog" % logpath, []),
-            ("%scobbler/syslog" % logpath, []),
-            ("%shttpd/cobbler" % logpath, []),
-            ("%scobbler/anamon" % logpath, []),
-            ("%scobbler/tasks" % logpath, []),
+            ("%s/cobbler/kicklog" % logpath, []),
+            ("%s/cobbler/syslog" % logpath, []),
+            ("%s/httpd/cobbler" % logpath, []),
+            ("%s/cobbler/anamon" % logpath, []),
+            ("%s/cobbler/tasks" % logpath, []),
             # web page directories that we own
-            ("%scobbler/localmirror" % webroot, []),
-            ("%scobbler/repo_mirror" % webroot, []),
-            ("%scobbler/distro_mirror" % webroot, []),
-            ("%scobbler/distro_mirror/config" % webroot, []),
-            ("%scobbler/links" % webroot, []),
-            ("%scobbler/misc" % webroot, []),
-            ("%scobbler/pub" % webroot, []),
-            ("%scobbler/rendered" % webroot, []),
-            ("%scobbler/images" % webroot, []),
+            ("%s/cobbler/localmirror" % webroot, []),
+            ("%s/cobbler/repo_mirror" % webroot, []),
+            ("%s/cobbler/distro_mirror" % webroot, []),
+            ("%s/cobbler/distro_mirror/config" % webroot, []),
+            ("%s/cobbler/links" % webroot, []),
+            ("%s/cobbler/misc" % webroot, []),
+            ("%s/cobbler/pub" % webroot, []),
+            ("%s/cobbler/rendered" % webroot, []),
+            ("%s/cobbler/images" % webroot, []),
             # A script that isn't really data, wsgi script
-            ("%scobbler/svc/" % webroot, ["svc/services.py"]),
+            ("%s/cobbler/svc/" % webroot, ["svc/services.py"]),
             # A script that isn't really data, wsgi script
             ("share/cobbler/web/", ["cobbler/web/settings.py"]),
             # zone-specific templates directory
-            ("%szone_templates" % etcpath, glob("templates/zone_templates/*")),
+            ("%s/zone_templates" % etcpath, glob("templates/zone_templates/*")),
             ("%s" % etcpath, ["config/cobbler/logging_config.conf"]),
             # man pages
             ("%s/man1" % docpath, glob("build/sphinx/man/*.1")),


### PR DESCRIPTION
This patch consolidates distro specifics.
Currently there are different:
- Package names
- Apaches user/group
- Lots of different file system paths

Before this info was spread across:
- setup.py
- Makefile
- spec file

Now this info is laid out and centralized into:
distro_build_configs.sh

For the spec file this unfortunately only works
for variables needed in the %build or %install section.

apache user and group for example is needed in the %file
section and can therefore not be sourced from outside.

But it is now double checked to be consistent. An error
is thrown in the %build section if data which needs to be
defined in the spec file and in distro_build_configs.sh for
setup.py or Makefile does not match.