### PR TITLE
Fix broken source installation including the documentation

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -317,10 +317,10 @@ class CobblerCLI(object):
         self.args = cliargs
 
     def start_task(self, name, options):
-        """
+        r"""
         Start an asynchronous task in the background.
 
-        :param name: "background_" % name function must exist in remote.py. This function will be called in a subthread.
+        :param name: "background\_" % name function must exist in remote.py. This function will be called in a subthread.
         :type name: str
         :param options: Dictionary of options passed to the newly started thread
         :type options: dict

--- a/cobbler/modules/authentication/pam.py
+++ b/cobbler/modules/authentication/pam.py
@@ -23,7 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 PAM python code based on the pam_python code created by Chris AtLee:
 http://atlee.ca/software/pam/
 
-------------------------------------------------
+#-----------------------------------------------
 pam_python (c) 2007 Chris AtLee <chris@atlee.ca>
 Licensed under the MIT license:
 http://www.opensource.org/licenses/mit-license.php

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -19,7 +19,6 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
-import sys
 from builtins import str
 from builtins import object
 import glob

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -208,9 +208,6 @@ class Settings(object):
         Constructor.
         """
         self._clear()
-        if (self.manage_tftp or self.manage_tftpd) and not os.path.isdir(self.tftpboot_location):
-            print("TFTP directory '{}' not found".format(self.tftpboot_location), file=sys.stderr)
-            sys.exit(1)
 
     def _clear(self):
         """

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -31,8 +31,8 @@ default: ``0``
 
 allow_dynamic_settings
 ======================
-If 1, Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can only
-change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
+If 1, Cobbler will allow settings to be changed dynamically without a restart of the `cobblerd` daemon. You can only
+change this variable by manually editing the settings file, and you MUST restart `cobblerd` after changing it.
 
 default: ``0``
 
@@ -115,7 +115,7 @@ cheetah_import_whitelist
 Cheetah-language autoinstall templates can import Python modules. while this is a useful feature, it is not safe to
 allow them to import anything they want. This whitelists which modules can be imported through Cheetah. Users can expand
 this as needed but should never allow modules such as subprocess or those that allow access to the filesystem as Cheetah
-templates are evaluated by cobblerd as code.
+templates are evaluated by `cobblerd` as code.
 
 default:
  - "random"

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -10,37 +10,37 @@ settings
 
 allow_duplicate_hostnames
 =========================
-if 1, cobbler will allow insertions of system records that duplicate the ``--dns-name`` information of other system records.
+if 1, Cobbler will allow insertions of system records that duplicate the ``--dns-name`` information of other system records.
 In general, this is undesirable and should be left 0.
 
 default: ``0``
 
 allow_duplicate_ips
 ===================
-if 1, cobbler will allow insertions of system records that duplicate the IP address information of other system records.
+if 1, Cobbler will allow insertions of system records that duplicate the IP address information of other system records.
 In general, this is undesirable and should be left 0.
 
 default: ``0``
 
 allow_duplicate_macs
 ====================
-If 1, cobbler will allow insertions of system records that duplicate the mac address information of other system
+If 1, Cobbler will allow insertions of system records that duplicate the mac address information of other system
 records. In general, this is undesirable.
 
 default: ``0``
 
 allow_dynamic_settings
 ======================
-If 1, cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can only
+If 1, Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can only
 change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
 
 default: ``0``
 
 anamon_enabled
 ==============
-By default, installs are *not* set to send installation logs to the cobbler server. With ``anamon_enabled``, automatic
+By default, installs are *not* set to send installation logs to the Cobbler server. With ``anamon_enabled``, automatic
 installation templates may use the ``pre_anamon`` snippet to allow remote live monitoring of their installations from
-the cobbler server. Installation logs will be stored under ``/var/log/cobbler/anamon/``.
+the Cobbler server. Installation logs will be stored under ``/var/log/cobbler/anamon/``.
 
 **Note**: This does allow an XML-RPC call to send logs to this directory, without authentication, so enable only if you
 are ok with this limitation.
@@ -62,14 +62,14 @@ default: ``3600``
 
 autoinstall_snippets_dir
 ========================
-This is a directory of files that cobbler uses to make templating easier. See the Wiki for more information. Changing
+This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information. Changing
 this directory should not be required.
 
 default: ``/var/lib/cobbler/snippets``
 
 autoinstall_templates_dir
 =========================
-This is a directory of files that cobbler uses to make templating easier. See the Wiki for more information. Changing
+This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information. Changing
 this directory should not be required.
 
 default: ``/var/lib/cobbler/templates``
@@ -82,7 +82,7 @@ default: ``"/etc/cobbler/boot_loader_conf"``
 
 build_reporting_*
 =================
-Email out a report when cobbler finishes installing a system.
+Email out a report when Cobbler finishes installing a system.
 
 - enabled: set to 1 to turn this feature on
 - sender: optional
@@ -161,7 +161,7 @@ default_password_crypted
 ========================
 Cobbler has various sample automatic installation templates stored in ``/var/lib/cobbler/autoinstall_templates/``. This
 controls what install (root) password is set up for those systems that reference this variable. The factory default is
-"cobbler" and cobbler check will warn if this is not changed. The simplest way to change the password is to run
+"cobbler" and Cobbler check will warn if this is not changed. The simplest way to change the password is to run
 ``openssl passwd -1`` and put the output between the ``""``.
 
 default: ``"$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."``
@@ -169,7 +169,7 @@ default: ``"$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."``
 default_template_type
 =====================
 The default template type to use in the absence of any other detected template. If you do not specify the template
-with ``#template=<template_type>`` on the first line of your templates/snippets, cobbler will assume try to use the
+with ``#template=<template_type>`` on the first line of your templates/snippets, Cobbler will assume try to use the
 following template engine to parse the templates.
 
 Current valid values are: cheetah, jinja2
@@ -209,14 +209,14 @@ default: ``xenpv``
 
 enable_gpxe
 ===========
-Enable gPXE booting? Enabling this option will cause cobbler to copy the ``undionly.kpxe`` file to the TFTP root
+Enable gPXE booting? Enabling this option will cause Cobbler to copy the ``undionly.kpxe`` file to the TFTP root
 directory, and if a profile/system is configured to boot via gPXE it will chain load off ``pxelinux.0``.
 
 default: ``0``
 
 enable_menu
 ===========
-Controls whether cobbler will add each new profile entry to the default PXE boot menu. This can be over-ridden on a
+Controls whether Cobbler will add each new profile entry to the default PXE boot menu. This can be over-ridden on a
 per-profile basis when adding/editing profiles with ``--enable-menu=0/1``. Users should ordinarily leave this setting
 enabled unless they are concerned with accidental reinstalls from users who select an entry at the PXE boot menu. Adding
 a password to the boot menus templates may also be a good solution to prevent unwanted reinstallations.
@@ -231,7 +231,7 @@ default: ``80``
 
 kernel_options
 ==============
-Kernel options that should be present in every cobbler installation. Kernel options can also be applied at the
+Kernel options that should be present in every Cobbler installation. Kernel options can also be applied at the
 distro/profile/system level.
 
 default: ``{}``
@@ -279,7 +279,7 @@ sign_puppet_certs_automatically
 ===============================
 When puppet starts on a system after installation it needs to have its certificate signed by the puppet master server.
 Enabling the following feature will ensure that the puppet server signs the certificate after installation if the puppet
-master server is running on the same machine as cobbler. This requires ``puppet_auto_setup`` above to be enabled.
+master server is running on the same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled.
 
 default: ``0``
 
@@ -294,7 +294,7 @@ remove_old_puppet_certs_automatically
 When a puppet managed machine is reinstalled it is necessary to remove the puppet certificate from the puppet master
 server before a new certificate is signed (see above). Enabling the following feature will ensure that the certificate
 for the machine to be installed is removed from the puppet master server if the puppet master server is running on the
-same machine as cobbler. This requires ``puppet_auto_setup`` above to be enabled
+same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled
 
 default: ``0``
 
@@ -307,7 +307,7 @@ default: ``'puppet'``
 
 puppet_version
 ==============
-Let cobbler know that you're using a newer version of puppet. Choose version 3 to use: 'puppet agent'; version 2 uses
+Let Cobbler know that you're using a newer version of puppet. Choose version 3 to use: 'puppet agent'; version 2 uses
 status quo: 'puppetd'. This one is commented out by default.
 
 default: ``2``
@@ -355,7 +355,7 @@ default: ``1``
 
 tftpboot_location
 =================
-This variable contains the location of the tftpboot directory. If this directory is not present cobbler does not start.
+This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not start.
 
 Default: ``/srv/tftpboot``
 
@@ -379,7 +379,7 @@ defaults:
 
 next_server
 ===========
-If using cobbler with ``manage_dhcp``, put the IP address of the cobbler server here so that PXE booting guests can find
+If using Cobbler with ``manage_dhcp``, put the IP address of the Cobbler server here so that PXE booting guests can find
 it. If you do not set this correctly, this will be manifested in TFTP open timeouts.
 
 default: ``127.0.0.1``
@@ -408,8 +408,8 @@ default: ``ipmitool``
 
 pxe_just_once
 =============
-If this setting is set to 1, cobbler systems that pxe boot will request at the end of their installation to toggle the
-``--netboot-enabled`` record in the cobbler system record. This eliminates the potential for a PXE boot loop if the
+If this setting is set to 1, Cobbler systems that pxe boot will request at the end of their installation to toggle the
+``--netboot-enabled`` record in the Cobbler system record. This eliminates the potential for a PXE boot loop if the
 system is set to PXE first in it's BIOS order. Enable this if PXE is first in your BIOS boot order, otherwise leave this
 disabled. See the manpage for ``--netboot-enabled``.
 
@@ -431,10 +431,10 @@ default: ``"xmlrpc.rhn.redhat.com"``
 
 redhat_management_permissive
 ============================
-If using ``authn_spacewalk`` in ``modules.conf`` to let cobbler authenticate against Satellite/Spacewalk's auth system,
+If using ``authn_spacewalk`` in ``modules.conf`` to let Cobbler authenticate against Satellite/Spacewalk's auth system,
 by default it will not allow per user access into Cobbler Web and Cobbler XML-RPC. In order to permit this, the following
 setting must be enabled HOWEVER doing so will permit all Spacewalk/Satellite users of certain types to edit all of
-cobbler's configuration. these roles are: ``config_admin`` and ``org_admin``. Users should turn this on only if they
+Cobbler's configuration. these roles are: ``config_admin`` and ``org_admin``. Users should turn this on only if they
 want this behavior and do not have a cross-multi-org separation concern. If you have a single org in your satellite,
 it's probably safe to turn this on and then you can use CobblerWeb alongside a Satellite install.
 
@@ -450,8 +450,8 @@ default: ``""``
 
 register_new_installs
 =====================
-If set to ``1``, allows ``/usr/bin/cobbler-register`` (part of the Koan package) to be used to remotely add new cobbler
-system records to cobbler. This effectively allows for registration of new hardware from system records.
+If set to ``1``, allows ``/usr/bin/cobbler-register`` (part of the Koan package) to be used to remotely add new Cobbler
+system records to Cobbler. This effectively allows for registration of new hardware from system records.
 
 default: ``0``
 
@@ -511,7 +511,7 @@ default:
 
 server
 ======
-This is the address of the cobbler server -- as it is used by systems during the install process, it must be the address
+This is the address of the Cobbler server -- as it is used by systems during the install process, it must be the address
 or hostname of the system as those systems can see the server. if you have a server that appears differently to
 different subnets (dual homed, etc), you need to read the ``--server-override`` section of the manpage for how that
 works.
@@ -521,7 +521,7 @@ default: ``127.0.0.1``
 client_use_localhost
 ====================
 If set to 1, all commands will be forced to use the localhost address instead of using the above value which can force
-commands like cobbler sync to open a connection to a remote address if one is in the configuration and would traceback.
+commands like Cobbler sync to open a connection to a remote address if one is in the configuration and would traceback.
 
 default: ``0``
 
@@ -541,7 +541,7 @@ default: ``1``
 
 webdir
 ======
-Cobbler's web directory.  Don't change this setting -- see the Wiki on "relocating your cobbler install" if your /var partition
+Cobbler's web directory.  Don't change this setting -- see the Wiki on "relocating your Cobbler install" if your /var partition
 is not large enough.
 
 default: ``@@webroot@@/cobbler``
@@ -579,11 +579,11 @@ default: ``25151``
 
 yum_post_install_mirror
 =======================
