### PR TITLE
move repoysync rsync flags to settings

### DIFF
--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -348,13 +348,39 @@ class RepoSync(object):
         if not repo.mirror.strip().endswith("/"):
             repo.mirror = "%s/" % repo.mirror
 
-        # FIXME: wrapper for subprocess that logs to logger
-        cmd = "rsync -rltDv --copy-unsafe-links --delete-after %s --delete --exclude-from=/etc/cobbler/rsync.exclude %s %s" % (spacer, pipes.quote(repo.mirror), pipes.quote(dest_path))
+        flags = ''
+        for x in repo.rsyncopts:
+            if repo.rsyncopts[x]:
+                flags += " %s %s" % (x, repo.rsyncopts[x])
+            else:
+                flags += " %s" % x
+        
+        if flags == '':
+            flags = self.settings.reposync_rsync_flags
+
+        cmd = "rsync %s --delete-after %s --delete --exclude-from=/etc/cobbler/rsync.exclude %s %s" % (flags, spacer, pipes.quote(repo.mirror), pipes.quote(dest_path))
         rc = utils.subprocess_call(self.logger, cmd)
 
         if rc != 0:
             utils.die(self.logger, "cobbler reposync failed")
-        repo_walker(dest_path, self.createrepo_walker, repo)
+        
+        # if ran in archive mode then repo should already contain all repodata and does not need createrepo ran 
+        archive = False
+        if '-a' in flags or '--archive' in flags:
+            archive = True
+        else:
+            # split flags and skip all --{options} as we need to look for combined flags like -vaH
+            fl = flags.split()
+            for f in fl:
+                if f.startswith('--'):
+                    pass
+                else:
+                    if 'a' in f:
+                        archive = True
+                        break
+        if not archive:
+            repo_walker(dest_path, self.createrepo_walker, repo)
+
         self.create_local_file(dest_path, repo)
 
     # ====================================================================================

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -366,7 +366,7 @@ class RepoSync(object):
         
         # if ran in archive mode then repo should already contain all repodata and does not need createrepo ran 
         archive = False
-        if '-a' in flags or '--archive' in flags:
+        if '--archive' in flags:
             archive = True
         else:
             # split flags and skip all --{options} as we need to look for combined flags like -vaH

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -364,7 +364,7 @@ class RepoSync(object):
         if rc != 0:
             utils.die(self.logger, "cobbler reposync failed")
         
-        # if ran in archive mode then repo should already contain all repodata and does not need createrepo ran 
+        # if ran in archive mode then repo should already contain all repodata and does not need createrepo run 
         archive = False
         if '--archive' in flags:
             archive = True

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -52,6 +52,7 @@ FIELDS = [
     ["proxy", "<<inherit>>", 0, "Proxy information", True, "http://example.com:8080, or <<inherit>> to use proxy_url_ext from settings, blank or <<None>> for no proxy", [], "str"],
     ["rpm_list", [], 0, "RPM List", True, "Mirror just these RPMs (yum only)", 0, "list"],
     ["yumopts", {}, 0, "Yum Options", True, "Options to write to yum config file", 0, "dict"],
+    ["rsyncopts", "", 0, "Rsync Options", True, "Options to use with rsync repo", 0, "dict"],
 ]
 
 
@@ -69,6 +70,7 @@ class Repo(item.Item):
         self.arch = None
         self.environment = {}
         self.yumopts = {}
+        self.rsyncopts = {}
 
     #
     # override some base class methods first (item.Item)
@@ -159,6 +161,18 @@ class Repo(item.Item):
             raise CX(_("invalid yum options"))
         else:
             self.yumopts = value
+
+    def set_rsyncopts(self, options):
+        """
+        rsync options are a space delimited list
+
+        :param options: Something like '-a -S -H -v'
+        """
+        (success, value) = utils.input_string_or_dict(options, allow_multiples=False)
+        if not success:
+            raise CX(_("invalid rsync options"))
+        else:
+            self.rsyncopts = value
 
     def set_environment(self, options):
         """

--- a/cobbler/web/field_ui_info.py
+++ b/cobbler/web/field_ui_info.py
@@ -139,7 +139,7 @@ REPO_UI_FIELDS_MAPPING = [
     {"General": ["name", "owners", "arch", "breed", "keep_updated",
                  "mirror", "rpm_list", "comment"]},
     {"Advanced": ["apt_components", "apt_dists", "createrepo_flags",
-                  "environment", "mirror_locally", "priority", "yumopts"]}
+                  "environment", "mirror_locally", "priority", "yumopts", "rsyncopts"]}
 ]
 
 SYSTEM_UI_FIELDS_MAPPING = [

--- a/config/cobbler/settings
+++ b/config/cobbler/settings
@@ -322,6 +322,10 @@ register_new_installs: 0
 # does not support -l, you may need to remove that option.
 reposync_flags: "-l -n -d"
 
+# Flags to use for rysync's reposync. If flag 'a' is used then createrepo
+# is not ran after the rsync
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+
 # when DHCP and DNS management are enabled, cobbler sync can automatically
 # restart those services to apply changes.  The exception for this is
 # if using ISC for DHCP, then omapi eliminates the need for a restart.

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -462,6 +462,12 @@ option.
 
 default: ``"-l -n -d"``
 
+reposync_rsync_flags
+==============
+Flags to use for rysync's reposync. If archive mode (-a,--archive) is used then createrepo is not ran after the rsync as it pulls down the repodata as well. This allows older OS's to mirror modular repos using rsync.
+
+default: ``"-rltDv --copy-unsafe-links"``
+
 restart_*
 =========
 When DHCP and DNS management are enabled, ``cobbler sync`` can automatically restart those services to apply changes.


### PR DESCRIPTION
#### Changes
* moved reposync rsync flags to settings, reposync_rsync_flags. This aligns with reposync_flags which is used for yum. The setting replicate_repo_rsync_opts is used in replicate.py and would possibly conflict with the '--copy-unsafe-links' option. Resolves #1480

* added Repo UI field "rsync options / rsyncopts" to allow for overrides on a per repo basis.

* Since RH8 has moved to modular repo the tools on RH7 and below are not able to sync RH8 repos as they are not module aware. rsync can be used in archive mode to properly mirror the repo. The updated workflow checks for archive mode and skips createrepo to support mirroring modular repos on older systems.

WIP as I still need to update the docs