### PR TITLE
add an generic signature for opensuse15

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -1613,35 +1613,11 @@
         "kernel_options_post": "",
         "boot_files": []
       },
-      "opensuse15.0": {
+      "opensuse15generic": {
         "signatures": [
           ""
         ],
-        "version_file": "openSUSE-release-15.0-(.*).rpm",
-        "version_file_regex": null,
-        "kernel_arch": "kernel-(.*)\\.rpm",
-        "kernel_arch_regex": null,
-        "supported_arches": [
-          "aarch64",
-          "x86_64",
-          "ppc64le"
-        ],
-        "supported_repo_breeds": [
-          "yum"
-        ],
-        "kernel_file": "(linux|vmlinuz(.*))",
-        "initrd_file": "initrd(.*)",
-        "isolinux_ok": false,
-        "default_autoinstall": "sample_autoyast.xml",
-        "kernel_options": "",
-        "kernel_options_post": "",
-        "boot_files": []
-      },
-      "opensuse15.1": {
-        "signatures": [
-          ""
-        ],
-        "version_file": "openSUSE-release-15.1-(.*).rpm",
+        "version_file": "openSUSE-release-15.(.*).rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,


### PR DESCRIPTION
- Remove opensuse 15.0 and 15.1
- Replace by a generic signature which works for opensuse 15.2 too