-``cobbler repo add`` commands set cobbler up with repository information that can be used during autoinstall and is
-automatically set up in the cobbler autoinstall templates. By default, these are only available at install time. To
-make these repositories usable on installed systems (since cobbler makes a very convenient mirror) set this to 1. Most
-users can safely set this to 1. Users who have a dual homed cobbler server, or are installing laptops that will not
-always have access to the cobbler server may wish to leave this as 0. In that case, the cobbler mirrored yum repos are
+``cobbler repo add`` commands set Cobbler up with repository information that can be used during autoinstall and is
+automatically set up in the Cobbler autoinstall templates. By default, these are only available at install time. To
+make these repositories usable on installed systems (since Cobbler makes a very convenient mirror) set this to 1. Most
+users can safely set this to 1. Users who have a dual homed Cobbler server, or are installing laptops that will not
+always have access to the Cobbler server may wish to leave this as 0. In that case, the Cobbler mirrored yum repos are
 still accessible at ``http://cobbler.example.org/cblr/repo_mirror`` and yum configuration can still be done manually.
 This is just a shortcut.
 
@@ -639,7 +639,7 @@ defaults:
 
 proxy_url_int
 =============
-Internal proxy - used by systems to reach cobbler for kickstarts.
+Internal proxy - used by systems to reach Cobbler for kickstarts.
 
 E.g.: proxy_url_int: ``http://10.0.0.1:8080``
 
@@ -647,7 +647,7 @@ default: ``""``
 
 jinja2_includedir
 =================
-This is a directory of files that cobbler uses to include files into Jinja2 templates. Per default this settings is
+This is a directory of files that Cobbler uses to include files into Jinja2 templates. Per default this settings is
 commented out.
 
 default: ``/var/lib/cobbler/jinja2``
@@ -700,7 +700,7 @@ Choices:
 - (user supplied)  -- you may write your own module
 
 **WARNING**: this is a security setting, do not choose an option blindly.
-If you want to further restrict cobbler with ACLs for various groups,
+If you want to further restrict Cobbler with ACLs for various groups,
 pick authz_ownership.  authz_allowall does not support ACLs. Configuration
 file does but does not support object ownership which is useful as an
 additional layer of control.
@@ -751,6 +751,6 @@ Chooses the TFTP management engine if manage_tftp is enabled in ``/etc/cobbler/s
 Choices:
 
 - manage_in_tftpd -- default, uses the system's TFTP server
-- manage_tftpd_py -- uses cobbler's TFTP server
+- manage_tftpd_py -- uses Cobbler's TFTP server
 
 default: ``manage_in_tftpd``

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -463,7 +463,7 @@ option.
 default: ``"-l -n -d"``
 
 reposync_rsync_flags
-==============
+====================
 Flags to use for rysync's reposync. If archive mode (-a,--archive) is used then createrepo is not ran after the rsync as it pulls down the repodata as well. This allows older OS's to mirror modular repos using rsync.
 
 default: ``"-rltDv --copy-unsafe-links"``

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -17,7 +17,7 @@ default: ``0``
 
 allow_duplicate_ips
 ===================
-if 1, cobbler will allow insertions of system records that duplicate the ip address information of other system records.
+if 1, cobbler will allow insertions of system records that duplicate the IP address information of other system records.
 In general, this is undesirable and should be left 0.
 
 default: ``0``
@@ -42,7 +42,7 @@ By default, installs are *not* set to send installation logs to the cobbler serv
 installation templates may use the ``pre_anamon`` snippet to allow remote live monitoring of their installations from
 the cobbler server. Installation logs will be stored under ``/var/log/cobbler/anamon/``.
 
-**Note**: This does allow an xmlrpc call to send logs to this directory, without authentication, so enable only if you
+**Note**: This does allow an XML-RPC call to send logs to this directory, without authentication, so enable only if you
 are ok with this limitation.
 
 default: ``0``
@@ -104,7 +104,7 @@ defaults:
 cache_enabled
 ========================
 If cache_enabled is 1, a cache will keep converted records in memory to make checking them faster.  This helps with
-use cases like writing out large numbers of records.  There is a known issue with cache and remote XMLRPC API calls.
+use cases like writing out large numbers of records.  There is a known issue with cache and remote XML-RPC API calls.
 If you will use Cobbler with config management or infrastructure-as-code tools such as Terraform, it is recommended
 to disable by setting to 0.
 
@@ -139,7 +139,7 @@ default: ``/var/lib/cobbler/autoinstall_templates/default.ks``
 
 default_name_*
 ==============
-Configure all installed systems to use these nameservers by default unless defined differently in the profile. For DHCP
+Configure all installed systems to use these name servers by default unless defined differently in the profile. For DHCP
 configurations you probably do /not/ want to supply this.
 
 defaults:
@@ -178,8 +178,8 @@ default: ``"cheetah"``
 
 default_virt_bridge
 ===================
-For libvirt based installs in koan, if no virt-bridge is specified, which bridge do we try? For EL 4/5 hosts this should
-be ``xenbr0``, for all versions of Fedora, try ``virbr0``. This can be overriden on a per-profile basis or at the koan
+For libvirt based installs in Koan, if no virt-bridge is specified, which bridge do we try? For EL 4/5 hosts this should
+be ``xenbr0``, for all versions of Fedora, try ``virbr0``. This can be overridden on a per-profile basis or at the Koan
 command line though this saves typing to just set it here to the most common option.
 
 default: ``xenbr0``
@@ -198,7 +198,7 @@ default: ``512``
 
 default_virt_type
 =================
-If koan is invoked without ``--virt-type`` and no virt-type is set on the profile/system, what virtualization type
+If Koan is invoked without ``--virt-type`` and no virt-type is set on the profile/system, what virtualization type
 should be assumed?
 
 Current valid values are: xenpv, xenfv, qemu, vmware
@@ -209,8 +209,8 @@ default: ``xenpv``
 
 enable_gpxe
 ===========
-Enable gPXE booting? Enabling this option will cause cobbler to copy the ``undionly.kpxe`` file to the tftp root
-directory, and if a profile/system is configured to boot via gpxe it will chain load off ``pxelinux.0``.
+Enable gPXE booting? Enabling this option will cause cobbler to copy the ``undionly.kpxe`` file to the TFTP root
+directory, and if a profile/system is configured to boot via gPXE it will chain load off ``pxelinux.0``.
 
 default: ``0``
 
@@ -219,13 +219,13 @@ enable_menu
 Controls whether cobbler will add each new profile entry to the default PXE boot menu. This can be over-ridden on a
 per-profile basis when adding/editing profiles with ``--enable-menu=0/1``. Users should ordinarily leave this setting
 enabled unless they are concerned with accidental reinstalls from users who select an entry at the PXE boot menu. Adding
-a password to the boot menus templates may also be a good solution to prevent unwanted reinstallations
+a password to the boot menus templates may also be a good solution to prevent unwanted reinstallations.
 
 default: ``1``
 
 http_port
 =========
-Change this port if Apache is not running plaintext on port 80. Most people can leave this alone.
+Change this port if Apache is not running plain text on port 80. Most people can leave this alone.
 
 default: ``80``
 
@@ -239,7 +239,7 @@ default: ``{}``
 ldap_*
 ======
 Configuration options if using the authn_ldap module. See the Wiki for details. This can be ignored if you are not
-using LDAP for WebUI/XMLRPC authentication.
+using LDAP for WebUI/XML-RPC authentication.
 
 defaults:
 
@@ -322,14 +322,14 @@ default: 1
 manage_dhcp
 ===========
 Set to 1 to enable Cobbler's DHCP management features. The choice of DHCP management engine is in
-``/etc/cobbler/modules.conf``
+``/etc/cobbler/modules.conf``.
 
 default: ``0``
 
 manage_dns
 ==========
 Set to 1 to enable Cobbler's DNS management features. The choice of DNS management engine is in
-``/etc/cobbler/modules.conf``
+``/etc/cobbler/modules.conf``.
 
 default: ``0``
 
@@ -349,7 +349,7 @@ default: ``127.0.0.1``
 manage_tftpd
 ==============
 Set to 1 to enable Cobbler's TFTP management features. the choice of TFTP management engine is in
-``/etc/cobbler/modules.conf``
+``/etc/cobbler/modules.conf``.
 
 default: ``1``
 
@@ -425,14 +425,14 @@ default: ``1``
 redhat_management_server
 ========================
 This setting is only used by the code that supports using Spacewalk/Satellite authentication within Cobbler Web and
-Cobbler XMLRPC.
+Cobbler XML-RPC.
 
 default: ``"xmlrpc.rhn.redhat.com"``
 
 redhat_management_permissive
 ============================
 If using ``authn_spacewalk`` in ``modules.conf`` to let cobbler authenticate against Satellite/Spacewalk's auth system,
-by default it will not allow per user access into Cobbler Web and Cobbler XMLRPC. In order to permit this, the following
+by default it will not allow per user access into Cobbler Web and Cobbler XML-RPC. In order to permit this, the following
 setting must be enabled HOWEVER doing so will permit all Spacewalk/Satellite users of certain types to edit all of
 cobbler's configuration. these roles are: ``config_admin`` and ``org_admin``. Users should turn this on only if they
 want this behavior and do not have a cross-multi-org separation concern. If you have a single org in your satellite,
@@ -450,7 +450,7 @@ default: ``""``
 
 register_new_installs
 =====================
-If set to ``1``, allows ``/usr/bin/cobbler-register`` (part of the koan package) to be used to remotely add new cobbler
+If set to ``1``, allows ``/usr/bin/cobbler-register`` (part of the Koan package) to be used to remotely add new cobbler
 system records to cobbler. This effectively allows for registration of new hardware from system records.
 
 default: ``0``
@@ -471,7 +471,7 @@ default: ``"-rltDv --copy-unsafe-links"``
 restart_*
 =========
 When DHCP and DNS management are enabled, ``cobbler sync`` can automatically restart those services to apply changes.
-The exception for this is if using ISC for DHCP, then omapi eliminates the need for a restart. ``omapi``, however, is
+The exception for this is if using ISC for DHCP, then OMAPI eliminates the need for a restart. ``omapi``, however, is
 experimental and not recommended for most configurations. If DHCP and DNS are going to be managed, but hosted on a box
 that is not on this server, disable restarts here and write some other script to ensure that the config files get
 copied/rsynced to the destination box. This can be done by modifying the restart services trigger. Note that if
@@ -527,7 +527,7 @@ default: ``0``
 
 client_use_https
 ================
-If set to 1, all commands to the API (not directly to the XMLRPC server) will go over HTTPS instead of plaintext. Be
+If set to 1, all commands to the API (not directly to the XML-RPC server) will go over HTTPS instead of plain text. Be
 sure to change the ``http_port`` setting to the correct value for the web server.
 
 default: ``0``
@@ -572,8 +572,8 @@ default:
 
 xmlrpc_port
 ===========
-Cobbler's public XMLRPC listens on this port. Change this only if absolutely needed, as you'll have to start supplying
-a new port option to koan if it is not the default.
+Cobbler's public XML-RPC listens on this port. Change this only if absolutely needed, as you'll have to start supplying
+a new port option to Koan if it is not the default.
 
 default: ``25151``
 
@@ -610,13 +610,13 @@ default: ``0``
 
 replicate_rsync_options
 =======================
-replication rsync options for distros, autoinstalls, snippets set to override default value of ``-avzH``
+replication rsync options for distros, autoinstalls, snippets set to override default value of ``-avzH``.
 
 default: ``"-avzH"``
 
 replicate_repo_rsync_options
 ============================
-Replication rsync options for repos set to override default value of ``-avzH``
+Replication rsync options for repos set to override default value of ``-avzH``.
 
 default: ``"-avzH"``
 
@@ -665,7 +665,7 @@ If you have own custom modules which are not shipped with Cobbler directly you m
 
 authentication
 ==============
-What users can log into the WebUI and Read-Write XMLRPC?
+What users can log into the WebUI and Read-Write XML-RPC?
 
 Choices:
 
@@ -691,7 +691,7 @@ default: ``authn_configfile``
 
 authorization
 =============
-Once a user has been cleared by the WebUI/XMLRPC, what can they do?
+Once a user has been cleared by the WebUI/XML-RPC, what can they do?
 
 Choices:
 
@@ -701,9 +701,9 @@ Choices:
 
 **WARNING**: this is a security setting, do not choose an option blindly.
 If you want to further restrict cobbler with ACLs for various groups,
-pick authz_ownership.  authz_allowall does not support ACLs. Configfile
-does but does not support object ownership which is useful as an additional
-layer of control.
+pick authz_ownership.  authz_allowall does not support ACLs. Configuration
+file does but does not support object ownership which is useful as an
+additional layer of control.
 
 For more information:
 
