### PR TITLE
Try except for mysterious FileNotFoundError with open

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -25,6 +25,7 @@ import os
 import os.path
 import re
 import socket
+from time import sleep
 
 from cobbler import templar
 from cobbler import utils

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -612,9 +612,17 @@ class TFTPGen(object):
 
         if filename is not None:
             self.logger.info("generating: %s" % filename)
-            fd = open(filename, "w")
-            fd.write(buffer)
-            fd.close()
+            # This try-except is a work-around for the cases where 'open' throws
+            # the FileNotFoundError for not apparent reason.
+            try:
+                with open(filename, "w") as fd:
+                    fd.write(buffer)
+            except FileNotFoundError as e:
+                self.logger.error("Got \"{}\" while trying to write {}".format(e, filename))
+                self.logger.error("Trying to write {} again after some delay.".format(filename))
+                sleep(1)
+                with open(filename, "w") as fd:
+                    fd.write(buffer)
         return buffer
 
     def build_kernel_options(self, system, profile, distro, image, arch, autoinstall_path):


### PR DESCRIPTION
Sometimes `open` seems to thrown the FileNotFoundError for no reason. The premission are right and the file actually gets created correctly. But there is still this error.

To prevent Cobbler from failing hard, I've implemented this retry.

This is a workaround for https://github.com/cobbler/cobbler/issues/2362