### PR TITLE
Fedora 31 EOL, replace with Fedora 33

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ jobs:
       name: "Build CentOS 8 RPMs"
       script: ./tests/build-and-install-rpms.sh el8 dockerfiles/CentOS8.dockerfile
     - stage: rpms
-      name: "Build Fedora 31 RPMs"
-      script: ./tests/build-and-install-rpms.sh fc31 dockerfiles/Fedora31.dockerfile
+      name: "Build Fedora 33 RPMs"
+      script: ./tests/build-and-install-rpms.sh fc33 dockerfiles/Fedora33.dockerfile
     - stage: debs
       name: "Build Debian 10 DEBs"
       script: ./tests/build-and-install-debs.sh deb10 dockerfiles/Debian10.dockerfile

--- a/Makefile
+++ b/Makefile
@@ -101,8 +101,8 @@ test-centos7: ## Executes the testscript for testing cobbler in a docker contain
 test-centos8: ## Executes the testscript for testing cobbler in a docker container on CentOS8.
 	./tests/build-and-install-rpms.sh --with-tests el8 dockerfiles/CentOS8.dockerfile
 
-test-fedora31: ## Executes the testscript for testing cobbler in a docker container on Fedora 31.
-	./tests/build-and-install-rpms.sh --with-tests f31 dockerfiles/Fedora31.dockerfile
+test-fedora33: ## Executes the testscript for testing cobbler in a docker container on Fedora 33.
+	./tests/build-and-install-rpms.sh --with-tests fc33 dockerfiles/Fedora33.dockerfile
 
 test-debian10: ## Executes the testscript for testing cobbler in a docker container on Debian 10.
 	./tests/build-and-install-debs.sh --with-tests deb10 dockerfiles/Debian10.dockerfile

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -303,8 +303,8 @@ echo "ERROR: DOCPATH: ${DOCPATH} does not match %{_mandir}"
 # [ "${ETCPATH}" != "/etc/cobbler" ]
 # [ "${LIBPATH}" != "/var/lib/cobbler" ]
 [ "${LOGPATH}" != %{_localstatedir}/log ] && echo "ERROR: LOGPATH: ${LOGPATH} does not match %{_localstatedir}/log"
-[ "${COMPLETION_PATH}" != %{_datadir}/bash-completion/completions/cobbler ] && \
-    echo "ERROR: COMPLETION: ${COMPLETION_PATH} does not match %{_datadir}/bash-completion/completions/cobbler"
+[ "${COMPLETION_PATH}" != %{_datadir}/bash-completion/completions ] && \
+    echo "ERROR: COMPLETION: ${COMPLETION_PATH} does not match %{_datadir}/bash-completion/completions"
 
 [ "${WEBROOT}" != %{apache_dir} ] && echo "ERROR: WEBROOT: ${WEBROOT} does not match %{apache_dir}"
 [ "${WEBCONFIG}" != %{apache_webconfigdir} ] && echo "ERROR: WEBCONFIG: ${WEBCONFIG} does not match %{apache_webconfigdir}"

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -16,8 +16,8 @@
 # Force bash instead of Debian dash
 %global _buildshell /bin/bash
 
-# Exclude "shebang which doesn't start with '/' (gpxe)"
-%global __brp_mangle_shebangs_exclude_from /etc/cobbler/boot_loader_conf/gpxe*
+# Stop mangling shebangs. It breaks CI.
+%undefine __brp_mangle_shebangs
 
 # Work around quirk in OBS about handling defines...
 %if 0%{?el7}

--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 export DATAPATH="/usr/share/cobbler"
-export DOCPATH="share/man"
+export DOCPATH="/usr/share/man"
 export ETCPATH="/etc/cobbler"
 export LIBPATH="/var/lib/cobbler"
 export LOGPATH="/var/log"

--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -38,18 +38,19 @@ if [ "$DISTRO" = "SUSE" ];then
     export APACHE_GROUP="www"
 elif [ "$DISTRO" = "UBUNTU" ];then
     export APACHE_USER="www-data"
+    export HTTP_USER=$APACHE_USER # overrule setup.py
     export APACHE_GROUP="www-data"
-    export WEBROOT="/var/www";
-    export WEBCONFIG="/etc/apache2/conf-available";
+    export WEBROOT="/var/www"
+    export WEBCONFIG="/etc/apache2/conf-available"
     export DEFAULTPATH="etc/default"
 elif [ "$DISTRO" = "FEDORA" ];then
     export APACHE_USER="apache"
+    export HTTP_USER=$APACHE_USER # overrule setup.py
     export APACHE_GROUP="apache"
-
     export HTTPD_SERVICE="httpd.service"
-    export WEBROOT="/var/www";
-    export WEBCONFIG="/etc/httpd/conf.d";
-    export WEBROOTCONFIG="/etc/httpd";
+    export WEBROOT="/var/www"
+    export WEBCONFIG="/etc/httpd/conf.d"
+    export WEBROOTCONFIG="/etc/httpd"
     export TFTPROOT="/var/lib/tftpboot"
 else
     echo "ERROR, unknown distro $DISTRO"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,11 +20,11 @@ services:
     volumes:
       - ./rpm-build/el8:/usr/src/cobbler/rpm-build
 
-  fedora31-build:
-    image: local/cobbler-fedora31
-    container_name: cobbler-fedora31
+  fedora33-build:
+    image: local/cobbler-fedora33
+    container_name: cobbler-fedora33
     build:
       context: .
-      dockerfile: ./dockerfiles/Fedora31.dockerfile
+      dockerfile: ./dockerfiles/Fedora33.dockerfile
     volumes:
-      - ./rpm-build/f31:/usr/src/cobbler/rpm-build
+      - ./rpm-build/f33:/usr/src/cobbler/rpm-build

--- a/dockerfiles/Fedora33.dockerfile
+++ b/dockerfiles/Fedora33.dockerfile
@@ -1,6 +1,6 @@
 # vim: ft=dockerfile
 
-FROM fedora:31
+FROM fedora:33
 
 RUN dnf makecache
 
@@ -18,7 +18,6 @@ RUN dnf install -y          \
     python3-wheel           \
     python3-distro          \
     python3-future          \
-    python3-pep8            \
     python3-pyflakes        \
     python3-pycodestyle     \
     python3-setuptools      \


### PR DESCRIPTION
[Fedora 31 has reached EOL](https://www.qubes-os.org/news/2020/11/24/fedora-31-eol/) on Nov. 24th 2020.

This PR will replace Docker Fedora 31 with Docker  Fedora 33.

I had to work around / fix errors like these:

`error: bare words are no longer supported, please use "...": redhat == debbuild` 

`shebang which doesn't start with '/' (gpxe)`