### PR TITLE
Fix for file dependency on CentOS 8. Fixes #2334

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -198,6 +198,7 @@ Requires(postun): systemd
 Requires:       %{apache_pkg}
 Requires:       %{tftpsrv_pkg}
 Requires:       %{createrepo_pkg}
+Requires:       file
 Requires:       rsync
 Requires:       xorriso
 %{?python_enable_dependency_generator}
@@ -240,13 +241,13 @@ Obsoletes:      cobbler-nsupdate < 3.0.99
 Provides:       cobbler-nsupdate = %{version}-%{release}
 
 %description
-Cobbler is a network install server.  Cobbler supports PXE, ISO
+Cobbler is a network install server. Cobbler supports PXE, ISO
 virtualized installs, and re-installing existing Linux machines.
 The last two modes use a helper tool, 'koan', that integrates with
-cobbler.  There is also a web interface 'cobbler-web'.  Cobbler's
+cobbler. There is also a web interface 'cobbler-web'. Cobbler's
 advanced features include importing distributions from DVDs and rsync
 mirrors, kickstart templating, integrated yum mirroring, and built-in
-DHCP/DNS Management.  Cobbler has a XMLRPC API for integration with
+DHCP/DNS Management. Cobbler has a XML-RPC API for integration with
 other applications.
 
 


### PR DESCRIPTION
* should fix #2334 according to @SchoolGuy
* remove some unnecessary whitespaces
* correct the writting of XML-RPC.

I built the package locally with `osc build` and it looks good so far.