### PR TITLE
Add schema validation for our settings file

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -28,11 +28,11 @@ pep257:
 
 pep8:
   options:
-    max-line-length: 120
     disable:
       - E304
       - E265
       - E266
+      - E501 # Covered by pylint
       - W291
       - W292
       - W391

--- a/autoinstall_snippets/cobbler_register
+++ b/autoinstall_snippets/cobbler_register
@@ -1,6 +1,6 @@
 # Begin cobbler registration
 #if $getVar('system_name','') == ''
-#if $str($getVar('register_new_installs','')) in [ "1", "true", "yes", "y" ]
+#if $getVar('register_new_installs','')
 if [ -f "/usr/bin/cobbler-register" ]; then
     cobbler-register --server=$server --port=$http_port --fqdn '*AUTO*' --profile=$profile_name --batch
 fi

--- a/autoinstall_snippets/post_anamon
+++ b/autoinstall_snippets/post_anamon
@@ -1,4 +1,4 @@
-#if $str($getVar('anamon_enabled','')) == "1"
+#if $str($getVar('anamon_enabled','')) == "True"
 
 ## install anamon script
 curl -o /usr/local/sbin/anamon "http://$server:$http_port/cobbler/misc/anamon"

--- a/autoinstall_snippets/pre_anamon
+++ b/autoinstall_snippets/pre_anamon
@@ -1,4 +1,4 @@
-#if $str($getVar('anamon_enabled','')) == "1"
+#if $str($getVar('anamon_enabled','')) == "True"
 curl -o /tmp/anamon "http://$server:$http_port/cobbler/misc/anamon"
 python=python
 [ -x /usr/libexec/platform-python ] && python=/usr/libexec/platform-python

--- a/autoinstall_snippets/puppet_install_if_enabled
+++ b/autoinstall_snippets/puppet_install_if_enabled
@@ -1,4 +1,4 @@
-#if $str($getVar('puppet_auto_setup','')) == "1"
+#if $str($getVar('puppet_auto_setup','')) == "True"
 puppet
 #end if
 

--- a/autoinstall_snippets/puppet_register_if_enabled
+++ b/autoinstall_snippets/puppet_register_if_enabled
@@ -1,5 +1,5 @@
 # start puppet registration 
-#if $str($getVar('puppet_auto_setup','')) == "1"
+#if $str($getVar('puppet_auto_setup','')) == "True"
 # generate puppet certificates and trigger a signing request, but
 # don't wait for signing to complete
 #if $int($getVar('puppet_version',2)) >= 3

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -169,6 +169,7 @@ BuildRequires:  %{py3_module_coverage}
 BuildRequires:  python%{python3_pkgversion}-distro
 BuildRequires:  python%{python3_pkgversion}-setuptools
 BuildRequires:  python%{python3_pkgversion}-netaddr
+BuildRequires:  python%{python3_pkgversion}-schema
 BuildRequires:  %{py3_module_cheetah}
 BuildRequires:  %{py3_module_sphinx}
 %if 0%{?suse_version}
@@ -216,6 +217,7 @@ Requires:       python%{python3_pkgversion}-requests
 Requires:       python%{python3_pkgversion}-simplejson
 Requires:       python%{python3_pkgversion}-tornado
 Requires:       python%{python3_pkgversion}-distro
+Requires:       python%{python3_pkgversion}-schema
 Requires:       %{py3_module_file}
 %if 0%{?suse_version}
 Recommends:     python%{python3_pkgversion}-ldap3

--- a/cobbler/actions/check.py
+++ b/cobbler/actions/check.py
@@ -141,18 +141,16 @@ class CobblerCheck(object):
         return_code = 0
         if self.checked_family in ("redhat", "suse"):
             if os.path.exists("/etc/rc.d/init.d/%s" % which):
-                return_code = utils.subprocess_call(self.logger,
-                                                    "/sbin/service %s status > /dev/null 2>/dev/null" % which,
-                                                    shell=True)
+                return_code = utils.subprocess_call(self.logger, "/sbin/service %s status > /dev/null 2>/dev/null" % which,
+                                           shell=True)
             if return_code != 0:
                 status.append("service %s is not running%s" % (which, notes))
                 return
         elif self.checked_family == "debian":
             # we still use /etc/init.d
             if os.path.exists("/etc/init.d/%s" % which):
-                return_code = utils.subprocess_call(self.logger,
-                                                    "/etc/init.d/%s status /dev/null 2>/dev/null" % which,
-                                                    shell=True)
+                return_code = utils.subprocess_call(self.logger, "/etc/init.d/%s status /dev/null 2>/dev/null" % which,
+                                           shell=True)
             if return_code != 0:
                 status.append("service %s is not running%s" % (which, notes))
                 return
@@ -169,9 +167,7 @@ class CobblerCheck(object):
         :param status: The status list with possible problems.
         """
         if os.path.exists("/etc/rc.d/init.d/iptables"):
-            return_code = utils.subprocess_call(self.logger,
-                                                "/sbin/service iptables status >/dev/null 2>/dev/null",
-                                                shell=True)
+            return_code = utils.subprocess_call(self.logger, "/sbin/service iptables status >/dev/null 2>/dev/null", shell=True)
             if return_code == 0:
                 status.append("since iptables may be running, ensure 69, 80/443, and %(xmlrpc)s are unblocked"
                               % {"xmlrpc": self.settings.xmlrpc_port})

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -547,7 +547,7 @@ class CobblerCLI(object):
                             raise RuntimeError("You must specify a --value when editing a setting")
                         elif not settings.get('allow_dynamic_settings', False):
                             raise RuntimeError("Dynamic settings changes are not enabled. Change the "
-                                               "allow_dynamic_settings to 1 and restart cobblerd to enable dynamic "
+                                               "allow_dynamic_settings to True and restart cobblerd to enable dynamic "
                                                "settings changes")
                         elif options.name == 'allow_dynamic_settings':
                             raise RuntimeError("Cannot modify that setting live")

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -398,7 +398,7 @@ class Collection(object):
                 elif isinstance(ref, profile.Profile):
                     # we don't need openvz containers to be network bootable
                     if ref.virt_type == "openvz":
-                        ref.enable_menu = 0
+                        ref.enable_menu = False
                     self.lite_sync.add_single_profile(ref.name)
                 elif isinstance(ref, distro.Distro):
                     self.lite_sync.add_single_distro(ref.name)

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -11,8 +11,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA.
 """
 
-from builtins import object
-from builtins import str
 import fnmatch
 import pprint
 
@@ -83,7 +81,7 @@ from cobbler.cexceptions import CX, NotImplementedException
 # must operate as normal with the default value for all fields and not choke on the default values.
 
 
-class Item(object):
+class Item:
     """
     An Item is a serializable thing that can appear in a Collection
     """

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 
 from cobbler import autoinstall_manager
-from cobbler.items import item
+from cobbler.items.item import Item
 from cobbler import power_manager
 from cobbler import utils
 from cobbler import validate
@@ -115,7 +115,7 @@ NETWORK_INTERFACE_FIELDS = [
 ]
 
 
-class System(item.Item):
+class System(Item):
     """
     A Cobbler system object.
     """
@@ -330,7 +330,7 @@ class System(item.Item):
         @returns: True or CX
         """
         dns_name = validate.hostname(dns_name)
-        if dns_name != "" and utils.input_boolean(self.collection_mgr._settings.allow_duplicate_hostnames) is False:
+        if dns_name != "" and self.collection_mgr.settings().allow_duplicate_hostnames is False:
             matched = self.collection_mgr.api.find_items("system", {"dns_name": dns_name})
             for x in matched:
                 if x.name != self.name:
@@ -357,7 +357,7 @@ class System(item.Item):
         @returns: True or CX
         """
         address = validate.ipv4_address(address)
-        if address != "" and utils.input_boolean(self.collection_mgr._settings.allow_duplicate_ips) is False:
+        if address != "" and self.collection_mgr.settings().allow_duplicate_ips is False:
             matched = self.collection_mgr.api.find_items("system", {"ip_address": address})
             for x in matched:
                 if x.name != self.name:
@@ -377,7 +377,7 @@ class System(item.Item):
         address = validate.mac_address(address)
         if address == "random":
             address = utils.get_random_mac(self.collection_mgr.api)
-        if address != "" and utils.input_boolean(self.collection_mgr._settings.allow_duplicate_macs) is False:
+        if address != "" and self.collection_mgr.settings().allow_duplicate_macs is False:
             matched = self.collection_mgr.api.find_items("system", {"mac_address": address})
             for x in matched:
                 if x.name != self.name:
@@ -481,7 +481,7 @@ class System(item.Item):
         @returns: True or CX
         """
         address = validate.ipv6_address(address)
-        if address != "" and utils.input_boolean(self.collection_mgr._settings.allow_duplicate_ips) is False:
+        if address != "" and self.collection_mgr.settings().allow_duplicate_ips is False:
             matched = self.collection_mgr.api.find_items("system", {"ipv6_address": address})
             for x in matched:
                 if x.name != self.name:
@@ -533,7 +533,7 @@ class System(item.Item):
         intf = self.__get_interface(interface)
         intf["connected_mode"] = utils.input_boolean(truthiness)
 
-    def set_enable_gpxe(self, enable_gpxe):
+    def set_enable_gpxe(self, enable_gpxe: bool):
         """
         Sets whether or not the system will use gPXE for booting.
         """
@@ -547,7 +547,7 @@ class System(item.Item):
         old_parent = self.get_parent()
         if profile_name in ["delete", "None", "~", ""] or profile_name is None:
             self.profile = ""
-            if isinstance(old_parent, item.Item):
+            if isinstance(old_parent, Item):
                 old_parent.children.pop(self.name, 'pass')
             return
 
@@ -557,10 +557,10 @@ class System(item.Item):
         if p is not None:
             self.profile = profile_name
             self.depth = p.depth + 1            # subprofiles have varying depths.
-            if isinstance(old_parent, item.Item):
+            if isinstance(old_parent, Item):
                 old_parent.children.pop(self.name, 'pass')
             new_parent = self.get_parent()
-            if isinstance(new_parent, item.Item):
+            if isinstance(new_parent, Item):
                 new_parent.children[self.name] = self
             return
         raise CX("invalid profile name: %s" % profile_name)

--- a/cobbler/modules/authentication/ldap.py
+++ b/cobbler/modules/authentication/ldap.py
@@ -58,8 +58,6 @@ def authenticate(api_handle, username, password):
     server = api_handle.settings().ldap_server
     basedn = api_handle.settings().ldap_base_dn
     port = str(api_handle.settings().ldap_port)
-    tls = api_handle.settings().ldap_tls
-    anon_bind = api_handle.settings().ldap_anonymous_bind
     prefix = api_handle.settings().ldap_search_prefix
 
     # Support for LDAP client certificates
@@ -100,9 +98,8 @@ def authenticate(api_handle, username, password):
     dir = ldap.initialize(uri)
 
     # start_tls if tls is 'on', 'true' or 'yes' and we're not already using old-SSL
-    tls = str(tls).lower()
     if port != '636':
-        if tls in ["on", "true", "yes", "1"]:
+        if api_handle.settings().ldap_tls:
             try:
                 dir.start_tls_s()
             except:
@@ -110,8 +107,7 @@ def authenticate(api_handle, username, password):
                 return False
 
     # if we're not allowed to search anonymously, grok the search bind settings and attempt to bind
-    anon_bind = str(anon_bind).lower()
-    if anon_bind not in ["on", "true", "yes", "1"]:
+    if api_handle.settings().ldap_anonymous_bind:
         searchdn = api_handle.settings().ldap_search_bind_dn
         searchpw = api_handle.settings().ldap_search_passwd
 

--- a/cobbler/modules/installation/post_puppet.py
+++ b/cobbler/modules/installation/post_puppet.py
@@ -39,10 +39,10 @@ def run(api, args, logger):
 
     settings = api.settings()
 
-    if not str(settings.puppet_auto_setup).lower() in ["1", "yes", "y", "true"]:
+    if not settings.puppet_auto_setup:
         return 0
 
-    if not str(settings.sign_puppet_certs_automatically).lower() in ["1", "yes", "y", "true"]:
+    if not settings.sign_puppet_certs_automatically:
         return 0
 
     system = api.find_system(name)

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -86,22 +86,21 @@ def run(api, args, logger):
     }
     metadata.update(target)
 
-    input_template = open("/etc/cobbler/reporting/build_report_email.template")
-    input_data = input_template.read()
-    input_template.close()
+    with open("/etc/cobbler/reporting/build_report_email.template") as input_template:
+        input_data = input_template.read()
 
-    message = templar.Templar(api._config).render(input_data, metadata, None)
+        message = templar.Templar(api._collection_mgr).render(input_data, metadata, None)
 
-    sendmail = True
-    for prefix in settings.build_reporting_ignorelist:
-        if prefix != '' and name.lower().startswith(prefix):
-            sendmail = False
+        sendmail = True
+        for prefix in settings.build_reporting_ignorelist:
+            if prefix != '' and name.lower().startswith(prefix):
+                sendmail = False
 
-    if sendmail:
-        # Send the mail
-        # FIXME: on error, return non-zero
-        server_handle = smtplib.SMTP(smtp_server)
-        server_handle.sendmail(from_addr, to_addr.split(','), message)
-        server_handle.quit()
+        if sendmail:
+            # Send the mail
+            # FIXME: on error, return non-zero
+            server_handle = smtplib.SMTP(smtp_server)
+            server_handle.sendmail(from_addr, to_addr.split(','), message)
+            server_handle.quit()
 
     return 0

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -41,7 +41,7 @@ def run(api, args, logger):
     settings = api.settings()
 
     # go no further if this feature is turned off
-    if not str(settings.build_reporting_enabled).lower() in ["1", "yes", "y", "true"]:
+    if not settings.build_reporting_enabled:
         return 0
 
     objtype = args[0]

--- a/cobbler/modules/installation/pre_clear_anamon_logs.py
+++ b/cobbler/modules/installation/pre_clear_anamon_logs.py
@@ -56,7 +56,6 @@ def run(api, args, logger):
     name = args[1]
 
     settings = api.settings()
-    anamon_enabled = str(settings.anamon_enabled)
 
     # Remove any files matched with the given glob pattern
     def unlink_files(globex):
@@ -67,7 +66,7 @@ def run(api, args, logger):
                 except OSError:
                     pass
 
-    if str(anamon_enabled) in ["true", "1", "y", "yes"]:
+    if settings.anamon_enabled:
         dirname = "/var/log/cobbler/anamon/%s" % name
         if os.path.isdir(dirname):
             unlink_files(os.path.join(dirname, "*"))

--- a/cobbler/modules/installation/pre_puppet.py
+++ b/cobbler/modules/installation/pre_puppet.py
@@ -45,10 +45,10 @@ def run(api, args, logger):
 
     settings = api.settings()
 
-    if not str(settings.puppet_auto_setup).lower() in ["1", "yes", "y", "true"]:
+    if not settings.puppet_auto_setup:
         return 0
 
-    if not str(settings.remove_old_puppet_certs_automatically).lower() in ["1", "yes", "y", "true"]:
+    if not settings.remove_old_puppet_certs_automatically:
         return 0
 
     system = api.find_system(name)

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -164,8 +164,8 @@ class BindManager(object):
                 host = re.sub(r'\.%s$' % best_match, '', host)
 
                 # if we are to manage ipmi hosts, add that too
-                if (self.settings.bind_manage_ipmi):
-                    if (system.power_address != ""):
+                if self.settings.bind_manage_ipmi:
+                    if system.power_address != "":
                         power_address_is_ip = False
                         # see if the power address is an IP
                         try:
@@ -176,7 +176,7 @@ class BindManager(object):
 
                         # if the power address is an IP, then add it to the DNS with the host suffix of "-ipmi"
                         # TODO: Perhpas the suffix can be configurable through settings?
-                        if (power_address_is_ip):
+                        if power_address_is_ip:
                             ipmi_host = host + "-ipmi"
                             ipmi_ips = []
                             ipmi_ips.append(system.power_address)
@@ -619,7 +619,7 @@ zone "%(arpa)s." {
 
     def write_dns_files(self):
         """
-        BIND files are written when manage_dns is set in our settings.
+        BIND files are written when ``manage_dns`` is set in our settings.
         """
 
         self.__write_named_conf()

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -229,8 +229,7 @@ class DnsmasqManager(object):
         """
         This restarts the dhcp server and thus applied the newly written config files.
         """
-        restart_dhcp = str(self.settings.restart_dhcp).lower()
-        if restart_dhcp != "0":
+        if self.settings.restart_dhcp:
             rc = utils.subprocess_call(self.logger, "service dnsmasq restart")
             if rc != 0:
                 error_msg = "service dnsmasq restart failed"

--- a/cobbler/modules/managers/genders.py
+++ b/cobbler/modules/managers/genders.py
@@ -23,7 +23,7 @@ def register():
 
 def write_genders_file(config, profiles_genders, distros_genders, mgmtcls_genders):
     """
