### PR TITLE
Added compatibility for Raspberry Pi OS

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -51,7 +51,7 @@ from cobbler import validate
 
 CHEETAH_ERROR_DISCLAIMER = """
 # *** ERROR ***
-#
+#  
 # There is a templating error preventing this file from rendering correctly.
 #
 # This is most likely not due to a bug in Cobbler and is something you can fix.
@@ -1023,7 +1023,7 @@ def get_family():
     for item in redhat_list:
         if item in distro_name:
             return "redhat"
-    if "debian" in distro_name or "ubuntu" in distro_name:
+    if "debian" in distro_name or "ubuntu" in distro_name or "raspbian" in distro_name:
         return "debian"
     if "suse" in distro.like():
         return "suse"
@@ -1039,6 +1039,11 @@ def os_release():
     family = get_family()
     distro_name = distro.name().lower()
     distro_version = distro.version()
+    
+    if "raspbian" in distro_name:
+        distro_name = "debian"
+        family = "debian"
+        
     if family == "redhat":
         if "fedora" in distro_name:
             make = "fedora"


### PR DESCRIPTION
Assume 'debian' for Raspbian GNU/Linux

This enables cobbler to work on Raspberry PI (we use a "mobile" cobbler for custom made embedded machines)