### PR TITLE
Order loading parent profiles before sub-profiles

### DIFF
--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -166,32 +166,18 @@ def deserialize(collection, topological=True):
     """
     Load a collection from file system.
 
-    :param collection: The collection type the deserialize
-    :param topological: If the dict/list should be sorted or not.
+    :param collection: The collection to deserialize.
+    :param topological: If the collection list should be sorted by the
+                        collection dict depth value or not.
     :type topological: bool
     """
 
     datastruct = deserialize_raw(collection.collection_types())
     if topological and type(datastruct) == list:
-        # FIXME
-        # datastruct.sort(key=__depth_cmp)
-        pass
+        datastruct.sort(key = lambda x: x["depth"])
     if type(datastruct) == dict:
         collection.from_dict(datastruct)
     elif type(datastruct) == list:
         collection.from_list(datastruct)
-
-
-def __depth_cmp(item1, item2):
-    """
-    The compare function to sort a dict.
-
-    :param item1: The first item to compare.
-    :param item2: The second item to compare.
-    :return: Weather the first or second item is bigger!
-    """
-    d1 = item1.get("depth", 1)
-    d2 = item2.get("depth", 1)
-    return (d1 > d2) - (d1 < d2)
 
 # EOF

--- a/cobbler/modules/serializers/mongodb.py
+++ b/cobbler/modules/serializers/mongodb.py
@@ -141,29 +141,17 @@ def deserialize(collection, topological=True):
     Load a collection from the database.
 
     :param collection: The collection to deserialize.
-    :param topological: This sorts the returned dict.
+    :param topological: If the collection list should be sorted by the
+                        collection dict depth value or not.
     :type topological: bool
     """
 
     datastruct = deserialize_raw(collection.collection_type())
     if topological and type(datastruct) == list:
-        datastruct.sort(__depth_cmp)
+        datastruct.sort(key = lambda x: x["depth"])
     if type(datastruct) == dict:
         collection.from_dict(datastruct)
     elif type(datastruct) == list:
         collection.from_list(datastruct)
-
-
-def __depth_cmp(item1, item2):
-    """
-    The comparison function to sort a dict.
-
-    :param item1: The first item to compare.
-    :param item2: The second item to compare.
-    :return: Weather the first or second item is bigger.
-    """
-    d1 = item1.get("depth", 1)
-    d2 = item2.get("depth", 1)
-    return (d1 > d2) - (d1 < d2)
 
 # EOF

--- a/cobbler/serializer.py
+++ b/cobbler/serializer.py
@@ -117,7 +117,11 @@ def deserialize(collection, topological=True):
     Load a collection from disk.
 
     :param collection: The Cobbler collection to know the type of the item.
-    :param topological: Unkown parameter.
+    :param topological: Sort collection based on each items' depth attribute
+                        in the list of collection items.  This ensures
+                        properly ordered object loading from disk with
+                        objects having parent/child relationships, i.e.
+                        profiles/subprofiles.  See cobbler/items/item.py
     :type topological: bool
     """
     __grab_lock()


### PR DESCRIPTION
Potential fix for [#2259](https://github.com/cobbler/cobbler/issues/2259)

I ran into the same issue and the following are my findings.
```
# cobbler --version
Cobbler 3.1.2
  source: b'97654ed0', b'Tue Oct 13 09:58:06 2020 +0200'
  build time: Thu Oct 15 23:35:55 2020
```
```
# pwd
/var/lib/cobbler/collections/profiles
```
Unsorted directory contents:
```
# ls -1U
CentOS-8.2.2004-x86_64.json.json
minimal-aimpart.json.json
worker-S2600JF.json.json
minimal.json.json
```
minimal has `---distro=CentOS-8.2.2004-x86_64`
minimal-aimpart has `--parent=minimal`
worker-S2600JF has `--parent=minimal-aimpart`
```
# /usr/bin/cobblerd -F
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/cobbler/cobbler_collections/manager.py", line 185, in deserialize
    serializer.deserialize(collection)
  File "/usr/lib/python3.6/site-packages/cobbler/serializer.py", line 125, in deserialize
    storage_module.deserialize(collection, topological)
  File "/usr/lib/python3.6/site-packages/cobbler/modules/serializers/file.py", line 185, in deserialize
    collection.from_list(datastruct)
  File "/usr/lib/python3.6/site-packages/cobbler/cobbler_collections/collection.py", line 211, in from_list
    self.add(item)
  File "/usr/lib/python3.6/site-packages/cobbler/cobbler_collections/collection.py", line 349, in add
    ref.check_if_valid()
  File "/usr/lib/python3.6/site-packages/cobbler/items/profile.py", line 137, in check_if_valid
    raise CX("Error with profile %s - distro is required" % (self.name))
cobbler.cexceptions.CX: 'Error with profile minimal-aimpart - distro is required'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/cobblerd", line 75, in main
    api = cobbler_api.CobblerAPI(is_cobblerd=True)
  File "/usr/lib/python3.6/site-packages/cobbler/api.py", line 106, in __init__
    self.deserialize()
  File "/usr/lib/python3.6/site-packages/cobbler/api.py", line 1526, in deserialize
    return self._collection_mgr.deserialize()
  File "/usr/lib/python3.6/site-packages/cobbler/cobbler_collections/manager.py", line 187, in deserialize
    raise CX("serializer: error loading collection %s: %s. Check /etc/cobbler/modules.conf" % (collection.collection_type(), e))
cobbler.cexceptions.CX: "serializer: error loading collection profile: 'Error with profile minimal-aimpart - distro is required'. Check /etc/cobbler/modules.conf"
```
mv files out/back into /var/lib/cobbler/collections/profiles so the
unsorted file list order will create parent profiles before sub-profiles:
```
# ls -1U
CentOS-8.2.2004-x86_64.json.json
minimal.json.json
minimal-aimpart.json.json
worker-S2600JF.json.json
```
```
# /usr/bin/cobblerd -F
SERVING!
```

This patch loads profiles that have distro specified or sub-profiles where the parent has already been loaded.