### PR TITLE
make changing $server to IP address for autoinstallation profile URLs conditional

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -58,6 +58,7 @@ DEFAULTS = {
     "client_use_https": [0, "bool"],
     "client_use_localhost": [0, "bool"],
     "cobbler_master": ["", "str"],
+    "convert_server_to_ip": [0, "bool"],
     "createrepo_flags": ["-c cache -s sha", "str"],
     "default_autoinstall": ["/var/lib/cobbler/templates/default.ks", "str"],
     "default_name_servers": [[], "list"],

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -446,5 +446,12 @@ proxy_url_int: ""
 # files into Jinja2 templates
 #jinja2_includedir: /var/lib/cobbler/jinja2
 
+# Up to now, cobblerd used $server's IP address instead of the DNS name in autoinstallation
+# file settings (pxelinux.cfg files) to save bytes, which seemed required for S/390 systems.
+# This behavior can have negative impact on installs with multi-homed cobbler servers, because
+# not all of the IP addresses may be reachable during system install.
+# This behavior was now made conditional, with default being "off".
+#convert_server_to_ip: 0
+
 # include other configuration snippets
 include: [ "/etc/cobbler/settings.d/*.settings" ]


### PR DESCRIPTION
changing http_server's server component to its IP address was intruduced with https://github.com/cobbler/cobbler/commit/588756aa7aefc122310847d007becf3112647944 to shorten the message length for S390 systems.

On multi-homed cobbler servers, this can lead to serious problems when installing systems in a dedicated isolated installation subnet:
- typically, $server is reachable by name (DNS resolution assumed) both during PXE install and during production, but via different IP addresses
- $http_server is explicitly constructed from $server
- the IP address for $server may resolv differently between cobbler server (production) and installing system
- using IP($http_server) may require to set $server in a way that matches the installation network
- using $server for later repository access then will fail, because the installation address isn't reachable for production systems

This PR "reverts" that change. In order to make the revert less intrusive, it'll depend on a configuration setting