### PR TITLE
Remove redundant '.json' addition in serialize_item and serialize_delete

### DIFF
--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -71,7 +71,6 @@ def serialize_item(collection, item):
         sort_keys = False
         indent = None
 
-    filename += ".json"
     _dict = item.to_dict()
     fd = open(filename, "w+")
     data = simplejson.dumps(_dict, encoding="utf-8", sort_keys=sort_keys, indent=indent)
@@ -91,7 +90,6 @@ def serialize_delete(collection, item):
     collection_types = collection.collection_types()
     filename = os.path.join(libpath, collection_types, item.name + ".json")
 
-    filename += ".json"
     if os.path.exists(filename):
         os.remove(filename)
 


### PR DESCRIPTION
Older versions of cobbler only had `*.json` files and not `*.json.json` files under `/var/lib/cobbler/config/*.d/`, however, cobbler 3.1.2 is showing this:
```
# ls /var/lib/cobbler/collections/profiles/
CentOS-8.2.2004-x86_64.json.json  minimal-aimpart.json.json   minimal.json.json
worker-S2600JF.json.json    minimal-autopart.json.json
# ls /var/lib/cobbler/collections/systems/
c1732.json.json  c2223.json.json
c2221.json.json  c2224.json.json
c2222.json.json  vm_cobbler.pki.json.json
```
Looks like issue was introduced in cf261719dc07429059cbd8912557ebb21bd7ea62