### PR TITLE
Permissions for /var/lib/cobbler/web.ss

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -328,6 +328,10 @@ ln -sf service %{buildroot}%{_sbindir}/rccobblerd
 # cobbler-web
 rm %{buildroot}%{_sysconfdir}/cobbler/cobbler_web.conf
 
+# ghosted files
+touch %{buildroot}%{_sharedstatedir}/cobbler/web.ss
+chmod 0600 %{buildroot}%{_sharedstatedir}/cobbler/web.ss
+
 
 %pre
 %if %{_vendor} == "debbuild"
@@ -503,10 +507,12 @@ sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler
 # Work around broken attr support
 # Cf. https://github.com/debbuild/debbuild/issues/160
 %{_datadir}/cobbler/web
+%ghost %{_sharedstatedir}/cobbler/web.ss
 %dir %{_sharedstatedir}/cobbler/webui_sessions
 %{apache_dir}/cobbler_webui_content/
 %else
 %attr(-,%{apache_user},%{apache_group}) %{_datadir}/cobbler/web
+%ghost %attr(0660,%{apache_user},root) %{_sharedstatedir}/cobbler/web.ss
 %dir %attr(700,%{apache_user},root) %{_sharedstatedir}/cobbler/webui_sessions
 %attr(-,%{apache_user},%{apache_group}) %{apache_dir}/cobbler_webui_content/
 %endif

--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -57,7 +57,7 @@ def regen_ss_file():
     data = fd.read(512)
     fd.close()
 
-    fd = os.open(ssfile, os.O_CREAT | os.O_RDWR, 0o600)
+    fd = os.open(ssfile, os.O_CREAT | os.O_RDWR, 0o660)
     os.write(fd, binascii.hexlify(data))
     os.close(fd)
 


### PR DESCRIPTION
On recent SELinux systems, root permissions must be explicitly given.  As is stands, root does not have read/write permissions to /var/lib/cobbler/web.ss.

I've also added the file as a %ghosted file to the spec.  Not quite sure about the debian workarounds for %attr and %ghosted files.