### PR TITLE
Better performing string replacements

### DIFF
--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -26,8 +26,7 @@ import weakref
 import uuid
 
 from cobbler.cexceptions import CX
-from cobbler.cobbler_collections import files as files, systems as systems, mgmtclasses as mgmtclasses, \
-    distros as distros, profiles as profiles, repos as repos, packages as packages, images as images
+from cobbler.cobbler_collections import files, systems, mgmtclasses, distros, profiles, repos, packages, images
 from cobbler import settings
 from cobbler import serializer
 

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -24,6 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 from builtins import str
 from builtins import object
+import re
 import Cheetah
 import functools
 import os
@@ -139,9 +140,11 @@ class Templar(object):
             repstr = server
         search_table["http_server"] = repstr
 
-        for x in list(search_table.keys()):
-            if type(x) == str:
-                data_out = data_out.replace("@@%s@@" % str(x), str(search_table[str(x)]))
+        # string replacements for @@xyz@@ in data_out with prior regex lookups of keys
+        regex = r"@@[a-zA-Z]*@@"
+        matches = re.finditer(regex, data_out, re.MULTILINE)
+        for matchNum, match in enumerate(matches, start=1):
+            data_out = data_out.replace(match.group(), search_table[str(match.group()).strip("@@")])
 
         # remove leading newlines which apparently breaks AutoYAST ?
         if data_out.startswith("\n"):

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -141,7 +141,7 @@ class Templar(object):
         search_table["http_server"] = repstr
 
         # string replacements for @@xyz@@ in data_out with prior regex lookups of keys
-        regex = r"@@[a-zA-Z]*@@"
+        regex = r"@@[\S]*@@"
         regex_matches = re.finditer(regex, data_out, re.MULTILINE)
         matches = set([match.group() for match_num, match in enumerate(regex_matches, start=1)])
         for match in matches:

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -142,9 +142,10 @@ class Templar(object):
 
         # string replacements for @@xyz@@ in data_out with prior regex lookups of keys
         regex = r"@@[a-zA-Z]*@@"
-        matches = re.finditer(regex, data_out, re.MULTILINE)
-        for matchNum, match in enumerate(matches, start=1):
-            data_out = data_out.replace(match.group(), search_table[str(match.group()).strip("@@")])
+        regex_matches = re.finditer(regex, data_out, re.MULTILINE)
+        matches = set([match.group() for match_num, match in enumerate(regex_matches, start=1)])
+        for match in matches:
+            data_out = data_out.replace(match, search_table[match.strip("@@")])
 
         # remove leading newlines which apparently breaks AutoYAST ?
         if data_out.startswith("\n"):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,7 @@ Here you should find a comprehensive overview about the usage of cobbler.
    Developer Guide <developer-guide>
    Cobbler-Code Documentation<code-autodoc/cobbler>
    Release Notes <release-notes>
+   Limitations and Surprises <limitations>
 
 Indices and tables
 ##################

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -1,0 +1,8 @@
+*************************
+Limitations and Surprises
+*************************
+
+Templating
+==========
+
+Before templates are passed to Jinja or Cheetah there is a pre-processing of templates happening. During pre-processing Cobbler replaces variables like ``@@my_key@@`` in the template. Those keys are currently limited by the regex of ``\S``, which translates to ``[^ \t\n\r\f\v]``.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,7 +13,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "env(name): mark test to run only on named environment")
 
 
-@pytest.fixture("session")
+@pytest.fixture(scope="session")
 def file_basedir():
     """
     This is the base-directory for fake files which are needed for the test. The advantage of the location under
@@ -24,7 +24,7 @@ def file_basedir():
     return "/dev/shm/cobbler_test"
 
 
-@pytest.fixture("session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def create_file_basedir(file_basedir):
     """
     This creates the directory needed for the cobbler tests.
@@ -35,7 +35,7 @@ def create_file_basedir(file_basedir):
         os.makedirs(file_basedir)
 
 
-@pytest.fixture("session", autouse=True)
+@pytest.fixture(scope="session", autouse=True)
 def delete_file_basedir(file_basedir):
     if os.path.exists(file_basedir):
         shutil.rmtree(file_basedir)


### PR DESCRIPTION
Previously we where iterating over the whole search table to do string replacements. This can and will in most of the cases be very wasteful.

In order to prevent this, a regex lookup is now performed that returns the keys that are used in the template and only for those keys we do a str.replace().

Here are some tests with 60 iterations of `cobbler profile create …` and `cobbler profile remove`.

```
##############################
#    Without regex lookup    #
##############################

localhost:/home/brejoc # time ./fake-cobbler.sh create
real    1m28.936s
user    0m47.902s
sys     0m3.037s
localhost:/home/brejoc # time ./fake-cobbler.sh remove
real    1m16.252s
user    0m47.524s
sys     0m3.197s
localhost:/home/brejoc # time ./fake-cobbler.sh create
real    1m28.280s
user    0m47.958s
sys     0m2.999s
localhost:/home/brejoc # time ./fake-cobbler.sh remove
real    1m16.329s
user    0m47.646s
sys     0m3.184s


##############################
#      With regex lookup     #
##############################

localhost:/home/brejoc # time ./fake-cobbler.sh create
real    1m20.998s
user    0m47.726s
sys     0m3.298s
localhost:/home/brejoc # time ./fake-cobbler.sh remove
real    1m11.269s
user    0m47.901s
sys     0m3.043s
localhost:/home/brejoc # time ./fake-cobbler.sh create
real    1m21.509s
user    0m48.258s
sys     0m3.061s
localhost:/home/brejoc # time ./fake-cobbler.sh remove
real    1m11.319s
user    0m47.692s
sys     0m3.206s
```