-    Genders file is over-written when manage_genders is set in our settings.
+    Genders file is over-written when ``manage_genders`` is set in our settings.
 
     :param config: The config file to template with the data.
     :param profiles_genders: The profiles which should be included.
@@ -60,7 +60,7 @@ def run(api, args, logger):
     :return: ``0`` or ``1``, depending on the outcome of the operation.
     """
     # do not run if we are not enabled.
-    if(not api.settings().manage_genders):
+    if not api.settings().manage_genders:
         return 0
 
     profiles_genders = dict()

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -240,9 +240,8 @@ class IscManager(object):
         """
         This syncs the dhcp server with it's new config files. Basically this restarts the service to apply the changes.
         """
-        restart_dhcp = str(self.settings.restart_dhcp).lower()
         service_name = utils.dhcp_service_name(self.api)
-        if restart_dhcp != "0":
+        if self.settings.restart_dhcp:
             rc = utils.subprocess_call(self.logger, "dhcpd -t -q", shell=True)
             if rc != 0:
                 error_msg = "dhcpd -t failed"

--- a/cobbler/modules/nsupdate_add_system_post.py
+++ b/cobbler/modules/nsupdate_add_system_post.py
@@ -68,7 +68,7 @@ def run(api, args, logger):
 
     settings = api.settings()
 
-    if not str(settings.nsupdate_enabled).lower() in ["1", "yes", "y", "true"]:
+    if not settings.nsupdate_enabled:
         return 0
 
     # read our settings

--- a/cobbler/modules/nsupdate_delete_system_pre.py
+++ b/cobbler/modules/nsupdate_delete_system_pre.py
@@ -68,7 +68,7 @@ def run(api, args, logger):
 
     settings = api.settings()
 
-    if not str(settings.nsupdate_enabled).lower() in ["1", "yes", "y", "true"]:
+    if not settings.nsupdate_enabled:
         return 0
 
     # Read our settings

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -87,9 +87,9 @@ def serialize_item(collection, item):
         indent = None
 
     _dict = item.to_dict()
-    with open(filename, "w+") as fd:
+    with open(filename, "w+") as file_descriptor:
         data = simplejson.dumps(_dict, encoding="utf-8", sort_keys=sort_keys, indent=indent)
-        fd.write(data)
+        file_descriptor.write(data)
 
 
 def serialize_delete(collection, item):
@@ -138,8 +138,8 @@ def deserialize_raw(collection_types):
         all_files = glob.glob("%s/*.json" % path)
 
         for f in all_files:
-            with open(f) as fd:
-                json_data = fd.read()
+            with open(f) as file_descriptor:
+                json_data = file_descriptor.read()
                 _dict = simplejson.loads(json_data, encoding='utf-8')
                 results.append(_dict)
         return results

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2367,7 +2367,7 @@ class CobblerXMLRPCInterface(object):
 
     def disable_netboot(self, name, token=None, **rest):
         """
-        This is a feature used by the pxe_just_once support, see manpage. Sets system named "name" to no-longer PXE.
+        This is a feature used by the ``pxe_just_once`` support, see manpage. Sets system named "name" to no-longer PXE.
         Disabled by default as this requires public API access and is technically a read-write operation.
 
         :param name: The name of the system to disable netboot for.
@@ -2380,7 +2380,7 @@ class CobblerXMLRPCInterface(object):
         if not self.api.settings().pxe_just_once:
             # feature disabled!
             return False