@@ -720,7 +720,7 @@ Chooses the DNS management engine if manage_dns is enabled in ``/etc/cobbler/set
 Choices:
 
 - manage_bind    -- default, uses BIND/named
-- manage_dnsmasq -- uses dnsmasq, also must select dnsmasq for dhcp below
+- manage_dnsmasq -- uses dnsmasq, also must select dnsmasq for DHCP below
 - manage_ndjbdns -- uses ndjbdns
 
 **NOTE**: More configuration is still required in ``/etc/cobbler``
@@ -736,7 +736,7 @@ Chooses the DHCP management engine if ``manage_dhcp`` is enabled in ``/etc/cobbl
 Choices:
 
 - manage_isc     -- default, uses ISC dhcpd
-- manage_dnsmasq -- uses dnsmasq, also must select dnsmasq for dns above
+- manage_dnsmasq -- uses dnsmasq, also must select dnsmasq for DNS above
 
 **NOTE**: More configuration is still required in ``/etc/cobbler``
 
@@ -750,7 +750,7 @@ Chooses the TFTP management engine if manage_tftp is enabled in ``/etc/cobbler/s
 
 Choices:
 
-- manage_in_tftpd -- default, uses the system's tftp server
-- manage_tftpd_py -- uses cobbler's tftp server
+- manage_in_tftpd -- default, uses the system's TFTP server
+- manage_tftpd_py -- uses cobbler's TFTP server
 
 default: ``manage_in_tftpd``

--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -102,12 +102,12 @@ If you want to be explicit with distribution definition, however, here's how it 
 | initrd         | An absolute filesystem path to a initrd image.                                                      |
 +----------------+-----------------------------------------------------------------------------------------------------+
 | remote-boot-   | A URL pointing to the installation initrd of a distribution. If the bootloader has this support,    |
-| kernel         | it will directly download the kernel from this URL, instead of the directory of the tftp client.    |
-|                | Note: The kernel (or initrd below) will still be copied into the image directory of the tftp server.|
+| kernel         | it will directly download the kernel from this URL, instead of the directory of the TFTP client.    |
+|                | Note: The kernel (or initrd below) will still be copied into the image directory of the TFTP server.|
 |                | The above kernel parameter is still needed (e.g. to build iso images, etc.).                        |
 |                | The advantage of letting the boot loader retrieve the kernel/initrd directly is the support of      |
 |                | changing/updated distributions. E.g. openSUSE Tumbleweed is updated on the fly and if cobbler would |
-|                | copy/cache the kernel/initrd in the tftp directory, you would get a "kernel does not match          |
+|                | copy/cache the kernel/initrd in the TFTP directory, you would get a "kernel does not match          |
 |                | distribution" (or similar) error when trying to install.                                            |
 +----------------+-----------------------------------------------------------------------------------------------------+
 | remote-boot-   | See remote-boot-kernel above.                                                                       |
@@ -129,7 +129,7 @@ If you want to be explicit with distribution definition, however, here's how it 
 +----------------+-----------------------------------------------------------------------------------------------------+
 |                | Example: ``noapic``                                                                                 |
 +----------------+-----------------------------------------------------------------------------------------------------+
-| arch           | Sets the architecture for the PXE bootloader and also controls how koan's ``--replace-self`` option |
+| arch           | Sets the architecture for the PXE bootloader and also controls how Koan's ``--replace-self`` option |
 |                | will operate.                                                                                       |
 +----------------+-----------------------------------------------------------------------------------------------------+
 |                | The default setting (``standard``) will use ``pxelinux``. Set to ``ppc`` and ``ppc64`` to use       |
@@ -160,15 +160,15 @@ If you want to be explicit with distribution definition, however, here's how it 
 |                | ``--autoinst`` when creating the profile.                                                           |
 +----------------+-----------------------------------------------------------------------------------------------------+
 | os-version     | Generally this field can be ignored. It is intended to alter some hardware setup for virtualized    |
-|                | instances when provisioning guests with koan. The valid options for ``--os-version`` vary depending |
+|                | instances when provisioning guests with Koan. The valid options for ``--os-version`` vary depending |
 |                | on what is specified for ``--breed``. If you specify an invalid option, the error message will      |
-|                | contain a list of valid os versions that can be used. If you don't know the os version or it does   |
+|                | contain a list of valid OS versions that can be used. If you don't know the OS version or it does   |
 |                | not appear in the list, omitting this argument or using ``other`` should be perfectly fine. If you  |
 |                | don't encounter any problems with virtualized instances, this option can be safely ignored.         |
 +----------------+-----------------------------------------------------------------------------------------------------+
 | owners         | Users with small sites and a limited number of admins can probably ignore this option.  All cobbler |
 |                | objects (distros, profiles, systems, and repos) can take a --owners parameter to specify what       |
-|                | cobbler users can edit particular objects.This only applies to the Cobbler WebUI and XMLRPC         |
+|                | cobbler users can edit particular objects.This only applies to the Cobbler WebUI and XML-RPC        |
 |                | interface, not the "cobbler" command line tool run from the shell. Furthermore, this is only        |
 |                | respected by the ``authz_ownership`` module which must be enabled in ``/etc/cobbler/modules.conf``. |
 |                | The value for ``--owners`` is a space separated list of users and groups as specified in            |
@@ -228,12 +228,12 @@ listed below:
 +---------------------+------------------------------------------------------------------------------------------------+
 | virt-type           | (Virt-only) Koan can install images using either Xen paravirt (``xenpv``) or QEMU/KVM          |
 |                     | (``qemu``). Choose one or the other strings to specify, or values will default to attempting to|
-|                     | find a compatible installation type on the client system("auto"). See the "koan" manpage for   |
+|                     | find a compatible installation type on the client system("auto"). See the "Koan" manpage for   |
 |                     | more documentation. The default ``--virt-type`` can be configured in the cobbler settings file |
 |                     | such that this parameter does not have to be provided. Other virtualization types are          |
 |                     | supported, for information on those options (such as VMware), see the Cobbler Wiki.            |
 +---------------------+------------------------------------------------------------------------------------------------+
-| virt-cpus           | (Virt-only) How many virtual CPUs should koan give the virtual machine? The default is 1. This |
+| virt-cpus           | (Virt-only) How many virtual CPUs should Koan give the virtual machine? The default is 1. This |
 |                     | is an integer.                                                                                 |
 +---------------------+------------------------------------------------------------------------------------------------+
 | virt-path           | (Virt-only) Where to store the virtual image on the host system. Except for advanced cases,    |
@@ -249,7 +249,7 @@ listed below:
 |                     | as shipped in the RPM is ``xenbr0``. If using KVM, this is most likely not correct. You may    |
 |                     | want to override this setting in the system object. Bridge settings are important as they      |
 |                     | define how outside networking will reach the guest. For more information on bridge setup, see  |
-|                     | the Cobbler Wiki, where there is a section describing koan usage.                              |
+|                     | the Cobbler Wiki, where there is a section describing Koan usage.                              |
 +---------------------+------------------------------------------------------------------------------------------------+
 | repos               | This is a space delimited list of all the repos (created with ``cobbler repo add`` and updated |
 |                     | with ``cobbler reposync``)that this profile can make use of during automated installation. For |
@@ -275,11 +275,11 @@ listed below:
 | server              | This parameter should be useful only in select circumstances. If machines are on a subnet that |
 |                     | cannot access the cobbler server using the name/IP as configured in the cobbler settings file, |
 |                     | use this parameter to override that servername. See also ``--dhcp-tag`` for configuring the    |
-|                     | next server and DHCP information of the system if you are also usingCobbler to help manage your|
-|                     | DHCP configuration.                                                                            |
+|                     | next server and DHCP information of the system if you are also using Cobbler to help manage    |
+|                     | your DHCP configuration.                                                                       |
 +---------------------+------------------------------------------------------------------------------------------------+
 | filename            | This parameter can be used to select the bootloader for network boot. If specified, this must  |
-|                     | be a path relative to the tftp servers root directory. (e.g. grub/grubx64.efi)                 |
+|                     | be a path relative to the TFTP servers root directory. (e.g. grub/grubx64.efi)                 |
 |                     | For most use cases the default bootloader is correct and this can be omitted                   |
 +---------------------+------------------------------------------------------------------------------------------------+
 
@@ -289,7 +289,7 @@ cobbler system
 System records map a piece of hardware (or a virtual machine) with the cobbler profile to be assigned to run on it. This
 may be thought of as choosing a role for a specific system.
 
-Note that if provisioning via koan and PXE menus alone, it is not required to create system records in cobbler, though
+Note that if provisioning via Koan and PXE menus alone, it is not required to create system records in cobbler, though
 they are useful when system specific customizations are required. One such customization would be defining the MAC
 address. If there is a specific role intended for a given machine, system records should be created for it.
 
@@ -365,15 +365,15 @@ Adds a cobbler System to the configuration. Arguments are specified as per "prof
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | This is a per-interface setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| virt-bridge                                                   | (Virt-only) While --virt-bridge is present in the profile object (see above), here it works on an interface by interfacebasis. For instance it would be possible to have --virt-bridge0=xenbr0 and --virt-bridge1=xenbr1. If not specified in cobbler for each interface, koan will use the value as specified in the profile for each interface, which may not always be what is intended, but will be sufficient in most cases.                                                                                                                                                                                                                                                                                                                                                                                    |
+| virt-bridge                                                   | (Virt-only) While --virt-bridge is present in the profile object (see above), here it works on an interface by interfacebasis. For instance it would be possible to have --virt-bridge0=xenbr0 and --virt-bridge1=xenbr1. If not specified in cobbler for each interface, Koan will use the value as specified in the profile for each interface, which may not always be what is intended, but will be sufficient in most cases.                                                                                                                                                                                                                                                                                                                                                                                    |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | This is a per-interface setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | autoinst                                                      | While it is recommended that the --autoinst parameter is only used within for the "profile add" command, there are limited scenarios when an install base switching to cobbler may have legacy automatic installation files created on aper-system basis (one automatic installation file for each system, nothing shared) and may not want to immediately make use of the cobbler templating system. This allows specifying a automatic installation file for use on a per-system basis. Creation of a parent profile is still required.  If the automatic installation file is a filesystem location, it will still be treated as a cobbler template.                                                                                                                                                              |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| netboot-enabled                                               | If set false, the system will be provisionable through koan but not through standard PXE. This will allow the system to fall back to default PXE boot behavior without deleting the cobbler system object. The default value allows PXE. Cobbler contains a PXE boot loop prevention feature (pxe_just_once, can be enabled in /etc/cobbler/settings) that can automatically trip off this value after a system gets done installing. This can prevent installs from appearing in an endless loop when the system is set to PXE first in the BIOS order.                                                                                                                                                                                                                                                             |
+| netboot-enabled                                               | If set false, the system will be provisionable through Koan but not through standard PXE. This will allow the system to fall back to default PXE boot behavior without deleting the cobbler system object. The default value allows PXE. Cobbler contains a PXE boot loop prevention feature (pxe_just_once, can be enabled in /etc/cobbler/settings) that can automatically trip off this value after a system gets done installing. This can prevent installs from appearing in an endless loop when the system is set to PXE first in the BIOS order.                                                                                                                                                                                                                                                             |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| repos-enabled                                                 | If set true, koan can reconfigure repositories after installation. This is described further on the Cobbler Wiki,https://github.com/cobbler/cobbler/wiki/Manage-yum-repos.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+| repos-enabled                                                 | If set true, Koan can reconfigure repositories after installation. This is described further on the Cobbler Wiki,https://github.com/cobbler/cobbler/wiki/Manage-yum-repos.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | dhcp-tag                                                      | If you are setting up a PXE environment with multiple subnets/gateways, and are using cobbler to manage a DHCP configuration, you will probably want to use this option. If not, it can be ignored.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -450,7 +450,7 @@ probably be overkill, though it can be very useful for larger setups (labs, data
 +------------------+---------------------------------------------------------------------------------------------------+
 |                  | Experimental support is also provided for mirroring RHN content when you need a fast local mirror.|
 |                  | The mirror syntax for this is ``--mirror=rhn://channel-name`` and you must have entitlements for  |
-|                  | this to work. This requires the cobbler server to be installed on RHEL5 or later. You will also   |
+|                  | this to work. This requires the cobbler server to be installed on RHEL 5 or later. You will also  |
 |                  | need a version of ``yum-utils`` equal or greater to 1.0.4.                                        |
 +------------------+---------------------------------------------------------------------------------------------------+
 | name             | This name is used as the save location for the mirror. If the mirror represented, say, Fedora     |
