### PR TITLE
New RPM release file prefixes for CentOS 8.3 and CentOS Stream 8.

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -124,7 +124,7 @@
         "signatures": [
           "BaseOS"
         ],
-        "version_file": "(redhat|sl|slf|centos|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
+        "version_file": "(redhat|sl|slf|centos|centos-linux|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -124,7 +124,7 @@
         "signatures": [
           "BaseOS"
         ],
-        "version_file": "(redhat|sl|slf|centos|centos-linux|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
+        "version_file": "(redhat|sl|slf|centos|centos-linux|centos-stream|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,

--- a/dockerfiles/CentOS8.dockerfile
+++ b/dockerfiles/CentOS8.dockerfile
@@ -4,7 +4,7 @@ FROM centos:8
 
 RUN dnf makecache && \
     dnf install -y epel-release dnf-utils && \
-    dnf config-manager --set-enabled PowerTools && \
+    dnf config-manager --set-enabled powertools && \
     dnf makecache
 
 # overlay2 bug with yum/dnf


### PR DESCRIPTION
The prefix of the CentOS 8.3 release RPM file has changed from centos-release to centos-linux-release (e.g. centos-linux-release-8.3-1.2011.el8.noarch.rpm). Without centos-linux added to the rhel8 version_file line of distro_signatures.json, attempts to import CentOS 8.3 fail with **No signature matched in /var/www/cobbler/ks_mirror/...** error. Adding centos-linux to that line allows the cobbler import to succeed.