### PR TITLE
Cobbler deletes the profile in rename operation

### DIFF
--- a/cobbler/item.py
+++ b/cobbler/item.py
@@ -25,7 +25,7 @@ class Item:
 
     TYPE_NAME = "generic"
 
-    _re_name = re.compile(r'[a-zA-Z0-9_\-.:+]*$')
+    _re_name = re.compile(r'[a-zA-Z0-9_\-.:+]+$')
 
     def __init__(self,config,is_subobject=False):
         """


### PR DESCRIPTION
, when value is not provided for option "--newname".

This commit provides the fix for this bug mentioned in the issue https://github.com/cobbler/cobbler/issues/2315