@@ -471,7 +471,7 @@ probably be overkill, though it can be very useful for larger setups (labs, data
 | rpm-list         | By specifying a space-delimited list of package names for ``--rpm-list``, one can decide to mirror|
 |                  | only a part of a repo (the list of packages given, plus dependencies). This may be helpful in     |
 |                  | conserving time/space/bandwidth. For instance, when mirroring FC6 Extras, it may be desired to    |
-|                  | mirror just cobbler and koan, and skip all of the game packages. To do this, use                  |
+|                  | mirror just cobbler and Koan, and skip all of the game packages. To do this, use                  |
 |                  | ``--rpm-list="cobbler koan"``.                                                                    |
 +------------------+---------------------------------------------------------------------------------------------------+
 |                  | This option only works for ``http://`` and ``ftp://`` repositories (as it is powered by           |
@@ -684,7 +684,7 @@ cobbler report
 =================
 
 This lists all configuration which cobbler can obtain from the saved data. There are also ``report`` subcommands for
-most of the other cobbler commands. (Currently: distro, profile, system, repo, image, mgmtclass, package, file)
+most of the other cobbler commands (currently: distro, profile, system, repo, image, mgmtclass, package, file).
 
 .. code-block:: shell
 
@@ -785,8 +785,7 @@ cobbler's command line returns a zero for success and non-zero for failure.
 Additional Help
 ###############
 
-We have a Gitter Channel and you also can ask questions as GitHub-Issues. The IRC Channel on Freenode (#cobbler) is not
+We have a Gitter Channel and you also can ask questions as GitHub issues. The IRC Channel on Freenode (#cobbler) is not
 that active but sometimes there are people who can help you.
 
-The way we would prefer are GitHub-Issues as they are easily searchable.
-
+The way we would prefer are GitHub issues as they are easily searchable.

--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -281,7 +281,7 @@ listed below:
 | filename            | This parameter can be used to select the bootloader for network boot. If specified, this must  |
 |                     | be a path relative to the tftp servers root directory. (e.g. grub/grubx64.efi)                 |
 |                     | For most use cases the default bootloader is correct and this can be omitted                   |
-+----------------------------------------------------------------------------------------------------------------------+
++---------------------+------------------------------------------------------------------------------------------------+
 
 cobbler system
 ==============

--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -76,10 +76,10 @@ Long Usage:
     cobbler <distro|profile|system|repo|image|mgmtclass|package|file> ... [add|edit|copy|get-autoinstall*|list|remove|rename|report] [options|--help]
     cobbler <aclsetup|buildiso|import|list|replicate|report|reposync|sync|validate-autoinstalls|version|signature|get-loaders|hardlink> [options|--help]
 
-cobbler distro
+Cobbler distro
 ==============
 
-This first step towards configuring what you want to install is to add a distribution record to cobbler's configuration.
+This first step towards configuring what you want to install is to add a distribution record to Cobbler's configuration.
 
 If there is an rsync mirror, DVD, NFS, or filesystem tree available that you would rather ``import`` instead, skip down
 to the documentation about the ``import`` command. It's really a lot easier to follow the import workflow -- it only
@@ -106,7 +106,7 @@ If you want to be explicit with distribution definition, however, here's how it 
 |                | Note: The kernel (or initrd below) will still be copied into the image directory of the TFTP server.|
 |                | The above kernel parameter is still needed (e.g. to build iso images, etc.).                        |
 |                | The advantage of letting the boot loader retrieve the kernel/initrd directly is the support of      |
-|                | changing/updated distributions. E.g. openSUSE Tumbleweed is updated on the fly and if cobbler would |
+|                | changing/updated distributions. E.g. openSUSE Tumbleweed is updated on the fly and if Cobbler would |
 |                | copy/cache the kernel/initrd in the TFTP directory, you would get a "kernel does not match          |
 |                | distribution" (or similar) error when trying to install.                                            |
 +----------------+-----------------------------------------------------------------------------------------------------+
@@ -114,13 +114,13 @@ If you want to be explicit with distribution definition, however, here's how it 
 | initrd         |                                                                                                     |
 +----------------+-----------------------------------------------------------------------------------------------------+
 | kopts          | Sets kernel command-line arguments that the distro, and profiles/systems depending on it, will use. |
-|                | To remove a kernel argument that may be added by a higher cobbler object (or in the global          |
+|                | To remove a kernel argument that may be added by a higher Cobbler object (or in the global          |
 |                | settings), you can prefix it with a ``!``.                                                          |
 +----------------+-----------------------------------------------------------------------------------------------------+
 |                | Example: ``--kopts="foo=bar baz=3 asdf !gulp"``                                                     |
 +----------------+-----------------------------------------------------------------------------------------------------+
 |                | This example passes the arguments ``foo=bar baz=3 asdf`` but will make sure ``gulp`` is not passed  |
-|                | even if it was requested at a level higher up in the cobbler configuration.                         |
+|                | even if it was requested at a level higher up in the Cobbler configuration.                         |
 +----------------+-----------------------------------------------------------------------------------------------------+
 | kopts-post     | This is just like ``--kopts``, though it governs kernel options on the installed OS, as opposed to  |
 |                | kernel options fed to the installer. The syntax is exactly the same. This requires some special     |
@@ -166,24 +166,24 @@ If you want to be explicit with distribution definition, however, here's how it 
 |                | not appear in the list, omitting this argument or using ``other`` should be perfectly fine. If you  |
 |                | don't encounter any problems with virtualized instances, this option can be safely ignored.         |
 +----------------+-----------------------------------------------------------------------------------------------------+
-| owners         | Users with small sites and a limited number of admins can probably ignore this option.  All cobbler |
+| owners         | Users with small sites and a limited number of admins can probably ignore this option.  All Cobbler |
 |                | objects (distros, profiles, systems, and repos) can take a --owners parameter to specify what       |
-|                | cobbler users can edit particular objects.This only applies to the Cobbler WebUI and XML-RPC        |
+|                | Cobbler users can edit particular objects.This only applies to the Cobbler WebUI and XML-RPC        |
 |                | interface, not the "cobbler" command line tool run from the shell. Furthermore, this is only        |
 |                | respected by the ``authz_ownership`` module which must be enabled in ``/etc/cobbler/modules.conf``. |
 |                | The value for ``--owners`` is a space separated list of users and groups as specified in            |
 |                | ``/etc/cobbler/users.conf``. For more information see the users.conf file as well as the Cobbler    |
 |                | Wiki. In the default Cobbler configuration, this value is completely ignored, as is ``users.conf``. |
 +----------------+-----------------------------------------------------------------------------------------------------+
-| template-files | This feature allows cobbler to be used as a configuration management system. The argument is a space|
+| template-files | This feature allows Cobbler to be used as a configuration management system. The argument is a space|
 |                | delimited string of ``key=value`` pairs. Each key is the path to a template file, each value is the |
 |                | path to install the file on the system. This is described in further detail on the Cobbler Wiki and |
 |                | is implemented using special code in the post install. Koan also can retrieve these files from a    |
-|                | cobbler server on demand, effectively allowing cobbler to function as a lightweight templated       |
+|                | Cobbler server on demand, effectively allowing Cobbler to function as a lightweight templated       |
 |                | configuration management system.                                                                    |
 +----------------+-----------------------------------------------------------------------------------------------------+
 
-cobbler profile
+Cobbler profile
 ===============
 
 A profile associates a distribution to additional specialized options, such as a installation automation file. Profiles
@@ -203,7 +203,7 @@ listed below:
 +=====================+================================================================================================+
 | name                | A descriptive name. This could be something like ``rhel5webservers`` or ``f9desktops``.        |
 +---------------------+------------------------------------------------------------------------------------------------+
-| distro              | The name of a previously defined cobbler distribution. This value is required.                 |
+| distro              | The name of a previously defined Cobbler distribution. This value is required.                 |
 +---------------------+------------------------------------------------------------------------------------------------+
 | autoinst            | Local filesystem path to a automatic installation file, the file must reside under             |
 |                     | ``/var/lib/cobbler/autoinstall_templates``                                                     |
@@ -229,7 +229,7 @@ listed below:
 | virt-type           | (Virt-only) Koan can install images using either Xen paravirt (``xenpv``) or QEMU/KVM          |
 |                     | (``qemu``). Choose one or the other strings to specify, or values will default to attempting to|
 |                     | find a compatible installation type on the client system("auto"). See the "Koan" manpage for   |
-|                     | more documentation. The default ``--virt-type`` can be configured in the cobbler settings file |
+|                     | more documentation. The default ``--virt-type`` can be configured in the Cobbler settings file |
 |                     | such that this parameter does not have to be provided. Other virtualization types are          |
 |                     | supported, for information on those options (such as VMware), see the Cobbler Wiki.            |
 +---------------------+------------------------------------------------------------------------------------------------+
@@ -245,7 +245,7 @@ listed below:
 |                     | ``/dev/sda4,/dev/sda5``. Both those examples would create two disks for the VM.                |
 +---------------------+------------------------------------------------------------------------------------------------+
 | virt-bridge         | (Virt-only) This specifies the default bridge to use for all systems defined under this        |
-|                     | profile. If not specified, it will assume the default value in the cobbler settings file, which|
+|                     | profile. If not specified, it will assume the default value in the Cobbler settings file, which|
 |                     | as shipped in the RPM is ``xenbr0``. If using KVM, this is most likely not correct. You may    |
 |                     | want to override this setting in the system object. Bridge settings are important as they      |
 |                     | define how outside networking will reach the guest. For more information on bridge setup, see  |
@@ -254,7 +254,7 @@ listed below:
 | repos               | This is a space delimited list of all the repos (created with ``cobbler repo add`` and updated |
 |                     | with ``cobbler reposync``)that this profile can make use of during automated installation. For |
 |                     | example, an example might be ``--repos="fc6i386updates fc6i386extras"`` if the profile wants to|
-|                     | access these two mirrors that are already mirrored on the cobbler server. Repo management is   |
+|                     | access these two mirrors that are already mirrored on the Cobbler server. Repo management is   |
 |                     | described in greater depth later in the manpage.                                               |
 +---------------------+------------------------------------------------------------------------------------------------+
 | parent              | This is an advanced feature.                                                                   |
@@ -273,7 +273,7 @@ listed below:
 |                     | the value from A.                                                                              |
 +---------------------+------------------------------------------------------------------------------------------------+
 | server              | This parameter should be useful only in select circumstances. If machines are on a subnet that |
-|                     | cannot access the cobbler server using the name/IP as configured in the cobbler settings file, |
+|                     | cannot access the Cobbler server using the name/IP as configured in the Cobbler settings file, |
 |                     | use this parameter to override that servername. See also ``--dhcp-tag`` for configuring the    |
 |                     | next server and DHCP information of the system if you are also using Cobbler to help manage    |
 |                     | your DHCP configuration.                                                                       |
@@ -283,21 +283,21 @@ listed below:
 |                     | For most use cases the default bootloader is correct and this can be omitted                   |
 +---------------------+------------------------------------------------------------------------------------------------+
 
-cobbler system
+Cobbler system
 ==============
 
-System records map a piece of hardware (or a virtual machine) with the cobbler profile to be assigned to run on it. This
+System records map a piece of hardware (or a virtual machine) with the Cobbler profile to be assigned to run on it. This
 may be thought of as choosing a role for a specific system.
 
-Note that if provisioning via Koan and PXE menus alone, it is not required to create system records in cobbler, though
+Note that if provisioning via Koan and PXE menus alone, it is not required to create system records in Cobbler, though
 they are useful when system specific customizations are required. One such customization would be defining the MAC
 address. If there is a specific role intended for a given machine, system records should be created for it.
 
 System commands have a wider variety of control offered over network details. In order to use these to the fullest
-possible extent, the automatic installation template used by cobbler must contain certain automatic installation
+possible extent, the automatic installation template used by Cobbler must contain certain automatic installation
 snippets (sections of code specifically written for Cobbler to make these values become reality). Compare your automatic
 installation templates with the stock ones in /var/lib/cobbler/autoinstall_templates if you have upgraded, to make sure
-you can take advantage of all options to their fullest potential. If you are a new cobbler user, base your automatic
+you can take advantage of all options to their fullest potential. If you are a new Cobbler user, base your automatic
 installation templates off of these templates.
 
 Read more about networking setup at: https://cobbler.readthedocs.io/en/release28/4_advanced/advanced%20networking.html
@@ -308,7 +308,7 @@ Example:
 
     $ cobbler system add --name=string --profile=string [--mac=macaddress] [--ip-address=ipaddress] [--hostname=hostname] [--kopts=string] [--ksmeta=string] [--autoinst=path] [--netboot-enabled=Y/N] [--server=string] [--gateway=string] [--dns-name=string] [--static-routes=string] [--power-address=string] [--power-type=string] [--power-user=string] [--power-pass=string] [--power-id=string]
 
-Adds a cobbler System to the configuration. Arguments are specified as per "profile add" with the following changes:
+Adds a Cobbler System to the configuration. Arguments are specified as per "profile add" with the following changes:
 
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | Name                                                          | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
@@ -321,13 +321,13 @@ Adds a cobbler System to the configuration. Arguments are specified as per "prof
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | When using "default" name, don't specify any other arguments than --profile ... they won't be used.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| mac                                                           | Specifying a mac address via --mac allows the system object to boot directly to a specific profile via PXE, bypassing cobbler's PXE menu.  If the name of the cobbler system already looks like a mac address, this is inferred from the system name and does not need to be specified.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| mac                                                           | Specifying a mac address via --mac allows the system object to boot directly to a specific profile via PXE, bypassing Cobbler's PXE menu.  If the name of the Cobbler system already looks like a mac address, this is inferred from the system name and does not need to be specified.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | MAC addresses have the format AA:BB:CC:DD:EE:FF. It's highly recommended to register your MAC-addresses in Cobbler if you're using static addressing with multiple interfaces, or if you are using any of the advanced networking features like bonding, bridges or VLANs.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | Cobbler does contain a feature (enabled in /etc/cobbler/settings) that can automatically add new system records when it finds profiles being provisioned on hardware it has seen before.  This may help if you do not have a report of all the MAC addresses in your datacenter/lab configuration.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| ip-address                                                    | If cobbler is configured to generate a DHCP configuration (see advanced section), use this setting to define a specific IP for this system in DHCP.  Leaving off this parameter will result in no DHCP management for this particular system.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
+| ip-address                                                    | If Cobbler is configured to generate a DHCP configuration (see advanced section), use this setting to define a specific IP for this system in DHCP.  Leaving off this parameter will result in no DHCP management for this particular system.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | Example: --ip-address=192.168.1.50                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -337,7 +337,7 @@ Adds a cobbler System to the configuration. Arguments are specified as per "prof
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | When using the CIDR notation trick, don't specify any arguments other than --name and --profile... they won't be used.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| dns-name                                                      | If using the DNS management feature (see advanced section -- cobbler supports auto-setup of BIND and dnsmasq), use this to define a hostname for the system to receive from DNS.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+| dns-name                                                      | If using the DNS management feature (see advanced section -- Cobbler supports auto-setup of BIND and dnsmasq), use this to define a hostname for the system to receive from DNS.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | Example: --dns-name=mycomputer.example.com                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -365,23 +365,23 @@ Adds a cobbler System to the configuration. Arguments are specified as per "prof
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | This is a per-interface setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| virt-bridge                                                   | (Virt-only) While --virt-bridge is present in the profile object (see above), here it works on an interface by interfacebasis. For instance it would be possible to have --virt-bridge0=xenbr0 and --virt-bridge1=xenbr1. If not specified in cobbler for each interface, Koan will use the value as specified in the profile for each interface, which may not always be what is intended, but will be sufficient in most cases.                                                                                                                                                                                                                                                                                                                                                                                    |
+| virt-bridge                                                   | (Virt-only) While --virt-bridge is present in the profile object (see above), here it works on an interface by interface basis. For instance it would be possible to have --virt-bridge0=xenbr0 and --virt-bridge1=xenbr1. If not specified in Cobbler for each interface, Koan will use the value as specified in the profile for each interface, which may not always be what is intended, but will be sufficient in most cases.                                                                                                                                                                                                                                                                                                                                                                                   |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | This is a per-interface setting.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| autoinst                                                      | While it is recommended that the --autoinst parameter is only used within for the "profile add" command, there are limited scenarios when an install base switching to cobbler may have legacy automatic installation files created on aper-system basis (one automatic installation file for each system, nothing shared) and may not want to immediately make use of the cobbler templating system. This allows specifying a automatic installation file for use on a per-system basis. Creation of a parent profile is still required.  If the automatic installation file is a filesystem location, it will still be treated as a cobbler template.                                                                                                                                                              |
+| autoinst                                                      | While it is recommended that the --autoinst parameter is only used within for the "profile add" command, there are limited scenarios when an install base switching to Cobbler may have legacy automatic installation files created on aper-system basis (one automatic installation file for each system, nothing shared) and may not want to immediately make use of the Cobbler templating system. This allows specifying a automatic installation file for use on a per-system basis. Creation of a parent profile is still required.  If the automatic installation file is a filesystem location, it will still be treated as a Cobbler template.                                                                                                                                                              |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| netboot-enabled                                               | If set false, the system will be provisionable through Koan but not through standard PXE. This will allow the system to fall back to default PXE boot behavior without deleting the cobbler system object. The default value allows PXE. Cobbler contains a PXE boot loop prevention feature (pxe_just_once, can be enabled in /etc/cobbler/settings) that can automatically trip off this value after a system gets done installing. This can prevent installs from appearing in an endless loop when the system is set to PXE first in the BIOS order.                                                                                                                                                                                                                                                             |
+| netboot-enabled                                               | If set false, the system will be provisionable through Koan but not through standard PXE. This will allow the system to fall back to default PXE boot behavior without deleting the Cobbler system object. The default value allows PXE. Cobbler contains a PXE boot loop prevention feature (pxe_just_once, can be enabled in /etc/cobbler/settings) that can automatically trip off this value after a system gets done installing. This can prevent installs from appearing in an endless loop when the system is set to PXE first in the BIOS order.                                                                                                                                                                                                                                                             |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | repos-enabled                                                 | If set true, Koan can reconfigure repositories after installation. This is described further on the Cobbler Wiki,https://github.com/cobbler/cobbler/wiki/Manage-yum-repos.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| dhcp-tag                                                      | If you are setting up a PXE environment with multiple subnets/gateways, and are using cobbler to manage a DHCP configuration, you will probably want to use this option. If not, it can be ignored.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
+| dhcp-tag                                                      | If you are setting up a PXE environment with multiple subnets/gateways, and are using Cobbler to manage a DHCP configuration, you will probably want to use this option. If not, it can be ignored.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | By default, the dhcp tag for all systems is "default" and means that in the DHCP template files the systems will expand out where $insert_cobbler_systems_definitions is found in the DHCP template. However, you may want certain systems to expand out in other places in the DHCP config file.  Setting --dhcp-tag=subnet2 for instance, will cause that system to expand out where $insert_cobbler_system_definitions_subnet2 is found, allowing you to insert directives to specify different subnets (or other parameters) before the DHCP configuration entries for those particular systems.                                                                                                                                                                                                                 |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | This is described further on the Cobbler Wiki.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| interface                                                     | By default flags like --ip, --mac, --dhcp-tag, --dns-name, --netmask, --virt-bridge, and --static-routes operate on the first network interface defined for a system (eth0). However, cobbler supports an arbitrary number of interfaces. Using--interface=eth1 for instance, will allow creating and editing of a second interface.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| interface                                                     | By default flags like --ip, --mac, --dhcp-tag, --dns-name, --netmask, --virt-bridge, and --static-routes operate on the first network interface defined for a system (eth0). However, Cobbler supports an arbitrary number of interfaces. Using--interface=eth1 for instance, will allow creating and editing of a second interface.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 |                                                               | Interface naming notes:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
@@ -420,10 +420,10 @@ Adds a cobbler System to the configuration. Arguments are specified as per "prof
 |                                                               | cobbler system report --name=foo                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 +---------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 
-cobbler repo
+Cobbler repo
 ============
 
-Repository mirroring allows cobbler to mirror not only install trees ("cobbler import" does this for you) but also
+Repository mirroring allows Cobbler to mirror not only install trees ("cobbler import" does this for you) but also
 optional packages, 3rd party content, and even updates. Mirroring all of this content locally on your network will
 result in faster, more up-to-date installations and faster updates. If you are only provisioning a home setup, this will
 probably be overkill, though it can be very useful for larger setups (labs, datacenters, etc).
@@ -450,7 +450,7 @@ probably be overkill, though it can be very useful for larger setups (labs, data
 +------------------+---------------------------------------------------------------------------------------------------+
 |                  | Experimental support is also provided for mirroring RHN content when you need a fast local mirror.|
 |                  | The mirror syntax for this is ``--mirror=rhn://channel-name`` and you must have entitlements for  |
-|                  | this to work. This requires the cobbler server to be installed on RHEL 5 or later. You will also  |
+|                  | this to work. This requires the Cobbler server to be installed on RHEL 5 or later. You will also  |
 |                  | need a version of ``yum-utils`` equal or greater to 1.0.4.                                        |
 +------------------+---------------------------------------------------------------------------------------------------+
 | name             | This name is used as the save location for the mirror. If the mirror represented, say, Fedora     |
@@ -471,7 +471,7 @@ probably be overkill, though it can be very useful for larger setups (labs, data
 | rpm-list         | By specifying a space-delimited list of package names for ``--rpm-list``, one can decide to mirror|
 |                  | only a part of a repo (the list of packages given, plus dependencies). This may be helpful in     |
 |                  | conserving time/space/bandwidth. For instance, when mirroring FC6 Extras, it may be desired to    |
-|                  | mirror just cobbler and Koan, and skip all of the game packages. To do this, use                  |
+|                  | mirror just Cobbler and Koan, and skip all of the game packages. To do this, use                  |
 |                  | ``--rpm-list="cobbler koan"``.                                                                    |
 +------------------+---------------------------------------------------------------------------------------------------+
 |                  | This option only works for ``http://`` and ``ftp://`` repositories (as it is powered by           |
@@ -486,12 +486,12 @@ probably be overkill, though it can be very useful for larger setups (labs, data
 |                  | feature. See "cobbler reposync" below.                                                            |
 +------------------+---------------------------------------------------------------------------------------------------+
 | mirror-locally   | When set to ``N``, specifies that this yum repo is to be referenced directly via automatic        |
-|                  | installation files and not mirrored locally on the cobbler server. Only ``http://`` and ``ftp://``|
+|                  | installation files and not mirrored locally on the Cobbler server. Only ``http://`` and ``ftp://``|
 |                  | mirror urls are supported when using ``--mirror-locally=N``, you cannot use filesystem URLs.      |
 +------------------+---------------------------------------------------------------------------------------------------+
 | priority         | Specifies the priority of the repository (the lower the number, the higher the priority), which   |
 |                  | applies to installed machines using the repositories that also have the yum priorities plugin     |
-|                  | installed. The default priority for the plugins 99, as is that of all cobbler mirrored            |
+|                  | installed. The default priority for the plugins 99, as is that of all Cobbler mirrored            |
 |                  | repositories.                                                                                     |
 +------------------+---------------------------------------------------------------------------------------------------+
 | arch             | Specifies what architecture the repository should use. By default the current system arch (of the |
@@ -502,11 +502,11 @@ probably be overkill, though it can be very useful for larger setups (labs, data
 |                  | if a yum plugin takes a certain parameter "alpha" and "beta", use something like                  |
 |                  | ``--yumopts="alpha=2 beta=3"``.                                                                   |
 +------------------+---------------------------------------------------------------------------------------------------+
-| breed            | Ordinarily cobbler's repo system will understand what you mean without supplying this parameter,  |
+| breed            | Ordinarily Cobbler's repo system will understand what you mean without supplying this parameter,  |
 |                  | though you can set it explicitly if needed.                                                       |
 +------------------+---------------------------------------------------------------------------------------------------+
 
-cobbler image
+Cobbler image
 =============
 
 Example:
@@ -518,7 +518,7 @@ Example:
 cobbler mgmtclass
 =================
 
-Management classes allows cobbler to function as an configuration management system. Cobbler currently supports the
+Management classes allows Cobbler to function as an configuration management system. Cobbler currently supports the
 following resource types:
 
 1. Packages
@@ -545,7 +545,7 @@ Resources are executed in the order listed above.
 +----------+-----------------------------------------------------------------------------------------------------------+
 
 
-cobbler package
+Cobbler package
 ===============
 
 Package resources are managed using ``cobbler package add``
@@ -576,7 +576,7 @@ Example:
 
     $ cobbler package add --name=string --comment=string [--action=install|uninstall] --installer=string [--version=string]
 
-cobbler file
+Cobbler file
 ============
 
 Actions:
@@ -620,7 +620,7 @@ Example:
 
     $ cobbler aclsetup
 
-cobbler buildiso
+Cobbler buildiso
 ================
 
 Example:
@@ -629,7 +629,7 @@ Example:
 
     $ cobbler buildiso
 
-cobbler import
+Cobbler import
 ==============
 
 Example:
@@ -638,20 +638,20 @@ Example:
 
     $ cobbler import
 
-cobbler list
+Cobbler list
 ============
 
 This list all the names grouped by type. Identically to ``cobbler report`` there are subcommands for most of the other
-cobbler commands. (Currently: distro, profile, system, repo, image, mgmtclass, package, file)
+Cobbler commands. (Currently: distro, profile, system, repo, image, mgmtclass, package, file)
 
 .. code-block:: shell
 
     $ cobbler list
 
-cobbler replicate
+Cobbler replicate
 =================
 
-Cobbler can replicate configurations from a master cobbler server. Each cobbler server is still expected to have a
+Cobbler can replicate configurations from a master Cobbler server. Each Cobbler server is still expected to have a
 locally relevant ``/etc/cobbler/cobbler.conf`` and ``modules.conf``, as these files are not synced.
 
 This feature is intended for load-balancing, disaster-recovery, backup, or multiple geography support.
@@ -671,7 +671,7 @@ Common data locations will be rsync'ed from the master server unless ``--omit-da
 To delete objects that are no longer present on the master server, use ``--prune``.
 
 **Warning**: This will delete all object types not present on the remote server from the local server, and is recursive.
-If you use prune, it is best to manage cobbler centrally and not expect changes made on the slave servers to be
+If you use prune, it is best to manage Cobbler centrally and not expect changes made on the slave servers to be
 preserved. It is not currently possible to just prune objects of a specific type.
 
 Example:
@@ -680,11 +680,11 @@ Example:
 
     $ cobbler replicate --master=cobbler.example.org [--distros=pattern] [--profiles=pattern] [--systems=pattern] [--repos-pattern] [--images=pattern] [--prune] [--omit-data]
 
-cobbler report
+Cobbler report
 =================
 
-This lists all configuration which cobbler can obtain from the saved data. There are also ``report`` subcommands for
-most of the other cobbler commands (currently: distro, profile, system, repo, image, mgmtclass, package, file).
+This lists all configuration which Cobbler can obtain from the saved data. There are also ``report`` subcommands for
+most of the other Cobbler commands (currently: distro, profile, system, repo, image, mgmtclass, package, file).
 
 .. code-block:: shell
 
@@ -694,7 +694,7 @@ most of the other cobbler commands (currently: distro, profile, system, repo, im
 
 Optional parameter which filters for object with the given name.
 
-cobbler reposync
+Cobbler reposync
 ================
 
 Example:
@@ -703,7 +703,7 @@ Example:
 
     $ cobbler reposync
 
-cobbler sync
+Cobbler sync
 ============
 
 The sync command is very important, though very often unnecessary for most situations. It's primary purpose is to force
@@ -715,13 +715,13 @@ When is a full sync required? When you are using ``manage_dhcpd`` (Managing DHCP
 In that case, a full sync is required to rewrite the ``dhcpd.conf`` file and to restart the dhcpd service.
 
 Cobbler sync is used to repair or rebuild the contents ``/tftpboot`` or ``/var/www/cobbler`` when something has changed
-behind the scenes. It brings the filesystem up to date with the configuration as understood by cobbler.
+behind the scenes. It brings the filesystem up to date with the configuration as understood by Cobbler.
 
 Sync should be run whenever files in ``/var/lib/cobbler`` are manually edited (which is not recommended except for the
 settings file) or when making changes to automatic installation files. In practice, this should not happen often, though
 running sync too many times does not cause any adverse effects.
 
-If using cobbler to manage a DHCP and/or DNS server (see the advanced section of this manpage), sync does need to be run
+If using Cobbler to manage a DHCP and/or DNS server (see the advanced section of this manpage), sync does need to be run
 after systems are added to regenerate and reload the DHCP/DNS configurations.
 
 The sync process can also be kicked off from the web interface.
@@ -732,7 +732,7 @@ Example:
 
     $ cobbler sync
 
-cobbler validate-autoinstalls
+Cobbler validate-autoinstalls
 =============================
 
 Example:
@@ -741,7 +741,7 @@ Example:
 
     $ cobbler validate-autoinstalls
 
-cobbler version
+Cobbler version
 ===============
 
 Example:
@@ -750,7 +750,7 @@ Example:
 
     $ cobbler version
 
-cobbler signature
+Cobbler signature
 =================
 
 Example:
@@ -759,7 +759,7 @@ Example:
 
     $ cobbler signature
 
-cobbler get-loaders
+Cobbler get-loaders
 ===================
 
 Example:
@@ -768,7 +768,7 @@ Example:
 
     $ cobbler get-loaders
 
-cobbler hardlink
+Cobbler hardlink
 ================
 
 Example:
@@ -780,7 +780,7 @@ Example:
 EXIT_STATUS
 ###########
 
-cobbler's command line returns a zero for success and non-zero for failure.
+Cobbler's command line returns a zero for success and non-zero for failure.
 
 Additional Help
 ###############

--- a/docs/cobblerd.rst
+++ b/docs/cobblerd.rst
@@ -7,7 +7,7 @@ cobbler - a provisioning and update server
 Preamble
 ########
 
-We will reefer to cobblerd here as "cobbler" because cobblerd is short for cobbler-daemon which is basically the server.
+We will refer to cobblerd here as "cobbler" because cobblerd is short for cobbler-daemon which is basically the server.
 The CLI will be referred to as Cobbler-CLI and Koan as Koan.
 
 Description
@@ -27,7 +27,7 @@ Systems associate a MAC, IP, and other networking details with a profile and opt
 Repositories contain yum mirror information. Using cobbler to mirror repositories is an optional feature, though
 provisioning and package management share a lot in common.
 
-Images are a catch-all concept for things that do not play nicely in the "distribution" category.  Most users will not
+Images are a catch-all concept for things that do not play nicely in the "distribution" category. Most users will not
 need these records initially and these are described later in the document.
 
 The main advantage of cobbler is that it glues together many disjoint technologies and concepts and abstracts the user
@@ -35,9 +35,9 @@ from the need to understand them. It allows the systems administrator to concent
 how it is done.
 
 This manpage will focus on the cobbler command line tool for use in configuring cobbler. There is also mention of the
-Cobbler WebUI which is usable for day-to-day operation of Cobbler once installed/configured. Docs on the API and XMLRPC
+Cobbler WebUI which is usable for day-to-day operation of Cobbler once installed/configured. Docs on the API and XML-RPC
 components are available online at `https://cobbler.github.io <https://cobbler.github.io>`_ or
-`https://cobbler.readthedocs.io <https://cobbler.readthedocs.io>`_
+`https://cobbler.readthedocs.io <https://cobbler.readthedocs.io>`_.
 
 Most users will be interested in the Web UI and should set it up, though the command line is needed for initial
 configuration -- in particular ``cobbler check`` and ``cobbler import``, as well as the repo mirroring features. All of
@@ -59,12 +59,12 @@ correct, automatic installation trees will not be found, and automated installat
 For PXE, if DHCP is to be run from the cobbler server, the DHCP configuration file should be changed as suggested by
 ``cobbler check``. If DHCP is not run locally, the ``next-server`` field on the DHCP server should at minimum point to
 the cobbler server's IP and the filename should be set to ``pxelinux.0``. Alternatively, cobbler can also generate your
-dhcp configuration file if you want to run dhcp locally -- this is covered in a later section. If you don't already have
+DHCP configuration file if you want to run DHCP locally -- this is covered in a later section. If you don't already have
 a DHCP setup managed by some other tool, allowing cobbler to manage your DHCP environment will prove to be useful as it
 can manage DHCP reservations and other data. If you already have a DHCP setup, moving an existing setup to be managed
 from within cobbler is relatively painless -- though usage of the DHCP management feature is entirely optional. If you
-are not interested in network booting via PXE and just want to use koan to install virtual systems or replace existing
-ones, DHCP configuration can be totally ignored. Koan also has a live CD (see koan's manpage) capability that can be
+are not interested in network booting via PXE and just want to use Koan to install virtual systems or replace existing
+ones, DHCP configuration can be totally ignored. Koan also has a live CD (see Koan's manpage) capability that can be
 used to simulate PXE environments.
 
 Autoinstallation (Autoyast/Kickstart)
@@ -74,7 +74,7 @@ For help in building kickstarts, try using the ``system-config-kickstart`` tool,
 ``/root/anaconda-ks.cfg`` file left over from the installer. General kickstart questions can also be asked at
 kickstart-list@redhat.com. Cobbler ships some autoinstall templates in /etc/cobbler that may also be helpful.
 
-For AutoYaST guides and help please reefer to `the opensuse project <https://doc.opensuse.org/projects/autoyast/>`_.
+For AutoYaST guides and help please refer to `the opensuse project <https://doc.opensuse.org/projects/autoyast/>`_.
 
 Also see the website or documentation for additional documentation, user contributed tips, and so on.
 

--- a/docs/cobblerd.rst
+++ b/docs/cobblerd.rst
@@ -2,12 +2,12 @@
 Cobblerd
 ***********************************
 
-cobbler - a provisioning and update server
+Cobbler - a provisioning and update server
 
 Preamble
 ########
 
-We will refer to cobblerd here as "cobbler" because cobblerd is short for cobbler-daemon which is basically the server.
+We will refer to `cobblerd` here as "cobbler" because `cobblerd` is short for cobbler-daemon which is basically the server.
 The CLI will be referred to as Cobbler-CLI and Koan as Koan.
 
 Description

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,13 +20,13 @@ sys.path.insert(0, os.path.abspath('..'))
 # -- Project information -----------------------------------------------------
 
 project = 'Cobbler'
-copyright = '2019, Enno Gotthold'
+copyright = '2020, Enno Gotthold'
 author = 'Enno Gotthold'
 
 # The short X.Y version
 version = '3.0'
 # The full version, including alpha/beta/rc tags
-release = '3.0.1'
+release = '3.1.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -103,7 +103,8 @@ html_theme_options = {
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# see https://github.com/readthedocs/readthedocs.org/issues/1776
+html_static_path = []
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.
@@ -196,7 +197,7 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,10 +13,10 @@ enabled by usage of 'Koan' on the remote system. Update server features include 
 mirrors with automated installation files. Cobbler has a command line interface, WebUI, and extensive Python and
 XML-RPC APIs for integration with external scripts and applications.
 
-If you want to explore tools or scripts which are using cobbler please use the GitHub Topic:
+If you want to explore tools or scripts which are using Cobbler please use the GitHub Topic:
 https://github.com/topics/cobbler
 
-Here you should find a comprehensive overview about the usage of cobbler.
+Here you should find a comprehensive overview about the usage of Cobbler.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -7,13 +7,13 @@
 Welcome to Cobbler's documentation!
 ***********************************
 
-cobbler is a provisioning (installation) and update server.  It supports deployments via PXE (network booting),
+Cobbler is a provisioning (installation) and update server. It supports deployments via PXE (network booting),
 virtualization (Xen, QEMU/KVM, or VMware), and re-installs of existing Linux systems. The latter two features are
-enabled by usage of 'koan' on the remote system. Update server features include yum mirroring and integration of those
-mirrors with automated installation files.  Cobbler has a command line interface, Web UI, and extensive Python and
-XMLRPC APIs for integration with external scripts and applications.
+enabled by usage of 'Koan' on the remote system. Update server features include yum mirroring and integration of those
+mirrors with automated installation files. Cobbler has a command line interface, WebUI, and extensive Python and
+XML-RPC APIs for integration with external scripts and applications.
 
-If you want to explore tools or scripts which are using cobbler please use the GitHub-Topic:
+If you want to explore tools or scripts which are using cobbler please use the GitHub Topic:
 https://github.com/topics/cobbler
 
 Here you should find a comprehensive overview about the usage of cobbler.

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -2,7 +2,7 @@
 Install Guide
 ***********************************
 
-Setting up and running cobblerd is not a easy task. Knowledge in apache configuration (setting up ssl, virtual hosts,
+Setting up and running `cobblerd` is not a easy task. Knowledge in apache configuration (setting up ssl, virtual hosts,
 apache module and wsgi) is needed. Certificates and some server administration knowledge is required too.
 
 Cobbler is available for installation in several different ways, through packaging systems for each distribution or
@@ -143,7 +143,7 @@ Init script:
 
 
 Source
-======
+######
 
 The latest source code is available through git:
 
@@ -173,7 +173,7 @@ To preserve your existing configuration files, snippets and automatic installati
 
 To install the Cobbler web GUI, use these steps:
 
-#. Copy the systemd service file for cobblerd from ``/etc/cobbler/cobblerd.service`` to your systemd unit directory.
+#. Copy the systemd service file for `cobblerd` from ``/etc/cobbler/cobblerd.service`` to your systemd unit directory.
 #. Install ``apache2-mod_wsgi-python3`` or the package responsible for your distro. (On Debian:
    ``libapache2-mod-wsgi-py3``)
 #. Enable the proxy module of Apache2 (``a2enmod proxy`` or something similar) if not enabled.

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -21,7 +21,7 @@ Packages
 Please note that installing any of the packages here via a package manager (such as dnf/yum or apt) can and will require
 a large number of ancilary packages, which we do not document here. The package definition should automatically pull
 these packages in and install them along with Cobbler, however it is always best to verify these requirements have been
-met prior to installing cobbler or any of its components.
+met prior to installing Cobbler or any of its components.
 
 First and foremost, Cobbler requires Python. Any 2.x version should work for 2.8.x releases. Since 3.0.0 you will need
 Python 3. Cobbler also requires the installation of the following packages:

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -155,8 +155,10 @@ The latest source code is available through git:
 The release30 branch corresponds to the official release version for the 3.0.x series. The master branch is the
 development series, and always uses an odd number for the minor version (for example, 3.1.0).
 
-When building from source, make sure you have the correct prerequisites. Once they are, you can install Cobbler with the
-following command:
+When building from source, make sure you have the correct prerequisites. The Makefile uses a script called
+`distro_build_configs.sh` which sets the correct environment variables. Be sure to source it if you do not
+use the Makefile.
+If all prerequisites are met, you can install Cobbler with the following command:
 
 .. code-block:: bash
 

--- a/docs/quickstart-guide.rst
+++ b/docs/quickstart-guide.rst
@@ -124,7 +124,7 @@ Notes on files and directories
 ##############################
 
 Cobbler makes heavy use of the ``/var`` directory. The ``/var/www/cobbler/distro_mirror`` directory is where all of the
-distrubtion and repository files are copied, so you will need 5-10GB of free space per distribution you wish to import.
+distribution and repository files are copied, so you will need 5-10GB of free space per distribution you wish to import.
 
 If you have installed Cobbler onto a system that has very little free space in the partition containing ``/var``, please
 read the :ref:`relocating-your-installation` section of the Installation Guide to learn how you can relocate your

--- a/docs/quickstart-guide.rst
+++ b/docs/quickstart-guide.rst
@@ -57,7 +57,7 @@ the quote marks):
 Server and next_server
 ======================
 
-The ``server`` option sets the IP that will be used for the address of the cobbler server. **DO NOT** use 0.0.0.0, as it
+The ``server`` option sets the IP that will be used for the address of the Cobbler server. **DO NOT** use 0.0.0.0, as it
 is not the listening address. This should be set to the IP you want hosts that are being built to contact the Cobbler
 server on for such protocols as HTTP and TFTP.
 
@@ -157,7 +157,7 @@ If everything has gone well, you should see output from the status command like 
 Checking for problems and your first sync
 #########################################
 
-Now that the cobblerd service is up and running, it's time to check for problems. Cobbler's check command will make some
+Now that the Cobblerd service is up and running, it's time to check for problems. Cobbler's check command will make some
 suggestions, but it is important to remember that these are mainly only suggestions and probably aren't critical for
 basic functionality. If you are running iptables or SELinux, it is important to review any messages concerning those that
 check may report.
@@ -262,7 +262,7 @@ In some cases (for instance when a Xen-based kernel is found), more than one dis
 Object details
 ++++++++++++++
 
-The report command shows the details of objects in cobbler:
+The report command shows the details of objects in Cobbler:
 
 .. code-block:: none
 
@@ -299,7 +299,7 @@ Creating a system
 +++++++++++++++++
 
 Now that you have a distro and profile, you can create a system. Profiles can be used to PXE boot, but most of the
-features in cobbler revolve around system objects. The more information you give about a system, the more cobbler will
+features in Cobbler revolve around system objects. The more information you give about a system, the more Cobbler will
 do automatically for you.
 
 First, we'll create a system object based on the profile that was created during the import. When creating a system, the
@@ -372,7 +372,7 @@ The ``--hostname`` field corresponds to the local system name and is returned by
 Neither are required, but it is a good practice to specify both. Some advanced features (like configuration management)
 rely on the ``--dns-name`` field for system record look-ups.
 
-Whenever a system is edited, cobbler executes what is known as a "lite sync", which regenerates critical files like the
+Whenever a system is edited, Cobbler executes what is known as a "lite sync", which regenerates critical files like the
 PXE boot file in the TFTP root directory. One thing it will **NOT** do is execute service management actions, like
 regenerating the ``dhcpd.conf`` and restarting the DHCP service. After adding a system with a static interface it is a
 good idea to execute a full ``cobbler sync`` to ensure the dhcpd.conf file is rewritten with the correct static lease

--- a/docs/quickstart-guide.rst
+++ b/docs/quickstart-guide.rst
@@ -31,10 +31,10 @@ TBD
 Changing settings
 ##################
 
-Before starting the cobblerd service, there are a few things you should modify.
+Before starting the `cobblerd` service, there are a few things you should modify.
 
 Settings are stored in ``/etc/cobbler/settings``. This file is a YAML formatted data file, so be sure to take care when
-editing this file as an incorrectly formatted file will prevent cobblerd from running.
+editing this file as an incorrectly formatted file will prevent `cobblerd` from running.
 
 
 Default encrypted password
@@ -157,7 +157,7 @@ If everything has gone well, you should see output from the status command like 
 Checking for problems and your first sync
 #########################################
 
-Now that the Cobblerd service is up and running, it's time to check for problems. Cobbler's check command will make some
+Now that the `cobblerd` service is up and running, it's time to check for problems. Cobbler's check command will make some
 suggestions, but it is important to remember that these are mainly only suggestions and probably aren't critical for
 basic functionality. If you are running iptables or SELinux, it is important to review any messages concerning those that
 check may report.
@@ -170,10 +170,10 @@ check may report.
     1. ....
     2. ....
 
-Restart cobblerd and then run ``cobbler sync`` to apply changes.
+Restart `cobblerd` and then run ``cobbler sync`` to apply changes.
 
 If you decide to follow any of the suggestions, such as installing extra packages, making configuration changes, etc.,
-be sure to restart the cobblerd service as it suggests so the changes are applied.
+be sure to restart the `cobblerd` service as it suggests so the changes are applied.
 
 Once you are done reviewing the output of ``cobbler check``, it is time to synchronize things for the first time. This
 is not critical, but a failure to properly sync at this point can reveal a configuration problem.

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -17,11 +17,11 @@ https://cobbler.github.io
 Triggers
 ########
 
-Triggers provide a way to integrate cobbler with arbitrary 3rd party software without modifying cobbler's code. When
+Triggers provide a way to integrate Cobbler with arbitrary 3rd party software without modifying Cobbler's code. When
 adding a distro, profile, system, or repo, all scripts in ``/var/lib/cobbler/triggers/add`` are executed for the
 particular object type. Each particular file must be executable and it is executed with the name of the item being added
 as a parameter. Deletions work similarly -- delete triggers live in ``/var/lib/cobbler/triggers/delete``. Order of
-execution is arbitrary, and cobbler does not ship with any triggers by default. There are also other kinds of triggers
+execution is arbitrary, and Cobbler does not ship with any triggers by default. There are also other kinds of triggers
 -- these are described on the Cobbler Wiki. For larger configurations, triggers should be written in Python -- in which
 case they are installed differently. This is also documented on the Wiki.
 
@@ -30,7 +30,7 @@ Images
 
 Cobbler can help with booting images physically and virtually, though the usage of these commands varies substantially
 by the type of image. Non-image based deployments are generally easier to work with and lead to more sustainable
-infrastructure. Some manual use of other commands beyond of what is typically required of cobbler may be needed to
+infrastructure. Some manual use of other commands beyond of what is typically required of Cobbler may be needed to
 prepare images for use with this feature.
 
 .. _power-management:
@@ -38,7 +38,7 @@ prepare images for use with this feature.
 Power Management
 ################
 
-Cobbler contains a power management feature that allows the user to associate system records in cobbler with the power
+Cobbler contains a power management feature that allows the user to associate system records in Cobbler with the power
 management configuration attached to them. This can ease installation by making it easy to reassign systems to new
 operating systems and then reboot those systems.
 
@@ -68,27 +68,27 @@ REPO MANAGEMENT
 
 This has already been covered a good bit in the command reference section.
 
-Yum repository management is an optional feature, and is not required to provision through cobbler. However, if cobbler
+Yum repository management is an optional feature, and is not required to provision through Cobbler. However, if Cobbler
 is configured to mirror certain repositories, it can then be used to associate profiles with those repositories. Systems
 installed under those profiles will then be autoconfigured to use these repository mirrors in ``/etc/yum.repos.d``, and
 if supported (Fedora Core 6 and later) these repositories can be leveraged even within Anaconda.  This can be useful if
 (A) you have a large install base, (B) you want fast installation and upgrades for your systems, or (C) have some extra
 software not in a standard repository but want provisioned systems to know about that repository.
 
-Make sure there is plenty of space in cobbler's webdir, which defaults to ``/var/www/cobbler``.
+Make sure there is plenty of space in Cobbler's webdir, which defaults to ``/var/www/cobbler``.
 
 .. code-block:: none
 
     cobbler reposync [--tries=N] [--no-fail]
 
 Cobbler reposync is the command to use to update repos as configured with "cobbler repo add".  Mirroring
-can take a long time, and usage of cobbler reposync prior to usage is needed to ensure provisioned systems have the
+can take a long time, and usage of Cobbler reposync prior to usage is needed to ensure provisioned systems have the
 files they need to actually use the mirrored repositories.  If you just add repos and never run "cobbler reposync", the
 repos will never be mirrored.  This is probably a command you would want to put on a crontab, though the frequency of
 that crontab and where the output goes is left up to the systems administrator.
 
-For those familiar with yum's reposync, cobbler's reposync is (in most uses) a wrapper around the yum command.  Please
-use "cobbler reposync" to update cobbler mirrors, as yum's reposync does not perform all required steps. Also cobbler
+For those familiar with yum's reposync, Cobbler's reposync is (in most uses) a wrapper around the yum command.  Please
+use "cobbler reposync" to update Cobbler mirrors, as yum's reposync does not perform all required steps. Also Cobbler
 adds support for rsync and SSH locations, where as yum's reposync only supports what yum supports (http/ftp).
 
 If you ever want to update a certain repository you can run:
@@ -100,8 +100,8 @@ If you ever want to update a certain repository you can run:
 When updating repos by name, a repo will be updated even if it is set to be not updated during a regular reposync
 operation (ex: cobbler repo edit --name=reponame1 --keep-updated=0).
 
-Note that if a cobbler import provides enough information to use the boot server as a yum mirror for core packages,
-cobbler can set up automatic installation files to use the cobbler server as a mirror instead of the outside world. If
+Note that if a Cobbler import provides enough information to use the boot server as a yum mirror for core packages,
+Cobbler can set up automatic installation files to use the Cobbler server as a mirror instead of the outside world. If
 this feature is desirable, it can be turned on by setting yum_post_install_mirror to 1 in /etc/settings (and running
 "cobbler sync").  You should not use this feature if machines are provisioned on a different VLAN/network than
 production, or if you are provisioning laptops that will want to acquire updates on multiple networks.
@@ -117,10 +117,10 @@ Cobbler can auto-add distributions and profiles from remote sources, whether thi
 mirror. This can save a lot of time when setting up a new provisioning environment. Import is a feature that many users
 will want to take advantage of, and is very simple to use.
 
-After an import is run, cobbler will try to detect the distribution type and automatically assign automatic installation
+After an import is run, Cobbler will try to detect the distribution type and automatically assign automatic installation
 files. By default, it will provision the system by erasing the hard drive, setting up eth0 for DHCP, and using a default
 password of "cobbler".  If this is undesirable, edit the automatic installation files in ``/etc/cobbler`` to do
-something else or change the automatic installation setting after cobbler creates the profile.
+something else or change the automatic installation setting after Cobbler creates the profile.
 
 Mirrored content is saved automatically in ``/var/www/cobbler/distro_mirror``.
 
@@ -146,7 +146,7 @@ stored on an external NAS box, or potentially on another partition on the same m
 
 For import methods using rsync, additional flags can be passed to rsync with the option ``--rsync-flags``.
 
-Should you want to force the usage of a specific cobbler automatic installation template for all profiles created by an
+Should you want to force the usage of a specific Cobbler automatic installation template for all profiles created by an
 import, you can feed the option ``--autoinst`` to import, to bypass the built-in automatic installation file
 auto-detection.
 
@@ -168,7 +168,7 @@ install those repository configurations on provisioned systems using that profil
 Import Workflow
 ===============
 
-Import is a very useful command that makes starting out with cobbler very quick and easy.
+Import is a very useful command that makes starting out with Cobbler very quick and easy.
 
 This example shows how to create a provisioning infrastructure from a distribution mirror or DVD ISO. Then a default PXE
 configuration is created, so that by default systems will PXE boot into a fully automated install process for that
@@ -180,7 +180,7 @@ Import knows how to autodetect the architecture of what is being imported, thoug
 correctly, it's always a good idea to specify ``--arch``. For instance, if you import a distribution named "fedora8"
 from an ISO, and it's an x86_64 ISO, specify ``--arch=x86_64`` and the distro will be named "fedora8-x86_64"
 automatically, and the right architecture field will also be set on the distribution object. If you are batch importing
-an entire mirror (containing multiple distributions and arches), you don't have to do this, as cobbler will set the
+an entire mirror (containing multiple distributions and arches), you don't have to do this, as Cobbler will set the
 names for things based on the paths it finds.
 
 .. code-block:: none
@@ -219,7 +219,7 @@ Define systems if desired. Koan can also provision based on the profile name.
 
     cobbler system add --name=AA:BB:CC:DD:EE:FE --profile=virtwebservers [...]
 
-If you have just installed cobbler, be sure that the "cobblerd" service is running and that port 25151 is unblocked.
+If you have just installed Cobbler, be sure that the "cobblerd" service is running and that port 25151 is unblocked.
 
 See the manpage for Koan for the client side steps.
 
@@ -240,7 +240,7 @@ To apply these changes, ``cobbler sync`` must be run to generate custom automati
 profile/system.
 
 For NFS and HTTP automatic installation file URLs, the ``--autoinstall_meta`` options will have no effect. This is a
-good reason to let cobbler manage your automatic installation files, though the URL functionality is provided for
+good reason to let Cobbler manage your automatic installation files, though the URL functionality is provided for
 integration with legacy infrastructure, possibly including web apps that already generate automatic installation files.
 
 Templated automatic files are processed by the templating program/package Cheetah, so anything you can do in a Cheetah
@@ -284,18 +284,18 @@ Cobbler will automatically generate PXE menus for all profiles it has defined. R
 generate and update these menus.
 
 To access the menus, type ``menu`` at the ``boot:`` prompt while a system is PXE booting. If nothing is typed, the
-network boot will default to a local boot. If "menu" is typed, the user can then choose and provision any cobbler
+network boot will default to a local boot. If "menu" is typed, the user can then choose and provision any Cobbler
 profile the system knows about.
 
 If the association between a system (MAC address) and a profile is already known, it may be more useful to just use
-``system add`` commands and declare that relationship in cobbler; however many use cases will prefer having a PXE
+``system add`` commands and declare that relationship in Cobbler; however many use cases will prefer having a PXE
 system, especially when provisioning is done at the same time as installing new physical machines.
 
 If this behavior is not desired, run ``cobbler system add --name=default --profile=plugh`` to default all PXE booting
 machines to get a new copy of the profile ``plugh``. To go back to the menu system, run
 ``cobbler system remove --name=default`` and then ``cobbler sync`` to regenerate the menus.
 
-When using PXE menu deployment exclusively, it is not necessary to make cobbler system records, although the two can
+When using PXE menu deployment exclusively, it is not necessary to make Cobbler system records, although the two can
 easily be mixed.
 
 Additionally, note that all files generated for the PXE menu configurations are templatable, so if you wish to change
@@ -304,13 +304,13 @@ the color scheme or equivalent, see the files in ``/etc/cobbler``.
 Default PXE Boot behavior
 =========================
 
-What happens when PXE booting a system when cobbler has no record of the system being booted?
+What happens when PXE booting a system when Cobbler has no record of the system being booted?
 
-By default, cobbler will configure PXE to boot to the contents of ``/etc/cobbler/default.pxe``, which (if unmodified)
+By default, Cobbler will configure PXE to boot to the contents of ``/etc/cobbler/default.pxe``, which (if unmodified)
 will just fall through to the local boot process. Administrators can modify this file if they like to change that
 behavior.
 
-An easy way to specify a default cobbler profile to PXE boot is to create a system named ``default``. This will cause
+An easy way to specify a default Cobbler profile to PXE boot is to create a system named ``default``. This will cause
 ``/etc/cobbler/default.pxe`` to be ignored. To restore the previous behavior do a ``cobbler system remove`` on the
 ``default`` system.
 
@@ -345,7 +345,7 @@ Cobbler knows how to keep track of the status of automatic installation of machi
 
     cobbler status
 
-Using the status command will show when cobbler thinks a machine started automatic installation and when it finished,
+Using the status command will show when Cobbler thinks a machine started automatic installation and when it finished,
 provided the proper snippets are found in the automatic installation template. This is a good way to track machines that
 may have gone interactive (or stalled/crashed) during automatic installation.
 
@@ -367,9 +367,9 @@ Choose either ``management = isc_and_bind`` in ``/etc/cobbler/dhcp.template`` or
 ``/etc/cobbler/modules.conf``.  Then set ``manage_dhcp=1`` in ``/etc/cobbler/settings``.
 
 This allows DHCP to be managed via "cobbler system add" commands, when you specify the mac address and IP address for
-systems you add into cobbler.
+systems you add into Cobbler.
 
-Depending on your choice, cobbler will use ``/etc/cobbler/dhcpd.template`` or ``/etc/cobbler/dnsmasq.template`` as a
+Depending on your choice, Cobbler will use ``/etc/cobbler/dhcpd.template`` or ``/etc/cobbler/dnsmasq.template`` as a
 starting point. This file must be user edited for the user's particular networking environment. Read the file and
 understand how the particular app (ISC dhcpd or dnsmasq) work before proceeding.
 
@@ -411,5 +411,5 @@ feature.
 Containerization
 ################
 
-We have a test-image which you can find in the cobbler repository and an old image made by the community:
+We have a test-image which you can find in the Cobbler repository and an old image made by the community:
 https://github.com/osism/docker-cobbler

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -11,7 +11,7 @@ User Guide
 
 API
 ###
-Cobbler also makes itself available as an XMLRPC API for use by higher level management software. Learn more at
+Cobbler also makes itself available as an XML-RPC API for use by higher level management software. Learn more at
 https://cobbler.github.io
 
 Triggers
@@ -213,7 +213,7 @@ Specify reasonable values for the Virt image size (in GB) and RAM requirements (
 
     cobbler profile add --name=virtwebservers --distro=fc7virt --autoinst=path --virt-file-size=10 --virt-ram=512 [...]
 
-Define systems if desired.  koan can also provision based on the profile name.
+Define systems if desired. Koan can also provision based on the profile name.
 
 .. code-block:: none
 
@@ -221,7 +221,7 @@ Define systems if desired.  koan can also provision based on the profile name.
 
 If you have just installed cobbler, be sure that the "cobblerd" service is running and that port 25151 is unblocked.
 
-See the manpage for koan for the client side steps.
+See the manpage for Koan for the client side steps.
 
 Autoinstallation
 ################
@@ -298,7 +298,7 @@ machines to get a new copy of the profile ``plugh``. To go back to the menu syst
 When using PXE menu deployment exclusively, it is not necessary to make cobbler system records, although the two can
 easily be mixed.
 
-Additionally, note that all files generated for the pxe menu configurations are templatable, so if you wish to change
+Additionally, note that all files generated for the PXE menu configurations are templatable, so if you wish to change
 the color scheme or equivalent, see the files in ``/etc/cobbler``.
 
 Default PXE Boot behavior
@@ -354,7 +354,7 @@ Boot CD
 
 Cobbler can build all of it's profiles into a bootable CD image using the ``cobbler buildiso`` command. This allows for
 PXE-menu like bring up of bare metal in environments where PXE is not possible. Another more advanced method is described
-in the koan manpage, though this method is easier and sufficient for most applications.
+in the Koan manpage, though this method is easier and sufficient for most applications.
 
 .. _dhcp-management:
 
@@ -381,7 +381,7 @@ By default, the DHCP configuration file will be updated each time ``cobbler sync
 important to remember to use ``cobbler sync`` when using this feature.
 
 If omapi_enabled is set to 1 in ``/etc/cobbler/settings``, the need to sync when adding new system records can be
-eliminated. However, the omapi feature is experimental and is not recommended for most users.
+eliminated. However, the OMAPI feature is experimental and is not recommended for most users.
 
 .. _dns-management:
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -219,7 +219,7 @@ Define systems if desired. Koan can also provision based on the profile name.
 
     cobbler system add --name=AA:BB:CC:DD:EE:FE --profile=virtwebservers [...]
 
-If you have just installed Cobbler, be sure that the "cobblerd" service is running and that port 25151 is unblocked.
+If you have just installed Cobbler, be sure that the `cobblerd` service is running and that port 25151 is unblocked.
 
 See the manpage for Koan for the client side steps.
 

--- a/docs/user-guide/configuration-management-integrations.rst
+++ b/docs/user-guide/configuration-management-integrations.rst
@@ -173,7 +173,7 @@ Further uses
 
 This Cobbler/Cheetah templating system can serve up templates via the magic URLs (see "Leveraging Mod Python" below).
 To do this ensure that the destination path given to any ``--template-files`` element is relative, not absolute; then
-Cobbler and koan won't download those files.
+Cobbler and Koan won't download those files.
 
 For example, in:
 
@@ -204,7 +204,7 @@ Terraform Provider
 ##################
 
 This is developed and maintained by the Terraform community. You will find more information in the docs under
-https://www.terraform.io/docs/providers/cobbler/index.html
+https://www.terraform.io/docs/providers/cobbler/index.html.
 
 The code for the Terraform-Provider can be found at: https://github.com/terraform-providers/terraform-provider-cobbler
 
@@ -263,7 +263,7 @@ have to be doing).
 External Nodes
 ==============
 
-For more documentation on Puppet's external nodes feature, see https://docs.puppetlabs.com
+For more documentation on Puppet's external nodes feature, see https://docs.puppetlabs.com.
 
 Cobbler provides one, so configure puppet to use ``/usr/bin/cobbler-ext-nodes``:
 

--- a/docs/user-guide/web-interface.rst
+++ b/docs/user-guide/web-interface.rst
@@ -9,7 +9,7 @@ Web-Interface
 
 Please be patient until we have time to rework this section or please file a PR for this section.
 
-The standard login for the Web-UI can be read below. We would recommend to change this as soon as possible!
+The standard login for the WebUI can be read below. We would recommend to change this as soon as possible!
 
 Username: ``cobbler``
 Password: ``cobbler``
@@ -100,7 +100,7 @@ Basic Setup
 
     cp /etc/httpd/conf.d/cobbler.conf.rpmnew /etc/httpd/conf.d/cobbler.conf
 
-6.  Now restart Apache and Cobblerd
+6.  Now restart Apache and cobblerd
 
 .. code-block:: none
 
@@ -191,7 +191,7 @@ Cobbler start and thus a change of the data requires that Cobbler is restarted t
 Rewrite Rule for secure-http
 ============================
 
-To redirect access to the WebUI via https on an Apache webserver, you can use the following rewrite rule, probably at
+To redirect access to the WebUI via HTTPS on an Apache webserver, you can use the following rewrite rule, probably at
 the end of Apache's ``ssl.conf``:
 
 .. code-block:: none

--- a/docs/user-guide/web-interface.rst
+++ b/docs/user-guide/web-interface.rst
@@ -100,7 +100,7 @@ Basic Setup
 
     cp /etc/httpd/conf.d/cobbler.conf.rpmnew /etc/httpd/conf.d/cobbler.conf
 
-6.  Now restart Apache and cobblerd
+6.  Now restart Apache and `cobblerd`.
 
 .. code-block:: none
 


### PR DESCRIPTION
See #2406.

This fixes:

- Broken source installation guide
- Grammar and Spelling
- A broken table in the manpage and the online view due to a missing `+`.