### PR TITLE
Spec: Add missing runtime requirement to python3-distro

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -212,6 +212,7 @@ Requires:       %{py3_module_pyyaml}
 Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-simplejson
 Requires:       python%{python3_pkgversion}-tornado
+Requires:       python%{python3_pkgversion}-distro
 %endif
 
 


### PR DESCRIPTION
Currently when doing a clean install for Cobbler the Specfile is missing `python3-distro` as a runtime requirement. Most of the time this is already installed but when using a minimal basesystem this is normally not the case.