### PR TITLE
Fix string replacements for @@xyz@@

### DIFF
--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -141,7 +141,7 @@ class Templar(object):
         search_table["http_server"] = repstr
 
         # string replacements for @@xyz@@ in data_out with prior regex lookups of keys
-        regex = r"@@[\S]*@@"
+        regex = r"@@[\S]*?@@"
         regex_matches = re.finditer(regex, data_out, re.MULTILINE)
         matches = set([match.group() for match_num, match in enumerate(regex_matches, start=1)])
         for match in matches:

--- a/tests/xmlrpcapi/distro_profile_system_test.py
+++ b/tests/xmlrpcapi/distro_profile_system_test.py
@@ -1157,3 +1157,20 @@ class TestDistroProfileSystem:
 
         # Assert --> Let the test pass if the call is okay.
         assert True
+
+    @pytest.mark.usefixtures("create_testdistro", "create_profile", "remove_testdistro", "remove_testprofile")
+    def test_render_vars(self, remote, token):
+        """
+        Test: string replacements for @@xyz@@
+        """
+
+        # Arrange --> There is nothing to be arranged
+        kernel_options = "tree=http://@@http_server@@/cblr/links/@@distro_name@@"
+
+        # Act
+        distro = remote.get_item_handle("distro", "testdistro0", token)
+        remote.modify_distro(distro, "kernel_options", kernel_options, token)
+        remote.save_distro(distro, token)
+
+        # Assert --> Let the test pass if the call is okay.
+        assert True


### PR DESCRIPTION
`regex = r"@@[\S]*@@"` for `"tree=http://@@http_server@@/cblr/links/@@distro_name@@"` returns:
`['@@http_server@@/cblr/links/@@distro_name@@']`

`regex = r"@@[\S]*?@@"`:
`['@@http_server@@', '@@distro_name@@']`


