### PR TITLE
docs: fix simple typo, vaild -> valid

### DIFF
--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -575,7 +575,7 @@ Attributes:
 +-----------+--------------------------------------------------------+
 | Name      | Description                                            |
 +===========+========================================================+
-| installer | Which package manager to use, vaild options [rpm|yum]. |
+| installer | Which package manager to use, valid options [rpm|yum]. |
 +-----------+--------------------------------------------------------+
 | version   | Which version of the package to install.               |
 +-----------+--------------------------------------------------------+


### PR DESCRIPTION
There is a small typo in docs/cobbler.rst.

Should read `valid` rather than `vaild`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md