### PR TITLE
Update validate.py to fix invalid mac error when copying a system configuration

### DIFF
--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -105,6 +105,11 @@ def mac_address(mac, for_item=True):
         if mac == "random":
             return mac
 
+        # copying system collection will set mac to ""
+        # netaddr will fail to validate this mac and throw an exception
+        if mac == "":
+            return mac
+
     if not netaddr.valid_mac(mac):
         raise CX("Invalid mac address format (%s)" % mac)
 


### PR DESCRIPTION
When copying a system configuration, collection.py sets the new system mac to be a blank string. when setting the mac this blank string is checked to be a valid mac and fails validation

Update to validate.py to allow a blank string to be treated as valid mac similar to "random". This seemed in line with previous versions of cobbler that had code specifically treating a blank mac as valid (2.8.5 was the version I was working with last that supported this function)