-        if str(self.api.settings().nopxe_with_triggers).upper() in ["1", "Y", "YES", "TRUE"]:
+        if self.api.settings().nopxe_with_triggers:
             # triggers should be enabled when calling nopxe
             triggers_enabled = True
         else:

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -535,11 +535,11 @@ def read_settings_file(filepath="/etc/cobbler/settings.yaml") -> Union[Dict[Hash
     try:
         validate_settings(filecontent)
     except SchemaMissingKeyError:
-        logging.exception("Settingsfile was not returned due to missing Keys.")
+        logging.exception("Settings file was not returned due to missing keys.")
         logging.debug("The settings to read were: \"%s\"", filecontent)
         return {}
     except SchemaError:
-        logging.exception("Settingsfile was returned due to an error in the schema.")
+        logging.exception("Settings file was returned due to an error in the schema.")
         logging.debug("The settings to read were: \"%s\"", filecontent)
         return {}
     return filecontent
@@ -567,11 +567,11 @@ def update_settings_file(data: dict, filepath="/etc/cobbler/settings.yaml") -> b
             settings_file.write(yaml_dump)
         return True
     except SchemaMissingKeyError:
-        logging.exception("Settingsfile was not written to the disc due to missing Keys.")
+        logging.exception("Settings file was not written to the disc due to missing keys.")
         logging.debug("The settings to write were: \"%s\"", data)
         return False
     except SchemaError:
-        logging.exception("Settingsfile was not written to the disc due to an error in the schema.")
+        logging.exception("Settings file was not written to the disc due to an error in the schema.")
         logging.debug("The settings to write were: \"%s\"", data)
         return False
 

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -20,25 +20,26 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 import glob
+import logging
 import os.path
 import re
 import traceback
 from typing import Union, Dict, Hashable, Any
 
 import yaml
+from schema import Schema, Optional, SchemaError, SchemaMissingKeyError
 
 from cobbler import utils
-from cobbler.cexceptions import CX
 
-
+# TODO: Convert this into properties for 3.3.0
 # defaults is to be used if the config file doesn't contain the value we need
 DEFAULTS = {
-    "allow_duplicate_hostnames": [0, "bool"],
-    "allow_duplicate_ips": [0, "bool"],
-    "allow_duplicate_macs": [0, "bool"],
-    "allow_dynamic_settings": [0, "bool"],
-    "always_write_dhcp_entries": [0, "bool"],
-    "anamon_enabled": [0, "bool"],
+    "allow_duplicate_hostnames": [False, "bool"],
+    "allow_duplicate_ips": [False, "bool"],
+    "allow_duplicate_macs": [False, "bool"],
+    "allow_dynamic_settings": [False, "bool"],
+    "always_write_dhcp_entries": [False, "bool"],
+    "anamon_enabled": [False, "bool"],
     "auth_token_expiration": [3600, "int"],
     "authn_pam_service": ["login", "str"],
     "autoinstall_snippets_dir": ["/var/lib/cobbler/snippets", "str"],
@@ -48,18 +49,19 @@ DEFAULTS = {
     "boot_loader_conf_template_dir": ["/etc/cobbler/boot_loader_conf", "str"],
     "bootloaders_dir": ["/var/lib/cobbler/loaders", "str"],
     "grubconfig_dir": ["/var/lib/cobbler/grub_config", "str"],
-    "build_reporting_enabled": [0, "bool"],
-    "build_reporting_ignorelist": ["", "str"],
+    "build_reporting_enabled": [False, "bool"],
+    "build_reporting_email": [[], "list"],
+    "build_reporting_ignorelist": [[], "list"],
     "build_reporting_sender": ["", "str"],
     "build_reporting_smtp_server": ["localhost", "str"],
     "build_reporting_subject": ["", "str"],
     "buildisodir": ["/var/cache/cobbler/buildiso", "str"],
-    "cache_enabled": [1, "bool"],
+    "cache_enabled": [True, "bool"],
     "cheetah_import_whitelist": [["re", "random", "time"], "list"],
-    "client_use_https": [0, "bool"],
-    "client_use_localhost": [0, "bool"],
+    "client_use_https": [False, "bool"],
+    "client_use_localhost": [False, "bool"],
     "cobbler_master": ["", "str"],
-    "convert_server_to_ip": [0, "bool"],
+    "convert_server_to_ip": [False, "bool"],
     "createrepo_flags": ["-c cache -s sha", "str"],
     "default_autoinstall": ["/var/lib/cobbler/templates/default.ks", "str"],
     "default_name_servers": [[], "list"],
@@ -72,74 +74,78 @@ DEFAULTS = {
     "default_virt_file_size": [5, "int"],
     "default_virt_ram": [512, "int"],
     "default_virt_type": ["auto", "str"],
-    "enable_gpxe": [0, "bool"],
-    "enable_menu": [1, "bool"],
+    "enable_gpxe": [False, "bool"],
+    "enable_menu": [True, "bool"],
     "http_port": [80, "int"],
     "include": [["/etc/cobbler/settings.d/*.settings"], "list"],
     "iso_template_dir": ["/etc/cobbler/iso", "str"],
+    "jinja2_includedir": ["/var/lib/cobbler/jinja2", "str"],
     "kernel_options": [{}, "dict"],
-    "ldap_anonymous_bind": [1, "bool"],
+    "ldap_anonymous_bind": [True, "bool"],
     "ldap_base_dn": ["DC=devel,DC=redhat,DC=com", "str"],
     "ldap_port": [389, "int"],
     "ldap_search_bind_dn": ["", "str"],
     "ldap_search_passwd": ["", "str"],
     "ldap_search_prefix": ['uid=', "str"],
     "ldap_server": ["grimlock.devel.redhat.com", "str"],
-    "ldap_tls": ["on", "str"],
+    "ldap_tls": [True, "bool"],
     "ldap_tls_cacertfile": ["", "str"],
     "ldap_tls_certfile": ["", "str"],
     "ldap_tls_keyfile": ["", "str"],
-    "bind_manage_ipmi": [0, "bool"],
-    "manage_dhcp": [0, "bool"],
-    "manage_dns": [0, "bool"],
+    "bind_manage_ipmi": [False, "bool"],
+    "manage_dhcp": [False, "bool"],
+    "manage_dns": [False, "bool"],
     "manage_forward_zones": [[], "list"],
     "manage_reverse_zones": [[], "list"],
-    "manage_genders": [0, "bool"],
-    "manage_rsync": [0, "bool"],
-    "manage_tftp": [1, "bool"],
-    "manage_tftpd": [1, "bool"],
+    "manage_genders": [False, "bool"],
+    "manage_rsync": [False, "bool"],
+    "manage_tftpd": [True, "bool"],
     "mgmt_classes": [[], "list"],
     "mgmt_parameters": [{}, "dict"],
     "next_server": ["127.0.0.1", "str"],
-    "nsupdate_enabled": [0, "bool"],
+    "nsupdate_enabled": [False, "bool"],
+    "nsupdate_log": ["/var/log/cobbler/nsupdate.log", "str"],
+    "nsupdate_tsig_algorithm": ["hmac-sha512", "str"],
+    "nsupdate_tsig_key": [[], "list"],
     "power_management_default_type": ["ipmilan", "str"],
     "proxy_url_ext": ["", "str"],
     "proxy_url_int": ["", "str"],
-    "puppet_auto_setup": [0, "bool"],
-    "puppet_parameterized_classes": [1, "bool"],
+    "puppet_auto_setup": [False, "bool"],
+    "puppet_parameterized_classes": [True, "bool"],
     "puppet_server": ["puppet", "str"],
     "puppet_version": [2, "int"],
     "puppetca_path": ["/usr/bin/puppet", "str"],
-    "pxe_just_once": [1, "bool"],
-    "nopxe_with_triggers": [1, "bool"],
-    "redhat_management_permissive": [0, "bool"],
+    "pxe_just_once": [True, "bool"],
+    "nopxe_with_triggers": [True, "bool"],
+    "redhat_management_permissive": [False, "bool"],
     "redhat_management_server": ["xmlrpc.rhn.redhat.com", "str"],
     "redhat_management_key": ["", "str"],
-    "register_new_installs": [0, "bool"],
-    "remove_old_puppet_certs_automatically": [0, "bool"],
+    "register_new_installs": [False, "bool"],
+    "remove_old_puppet_certs_automatically": [False, "bool"],
     "replicate_repo_rsync_options": ["-avzH", "str"],
     "replicate_rsync_options": ["-avzH", "str"],
     "reposync_flags": ["-l -m -d", "str"],
-    "restart_dhcp": [1, "bool"],
-    "restart_dns": [1, "bool"],
-    "run_install_triggers": [1, "bool"],
-    "scm_track_enabled": [0, "bool"],
+    "reposync_rsync_flags": ["", "str"],
+    "restart_dhcp": [True, "bool"],
+    "restart_dns": [True, "bool"],
+    "run_install_triggers": [True, "bool"],
+    "scm_track_enabled": [False, "bool"],
     "scm_track_mode": ["git", "str"],
     "scm_track_author": ["cobbler <cobbler@localhost>", "str"],
     "scm_push_script": ["/bin/true", "str"],
-    "serializer_pretty_json": [0, "bool"],
+    "serializer_pretty_json": [False, "bool"],
     "server": ["127.0.0.1", "str"],
-    "sign_puppet_certs_automatically": [0, "bool"],
+    "sign_puppet_certs_automatically": [False, "bool"],
     "signature_path": ["/var/lib/cobbler/distro_signatures.json", "str"],
     "signature_url": ["https://cobbler.github.io/signatures/3.0.x/latest.json", "str"],
     "tftpboot_location": ["/var/lib/tftpboot", "str"],
-    "virt_auto_boot": [0, "bool"],
+    "virt_auto_boot": [False, "bool"],
     "webdir": ["/var/www/cobbler", "str"],
     "webdir_whitelist": [".link_cache", "misc", "distro_mirror", "images", "links", "localmirror", "pub", "rendered",
                          "repo_mirror", "repo_profile", "repo_system", "svc", "web", "webui"],
     "xmlrpc_port": [25151, "int"],
     "yum_distro_priority": [1, "int"],
-    "yum_post_install_mirror": [1, "bool"],
+    "yum_post_install_mirror": [True, "bool"],
     "yumdownloader_flags": ["--resolve", "str"],
 }
 
@@ -174,13 +180,6 @@ class Settings:
         """
         Constructor.
         """
-        self._clear()
-
-    def _clear(self):
-        """
-        This resets all settings to the defaults which are built into Cobbler.
-        """
-        self.__dict__ = {}
         for key in list(DEFAULTS.keys()):
             self.__dict__[key] = DEFAULTS[key][0]
 
@@ -188,10 +187,14 @@ class Settings:
         """
         Alias for setting an option "name" to the new value "value". (See __settattr__)
 
+        .. deprecated:: 3.2.1
+           Use ``obj.__settattr__`` directly please. Will be removed with 3.3.0
+
         :param name: The name of the setting to set.
         :param value: The value of the setting to set.
         :return: 0 if the action was completed successfully. No return if there is an error.
         """
+        # TODO: Deprecate and remove. Tailcall is not needed.
         return self.__setattr__(name, value)
 
     def to_string(self) -> str:
@@ -208,27 +211,48 @@ class Settings:
         """
         Return an easily serializable representation of the config.
 
+        .. deprecated:: 3.2.1
+           Use ``obj.__dict__`` directly please. Will be removed with 3.3.0
+
         :return: The dict with all user settings combined with settings which are left to the default.
         """
+        # TODO: Deprecate and remove. Tailcall is not needed.
         return self.__dict__
 
-    def from_dict(self, _dict):
+    def from_dict(self, new_values):
         """
-        Modify this object to load values in dictionary.
+        Modify this object to load values in dictionary. If the handed dict would lead to an invalid object it is
+        silently discarded.
 
-        WARNING: If the dict from the args has not all settings included Cobbler may behave unexpectedly.
+        .. warning:: If the dict from the args has not all settings included Cobbler may behave unexpectedly.
 
-        :param _dict: The dictionary with settings to replace.
+        :param new_values: The dictionary with settings to replace.
         :return: Returns the settings instance this method was called from.
         """
-        if _dict is None:
-            print("warning: not loading empty structure for %s" % self.filename())
+        if new_values is None:
+            logging.warning("Not loading empty settings dictionary!")
             return
 
-        self._clear()
-        self.__dict__.update(_dict)
+        old_settings = self.__dict__
+
+        self.__dict__.update(new_values)
+
+        if not self.is_valid():
+            self.__dict__ = old_settings
 
         return self
+
+    def is_valid(self) -> bool:
+        """
+        Silently drops all errors and returns ``True`` when everything is valid.
+
+        :return: If this settings object is valid this returns true. Otherwise false.
+        """
+        try:
+            validate_settings(self.__dict__)
+        except SchemaError:
+            return False
+        return True
 
     def __setattr__(self, name, value):
         """
@@ -246,26 +270,21 @@ class Settings:
                 elif DEFAULTS[name][1] == "int":
                     value = int(value)
                 elif DEFAULTS[name][1] == "bool":
-                    if utils.input_boolean(value):
-                        value = 1
-                    else:
-                        value = 0
+                    value = utils.input_boolean(value)
                 elif DEFAULTS[name][1] == "float":
                     value = float(value)
                 elif DEFAULTS[name][1] == "list":
                     value = utils.input_string_or_list(value)
                 elif DEFAULTS[name][1] == "dict":
                     value = utils.input_string_or_dict(value)[1]
-            except:
-                raise AttributeError
+            except Exception as error:
+                raise AttributeError from error
 
             self.__dict__[name] = value
             update_settings_file(self.to_dict())
 
             return 0
         else:
-            # FIXME. Not sure why __dict__ is part of name workaround applied, ignore exception
-            # raise AttributeError
             pass
 
     def __getattr__(self, name):
@@ -282,13 +301,141 @@ class Settings:
                 self.__dict__[name] = result
                 return result
             return self.__dict__[name]
-        except:
+        except Exception as error:
             if name in DEFAULTS:
                 lookup = DEFAULTS[name][0]
                 self.__dict__[name] = lookup
                 return lookup
             else:
-                raise AttributeError(f"no settings attribute named '{name}' found")
+                raise AttributeError(f"no settings attribute named '{name}' found") from error
+
+
+def validate_settings(settings_content: dict) -> dict:
+    """
+    This function performs logical validation of our loaded YAML files.
+    This function will:
+    - Perform type validation on all values of all keys.
+    - Provide defaults for optional settings.
+    :param settings_content: The dictionary content from the YAML file.
+    :raises SchemaError: In case the data given is invalid.
+    :return: The Settings of Cobbler which can be safely used inside this instance.
+    """
+    schema = Schema({
+        "allow_duplicate_hostnames": bool,
+        "allow_duplicate_ips": bool,
+        "allow_duplicate_macs": bool,
+        "allow_dynamic_settings": bool,
+        "always_write_dhcp_entries": bool,
+        "anamon_enabled": bool,
+        "auth_token_expiration": int,
+        "authn_pam_service": str,
+        "autoinstall_snippets_dir": str,
+        "autoinstall_templates_dir": str,
+        "bind_chroot_path": str,
+        "bind_master": str,
+        "boot_loader_conf_template_dir": str,
+        Optional("bootloaders_dir", default="/var/lib/cobbler/loaders"): str,
+        Optional("grubconfig_dir", default="/var/lib/cobbler/grub_config"): str,
+        "build_reporting_enabled": bool,
+        "build_reporting_email": [str],
+        "build_reporting_ignorelist": [str],
+        "build_reporting_sender": str,
+        "build_reporting_smtp_server": str,
+        "build_reporting_subject": str,
+        Optional("buildisodir", default="/var/cache/cobbler/buildiso"): str,
+        "cache_enabled": bool,
+        "cheetah_import_whitelist": [str],
+        "client_use_https": bool,
+        "client_use_localhost": bool,
+        Optional("cobbler_master", default=""): str,
+        Optional("convert_server_to_ip", default=False): bool,
+        "createrepo_flags": str,
+        "default_autoinstall": str,
+        "default_name_servers": [str],
+        "default_name_servers_search": [str],
+        "default_ownership": [str],
+        "default_password_crypted": str,
+        "default_template_type": str,
+        "default_virt_bridge": str,
+        Optional("default_virt_disk_driver", default="raw"): str,
+        "default_virt_file_size": int,
+        "default_virt_ram": int,
+        "default_virt_type": str,
+        "enable_gpxe": bool,
+        "enable_menu": bool,
+        "http_port": int,
+        "include": [str],
+        Optional("iso_template_dir", default="/etc/cobbler/iso"): str,
+        Optional("jinja2_includedir", default="/var/lib/cobbler/jinja2"): str,
+        "kernel_options": dict,
+        "ldap_anonymous_bind": bool,
+        "ldap_base_dn": str,
+        "ldap_port": int,
+        "ldap_search_bind_dn": str,
+        "ldap_search_passwd": str,
+        "ldap_search_prefix": str,
+        "ldap_server": str,
+        "ldap_tls": bool,
+        "ldap_tls_cacertfile": str,
+        "ldap_tls_certfile": str,
+        "ldap_tls_keyfile": str,
+        Optional("bind_manage_ipmi", default=False): bool,
+        "manage_dhcp": bool,
+        "manage_dns": bool,
+        "manage_forward_zones": [str],
+        "manage_reverse_zones": [str],
+        Optional("manage_genders", False): bool,
+        "manage_rsync": bool,
+        "manage_tftpd": bool,
+        "mgmt_classes": [str],
+        # TODO: Validate Subdict
+        "mgmt_parameters": dict,
+        "next_server": str,
+        Optional("nsupdate_enabled", False): bool,
+        Optional("nsupdate_log", default="/var/log/cobbler/nsupdate.log"): str,
+        Optional("nsupdate_tsig_algorithm", default="hmac-sha512"): str,
+        Optional("nsupdate_tsig_key", default=[]): [str],
+        "power_management_default_type": str,
+        "proxy_url_ext": str,
+        "proxy_url_int": str,
+        "puppet_auto_setup": bool,
+        Optional("puppet_parameterized_classes", default=True): bool,
+        Optional("puppet_server", default="puppet"): str,
+        Optional("puppet_version", default=2): int,
+        "puppetca_path": str,
+        "pxe_just_once": bool,
+        "nopxe_with_triggers": bool,
+        "redhat_management_permissive": bool,
+        "redhat_management_server": str,
+        "redhat_management_key": str,
+        "register_new_installs": bool,
+        "remove_old_puppet_certs_automatically": bool,
+        "replicate_repo_rsync_options": str,
+        "replicate_rsync_options": str,
+        "reposync_flags": str,
+        "reposync_rsync_flags": str,
+        "restart_dhcp": bool,
+        "restart_dns": bool,
+        "run_install_triggers": bool,
+        "scm_track_enabled": bool,
+        "scm_track_mode": str,
+        "scm_track_author": str,
+        "scm_push_script": str,
+        "serializer_pretty_json": bool,
+        "server": str,
+        "sign_puppet_certs_automatically": bool,
+        Optional("signature_path", default="/var/lib/cobbler/distro_signatures.json"): str,
+        Optional("signature_url", default="https://cobbler.github.io/signatures/3.0.x/latest.json"): str,
+        "tftpboot_location": str,
+        "virt_auto_boot": bool,
+        "webdir": str,
+        "webdir_whitelist": [str],
+        "xmlrpc_port": int,
+        "yum_distro_priority": int,
+        "yum_post_install_mirror": bool,
+        "yumdownloader_flags": str,
+    }, ignore_extra_keys=False)
+    return schema.validate(settings_content)
 
 
 def parse_bind_config(configpath: str):
@@ -320,7 +467,7 @@ def parse_bind_config(configpath: str):
                 DEFAULTS["bind_chroot_path"] = rootdirmatch.group(1)
 
 
-def autodect_bind_chroot():
+def autodetect_bind_chroot():
     """
     Autodetect bind chroot configuration
     """
@@ -339,24 +486,38 @@ def autodect_bind_chroot():
         parse_bind_config(bind_config_filename)
 
 
-def __migrate_settingsfile_name():
-    if os.path.exists("/etc/cobbler/settings"):
-        os.rename("/etc/cobbler/settings", "/etc/cobbler/settings.yaml")
+def __migrate_settingsfile_name(filename="/etc/cobbler/settings") -> str:
+    if filename[-8:] == "settings" and os.path.exists(filename):
+        os.rename(filename, filename + ".yaml")
+        filename += ".yaml"
+    return filename
+
+
+def __migrate_settingsfile_int_bools(settings_dict: dict) -> dict:
+    for key in settings_dict:
+        if DEFAULTS[key][1] == "bool":
+            settings_dict[key] = utils.input_boolean(settings_dict[key])
+    mgmt_parameters = "mgmt_parameters"
+    if mgmt_parameters in settings_dict and "from_cobbler" in settings_dict[mgmt_parameters]:
+        settings_dict[mgmt_parameters]["from_cobbler"] = utils.input_boolean(
+            settings_dict[mgmt_parameters]["from_cobbler"]
+        )
+    return settings_dict
 
 
 def read_settings_file(filepath="/etc/cobbler/settings.yaml") -> Union[Dict[Hashable, Any], list, None]:
     """
     Reads the settings file from the default location or the given one. This method then also recursively includes all
     files in the ``include`` directory. Any key may be overwritten in a later loaded settings file. The last loaded file
-    wins.
+    wins. If the read settings file is invalid in the context of Cobbler we will return an empty Dictionary.
 
     :param filepath: The path to the settings file.
     :return: A dictionary with the settings. As a word of caution: This may not represent a correct settings object, it
              will only contain a correct YAML representation.
-    :raises CX: If the YAML file is not syntactically valid or could not be read.
+    :raises yaml.YAMLError: If the YAML file is not syntactically valid or could not be read.
     :raises FileNotFoundError: If the file handed to the function does not exist.
     """
-    __migrate_settingsfile_name()
+    filepath = __migrate_settingsfile_name(filepath)
     if not os.path.exists(filepath):
         raise FileNotFoundError("Given path \"%s\" does not exist." % filepath)
     try:
@@ -367,24 +528,53 @@ def read_settings_file(filepath="/etc/cobbler/settings.yaml") -> Union[Dict[Hash
                 for ifile in glob.glob(ival):
                     with open(ifile, 'r') as extra_settingsfile:
                         filecontent.update(yaml.safe_load(extra_settingsfile.read()))
-    except yaml.YAMLError as e:
+    except yaml.YAMLError as error:
         traceback.print_exc()
-        raise CX("\"%s\" is not a valid YAML file" % filepath) from e
+        raise yaml.YAMLError("\"%s\" is not a valid YAML file" % filepath) from error
+    filecontent = __migrate_settingsfile_int_bools(filecontent)
+    try:
+        validate_settings(filecontent)
+    except SchemaMissingKeyError:
+        logging.exception("Settingsfile was not returned due to missing Keys.")
+        logging.debug("The settings to read were: \"%s\"", filecontent)
+        return {}
+    except SchemaError:
+        logging.exception("Settingsfile was returned due to an error in the schema.")
+        logging.debug("The settings to read were: \"%s\"", filecontent)
+        return {}
     return filecontent
 
 
-def update_settings_file(data, filepath="/etc/cobbler/settings.yaml"):
+def update_settings_file(data: dict, filepath="/etc/cobbler/settings.yaml") -> bool:
     """
     Write data handed to this function into the settings file of Cobbler. This function overwrites the existing content.
+    It will only write valid settings. If you are trying to save invalid data this will raise a SchemaException
+    described in :py:meth:`cobbler.settings.validate`.
 
     :param data: The data to put into the settings file.
     :param filepath: This sets the path of the settingsfile to write.
-    :return: True if the action succeeded. Otherwise return nothing.
+    :return: True if the action succeeded. Otherwise return False.
     """
-    __migrate_settingsfile_name()
-    with open(filepath, "w") as settings_file:
-        yaml.safe_dump(data, settings_file)
+    try:
+        validated_data = validate_settings(data)
+        filepath = __migrate_settingsfile_name(filepath)
+        with open(filepath, "w") as settings_file:
+            yaml_dump = yaml.safe_dump(validated_data)
+            header = "# Cobbler settings file\n"
+            header += "# Docs for this file can be found at: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html"
+            header += "\n\n"
+            yaml_dump = header + yaml_dump
+            settings_file.write(yaml_dump)
+        return True
+    except SchemaMissingKeyError:
+        logging.exception("Settingsfile was not written to the disc due to missing Keys.")
+        logging.debug("The settings to write were: \"%s\"", data)
+        return False
+    except SchemaError:
+        logging.exception("Settingsfile was not written to the disc due to an error in the schema.")
+        logging.debug("The settings to write were: \"%s\"", data)
+        return False
 
 
 # Initialize Settings module for manipulating the global DEFAULTS variable
-autodect_bind_chroot()
+autodetect_bind_chroot()

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -567,14 +567,12 @@ def input_string_or_dict(options, allow_multiples=True):
         raise CX("invalid input type")
 
 
-def input_boolean(value):
+def input_boolean(value: str) -> bool:
     """
     Convert a str to a boolean. If this is not possible or the value is false return false.
 
     :param value: The value to convert to boolean.
-    :type value: str
     :return: True if the value is in the following list, otherwise false: "true", "1", "on", "yes", "y" .
-    :rtype: bool
     """
     value = str(value)
     if value.lower() in ["true", "1", "on", "yes", "y"]:
@@ -1582,8 +1580,11 @@ def set_virt_auto_boot(self, num):
     # num is a non-negative integer (0 means default)
     try:
         inum = int(num)
-        if (inum == 0) or (inum == 1):
-            self.virt_auto_boot = inum
+        if inum == 0:
+            self.virt_auto_boot = False
+            return
+        elif inum == 1:
+            self.virt_auto_boot = True
             return
         raise CX("invalid virt_auto_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % inum)
     except:

--- a/config/cobbler/modules.conf
+++ b/config/cobbler/modules.conf
@@ -74,7 +74,7 @@ module = managers.bind
 module = managers.isc
 
 # tftpd:
-# chooses the TFTP management engine if manage_tftp is enabled
+# chooses the TFTP management engine if manage_tftpd is enabled
 # in /etc/cobbler/settings.yaml, which is ON by default.
 #
 # choices:

--- a/config/cobbler/settings.d/bind_manage_ipmi.settings
+++ b/config/cobbler/settings.d/bind_manage_ipmi.settings
@@ -1,2 +1,3 @@
-# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind is set.
-bind_manage_ipmi: 1
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind
+# is set.
+bind_manage_ipmi: true

--- a/config/cobbler/settings.d/manage_genders.settings
+++ b/config/cobbler/settings.d/manage_genders.settings
@@ -1,2 +1,2 @@
 # manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
-manage_genders: False
+manage_genders: false

--- a/config/cobbler/settings.d/manage_genders.settings
+++ b/config/cobbler/settings.d/manage_genders.settings
@@ -1,2 +1,2 @@
 # manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
-manage_genders: 0
+manage_genders: False

--- a/config/cobbler/settings.d/nsupdate.settings
+++ b/config/cobbler/settings.d/nsupdate.settings
@@ -1,6 +1,5 @@
-
-# set to 1 to enable Cobbler's dynamic DNS updates.
-nsupdate_enabled: 0
+# Set to "true" to enable Cobbler's dynamic DNS updates.
+nsupdate_enabled: false
 
 # define tsig key
 # please don't use this one, instead generate your own:

--- a/docker/CentOS8.dockerfile
+++ b/docker/CentOS8.dockerfile
@@ -32,6 +32,7 @@ RUN touch /var/lib/rpm/* &&   \
     python3-pycodestyle       \
     python3-setuptools        \
     python3-sphinx            \
+    python3-schema            \
     epel-rpm-macros           \
     rpm-build                 \
     which

--- a/docker/Debian10.dockerfile
+++ b/docker/Debian10.dockerfile
@@ -44,6 +44,7 @@ RUN apt-get update -qq && \
     python3-tornado \
     python3-tz \
     python3-yaml \
+    python3-schema \
     liblocale-gettext-perl \
     lsb-release \
     xz-utils \

--- a/docker/Fedora33.dockerfile
+++ b/docker/Fedora33.dockerfile
@@ -40,6 +40,7 @@ RUN yum install -y          \
     python3-ldap3           \
     python3-librepo         \
     python3-pymongo         \
+    python3-schema          \
     createrepo_c            \
     dnf-plugins-core        \
     xorriso                 \

--- a/docker/openSUSE_Leap.dockerfile
+++ b/docker/openSUSE_Leap.dockerfile
@@ -10,8 +10,9 @@ RUN ["zypper", "-n", "update"]
 
 # Install runtime dependencies for Cobbler
 RUN ["zypper", "-n", "in", "python3", "python3-devel", "python3-pip", "python3-setuptools", "python3-wheel", \
-    "python3-distro", "python3-coverage", "apache2", "apache2-devel", "acl", "apache2-mod_wsgi-python3", "ipmitool", \
-    "rsync", "fence-agents", "genders", "xorriso", "python3-ldap", "tftp", "python3-Sphinx", "hardlink", "supervisor"]
+    "python3-distro", "python3-coverage", "python3-schema", "apache2", "apache2-devel", "acl", "ipmitool", \
+    "rsync", "fence-agents", "genders", "xorriso", "python3-ldap", "tftp", "python3-Sphinx", "hardlink", "supervisor", \
+    "apache2-mod_wsgi-python3"]
 RUN ["pip3", "install", "pykickstart"]
 
 # Packages for building & installing cobbler from sourceless

--- a/docker/openSUSE_TW.dockerfile
+++ b/docker/openSUSE_TW.dockerfile
@@ -10,8 +10,9 @@ RUN ["zypper", "-n", "update"]
 
 # Install runtime dependencies for Cobbler
 RUN ["zypper", "-n", "in", "python3", "python3-devel", "python3-pip", "python3-setuptools", "python3-wheel", \
-    "python3-distro", "python3-coverage", "apache2", "apache2-devel", "acl", "apache2-mod_wsgi-python3", "ipmitool", \
-    "rsync", "fence-agents", "genders", "xorriso", "python3-ldap", "tftp", "python3-Sphinx", "hardlink", "supervisor"]
+    "python3-distro", "python3-coverage", "python3-schema", "apache2", "apache2-devel", "acl", "ipmitool", \
+    "rsync", "fence-agents", "genders", "xorriso", "python3-ldap", "tftp", "python3-Sphinx", "hardlink", "supervisor", \
+    "apache2-mod_wsgi-python3"]
 RUN ["pip3", "install", "pykickstart"]
 
 # Packages for building & installing cobbler from source

--- a/docker/release.dockerfile
+++ b/docker/release.dockerfile
@@ -12,7 +12,7 @@ RUN ["zypper", "-n", "update"]
 RUN ["zypper", "-n", "in", "apache2", "apache2-devel", "acl", "apache2-mod_wsgi-python3", "ipmitool", "rsync"]
 RUN ["zypper", "-n", "in", "fence-agents", "genders", "xorriso", "tftp", "hardlink"]
 # Install Python dependencies for Cobbler
-RUN ["zypper", "-n", "in", "python3", "python3-devel", "python3-pip", "python3-setuptools", "python3-future"]
+RUN ["zypper", "-n", "in", "python3", "python3-devel", "python3-pip", "python3-setuptools", "python3-schema"]
 RUN ["zypper", "-n", "in", "python3-distro", "python3-ldap", "python3-netaddr", "python3-Django", "python3-pykickstart"]
 RUN ["zypper", "-n", "in", "python3-simplejson", "python3-dnspython", "python3-Cheetah3", "python3-PyYAML"]
 # Packages for building & installing Cobbler from source

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -15,7 +15,7 @@ There are two main settings files which are located per default at ``/etc/cobble
              change due to the fact that PyYAML doesn't support comments
              (`Source <https://github.com/yaml/pyyaml/issues/90>`_)
 
-There are additional configuration files location which need to follow the YAML Syntax. These are loaded from the
+There are additional configuration file locations which need to follow the YAML Syntax. These are loaded from the
 ``include`` directory in the ``settings.yaml`` file. Any key specified in one of these files overwrites values from the
 main file.
 
@@ -30,12 +30,12 @@ Starting with 3.2.1:
 
 - We require the extension ``.yaml`` on our settings file to indicate the format of the file to editors and comply to
   standards of the YAML specification.
-- We require the usage of Booleans in the format of ``True`` and ``False``. If you have old integer style booleans with
-  ``1`` and ``0`` this is fine but may should convert them as soon as possible. We may decide in a future version to
+- We require the usage of booleans in the format of ``True`` and ``False``. If you have old integer style booleans with
+  ``1`` and ``0`` this is fine but you may should convert them as soon as possible. We may decide in a future version to
   enforce our new way in a stricter manner. Automatic conversion is only done on a best-effort/available-resources
   basis.
 - We enforce the types of values to the keys. Additional unexpected keys will throw errors. If you have those used in
-  Cobbler please report this in our Issue Tracker. We have decided to go this way to be able to rely on the existence
+  Cobbler please report this in our issue tracker. We have decided to go this way to be able to rely on the existence
   of the values. This gives us the freedom to write less access checks to the settings without loosing stability.
 
 ``settings.yaml``
@@ -52,7 +52,7 @@ default: ``False``
 allow_duplicate_ips
 ===================
 
-If "True", Cobbler will allow insertions of system records that duplicate the IP address information of other system
+If ``True``, Cobbler will allow insertions of system records that duplicate the IP address information of other system
 records. In general, this is undesirable and should be left False.
 
 default: ``False``
@@ -155,7 +155,7 @@ default: ``/var/lib/cobbler/loaders``
 grubconfig_dir
 ==============
 
-The location where Cobbler searches for Grub configuration files.
+The location where Cobbler searches for GRUB configuration files.
 
 default: ``/var/lib/cobbler/grub_config``
 
@@ -164,10 +164,10 @@ build_reporting_*
 
 Email out a report when Cobbler finishes installing a system.
 
-- enabled: set to ``True`` to turn this feature on
+- enabled: Set to ``true`` to turn this feature on
 - email: Which addresses to email
 - ignorelist: TODO
-- sender: optional
+- sender: Optional
 - smtp_server: Used to specify another server for an MTA.
 - subject: Use the default subject unless overridden.
 
@@ -175,7 +175,7 @@ defaults:
 
 .. code:: YAML
 
-    build_reporting_enabled: False
+    build_reporting_enabled: false
     build_reporting_sender: ""
     build_reporting_email: [ 'root@localhost' ]
     build_reporting_smtp_server: "localhost"
@@ -185,8 +185,8 @@ defaults:
 buildisodir
 ===========
 
-Used for caching the intermediate files for ISO-Building. You may want to use an SSD, a tmpfs or something which is not
-persisted across reboots and can be easily thrown away but is also fast.
+Used for caching the intermediate files for ISO-Building. You may want to use a SSD, a tmpfs or something which does not
+persist across reboots and can be easily thrown away but is also fast.
 
 default: ``/var/cache/cobbler/buildiso``
 
@@ -226,7 +226,7 @@ client_use_localhost
 ====================
 
 If set to ``True``, all commands will be forced to use the localhost address instead of using the above value which can
-force commands like Cobbler sync to open a connection to a remote address if one is in the configuration and would
+force commands like ``cobbler sync`` to open a connection to a remote address if one is in the configuration and would
 traceback.
 
 default: ``False``
@@ -241,7 +241,7 @@ default: ``""``
 convert_server_to_ip
 ====================
 
-Convert hostnames to IP-addresses (where possible) so DNS isn't a requirement for various tasks to work correctly.
+Convert hostnames to IP addresses (where possible) so DNS isn't a requirement for various tasks to work correctly.
 
 default: ``False``
 
@@ -300,7 +300,7 @@ following template engine to parse the templates.
 
 .. note:: Over time we will try to deprecate and remove Cheetah3 as a template engine. It is hard to package and there
           are fewer guides then with Jinja2. Making the templating independent of the engine is a task which complicates
-          the code. Thus please try to use Jinja2. We will try to support a seamless transition on a best-effort basis.
+          the code. Thus, please try to use Jinja2. We will try to support a seamless transition on a best-effort basis.
 
 Current valid values are: ``cheetah``, ``jinja2``
 
@@ -422,8 +422,8 @@ defaults:
     ldap_server: "ldap.example.com"
     ldap_base_dn: "DC=example,DC=com"
     ldap_port: 389
-    ldap_tls: True
-    ldap_anonymous_bind: True
+    ldap_tls: true
+    ldap_anonymous_bind: true
     ldap_search_bind_dn: ''
     ldap_search_passwd: ''
     ldap_search_prefix: 'uid='
@@ -434,7 +434,7 @@ defaults:
 bind_manage_ipmi
 ================
 
-When using the Bind9 DNS Server, you can enable or disable if the BMCs should receive own DNS entries.
+When using the Bind9 DNS server, you can enable or disable if the BMCs should receive own DNS entries.
 
 default: ``False``
 
@@ -470,7 +470,7 @@ defaults:
 manage_genders
 ==============
 
-Whether or not to manage the Genders file. For more information on that visit:
+Whether or not to manage the genders file. For more information on that visit:
 `github.com/chaos/genders <https://github.com/chaos/genders>`_
 
 default: ``False``
@@ -497,11 +497,11 @@ Cobbler has a feature that allows for integration with config management systems
 parameters work in conjunction with ``--mgmt-classes`` and are described in further detail at
 :ref:`configuration-management`.
 
-.. code-block:: Yaml
+.. code-block:: YAML
 
     mgmt_classes: []
     mgmt_parameters:
-        from_cobbler: True
+        from_cobbler: true
 
 next_server
 ===========
@@ -514,7 +514,7 @@ default: ``127.0.0.1``
 nsupdate_enabled
 ================
 
-This enabled or disables the replacement (or removal) of records in the DNS zone for systems created (or removed) by
+This enables or disables the replacement (or removal) of records in the DNS zone for systems created (or removed) by
 Cobbler.
 
 .. note:: There are additional settings needed when enabling this. Due to the limited number of resources, this won't
@@ -665,7 +665,7 @@ default: ``False``
 redhat_management_server
 ========================
 
-This setting is only used by the code that supports using Spacewalk/Satellite authentication within Cobbler Web and
+This setting is only used by the code that supports using Uyuni/SUSE Manager/Spacewalk/Satellite authentication within Cobbler Web and
 Cobbler XML-RPC.
 
 default: ``"xmlrpc.rhn.redhat.com"``
@@ -739,10 +739,10 @@ need to change this.
 
 defaults:
 
-.. code::
+.. code:: YAML
 
-    restart_dns: True
-    restart_dhcp: True
+    restart_dns: true
+    restart_dhcp: true
 
 run_install_triggers
 ====================
@@ -752,7 +752,7 @@ sections. Any executable script in those directories is run. They can be used to
 They are currently run as root so if you do not need this functionality you can disable it, though this will also
 disable ``cobbler status`` which uses a logging trigger to audit install progress.
 
-default: ``True``
+default: ``true``
 
 scm_track_*
 ===========
@@ -763,9 +763,9 @@ purposes. Git and Mercurial are currently supported, but Git is the recommend SC
 
 default:
 
-.. code::
+.. code:: YAML
 
-    scm_track_enabled: False
+    scm_track_enabled: false
     scm_track_mode: "git"
     scm_track_author: "cobbler <cobbler@localhost>"
     scm_push_script: "/bin/true"
@@ -794,12 +794,12 @@ When puppet starts on a system after installation it needs to have its certifica
 Enabling the following feature will ensure that the puppet server signs the certificate after installation if the puppet
 master server is running on the same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled.
 
-default: ``False``
+default: ``false``
 
 signature_path
 ==============
 
-The Cobbler Import workflow is powered by this file. Its location can be set with this config option.
+The ``cobbler import`` workflow is powered by this file. Its location can be set with this config option.
 
 default: ``/var/lib/cobbler/distro_signatures.json``
 
@@ -824,7 +824,7 @@ virt_auto_boot
 Should new profiles for virtual machines default to auto booting with the physical host when the physical host reboots?
 This can be overridden on each profile or system object.
 
-default: ``True``
+default: ``true``
 
 webdir
 ======
@@ -873,7 +873,7 @@ yum_distro_priority
 The default yum priority for all the distros. This is only used if yum-priorities plugin is used. 1 is the maximum
 value. Tweak with caution.
 
-default: ``True``
+default: ``true``
 
 yum_post_install_mirror
 =======================
@@ -883,7 +883,7 @@ automatically set up in the Cobbler autoinstall templates. By default, these are
 make these repositories usable on installed systems (since Cobbler makes a very convenient mirror) set this to ``True``.
 Most users can safely set this to ``True``. Users who have a dual homed Cobbler server, or are installing laptops that
 will not always have access to the Cobbler server may wish to leave this as ``False``. In that case, the Cobbler
-mirrored yum repos are still accessible at ``http://cobbler.example.org/cblr/repo_mirror`` and yum configuration can
+mirrored yum repos are still accessible at ``http://cobbler.example.org/cblr/repo_mirror`` and YUM configuration can
 still be done manually. This is just a shortcut.
 
 default: ``True``
@@ -990,7 +990,7 @@ default: ``manage_isc``
 tftpd
 =====
 
-Chooses the TFTP management engine if ``manage_tftpd`` is enabled in ``/etc/cobbler/settings.yaml``, which is ON by
+Chooses the TFTP management engine if ``manage_tftpd`` is enabled in ``/etc/cobbler/settings.yaml``, which is **on** by
 default.
 
 Choices:

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -2,66 +2,114 @@
 Cobbler Configuration
 *********************
 
-There are two main settings files: settings and modules.conf. Both files can be found under ``/etc/cobbler/`` and both are
-written in YAML.
+There are two main settings files which are located per default at ``/etc/cobbler/``:
 
-settings
-########
+- The file ``settings.yaml`` is following `YAML <https://yaml.org/spec/1.2/spec.html>`_ specification.
+- The file ``modules.conf`` is following
+  `INI <https://docs.python.org/3/library/configparser.html#supported-ini-file-structure>`_ specification.
+
+.. note:: Since we are cleaning a lot of tech-debt this may change over time. We are trying to find the balance which
+          format is the best for us to handle in the code and the best for admins to handle in the config files.
+
+.. warning:: If you are using ``allow_dynamic_settings``, then the comments in the YAML file will vanish after the first
+             change due to the fact that PyYAML doesn't support comments
+             (`Source <https://github.com/yaml/pyyaml/issues/90>`_)
+
+There are additional configuration files location which need to follow the YAML Syntax. These are loaded from the
+``include`` directory in the ``settings.yaml`` file. Any key specified in one of these files overwrites values from the
+main file.
+
+.. warning:: When using ``allow_dynamic_settings`` the values are only persisted in the file ``settings.yaml``. This
+             may lead to a non expected behaviour after ``cobblerd`` restarts. This is a
+             `known issue <https://github.com/cobbler/cobbler/issues/2549>`_.
+
+Updates to the yaml-settings-file
+#################################
+
+Starting with 3.2.1:
+
+- We require the extension ``.yaml`` on our settings file to indicate the format of the file to editors and comply to
+  standards of the YAML specification.
+- We require the usage of Booleans in the format of ``True`` and ``False``. If you have old integer style booleans with
+  ``1`` and ``0`` this is fine but may should convert them as soon as possible. We may decide in a future version to
+  enforce our new way in a stricter manner. Automatic conversion is only done on a best-effort/available-resources
+  basis.
+- We enforce the types of values to the keys. Additional unexpected keys will throw errors. If you have those used in
+  Cobbler please report this in our Issue Tracker. We have decided to go this way to be able to rely on the existence
+  of the values. This gives us the freedom to write less access checks to the settings without loosing stability.
+
+``settings.yaml``
+#################
 
 allow_duplicate_hostnames
 =========================
-if 1, Cobbler will allow insertions of system records that duplicate the ``--dns-name`` information of other system records.
-In general, this is undesirable and should be left 0.
 
-default: ``0``
+If ``True``, Cobbler will allow insertions of system records that duplicate the ``--dns-name`` information of other
+system records. In general, this is undesirable and should be left False.
+
+default: ``False``
 
 allow_duplicate_ips
 ===================
-if 1, Cobbler will allow insertions of system records that duplicate the IP address information of other system records.
-In general, this is undesirable and should be left 0.
 
-default: ``0``
+If "True", Cobbler will allow insertions of system records that duplicate the IP address information of other system
+records. In general, this is undesirable and should be left False.
+
+default: ``False``
 
 allow_duplicate_macs
 ====================
-If 1, Cobbler will allow insertions of system records that duplicate the mac address information of other system
+
+If ``True``, Cobbler will allow insertions of system records that duplicate the mac address information of other system
 records. In general, this is undesirable.
 
-default: ``0``
+default: ``False``
 
 allow_dynamic_settings
 ======================
-If 1, Cobbler will allow settings to be changed dynamically without a restart of the `cobblerd` daemon. You can only
-change this variable by manually editing the settings file, and you MUST restart `cobblerd` after changing it.
 
-default: ``0``
+If ``True``, Cobbler will allow settings to be changed dynamically without a restart of the ``cobblerd`` daemon. You can
+only change this variable by manually editing the settings file, and you MUST restart ``cobblerd`` after changing it.
+
+default: ``False``
+
+always_write_dhcp_entries
+=========================
+
+Always write DHCP entries, regardless if netboot is enabled.
+
+default: ``False``
 
 anamon_enabled
 ==============
+
 By default, installs are *not* set to send installation logs to the Cobbler server. With ``anamon_enabled``, automatic
 installation templates may use the ``pre_anamon`` snippet to allow remote live monitoring of their installations from
 the Cobbler server. Installation logs will be stored under ``/var/log/cobbler/anamon/``.
 
-**Note**: This does allow an XML-RPC call to send logs to this directory, without authentication, so enable only if you
-are ok with this limitation.
+.. note:: This does allow an XML-RPC call to send logs to this directory, without authentication, so enable only if you
+          are ok with this limitation.
 
-default: ``0``
+default: ``False``
+
+auth_token_expiration
+=====================
+
+How long the authentication token is valid for, in seconds.
+
+default: ``3600``
 
 authn_pam_service
 =================
+
 If using authn_pam in the ``modules.conf``, this can be configured to change the PAM service authentication will be
 tested against.
 
 default: ``"login"``
 
-auth_token_expiration
-=====================
-How long the authentication token is valid for, in seconds.
-
-default: ``3600``
-
 autoinstall_snippets_dir
 ========================
+
 This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information. Changing
 this directory should not be required.
 
@@ -69,96 +117,173 @@ default: ``/var/lib/cobbler/snippets``
 
 autoinstall_templates_dir
 =========================
+
 This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information. Changing
 this directory should not be required.
 
 default: ``/var/lib/cobbler/templates``
 
+bind_chroot_path
+================
+
+Set to path of bind chroot to create bind-chroot compatible bind configuration files. This should be automatically
+detected.
+
+default: ``""``
+
+bind_master
+===========
+
+Set to the ip address of the master bind DNS server for creating secondary bind configuration files.
+
+default: ``127.0.0.1``
+
 boot_loader_conf_template_dir
 =============================
+
 Location of templates used for boot loader config generation.
 
 default: ``"/etc/cobbler/boot_loader_conf"``
 
+bootloaders_dir
+===============
+
+The location where Cobbler searches for the bootloaders to copy into the web directory.
+
+default: ``/var/lib/cobbler/loaders``
+
+grubconfig_dir
+==============
+
+The location where Cobbler searches for Grub configuration files.
+
+default: ``/var/lib/cobbler/grub_config``
+
 build_reporting_*
 =================
+
 Email out a report when Cobbler finishes installing a system.
 
-- enabled: set to 1 to turn this feature on
+- enabled: set to ``True`` to turn this feature on
+- email: Which addresses to email
+- ignorelist: TODO
 - sender: optional
-- email: which addresses to email
-- smtp_server: used to specify another server for an MTA
-- subject: use the default subject unless overridden
+- smtp_server: Used to specify another server for an MTA.
+- subject: Use the default subject unless overridden.
 
 defaults:
 
-.. code::
+.. code:: YAML
 
-    build_reporting_enabled: 0
+    build_reporting_enabled: False
     build_reporting_sender: ""
     build_reporting_email: [ 'root@localhost' ]
     build_reporting_smtp_server: "localhost"
     build_reporting_subject: ""
     build_reporting_ignorelist: [ "" ]
 
-cache_enabled
-========================
-If cache_enabled is 1, a cache will keep converted records in memory to make checking them faster.  This helps with
-use cases like writing out large numbers of records.  There is a known issue with cache and remote XML-RPC API calls.
-If you will use Cobbler with config management or infrastructure-as-code tools such as Terraform, it is recommended
-to disable by setting to 0.
+buildisodir
+===========
 
-default: ``1``
+Used for caching the intermediate files for ISO-Building. You may want to use an SSD, a tmpfs or something which is not
+persisted across reboots and can be easily thrown away but is also fast.
+
+default: ``/var/cache/cobbler/buildiso``
+
+cache_enabled
+=============
+
+If ``cache_enabled`` is ``True``, a cache will keep converted records in memory to make checking them faster. This helps
+with use cases like writing out large numbers of records. There is a known issue with cache and remote XML-RPC API
+calls. If you will use Cobbler with config management or infrastructure-as-code tools such as Terraform, it is
+recommended to disable by setting to ``False``.
+
+default: ``True``
 
 cheetah_import_whitelist
 ========================
+
 Cheetah-language autoinstall templates can import Python modules. while this is a useful feature, it is not safe to
 allow them to import anything they want. This whitelists which modules can be imported through Cheetah. Users can expand
 this as needed but should never allow modules such as subprocess or those that allow access to the filesystem as Cheetah
-templates are evaluated by `cobblerd` as code.
+templates are evaluated by ``cobblerd`` as code.
 
 default:
- - "random"
- - "re"
- - "time"
- - "netaddr"
+ - ``random``
+ - ``re``
+ - ``time``
+ - ``netaddr``
+
+client_use_https
+================
+
+If set to ``True``, all commands to the API (not directly to the XML-RPC server) will go over HTTPS instead of plain
+text. Be sure to change the ``http_port`` setting to the correct value for the web server.
+
+default: ``False``
+
+client_use_localhost
+====================
+
+If set to ``True``, all commands will be forced to use the localhost address instead of using the above value which can
+force commands like Cobbler sync to open a connection to a remote address if one is in the configuration and would
+traceback.
+
+default: ``False``
+
+cobbler_master
+==============
+
+Used for replicating the Cobbler instance.
+
+default: ``""``
+
+convert_server_to_ip
+====================
+
+Convert hostnames to IP-addresses (where possible) so DNS isn't a requirement for various tasks to work correctly.
+
+default: ``False``
 
 createrepo_flags
 ================
-Default createrepo_flags to use for new repositories. If you have ``createrepo >= 0.4.10``, consider
-``-c cache --update -C``, which can dramatically improve your ``cobbler reposync`` time. ``-s sha`` enables working with
-Fedora repos from F11/F12 from EL-4 or EL-5 without python-hashlib installed (which is not available on EL-4)
+
+Default ``createrepo_flags`` to use for new repositories.
 
 default: ``"-c cache -s sha"``
 
 default_autoinstall
 ===================
+
 If no autoinstall template is specified to profile add, use this template.
 
 default: ``/var/lib/cobbler/autoinstall_templates/default.ks``
 
 default_name_*
 ==============
+
 Configure all installed systems to use these name servers by default unless defined differently in the profile. For DHCP
-configurations you probably do /not/ want to supply this.
+configurations you probably do **not** want to supply this.
 
 defaults:
 
-.. code::
+.. code:: YAML
 
     default_name_servers: []
     default_name_servers_search: []
 
 default_ownership
 =================
-if using the ``authz_ownership`` module (see the Wiki), objects created without specifying an owner are assigned to this
-owner and/or group. Can be a comma separated list.
+
+if using the ``authz_ownership`` module, objects created without specifying an owner are assigned to this owner and/or
+group.
 
 default:
- - "admin"
+ - ``admin``
 
 default_password_crypted
 ========================
+
 Cobbler has various sample automatic installation templates stored in ``/var/lib/cobbler/autoinstall_templates/``. This
 controls what install (root) password is set up for those systems that reference this variable. The factory default is
 "cobbler" and Cobbler check will warn if this is not changed. The simplest way to change the password is to run
@@ -168,40 +293,61 @@ default: ``"$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."``
 
 default_template_type
 =====================
+
 The default template type to use in the absence of any other detected template. If you do not specify the template
 with ``#template=<template_type>`` on the first line of your templates/snippets, Cobbler will assume try to use the
 following template engine to parse the templates.
 
-Current valid values are: cheetah, jinja2
+.. note:: Over time we will try to deprecate and remove Cheetah3 as a template engine. It is hard to package and there
+          are fewer guides then with Jinja2. Making the templating independent of the engine is a task which complicates
+          the code. Thus please try to use Jinja2. We will try to support a seamless transition on a best-effort basis.
+
+Current valid values are: ``cheetah``, ``jinja2``
 
 default: ``"cheetah"``
 
 default_virt_bridge
 ===================
+
 For libvirt based installs in Koan, if no virt-bridge is specified, which bridge do we try? For EL 4/5 hosts this should
 be ``xenbr0``, for all versions of Fedora, try ``virbr0``. This can be overridden on a per-profile basis or at the Koan
 command line though this saves typing to just set it here to the most common option.
 
 default: ``xenbr0``
 
+default_virt_disk_driver
+========================
+
+The on-disk format for the virtualization disk.
+
+default: ``raw``
+
 default_virt_file_size
 ======================
+
 Use this as the default disk size for virt guests (GB).
 
 default: ``5``
 
 default_virt_ram
 ================
+
 Use this as the default memory size for virt guests (MB).
 
 default: ``512``
 
 default_virt_type
 =================
+
 If Koan is invoked without ``--virt-type`` and no virt-type is set on the profile/system, what virtualization type
 should be assumed?
 
-Current valid values are: xenpv, xenfv, qemu, vmware
+Current valid values are:
+
+- ``xenpv``
+- ``xenfv``
+- ``qemu``
+- ``vmware``
 
 **NOTE**: this does not change what ``virt_type`` is chosen by import.
 
@@ -209,28 +355,56 @@ default: ``xenpv``
 
 enable_gpxe
 ===========
+
 Enable gPXE booting? Enabling this option will cause Cobbler to copy the ``undionly.kpxe`` file to the TFTP root
 directory, and if a profile/system is configured to boot via gPXE it will chain load off ``pxelinux.0``.
 
-default: ``0``
+.. note:: We now gPXE is not active anymore and try to transition the code, settings and guide we have to iPXE.
+
+default: ``False``
 
 enable_menu
 ===========
-Controls whether Cobbler will add each new profile entry to the default PXE boot menu. This can be over-ridden on a
-per-profile basis when adding/editing profiles with ``--enable-menu=0/1``. Users should ordinarily leave this setting
-enabled unless they are concerned with accidental reinstalls from users who select an entry at the PXE boot menu. Adding
-a password to the boot menus templates may also be a good solution to prevent unwanted reinstallations.
 
-default: ``1``
+Controls whether Cobbler will add each new profile entry to the default PXE boot menu. This can be over-ridden on a
+per-profile basis when adding/editing profiles with ``--enable-menu=False/True``. Users should ordinarily leave this
+setting enabled unless they are concerned with accidental reinstall from users who select an entry at the PXE boot
+menu. Adding a password to the boot menus templates may also be a good solution to prevent unwanted reinstallations.
+
+default: ``True``
 
 http_port
 =========
+
 Change this port if Apache is not running plain text on port 80. Most people can leave this alone.
 
 default: ``80``
 
+include
+=======
+
+Include other configuration snippets with this regular expression. This is a list of folders.
+
+default: ``[ "/etc/cobbler/settings.d/*.settings" ]``
+
+iso_template_dir
+================
+
+Folder to search for the ISO templates. These will build the boot-menu of the built ISO.
+
+default: ``/etc/cobbler/iso``
+
+jinja2_includedir
+=================
+
+This is a directory of files that Cobbler uses to include files into Jinja2 templates. Per default this settings is
+commented out.
+
+default: ``/var/lib/cobbler/jinja2``
+
 kernel_options
 ==============
+
 Kernel options that should be present in every Cobbler installation. Kernel options can also be applied at the
 distro/profile/system level.
 
@@ -248,8 +422,8 @@ defaults:
     ldap_server: "ldap.example.com"
     ldap_base_dn: "DC=example,DC=com"
     ldap_port: 389
-    ldap_tls: 1
-    ldap_anonymous_bind: 1
+    ldap_tls: True
+    ldap_anonymous_bind: True
     ldap_search_bind_dn: ''
     ldap_search_passwd: ''
     ldap_search_prefix: 'uid='
@@ -257,118 +431,34 @@ defaults:
     ldap_tls_keyfile: ''
     ldap_tls_certfile: ''
 
-mgmt_*
-======
-Cobbler has a feature that allows for integration with config management systems such as Puppet. The following
-parameters work in conjunction with ``--mgmt-classes`` and are described in further detail at :ref:`configuration-management`.
+bind_manage_ipmi
+================
 
-.. code-block:: Yaml
+When using the Bind9 DNS Server, you can enable or disable if the BMCs should receive own DNS entries.
 
-    mgmt_classes: []
-    mgmt_parameters:
-        from_cobbler: 1
-
-puppet_auto_setup
-=================
-If enabled, this setting ensures that puppet is installed during machine provision, a client certificate is generated
-and a certificate signing request is made with the puppet master server.
-
-default: ``0``
-
-sign_puppet_certs_automatically
-===============================
-When puppet starts on a system after installation it needs to have its certificate signed by the puppet master server.
-Enabling the following feature will ensure that the puppet server signs the certificate after installation if the puppet
-master server is running on the same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled.
-
-default: ``0``
-
-puppetca_path
-=============
-Location of the puppet executable, used for revoking certificates.
-
-default: ``"/usr/bin/puppet"``
-
-remove_old_puppet_certs_automatically
-=====================================
-When a puppet managed machine is reinstalled it is necessary to remove the puppet certificate from the puppet master
-server before a new certificate is signed (see above). Enabling the following feature will ensure that the certificate
-for the machine to be installed is removed from the puppet master server if the puppet master server is running on the
-same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled
-
-default: ``0``
-
-puppet_server
-=============
-Choose a ``--server`` argument when running puppetd/puppet agent during autoinstall. This one is commented out by
-default.
-
-default: ``'puppet'``
-
-puppet_version
-==============
-Let Cobbler know that you're using a newer version of puppet. Choose version 3 to use: 'puppet agent'; version 2 uses
-status quo: 'puppetd'. This one is commented out by default.
-
-default: ``2``
-
-puppet_parameterized_classes
-============================
-Choose whether to enable puppet parameterized classes or not. Puppet versions prior to 2.6.5 do not support parameters.
-This one is commented out by default.
-
-default: 1
+default: ``False``
 
 manage_dhcp
 ===========
-Set to 1 to enable Cobbler's DHCP management features. The choice of DHCP management engine is in
+
+Set to ``True`` to enable Cobbler's DHCP management features. The choice of DHCP management engine is in
 ``/etc/cobbler/modules.conf``.
 
-default: ``0``
+default: ``True``
 
 manage_dns
 ==========
-Set to 1 to enable Cobbler's DNS management features. The choice of DNS management engine is in
+
+Set to ``True`` to enable Cobbler's DNS management features. The choice of DNS management engine is in
 ``/etc/cobbler/modules.conf``.
 
-default: ``0``
+default: ``False``
 
-bind_chroot_path
-================
-Set to path of bind chroot to create bind-chroot compatible bind configuration files. This should be automatically
-detected.
-
-default: ``""``
-
-bind_master
-===========
-Set to the ip address of the master bind DNS server for creating secondary bind configuration files.
-
-default: ``127.0.0.1``
-
-manage_tftpd
+manage_*_zones
 ==============
-Set to 1 to enable Cobbler's TFTP management features. the choice of TFTP management engine is in
-``/etc/cobbler/modules.conf``.
 
-default: ``1``
-
-tftpboot_location
-=================
-This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not start.
-
-Default: ``/srv/tftpboot``
-
-manage_rsync
-============
-Set to 1 to enable Cobbler's RSYNC management features.
-
-default: ``0``
-
-manage_*
-========
-If using BIND (named) for DNS management in ``/etc/cobbler/modules.conf`` and manage_dns is enabled (above), this lists
-which zones are managed. See :ref:`dns-management` for more information.
+If using BIND (named) for DNS management in ``/etc/cobbler/modules.conf`` and ``manage_dns`` is enabled (above), this
+lists which zones are managed. See :ref:`dns-management` for more information.
 
 defaults:
 
@@ -377,18 +467,96 @@ defaults:
     manage_forward_zones: []
     manage_reverse_zones: []
 
+manage_genders
+==============
+
+Whether or not to manage the Genders file. For more information on that visit:
+`github.com/chaos/genders <https://github.com/chaos/genders>`_
+
+default: ``False``
+
+manage_rsync
+============
+
+Set to ``True`` to enable Cobbler's RSYNC management features.
+
+default: ``False``
+
+manage_tftpd
+==============
+
+Set to ``True`` to enable Cobbler's TFTP management features. The choice of TFTP management engine is in
+``/etc/cobbler/modules.conf``.
+
+default: ``True``
+
+mgmt_*
+======
+
+Cobbler has a feature that allows for integration with config management systems such as Puppet. The following
+parameters work in conjunction with ``--mgmt-classes`` and are described in further detail at
+:ref:`configuration-management`.
+
+.. code-block:: Yaml
+
+    mgmt_classes: []
+    mgmt_parameters:
+        from_cobbler: True
+
 next_server
 ===========
+
 If using Cobbler with ``manage_dhcp``, put the IP address of the Cobbler server here so that PXE booting guests can find
 it. If you do not set this correctly, this will be manifested in TFTP open timeouts.
 
 default: ``127.0.0.1``
 
+nsupdate_enabled
+================
+
+This enabled or disables the replacement (or removal) of records in the DNS zone for systems created (or removed) by
+Cobbler.
+
+.. note:: There are additional settings needed when enabling this. Due to the limited number of resources, this won't
+          be done until 3.3.0. Thus please expect to run into troubles when enabling this setting.
+
+default: ``False``
+
+nsupdate_log
+============
+
+The logfile to document what records are added or removed in the DNS zone for systems.
+
+.. note:: The functionality this settings is related to is currently not tested due to tech-debt. Please use it with
+          caution. This note will be removed once we were able to look deeper into this functionality of Cobbler.
+
+- Required: No
+- Default: ``/var/log/cobbler/nsupdate.log``
+
+nsupdate_tsig_algorithm
+=======================
+
+.. note:: The functionality this settings is related to is currently not tested due to tech-debt. Please use it with
+          caution. This note will be removed once we were able to look deeper into this functionality of Cobbler.
+
+- Required: No
+- Default: ``hmac-sha512``
+
+nsupdate_tsig_key
+=================
+
+.. note:: The functionality this settings is related to is currently not tested due to tech-debt. Please use it with
+          caution. This note will be removed once we were able to look deeper into this functionality of Cobbler.
+
+- Required: No
+- Default: ``[]``
+
 power_management_default_type
 =============================
+
 Settings for power management features. These settings are optional. See :ref:`power-management` to learn more.
 
-Choices (refer to codes.py):
+Choices (refer to the `fence-agents project <https://github.com/ClusterLabs/fence-agents>`_ for a complete list):
 
 - apc_snmp
 - bladecenter
@@ -406,31 +574,85 @@ Choices (refer to codes.py):
 
 default: ``ipmilanplus``
 
+proxy_url_ext
+=============
+
+External proxy which is used by the following commands: ``get-loaders``, ``reposync``, ``signature update``
+
+defaults:
+
+.. code::
+
+  http: http://192.168.1.1:8080
+  https: https://192.168.1.1:8443
+
+proxy_url_int
+=============
+
+Internal proxy which is used by systems to reach Cobbler for kickstarts.
+
+e.g.: ``proxy_url_int: http://10.0.0.1:8080``
+
+default: ``""``
+
+puppet_auto_setup
+=================
+
+If enabled, this setting ensures that puppet is installed during machine provision, a client certificate is generated
+and a certificate signing request is made with the puppet master server.
+
+default: ``False``
+
+puppet_parameterized_classes
+============================
+
+Choose whether to enable puppet parameterized classes or not. Puppet versions prior to 2.6.5 do not support parameters.
+
+default: ``True``
+
+puppet_server
+=============
+
+Choose a ``--server`` argument when running puppetd/puppet agent during autoinstall.
+
+default: ``'puppet'``
+
+puppet_version
+==============
+
+Let Cobbler know that you're using a newer version of puppet. Choose version 3 to use: 'puppet agent'; version 2 uses
+status quo: 'puppetd'.
+
+default: ``2``
+
+puppetca_path
+=============
+
+Location of the puppet executable, used for revoking certificates.
+
+default: ``"/usr/bin/puppet"``
+
 pxe_just_once
 =============
-If this setting is set to 1, Cobbler systems that pxe boot will request at the end of their installation to toggle the
-``--netboot-enabled`` record in the Cobbler system record. This eliminates the potential for a PXE boot loop if the
-system is set to PXE first in it's BIOS order. Enable this if PXE is first in your BIOS boot order, otherwise leave this
-disabled. See the manpage for ``--netboot-enabled``.
 
-default: ``1``
+If this setting is set to ``True``, Cobbler systems that pxe boot will request at the end of their installation to
+toggle the ``--netboot-enabled`` record in the Cobbler system record. This eliminates the potential for a PXE boot loop
+if the system is set to PXE first in it's BIOS order. Enable this if PXE is first in your BIOS boot order, otherwise
+leave this disabled. See the manpage for ``--netboot-enabled``.
+
+default: ``True``
 
 nopxe_with_triggers
 ===================
-If this setting is set to one, triggers will be executed when systems will request to toggle the ``--netboot-enabled``
-record at the end of their installation.
 
-default: ``1``
+If this setting is set to ``True``, triggers will be executed when systems will request to toggle the
+``--netboot-enabled`` record at the end of their installation.
 
-redhat_management_server
-========================
-This setting is only used by the code that supports using Spacewalk/Satellite authentication within Cobbler Web and
-Cobbler XML-RPC.
-
-default: ``"xmlrpc.rhn.redhat.com"``
+default: ``True``
 
 redhat_management_permissive
 ============================
+
 If using ``authn_spacewalk`` in ``modules.conf`` to let Cobbler authenticate against Satellite/Spacewalk's auth system,
 by default it will not allow per user access into Cobbler Web and Cobbler XML-RPC. In order to permit this, the following
 setting must be enabled HOWEVER doing so will permit all Spacewalk/Satellite users of certain types to edit all of
@@ -438,10 +660,19 @@ Cobbler's configuration. these roles are: ``config_admin`` and ``org_admin``. Us
 want this behavior and do not have a cross-multi-org separation concern. If you have a single org in your satellite,
 it's probably safe to turn this on and then you can use CobblerWeb alongside a Satellite install.
 
-default: ``0``
+default: ``False``
+
+redhat_management_server
+========================
+
+This setting is only used by the code that supports using Spacewalk/Satellite authentication within Cobbler Web and
+Cobbler XML-RPC.
+
+default: ``"xmlrpc.rhn.redhat.com"``
 
 redhat_management_key
 =====================
+
 Specify the default Red Hat authorization key to use to register system. If left blank, no registration will be
 attempted. Similarly you can set the ``--redhat-management-key`` to blank on any system to keep it from trying to
 register.
@@ -450,13 +681,39 @@ default: ``""``
 
 register_new_installs
 =====================
-If set to ``1``, allows ``/usr/bin/cobbler-register`` (part of the Koan package) to be used to remotely add new Cobbler
-system records to Cobbler. This effectively allows for registration of new hardware from system records.
 
-default: ``0``
+If set to ``True``, allows ``/usr/bin/cobbler-register`` (part of the Koan package) to be used to remotely add new
+Cobbler system records to Cobbler. This effectively allows for registration of new hardware from system records.
+
+default: ``False``
+
+remove_old_puppet_certs_automatically
+=====================================
+
+When a puppet managed machine is reinstalled it is necessary to remove the puppet certificate from the puppet master
+server before a new certificate is signed (see above). Enabling the following feature will ensure that the certificate
+for the machine to be installed is removed from the puppet master server if the puppet master server is running on the
+same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled
+
+default: ``False``
+
+replicate_repo_rsync_options
+============================
+
+Replication rsync options for repos set to override default value of ``-avzH``.
+
+default: ``"-avzH"``
+
+replicate_rsync_options
+=======================
+
+replication rsync options for distros, autoinstalls, snippets set to override default value of ``-avzH``.
+
+default: ``"-avzH"``
 
 reposync_flags
 ==============
+
 Flags to use for yum's reposync. If your version of yum reposync does not support ``-l``, you may need to remove that
 option.
 
@@ -464,12 +721,14 @@ default: ``"-l -n -d"``
 
 reposync_rsync_flags
 ====================
-Flags to use for rysync's reposync. If archive mode (-a,--archive) is used then createrepo is not ran after the rsync as it pulls down the repodata as well. This allows older OS's to mirror modular repos using rsync.
+Flags to use for rysync's reposync. If archive mode (-a,--archive) is used then createrepo is not ran after the rsync as
+it pulls down the repodata as well. This allows older OS's to mirror modular repos using rsync.
 
 default: ``"-rltDv --copy-unsafe-links"``
 
 restart_*
 =========
+
 When DHCP and DNS management are enabled, ``cobbler sync`` can automatically restart those services to apply changes.
 The exception for this is if using ISC for DHCP, then OMAPI eliminates the need for a restart. ``omapi``, however, is
 experimental and not recommended for most configurations. If DHCP and DNS are going to be managed, but hosted on a box
@@ -482,20 +741,22 @@ defaults:
 
 .. code::
 
-    restart_dns: 1
-    restart_dhcp: 1
+    restart_dns: True
+    restart_dhcp: True
 
 run_install_triggers
 ====================
+
 Install triggers are scripts in ``/var/lib/cobbler/triggers/install`` that are triggered in autoinstall pre and post
 sections. Any executable script in those directories is run. They can be used to send email or perform other actions.
 They are currently run as root so if you do not need this functionality you can disable it, though this will also
 disable ``cobbler status`` which uses a logging trigger to audit install progress.
 
-default: ``1``
+default: ``True``
 
 scm_track_*
 ===========
+
 enables a trigger which version controls all changes to ``/var/lib/cobbler`` when add, edit, or sync events are
 performed. This can be used to revert to previous database versions, generate RSS feeds, or for other auditing or backup
 purposes. Git and Mercurial are currently supported, but Git is the recommend SCM for use with this feature.
@@ -504,13 +765,21 @@ default:
 
 .. code::
 
-    scm_track_enabled: 0
+    scm_track_enabled: False
     scm_track_mode: "git"
     scm_track_author: "cobbler <cobbler@localhost>"
     scm_push_script: "/bin/true"
 
+serializer_pretty_json
+======================
+
+Sort and indent JSON output to make it more human-readable.
+
+default: ``False``
+
 server
 ======
+
 This is the address of the Cobbler server -- as it is used by systems during the install process, it must be the address
 or hostname of the system as those systems can see the server. if you have a server that appears differently to
 different subnets (dual homed, etc), you need to read the ``--server-override`` section of the manpage for how that
@@ -518,29 +787,48 @@ works.
 
 default: ``127.0.0.1``
 
-client_use_localhost
-====================
-If set to 1, all commands will be forced to use the localhost address instead of using the above value which can force
-commands like Cobbler sync to open a connection to a remote address if one is in the configuration and would traceback.
+sign_puppet_certs_automatically
+===============================
 
-default: ``0``
+When puppet starts on a system after installation it needs to have its certificate signed by the puppet master server.
+Enabling the following feature will ensure that the puppet server signs the certificate after installation if the puppet
+master server is running on the same machine as Cobbler. This requires ``puppet_auto_setup`` above to be enabled.
 
-client_use_https
-================
-If set to 1, all commands to the API (not directly to the XML-RPC server) will go over HTTPS instead of plain text. Be
-sure to change the ``http_port`` setting to the correct value for the web server.
+default: ``False``
 
-default: ``0``
+signature_path
+==============
+
+The Cobbler Import workflow is powered by this file. Its location can be set with this config option.
+
+default: ``/var/lib/cobbler/distro_signatures.json``
+
+signature_url
+=============
+
+Updates to the signatures may happen more often then we have releases. To enable you to import new version we provide
+the most up to date signatures we offer on this like. You may host this file for yourself and adjust it for your needs.
+
+default: ``https://cobbler.github.io/signatures/3.0.x/latest.json``
+
+tftpboot_location
+=================
+
+This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not start.
+
+Default: ``/srv/tftpboot``
 
 virt_auto_boot
 ==============
+
 Should new profiles for virtual machines default to auto booting with the physical host when the physical host reboots?
 This can be overridden on each profile or system object.
 
-default: ``1``
+default: ``True``
 
 webdir
 ======
+
 Cobbler's web directory.  Don't change this setting -- see the Wiki on "relocating your Cobbler install" if your /var partition
 is not large enough.
 
@@ -548,6 +836,7 @@ default: ``@@webroot@@/cobbler``
 
 webdir_whitelist
 ================
+
 Directories that will not get wiped and recreated on a ``cobbler sync``.
 
 default:
@@ -572,99 +861,48 @@ default:
 
 xmlrpc_port
 ===========
+
 Cobbler's public XML-RPC listens on this port. Change this only if absolutely needed, as you'll have to start supplying
 a new port option to Koan if it is not the default.
 
 default: ``25151``
 
-yum_post_install_mirror
-=======================
-``cobbler repo add`` commands set Cobbler up with repository information that can be used during autoinstall and is
-automatically set up in the Cobbler autoinstall templates. By default, these are only available at install time. To
-make these repositories usable on installed systems (since Cobbler makes a very convenient mirror) set this to 1. Most
-users can safely set this to 1. Users who have a dual homed Cobbler server, or are installing laptops that will not
-always have access to the Cobbler server may wish to leave this as 0. In that case, the Cobbler mirrored yum repos are
-still accessible at ``http://cobbler.example.org/cblr/repo_mirror`` and yum configuration can still be done manually.
-This is just a shortcut.
-
-default: ``1``
-
 yum_distro_priority
 ===================
+
 The default yum priority for all the distros. This is only used if yum-priorities plugin is used. 1 is the maximum
 value. Tweak with caution.
 
-default: ``1``
+default: ``True``
+
+yum_post_install_mirror
+=======================
+
+``cobbler repo add`` commands set Cobbler up with repository information that can be used during autoinstall and is
+automatically set up in the Cobbler autoinstall templates. By default, these are only available at install time. To
+make these repositories usable on installed systems (since Cobbler makes a very convenient mirror) set this to ``True``.
+Most users can safely set this to ``True``. Users who have a dual homed Cobbler server, or are installing laptops that
+will not always have access to the Cobbler server may wish to leave this as ``False``. In that case, the Cobbler
+mirrored yum repos are still accessible at ``http://cobbler.example.org/cblr/repo_mirror`` and yum configuration can
+still be done manually. This is just a shortcut.
+
+default: ``True``
 
 yumdownloader_flags
 ===================
+
 Flags to use for yumdownloader. Not all versions may support ``--resolve``.
 
 default: ``"--resolve"``
 
-serializer_pretty_json
-======================
-Sort and indent JSON output to make it more human-readable.
-
-default: ``0``
-
-replicate_rsync_options
-=======================
-replication rsync options for distros, autoinstalls, snippets set to override default value of ``-avzH``.
-
-default: ``"-avzH"``
-
-replicate_repo_rsync_options
-============================
-Replication rsync options for repos set to override default value of ``-avzH``.
-
-default: ``"-avzH"``
-
-always_write_dhcp_entries
-=========================
-Always write DHCP entries, regardless if netboot is enabled.
-
-default: ``0``
-
-proxy_url_ext:
-==============
-External proxy - used by: get-loaders, reposync, signature update. Per default commented out.
-
-defaults:
-
-.. code::
-
-  http: http://192.168.1.1:8080
-  https: https://192.168.1.1:8443
-
-proxy_url_int
-=============
-Internal proxy - used by systems to reach Cobbler for kickstarts.
-
-E.g.: proxy_url_int: ``http://10.0.0.1:8080``
-
-default: ``""``
-
-jinja2_includedir
-=================
-This is a directory of files that Cobbler uses to include files into Jinja2 templates. Per default this settings is
-commented out.
-
-default: ``/var/lib/cobbler/jinja2``
-
-include
-=======
-Include other configuration snippets with this regular expression.
-
-default: ``[ "/etc/cobbler/settings.d/*.settings" ]``
-
-modules.conf
-############
+``modules.conf``
+################
 
 If you have own custom modules which are not shipped with Cobbler directly you may have additional sections here.
 
 authentication
 ==============
+
 What users can log into the WebUI and Read-Write XML-RPC?
 
 Choices:
@@ -691,6 +929,7 @@ default: ``authn_configfile``
 
 authorization
 =============
+
 Once a user has been cleared by the WebUI/XML-RPC, what can they do?
 
 Choices:
@@ -715,7 +954,9 @@ default: ``authz_allowall``
 
 dns
 ===
-Chooses the DNS management engine if manage_dns is enabled in ``/etc/cobbler/settings.yaml``, which is off by default.
+
+Chooses the DNS management engine if ``manage_dns`` is enabled in ``/etc/cobbler/settings.yaml``, which is off by
+default.
 
 Choices:
 
@@ -731,6 +972,7 @@ default: ``manage_bind``
 
 dhcp
 ====
+
 Chooses the DHCP management engine if ``manage_dhcp`` is enabled in ``/etc/cobbler/settings.yaml``, which is off by
 default.
 
@@ -747,7 +989,9 @@ default: ``manage_isc``
 
 tftpd
 =====
-Chooses the TFTP management engine if manage_tftp is enabled in ``/etc/cobbler/settings.yaml``, which is ON by default.
+
+Chooses the TFTP management engine if ``manage_tftpd`` is enabled in ``/etc/cobbler/settings.yaml``, which is ON by
+default.
 
 Choices:
 

--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -1006,13 +1006,14 @@ When updating repos by name, a repo will be updated even if it is set to be not 
 operation (ex: ``cobbler repo edit –name=reponame1 –keep-updated=0``).
 Note that if a cobbler import provides enough information to use the boot server as a yum mirror for core packages,
 cobbler can set up automatic installation files to use the cobbler server as a mirror instead of the outside world. If
-this feature is desirable, it can be turned on by ``setting yum_post_install_mirror`` to 1 in /etc/settings (and running
-``cobbler sync``). You should not use this feature if machines are provisioned on a different VLAN/network than
-production, or if you are provisioning laptops that will want to acquire updates on multiple networks.
+this feature is desirable, it can be turned on by ``setting yum_post_install_mirror`` to ``True`` in
+``/etc/cobbler/settings.yaml`` (and running ``cobbler sync``). You should not use this feature if machines are
+provisioned on a different VLAN/network than production, or if you are provisioning laptops that will want to acquire
+updates on multiple networks.
 
-The flags --tries=N (for example, ``--tries=3``) and ``--no-fail`` should likely be used when putting re-posync on a crontab.
-They ensure network glitches in one repo can be retried and also that a failure to synchronize
-one repo does not stop other repositories from being synchronized.
+The flags ``--tries=N`` (for example, ``--tries=3``) and ``--no-fail`` should likely be used when putting re-posync on a
+crontab. They ensure network glitches in one repo can be retried and also that a failure to synchronize one repo does
+not stop other repositories from being synchronized.
 
 Cobbler sync
 ============

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -101,13 +101,14 @@ If you ever want to update a certain repository you can run:
     cobbler reposync --only="reponame1" ...
 
 When updating repos by name, a repo will be updated even if it is set to be not updated during a regular reposync
-operation (ex: cobbler repo edit --name=reponame1 --keep-updated=0).
+operation (ex: ``cobbler repo edit --name=reponame1 --keep-updated=False``).
 
 Note that if a Cobbler import provides enough information to use the boot server as a yum mirror for core packages,
 Cobbler can set up automatic installation files to use the Cobbler server as a mirror instead of the outside world. If
-this feature is desirable, it can be turned on by setting yum_post_install_mirror to 1 in /etc/settings (and running
-"cobbler sync").  You should not use this feature if machines are provisioned on a different VLAN/network than
-production, or if you are provisioning laptops that will want to acquire updates on multiple networks.
+this feature is desirable, it can be turned on by setting ``yum_post_install_mirror`` to ``True`` in
+``/etc/cobbler/settings.yaml`` (and running ``cobbler sync``). You should not use this feature if machines are
+provisioned on a different VLAN/network than production, or if you are provisioning laptops that will want to acquire
+updates on multiple networks.
 
 The flags ``--tries=N`` (for example, ``--tries=3``) and ``--no-fail`` should likely be used when putting reposync on a
 crontab. They ensure network glitches in one repo can be retried and also that a failure to synchronize one repo does

--- a/setup.py
+++ b/setup.py
@@ -524,7 +524,8 @@ if __name__ == "__main__":
             "ldap3",
             "dnspython",
             "tornado",
-            "file-magic"
+            "file-magic",
+            "schema"
         ],
         extras_require={"lint": ["pyflakes", "pycodestyle"], "test": ["pytest", "pytest-cov", "codecov"]},
         packages=find_packages(exclude=["*tests*"]),

--- a/tests/build-and-install-debs.sh
+++ b/tests/build-and-install-debs.sh
@@ -38,8 +38,8 @@ docker exec -it cobbler bash -c 'a2enconf cobbler cobbler_web'
 echo "==> Start Supervisor"
 docker exec -it cobbler bash -c 'supervisord -c /etc/supervisord.conf'
 
-echo "==> Wait 3 sec. and show Cobbler version ..."
-docker exec -it cobbler bash -c 'sleep 3 && cobbler --version'
+echo "==> Wait 5 sec. and show Cobbler version ..."
+docker exec -it cobbler bash -c 'sleep 5 && cobbler --version'
 
 if $RUN_TESTS
 then

--- a/tests/build-and-install-rpms.sh
+++ b/tests/build-and-install-rpms.sh
@@ -47,8 +47,8 @@ docker exec -it cobbler bash -c 'supervisord -c /etc/supervisord.conf'
 echo "==> Show Logs ..."
 docker exec -it cobbler bash -c 'cat /var/log/supervisor/supervisor.log'
 
-echo "==> Wait 3 sec. and show Cobbler version ..."
-docker exec -it cobbler bash -c 'sleep 3 && cobbler version'
+echo "==> Wait 5 sec. and show Cobbler version ..."
+docker exec -it cobbler bash -c 'sleep 5 && cobbler version'
 
 if $RUN_TESTS
 then

--- a/tests/settings_test.py
+++ b/tests/settings_test.py
@@ -1,24 +1,177 @@
 import os
+import pathlib
+import shutil
 import time
 
 import pytest
+import yaml
+from schema import SchemaError
 
 from cobbler import settings
+from cobbler.settings import Settings
+from tests.conftest import does_not_raise
 
 
-@pytest.mark.skip("This breaks a lot of tests if we don't insert the full settings here.")
-def test_update_settings_file():
+class TestSettings:
+    @pytest.mark.parametrize("test_name,test_value,expected_exception,expected_result", [
+        ("server", "127.0.0.1", does_not_raise(), "127.0.0.1"),
+        ("manage_forward_zones", True, pytest.raises(AttributeError), []),
+        ("does_not_exist", None, pytest.raises(KeyError), None)
+    ])
+    def test_set(self, test_name, test_value, expected_exception, expected_result):
+        # Arrange
+        test_settings = Settings()
+
+        # Act
+        with expected_exception:
+            test_settings.set(test_name, test_value)
+
+            # Assert
+            assert test_settings.__dict__[test_name] == expected_result
+
+    def test_to_string(self):
+        # Arrange
+        test_settings = Settings()
+
+        # Act
+        result = test_settings.to_string()
+
+        # Assert
+        result_list = result.split("\n")
+        assert len(result_list) == 3
+        assert result_list[1] == "kernel options  : {}"
+
+    def test_to_dict(self):
+        # Arrange
+        test_settings = Settings()
+
+        # Act
+        result = test_settings.to_dict()
+
+        # Assert
+        assert result == test_settings.__dict__
+
+    @pytest.mark.parametrize("parameter,expected_exception,expected_result", [
+        ({}, does_not_raise(), "127.0.0.1"),
+        (None, does_not_raise(), "127.0.0.1")
+    ])
+    def test_from_dict(self, parameter, expected_exception, expected_result):
+        # Arrange
+        test_settings = Settings()
+
+        # Act
+        with expected_exception:
+            test_settings.from_dict(parameter)
+
+        # Assert
+        assert test_settings.server == expected_result
+
+
+@pytest.mark.parametrize("parameter,expected_exception,expected_result", [
+    ({}, pytest.raises(SchemaError), None)
+])
+def test_validate_settings(parameter, expected_exception, expected_result):
     # Arrange
-    settings_data = None
-    time_before_write = time.time()
 
     # Act
-    result = settings.update_settings_file(settings_data)
+    with expected_exception:
+        result = settings.validate_settings(parameter)
+
+        # Assert
+        assert result == expected_result
+
+
+def test_parse_bind_config():
+    # Arrange
+
+    # Act
+    settings.parse_bind_config("/test_dir/tests/test_data/named.conf")
+
+    # Assert
+    assert True
+
+
+def test_autodect_bind_chroot():
+    # Arrange
+
+    # Act
+    settings.autodetect_bind_chroot()
+
+    # Assert
+    assert True
+
+
+def test_read_settings_file():
+    # Arrange
+    # Default path should be fine for the tests.
+
+    # Act
+    result = settings.read_settings_file()
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("include")
+
+
+def test_update_settings_file(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/etc/cobbler/settings.yaml"
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+    shutil.copyfile(src, settings_path)
+    with open(settings_path) as settings_file:
+        settings_read_pre = yaml.safe_load(settings_file)
+        settings_read_pre.update({"include": ["mystring"]})
+
+    # Act
+    result = settings.update_settings_file(settings_read_pre, filepath=settings_path)
 
     # Assert
     assert result
-    # This should work the following: The time of modifying the settings file should be greater then the time taken
-    # before modifying it. Thus the value of the subtraction of both should be greater than zero. If writing to the
-    # files does not work, this is smaller then 0. The content is a yaml file thus we don't want to test if writing a
-    # YAML file is logically correct. This is the matter of the library we are using.
-    assert os.path.getmtime("/etc/cobbler/settings.yaml") - time_before_write > 0
+    with open(settings_path) as settings_file:
+        settings_read_post = yaml.safe_load(settings_file)
+        assert "include" in settings_read_post
+        assert settings_read_post["include"] == ["mystring"]
+
+
+def test_update_settings_file_emtpy_dict(tmpdir: pathlib.Path):
+    # Arrange
+    settings_data = {}
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+
+    # Act
+    result = settings.update_settings_file(settings_data, filepath=settings_path)
+
+    # Assert
+    assert not result
+
+
+def test_settingsfile_migration_extension(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/test_dir/tests/test_data/settings_old"
+    dst = os.path.join(tmpdir, "settings")
+    shutil.copyfile(src, dst)
+    expected_path = os.path.join(tmpdir, "settings.yaml")
+
+    # Act
+    result_settings = settings.read_settings_file(filepath=dst)
+
+    # Assert
+    assert os.path.exists(expected_path)
+    assert isinstance(result_settings, dict)
+    assert "include" in result_settings
+
+
+def test_settingsfile_migration_content(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/test_dir/tests/test_data/settings_old"
+    dst = os.path.join(tmpdir, "settings")
+    shutil.copyfile(src, dst)
+
+    # Act
+    result_settings = settings.read_settings_file(filepath=dst)
+    settings_obj = Settings().from_dict(result_settings)
+    clean_settings = settings.validate_settings(settings_obj.to_dict())
+
+    # Assert
+    assert isinstance(clean_settings, dict)
+    assert "include" in result_settings

--- a/tests/test_data/named.conf
+++ b/tests/test_data/named.conf
@@ -1,0 +1,24 @@
+// Managing acls
+acl internals { 127.0.0.0/8; 192.168.0.0/24; };
+
+// Load options
+include "/etc/bind/named.conf.options";
+
+// TSIG key used for the dynamic update
+include "/etc/bind/ns-example-com_rndc-key";
+
+// Configure the communication channel for Administrative BIND9 with rndc
+// By default, they key is in the rndc.key file and is used by rndc and bind9
+// on the localhost
+controls {
+        inet 127.0.0.1 port 953 allow { 127.0.0.1; };
+};
+
+// prime the server with knowledge of the root servers
+zone "." {
+        type hint;
+        file "/etc/bind/db.root";
+};
+
+include "/etc/bind/named.conf.default-zones";
+include "/etc/bind/named.conf.local";

--- a/tests/test_data/settings_old
+++ b/tests/test_data/settings_old
@@ -1,40 +1,49 @@
-# Cobbler settings file
+---
+# cobbler settings file
+# restart cobblerd and run "cobbler sync" after making changes
+# This config file is in YAML 1.0 format
+# see http://yaml.org
+# ==========================================================
+# if 1, cobbler will allow insertions of system records that duplicate
+# the --dns-name information of other system records.  In general,
+# this is undesirable and should be left 0.
+allow_duplicate_hostnames: 0
 
-# Restart cobblerd and run "cobbler sync" after making changes.
-# This config file is in YAML 1.2 format; see "http://yaml.org".
+# if 1, cobbler will allow insertions of system records that duplicate
+# the ip address information of other system records.  In general,
+# this is undesirable and should be left 0.
+allow_duplicate_ips: 0
 
-# If "true", Cobbler will allow insertions of system records that duplicate the "--dns-name" information of other system
-# records. In general, this is undesirable and should be left "false".
-allow_duplicate_hostnames: false
+# if 1, cobbler will allow insertions of system records that duplicate
+# the mac address information of other system records.  In general,
+# this is undesirable.
+allow_duplicate_macs: 0
 
-# If "true", Cobbler will allow insertions of system records that duplicate the ip address information of other system
-# records. In general, this is undesirable and should be left "false".
-allow_duplicate_ips: false
+# if 1, cobbler will allow settings to be changed dynamically without
+# a restart of the cobblerd daemon. You can only change this variable
+# by manually editing the settings file, and you MUST restart cobblerd
+# after changing it.
+allow_dynamic_settings: 0
 
-# If "true", Cobbler will allow insertions of system records that duplicate the MAC address information of other system
-# records. In general, this is undesirable.
-allow_duplicate_macs: false
-
-# If "true", Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can
-# only change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
-allow_dynamic_settings: false
-
-# By default, installs are *not* set to send installation logs to the Cobbler server. With "anamon_enabled", automatic
-# installation templates may use the "pre_anamon" snippet to allow remote live monitoring of their installations from
-# the Cobbler server. Installation logs will be stored under "/var/log/cobbler/anamon/".
-# NOTE: This does allow an xmlrpc call to send logs to this directory, without authentication, so enable only if you are
+# by default, installs are *not* set to send installation logs to the cobbler
+# server.  With 'anamon_enabled', automatic installation templates may use
+# the pre_anamon snippet to allow remote live monitoring of their installations
+# from the cobbler server.  Installation logs will be stored under
+# /var/log/cobbler/anamon/.  NOTE: This does allow an xmlrpc call to send logs
+# to this directory, without authentication, so enable only if you are
 # ok with this limitation.
-anamon_enabled: false
+anamon_enabled: 0
 
-# If using "authn_pam" in the "modules.conf", this can be configured to change the PAM service authentication will be
-# tested against.
+# If using authn_pam in the modules.conf, this can be configured
+# to change the PAM service authentication will be tested against.
 # The default value is "login".
 authn_pam_service: "login"
 
-# How long the authentication token is valid for, in seconds.
+# How long the authentication token is valid for, in seconds
 auth_token_expiration: 3600
 
-# This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information.  Changing
+# this is a directory of files that cobbler uses to make
+# templating easier.  See the Wiki for more information.  Changing
 # this directory should not be required.
 autoinstall_snippets_dir: /var/lib/cobbler/snippets
 autoinstall_templates_dir: /var/lib/cobbler/templates
@@ -42,38 +51,44 @@ autoinstall_templates_dir: /var/lib/cobbler/templates
 # location of templates used for boot loader config generation
 boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
 
-# Email out a report when Cobbler finishes installing a system.
-# enabled: set to true to turn this feature on
+# Email out a report when cobbler finishes installing a system.
+# enabled: set to 1 to turn this feature on
 # sender: optional
 # email: which addresses to email
 # smtp_server: used to specify another server for an MTA
 # subject: use the default subject unless overridden
-build_reporting_enabled: false
+build_reporting_enabled: 0
 build_reporting_sender: ""
 build_reporting_email: [ 'root@localhost' ]
 build_reporting_smtp_server: "localhost"
 build_reporting_subject: ""
-build_reporting_ignorelist: []
+build_reporting_ignorelist: [ "" ]
 
-# If cache_enabled is true, a cache will keep converted records in memory to make checking them faster. This helps with
-# use cases like writing out large numbers of records. There is a known issue with cache and remote XMLRPC API calls.
+# If cache_enabled is 1, a cache will keep converted records in memory to make checking them faster.  This helps with
+# use cases like writing out large numbers of records.  There is a known issue with cache and remote XMLRPC API calls.
 # If you will use Cobbler with config management or infrastructure-as-code tools such as Terraform, it is recommended
-# to disable by setting to false.
-cache_enabled: true
+# to disable by setting to 0.
+cache_enabled: 1
 
-# Cheetah-language autoinstall templates can import Python modules. While this is a useful feature, it is not safe to
-# allow them to import anything they want. This whitelists which modules can be imported through Cheetah. Users can
-# expand this as needed but should never allow modules such as subprocess or those that allow access to the filesystem
-# as Cheetah templates are evaluated by cobblerd as code.
+# Cheetah-language autoinstall templates can import Python modules.
+# while this is a useful feature, it is not safe to allow them to
+# import anything they want. This whitelists which modules can be
+# imported through Cheetah.  Users can expand this as needed but
+# should never allow modules such as subprocess or those that
+# allow access to the filesystem as Cheetah templates are evaluated
+# by cobblerd as code.
 cheetah_import_whitelist:
  - "random"
  - "re"
  - "time"
  - "netaddr"
 
-# Default "createrepo_flags" to use for new repositories. If you have createrepo >= 0.4.10, consider
-# "-c cache --update -C", which can dramatically improve your "cobbler reposync" time. "-s sha" enables working with
-# Fedora repos from F11/F12 from EL-4 or EL-5 without python-hashlib installed (which is not available on EL-4)
+# Default createrepo_flags to use for new repositories. If you have
+# createrepo >= 0.4.10, consider "-c cache --update -C", which can
+# dramatically improve your "cobbler reposync" time.  "-s sha"
+# enables working with Fedora repos from F11/F12 from EL-4 or
+# EL-5 without python-hashlib installed (which is not available
+# on EL-4)
 createrepo_flags: "-c cache -s sha"
 
 # if no autoinstall template is specified to profile add, use this template
@@ -91,11 +106,11 @@ default_name_servers_search: []
 default_ownership:
  - "admin"
 
-# Cobbler has various sample automatic installation templates stored
+# cobbler has various sample automatic installation templates stored
 # in /var/lib/cobbler/autoinstall_templates/.  This controls
 # what install (root) password is set up for those
 # systems that reference this variable.  The factory
-# default is "cobbler" and Cobbler check will warn if
+# default is "cobbler" and cobbler check will warn if
 # this is not changed.
 # The simplest way to change the password is to run
 # openssl passwd -1
@@ -105,7 +120,7 @@ default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
 # the default template type to use in the absence of any
 # other detected template. If you do not specify the template
 # with '#template=<template_type>' on the first line of your
-# templates/snippets, Cobbler will assume try to use the
+# templates/snippets, cobbler will assume try to use the
 # following template engine to parse the templates.
 #
 # Current valid values are: cheetah, jinja2
@@ -131,27 +146,27 @@ default_virt_ram: 512
 # (NOTE: this does not change what virt_type is chosen by import)
 default_virt_type: xenpv
 
-# enable gPXE booting? Enabling this option will cause Cobbler
+# enable gPXE booting? Enabling this option will cause cobbler
 # to copy the undionly.kpxe file to the tftp root directory,
 # and if a profile/system is configured to boot via gpxe it will
 # chain load off pxelinux.0.
-# Default: false
-enable_gpxe: false
+# Default: 0
+enable_gpxe: 0
 
-# controls whether Cobbler will add each new profile entry to the default
+# controls whether cobbler will add each new profile entry to the default
 # PXE boot menu.  This can be over-ridden on a per-profile
-# basis when adding/editing profiles with --enable-menu=false/true.  Users
+# basis when adding/editing profiles with --enable-menu=0/1.  Users
 # should ordinarily leave this setting enabled unless they are concerned
 # with accidental reinstalls from users who select an entry at the PXE
 # boot menu.  Adding a password to the boot menus templates
 # may also be a good solution to prevent unwanted reinstallations
-enable_menu: true
+enable_menu: 1
 
 # change this port if Apache is not running plaintext on port
 # 80.  Most people can leave this alone.
 http_port: 80
 
-# kernel options that should be present in every Cobbler installation.
+# kernel options that should be present in every cobbler installation.
 # kernel options can also be applied at the distro/profile/system
 # level.
 kernel_options: {}
@@ -162,8 +177,8 @@ kernel_options: {}
 ldap_server: "ldap.example.com"
 ldap_base_dn: "DC=example,DC=com"
 ldap_port: 389
-ldap_tls: true
-ldap_anonymous_bind: true
+ldap_tls: 1
+ldap_anonymous_bind: 1
 ldap_search_bind_dn: ''
 ldap_search_passwd: ''
 ldap_search_prefix: 'uid='
@@ -171,26 +186,26 @@ ldap_tls_cacertfile: ''
 ldap_tls_keyfile: ''
 ldap_tls_certfile: ''
 
-# Cobbler has a feature that allows for integration with config management
+# cobbler has a feature that allows for integration with config management
 # systems such as Puppet.  The following parameters work in conjunction with
-# --mgmt-classes  and are described in further detail at:
+# --mgmt-classes  and are described in furhter detail at:
 # https://github.com/cobbler/cobbler/wiki/Using-cobbler-with-a-configuration-management-system
 mgmt_classes: []
 mgmt_parameters:
- from_cobbler: true
+ from_cobbler: 1
 
 # if enabled, this setting ensures that puppet is installed during
 # machine provision, a client certificate is generated and a
 # certificate signing request is made with the puppet master server
-puppet_auto_setup: false
+puppet_auto_setup: 0
 
 # when puppet starts on a system after installation it needs to have
 # its certificate signed by the puppet master server. Enabling the
 # following feature will ensure that the puppet server signs the
 # certificate after installation if the puppet master server is
-# running on the same machine as Cobbler. This requires
+# running on the same machine as cobbler. This requires
 # puppet_auto_setup above to be enabled
-sign_puppet_certs_automatically: false
+sign_puppet_certs_automatically: 0
 
 # location of the puppet executable, used for revoking certificates
 puppetca_path: "/usr/bin/puppet"
@@ -200,28 +215,28 @@ puppetca_path: "/usr/bin/puppet"
 # new certificate is signed (see above). Enabling the following
 # feature will ensure that the certificate for the machine to be
 # installed is removed from the puppet master server if the puppet
-# master server is running on the same machine as Cobbler. This
+# master server is running on the same machine as cobbler. This
 # requires puppet_auto_setup above to be enabled
-remove_old_puppet_certs_automatically: false
+remove_old_puppet_certs_automatically: 0
 
 # choose a --server argument when running puppetd/puppet agent during autoinstall
 #puppet_server: 'puppet'
 
-# let Cobbler know that you're using a newer version of puppet
+# let cobbler know that you're using a newer version of puppet
 # choose version 3 to use: 'puppet agent'; version 2 uses status quo: 'puppetd'
 #puppet_version: 2
 
 # choose whether to enable puppet parameterized classes or not.
 # puppet versions prior to 2.6.5 do not support parameters
-puppet_parameterized_classes: true
+#puppet_parameterized_classes: 1
 
-# set to true to enable Cobbler's DHCP management features.
+# set to 1 to enable Cobbler's DHCP management features.
 # the choice of DHCP management engine is in /etc/cobbler/modules.conf
-manage_dhcp: false
+manage_dhcp: 0
 
-# set to true to enable Cobbler's DNS management features.
+# set to 1 to enable Cobbler's DNS management features.
 # the choice of DNS mangement engine is in /etc/cobbler/modules.conf
-manage_dns: false
+manage_dns: 0
 
 # set to path of bind chroot to create bind-chroot compatible bind
 # configuration files.  This should be automatically detected.
@@ -231,17 +246,17 @@ bind_chroot_path: ""
 # bind configuration files
 bind_master: 127.0.0.1
 
-# set to true to enable Cobbler's TFTP management features.
+# set to 1 to enable Cobbler's TFTP management features.
 # the choice of TFTP mangement engine is in /etc/cobbler/modules.conf
-manage_tftpd: true
+manage_tftpd: 1
 
-# This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not
+# This variable contains the location of the tftpboot directory. If this directory is not present cobbler does not
 # start.
-# Default: @@tftproot@@
-tftpboot_location: "@@tftproot@@"
+# Default: /srv/tftpboot
+tftpboot_location: "/srv/tftpboot"
 
-# set to true to enable Cobbler's RSYNC management features.
-manage_rsync: false
+# set to 1 to enable Cobbler's RSYNC management features.
+manage_rsync: 0
 
 # if using BIND (named) for DNS management in /etc/cobbler/modules.conf
 # and manage_dns is enabled (above), this lists which zones are managed
@@ -249,8 +264,8 @@ manage_rsync: false
 manage_forward_zones: []
 manage_reverse_zones: []
 
-# if using Cobbler with manage_dhcp, put the IP address
-# of the Cobbler server here so that PXE booting guests can find it
+# if using cobbler with manage_dhcp, put the IP address
+# of the cobbler server here so that PXE booting guests can find it
 # if you do not set this correctly, this will be manifested in TFTP open timeouts.
 next_server: 127.0.0.1
 
@@ -258,38 +273,38 @@ next_server: 127.0.0.1
 # see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
 # choices (refer to codes.py):
 #    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
-#    ipmilan lpar rsa virsh wti
-power_management_default_type: 'ipmilan'
+#    ipmilan ipmitool lpar rsa virsh wti
+power_management_default_type: 'ipmitool'
 
-# if this setting is set to true, Cobbler systems that pxe boot
+# if this setting is set to 1, cobbler systems that pxe boot
 # will request at the end of their installation to toggle the
-# --netboot-enabled record in the Cobbler system record.  This eliminates
+# --netboot-enabled record in the cobbler system record.  This eliminates
 # the potential for a PXE boot loop if the system is set to PXE
 # first in it's BIOS order.  Enable this if PXE is first in your BIOS
 # boot order, otherwise leave this disabled.   See the manpage
 # for --netboot-enabled.
-pxe_just_once: true
+pxe_just_once: 1
 
 # if this setting is set to one, triggers will be executed when systems
 # will request to toggle the --netboot-enabled record at the end of their installation.
-nopxe_with_triggers: true
+nopxe_with_triggers: 1
 
 # This setting is only used by the code that supports using Spacewalk/Satellite
 # authentication within Cobbler Web and Cobbler XMLRPC.
 redhat_management_server: "xmlrpc.rhn.redhat.com"
 
-# if using authn_spacewalk in modules.conf to let Cobbler authenticate
+# if using authn_spacewalk in modules.conf to let cobbler authenticate
 # against Satellite/Spacewalk's auth system, by default it will not allow per user
 # access into Cobbler Web and Cobbler XMLRPC.
 # in order to permit this, the following setting must be enabled HOWEVER
 # doing so will permit all Spacewalk/Satellite users of certain types to edit all
-# of Cobbler's configuration.
+# of cobbler's configuration.
 # these roles are:  config_admin and org_admin
 # users should turn this on only if they want this behavior and
 # do not have a cross-multi-org seperation concern.  If you have
 # a single org in your satellite, it's probably safe to turn this
 # on and then you can use CobblerWeb alongside a Satellite install.
-redhat_management_permissive: false
+redhat_management_permissive: 0
 
 # specify the default Red Hat authorization key to use to register
 # system.  If left blank, no registration will be attempted.  Similarly
@@ -297,11 +312,11 @@ redhat_management_permissive: false
 # keep it from trying to register.
 redhat_management_key: ""
 
-# if set to true, allows /usr/bin/cobbler-register (part of the koan package)
-# to be used to remotely add new Cobbler system records to Cobbler.
+# if set to 1, allows /usr/bin/cobbler-register (part of the koan package)
+# to be used to remotely add new cobbler system records to cobbler.
 # this effectively allows for registration of new hardware from system
 # records.
-register_new_installs: false
+register_new_installs: 0
 
 # Flags to use for yum's reposync.  If your version of yum reposync
 # does not support -l, you may need to remove that option.
@@ -311,7 +326,7 @@ reposync_flags: "-l -n -d"
 # is not ran after the rsync
 reposync_rsync_flags: "-rltDv --copy-unsafe-links"
 
-# when DHCP and DNS management are enabled, Cobbler sync can automatically
+# when DHCP and DNS management are enabled, cobbler sync can automatically
 # restart those services to apply changes.  The exception for this is
 # if using ISC for DHCP, then omapi eliminates the need for a restart.
 # omapi, however, is experimental and not recommended for most configurations.
@@ -322,8 +337,8 @@ reposync_rsync_flags: "-rltDv --copy-unsafe-links"
 # Note that if manage_dhcp and manage_dns are disabled, the respective
 # parameter will have no effect.  Most users should not need to change
 # this.
-restart_dns: true
-restart_dhcp: true
+restart_dns: 1
+restart_dhcp: 1
 
 # install triggers are scripts in /var/lib/cobbler/triggers/install
 # that are triggered in autoinstall pre and post sections.  Any
@@ -332,19 +347,19 @@ restart_dhcp: true
 # run as root so if you do not need this functionality you can
 # disable it, though this will also disable "cobbler status" which
 # uses a logging trigger to audit install progress.
-run_install_triggers: true
+run_install_triggers: 1
 
 # enables a trigger which version controls all changes to /var/lib/cobbler
 # when add, edit, or sync events are performed.  This can be used
 # to revert to previous database versions, generate RSS feeds, or for
 # other auditing or backup purposes. "git" and "hg" are currently suported,
 # but git is the recommend SCM for use with this feature.
-scm_track_enabled: false
+scm_track_enabled: 0
 scm_track_mode: "git"
 scm_track_author: "cobbler <cobbler@localhost>"
 scm_push_script: "/bin/true"
 
-# this is the address of the Cobbler server -- as it is used
+# this is the address of the cobbler server -- as it is used
 # by systems during the install process, it must be the address
 # or hostname of the system as those systems can see the server.
 # if you have a server that appears differently to different subnets
@@ -352,25 +367,28 @@ scm_push_script: "/bin/true"
 # of the manpage for how that works.
 server: 127.0.0.1
 
-# If set to true, all commands will be forced to use the localhost address
+# If set to 1, all commands will be forced to use the localhost address
 # instead of using the above value which can force commands like
 # cobbler sync to open a connection to a remote address if one is in the
 # configuration and would traceback.
-client_use_localhost: false
+client_use_localhost: 0
 
-# If set to "true", all commands to the API (not directly to the XMLRPC server) will go over HTTPS instead of plaintext.
-# Be sure to change the "http_port" setting to the correct value for the web server.
-client_use_https: false
+# If set to 1, all commands to the API (not directly to the XMLRPC
+# server) will go over HTTPS instead of plaintext. Be sure to change
+# the http_port setting to the correct value for the web server
+client_use_https: 0
 
-# Should new profiles for virtual machines default to auto booting with the physical host when the physical host
-# reboots? This can be overridden on each profile or system object.
-virt_auto_boot: true
+# should new profiles for virtual machines default to auto booting with
+# the physical host when the physical host reboots?
+# this can be overridden on each profile or system object.
+virt_auto_boot: 1
 
-# Cobbler's web directory. Don't change this setting -- see the Wiki on "Relocating your Cobbler install" if your "/var"
-# partition is not large enough.
-webdir: "@@webroot@@/cobbler"
+# cobbler's web directory.  Don't change this setting -- see the
+# Wiki on "relocating your cobbler install" if your /var partition
+# is not large enough.
+webdir: /srv/www/cobbler
 
-# Directories that will not get wiped and recreated on a "cobbler sync".
+# directories that will not get wiped and recreated on a 'cobbler sync'
 webdir_whitelist:
   - misc
   - web
@@ -387,27 +405,26 @@ webdir_whitelist:
   - rendered
   - .link_cache
 
-# Cobbler's public XMLRPC listens on this port.  Change this only
+# cobbler's public XMLRPC listens on this port.  Change this only
 # if absolutely needed, as you'll have to start supplying a new
 # port option to koan if it is not the default.
 xmlrpc_port: 25151
 
-# "cobbler repo add" commands set Cobbler up with repository
+# "cobbler repo add" commands set cobbler up with repository
 # information that can be used during autoinstall and is automatically
-# set up in the Cobbler autoinstall templates.  By default, these
+# set up in the cobbler autoinstall templates.  By default, these
 # are only available at install time.  To make these repositories
-# usable on installed systems (since Cobbler makes a very convenient
-# mirror) set this to true.  Most users can safely set this to true.  Users
-# who have a dual homed Cobbler server, or are installing laptops that
-# will not always have access to the Cobbler server may wish to leave
-# this as false.  In that case, the Cobbler mirrored yum repos are still
+# usable on installed systems (since cobbler makes a very convenient
+# mirror) set this to 1.  Most users can safely set this to 1.  Users
+# who have a dual homed cobbler server, or are installing laptops that
+# will not always have access to the cobbler server may wish to leave
+# this as 0.  In that case, the cobbler mirrored yum repos are still
 # accessable at http://cobbler.example.org/cblr/repo_mirror and yum
 # configuration can still be done manually.  This is just a shortcut.
-yum_post_install_mirror: true
+yum_post_install_mirror: 1
 
-# the default yum priority for all the distros. This is only used if yum-priorities plugin is used.
-# 1=maximum
-# Tweak with caution!
+# the default yum priority for all the distros.  This is only used
+# if yum-priorities plugin is used.  1=maximum.  Tweak with caution.
 yum_distro_priority: 1
 
 # Flags to use for yumdownloader.  Not all versions may support
@@ -415,7 +432,7 @@ yum_distro_priority: 1
 yumdownloader_flags: "--resolve"
 
 # sort and indent JSON output to make it more human-readable
-serializer_pretty_json: false
+serializer_pretty_json: 0
 
 # replication rsync options for distros, autoinstalls, snippets set to override default value of "-avzH"
 replicate_rsync_options: "-avzH"
@@ -424,43 +441,27 @@ replicate_rsync_options: "-avzH"
 replicate_repo_rsync_options: "-avzH"
 
 # always write DHCP entries, regardless if netboot is enabled
-always_write_dhcp_entries: false
+always_write_dhcp_entries: 0
 
-# External proxy - used by: "get-loaders", "reposync", "signature update"
-# Eg: "http://192.168.1.1:8080" (HTTP), "https://192.168.1.1:8443" (HTTPS)
+# external proxy - used by: get-loaders, reposync, signature update
+# eg: proxy_url_ext: "http://192.168.1.1:8080" (HTTP)
+# or: proxy_url_ext: "https://192.168.1.1:8443" (HTTPS)
 proxy_url_ext: ""
 
-# Internal proxy - used by systems to reach Cobbler for templates
-# Eg: proxy_url_int: "http://10.0.0.1:8080"
+# internal proxy - used by systems to reach cobbler for templates
+# eg: proxy_url_int: "http://10.0.0.1:8080"
 proxy_url_int: ""
 
-# This is a directory of files that Cobbler uses to include
+# this is a directory of files that cobbler uses to include
 # files into Jinja2 templates
-jinja2_includedir: "/var/lib/cobbler/jinja2"
+#jinja2_includedir: /var/lib/cobbler/jinja2
 
 # Up to now, cobblerd used $server's IP address instead of the DNS name in autoinstallation
 # file settings (pxelinux.cfg files) to save bytes, which seemed required for S/390 systems.
-# This behavior can have negative impact on installs with multi-homed Cobbler servers, because
+# This behavior can have negative impact on installs with multi-homed cobbler servers, because
 # not all of the IP addresses may be reachable during system install.
 # This behavior was now made conditional, with default being "off".
-convert_server_to_ip: false
+#convert_server_to_ip: 0
 
-# Leftover settings
-bootloaders_dir: "/var/lib/cobbler/loaders"
-buildisodir: "/var/cache/cobbler/buildiso"
-cobbler_master: ""
-default_virt_disk_driver: "raw"
-grubconfig_dir: "/var/lib/cobbler/grub_config"
-iso_template_dir: "/etc/cobbler/iso"
-
-# Puppet
-puppet_server: ""
-puppet_version: 2
-
-# Signatures
-signature_path: "/var/lib/cobbler/distro_signatures.json"
-signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
-
-# Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
-# this file.
+# include other configuration snippets
 include: [ "/etc/cobbler/settings.d/*.settings" ]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -741,8 +741,8 @@ def test_set_virt_auto_boot(test_autoboot, expectation):
         utils.set_virt_auto_boot(testprofile, test_autoboot)
 
         # Assert
-        assert isinstance(testprofile.virt_auto_boot, int)
-        assert testprofile.virt_auto_boot == 1 or testprofile.virt_auto_boot == 0
+        assert isinstance(testprofile.virt_auto_boot, bool)
+        assert testprofile.virt_auto_boot is True or testprofile.virt_auto_boot is False
 
 
 @pytest.mark.parametrize("test_input,expected_exception", [


### PR DESCRIPTION
This PR shall close #2419 

This PR also tries to pull all application settings related functionality inside the module and remove the factor that we require the file to be exactly at `/etc/cobbler/settings`. I see this as a first step into the direction of of containerized Cobbler.