### PR TITLE
cobbler issue #2467: add name of missing configuration parameter.

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -325,4 +325,4 @@ class Settings(object):
                 self.__dict__[name] = lookup
                 return lookup
             else:
-                raise AttributeError
+		raise AttributeError(f"no settings attribute named '{ name }' found")

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -325,4 +325,4 @@ class Settings(object):
                 self.__dict__[name] = lookup
                 return lookup
             else:
-		raise AttributeError(f"no settings attribute named '{ name }' found")
+        raise AttributeError(f"no settings attribute named '{ name }' found")

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -325,4 +325,4 @@ class Settings(object):
                 self.__dict__[name] = lookup
                 return lookup
             else:
-        raise AttributeError(f"no settings attribute named '{ name }' found")
+                raise AttributeError(f"no settings attribute named '{ name }' found")

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -115,7 +115,7 @@ def log_exc(logger):
     :param logger: The logger to audit all action.
     """
     (t, v, tb) = sys.exc_info()
-    logger.info("Exception occured: %s" % t)
+    logger.info("Exception occurred: %s" % t)
     logger.info("Exception value: %s" % v)
     logger.info("Exception Info:\n%s" % "\n".join(traceback.format_list(traceback.extract_tb(tb))))
 


### PR DESCRIPTION
One line change to settings to show the name of a missing configuration parameter instead of just raising an AttributeError without a description.

I also fixed a typo in the utils error message: Occured -> Occurred.