### PR TITLE
config variable called before it is instantiated.

### DIFF
--- a/cobbler/modules/authorization/ownership.py
+++ b/cobbler/modules/authorization/ownership.py
@@ -56,8 +56,8 @@ def __parse_config():
     if not os.path.exists(etcfile):
         raise CX(_("/etc/cobbler/users.conf does not exist"))
     # Make users case sensitive to handle kerberos
-    config.optionxform = str
     config = ConfigParser()
+    config.optionxform = str
     config.read(etcfile)
     alldata = {}
     sections = config.sections()


### PR DESCRIPTION
"config" variable called before instantiated with a ConfigParser object. led to traceback error as well as breaking of ownership authz module.