### PR TITLE
Update validate.py

### DIFF
--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -104,6 +104,11 @@ def mac_address(mac, for_item=True):
         # this value has special meaning for items
         if mac == "random":
             return mac
+            
+        # copying system collection will set mac to ""
+        # netaddr will fail to validate this mac and throw an exception
+        if mac == "":
+            return mac
 
     if not netaddr.valid_mac(mac):
         raise CX("Invalid mac address format (%s)" % mac)


### PR DESCRIPTION
Copy function in collection.py will set the mac address on a new system collection to a blank string ("") and then attempt to validate this. Validation will fail on a blank string. When looking into the issue I saw that previous versions of cobbler had specifically accepted "" as a valid mac. Unsure if this was an oversight or was intentionally removed in newer versions due to other issues.

Debated between changing logic to accept a blank string as a mac or changing the copy function to set the mac to "random". Keeping in line with the previous intentions it would appear that allowing the blank string would be the least breaking change. If this blank string would break later functions should the copied system mac be set to "random" instead?