### PR TITLE
Impove the Install Docs for Source Installations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,20 +150,9 @@ restorestate: ## This restores a state which was previously saved via the target
 	fi
 	rm -rf $(statepath)
 
-webtest: devinstall ## Runs the task devinstall and then runs the targets clean, devinstall and restartservices.
+webtest: devinstall ## Runs the task devinstall and then runs the targets clean and devinstall.
 	make clean
 	make devinstall
-	make restartservices
-
-restartservices: ## Restarts the Apache2 and Cobbler-Web via init.d, service or systemctl.
-	$(shell systemctl restart cobblerd)
-ifneq ($(strip $(HTTPD)),)
-	systemctl restart httpd
-else ifneq ($(strip $(APACHE2)),)
-	systemctl restart apache2
-else
-	$(error "No apache2 or httpd in $(PATH), consider installing one of the two (depending on the distro)!")
-endif
 
 rpms: release ## Runs the target release and then creates via rpmbuild the rpms in a directory called rpm-build.
 	mkdir -p rpm-build

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -63,13 +63,14 @@ Installation from source requires the following additional software:
 
 - git
 - make
-- python-devel (on Debian based distributions ``python-dev``)
-- python-cheetah
-- python-future
-- python-Sphinx
-- python-coverage
+- python3-devel (on Debian based distributions ``python3-dev``)
+- python3-Cheetah3
+- python3-future
+- python3-Sphinx
+- python3-coverage
 - openssl
-- A web server (preferably Apache2)
+- apache2-devel (and thus apache2)
+- A TFTP server
 
 
 Installation
@@ -162,18 +163,23 @@ following command:
     $ make install
 
 This command will rewrite all configuration files on your system if you have an existing installation of Cobbler
-(whether it was installed via packages or from an older source tree). To preserve your existing configuration files,
-snippets and automatic installation files, run this command:
+(whether it was installed via packages or from an older source tree).
+
+To preserve your existing configuration files, snippets and automatic installation files, run this command:
 
 .. code-block:: bash
 
     $ make devinstall
 
-To install the Cobbler web GUI, use this command:
+To install the Cobbler web GUI, use these steps:
 
-.. code-block:: bash
-
-    $ make webtest
+#. Copy the systemd service file for cobblerd from ``/etc/cobbler/cobblerd.service`` to your systemd unit directory.
+#. Install ``apache2-mod_wsgi-python3`` or the package responsible for your distro. (On Debian:
+   ``libapache2-mod-wsgi-py3``)
+#. Enable the proxy module of Apache2 (``a2enmod proxy`` or something similar) if not enabled.
+#. ``make webtest``
+#. Configure a secret in ``/usr/share/cobbler/settings.py``
+#. Restart your Apache2 and ``cobblerd``.
 
 This will do a full install, not just the web GUI. ``make webtest`` is a wrapper around ``make devinstall``, so your
 configuration files will also be saved when running this command. Be adviced that we don't copy the service file into

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -51,13 +51,25 @@ Koan can be installed apart from Cobbler, and has only the following requirement
 Source
 ======
 
+.. note::
+   Please be aware that on some distributions the python packages are named differently. On Debian based systems
+   everything which is named ``something-devel`` is named ``something-dev`` there. Also please remember that the case of
+   some packages is slightly different.
+
+.. warning::
+   Some distributions still have Python 2 available. It is your responsibility to adjust the package names to Python3.
+
 Installation from source requires the following additional software:
 
 - git
 - make
-- python-devel
+- python-devel (on Debian based distributions ``python-dev``)
 - python-cheetah
+- python-future
+- python-Sphinx
+- python-coverage
 - openssl
+- A web server (preferably Apache2)
 
 
 Installation


### PR DESCRIPTION
This superseedes #2328 
This fixes #2152 through removing the problematic `Makefile` code.

Why not fix it in the Makefile? Well in my eyes I should not decide during a Source Installation when to restart a service. Also it appears to be pretty complex to restart Apache2 on all supported Distros. Thus documenting this and leaving it to the admin is an appropriate solution in my eyes.