### PR TITLE
cgi.parse_qs is deprecated

### DIFF
--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -132,7 +132,7 @@ class Templar(object):
         # Now apply some magic post-filtering that is used by "cobbler import" and some other places. Forcing folks to
         # double escape things would be very unwelcome.
         hp = search_table.get("http_port", "80")
-        server = search_table.get("server", "server.example.org")
+        server = search_table.get("server", self.settings.server)
         if hp not in (80, '80'):
             repstr = "%s:%s" % (server, hp)
         else:

--- a/svc/services.py
+++ b/svc/services.py
@@ -63,7 +63,7 @@ def application(environ, start_response):
             form[field] = t
         label = not label
 
-    form["query_string"] = cgi.parse_qs(environ['QUERY_STRING'])
+    form["query_string"] = urllib.parse.parse_qs(environ['QUERY_STRING'])
 
     # This MAC header is set by anaconda during a kickstart booted with the
     # kssendmac kernel option. The field will appear here as something


### PR DESCRIPTION
This PR solves problem  #2375 

From https://docs.python.org/3.2/library/cgi.html:
cgi.parse_qs(qs, keep_blank_values=False, strict_parsing=False)
This function is deprecated in this module. Use urllib.parse.parse_qs() instead. It is maintained here only for backward compatibility.

urllib.parse.parse_qs also works in the python-2.7 (cobbler-2.8.5)