### PR TITLE
Remove multi-language support since it is not implemented and causes problems

### DIFF
--- a/cobbler/actions/check.py
+++ b/cobbler/actions/check.py
@@ -26,7 +26,6 @@ import re
 
 from cobbler import clogger
 from cobbler import utils
-from cobbler.utils import _
 
 
 class CobblerCheck(object):
@@ -142,17 +141,17 @@ class CobblerCheck(object):
             if os.path.exists("/etc/rc.d/init.d/%s" % which):
                 rc = utils.subprocess_call(self.logger, "/sbin/service %s status > /dev/null 2>/dev/null" % which, shell=True)
             if rc != 0:
-                status.append(_("service %s is not running%s") % (which, notes))
+                status.append("service %s is not running%s" % (which, notes))
                 return
         elif self.checked_family == "debian":
             # we still use /etc/init.d
             if os.path.exists("/etc/init.d/%s" % which):
                 rc = utils.subprocess_call(self.logger, "/etc/init.d/%s status /dev/null 2>/dev/null" % which, shell=True)
             if rc != 0:
-                status.append(_("service %s is not running%s") % (which, notes))
+                status.append("service %s is not running%s" % (which, notes))
                 return
         else:
-            status.append(_("Unknown distribution type, cannot check for running service %s" % which))
+            status.append("Unknown distribution type, cannot check for running service %s" % which)
             return
 
     def check_iptables(self, status):
@@ -166,7 +165,7 @@ class CobblerCheck(object):
         if os.path.exists("/etc/rc.d/init.d/iptables"):
             rc = utils.subprocess_call(self.logger, "/sbin/service iptables status >/dev/null 2>/dev/null", shell=True)
             if rc == 0:
-                status.append(_("since iptables may be running, ensure 69, 80/443, and %(xmlrpc)s are unblocked") % {"xmlrpc": self.settings.xmlrpc_port})
+                status.append("since iptables may be running, ensure 69, 80/443, and %(xmlrpc)s are unblocked" % {"xmlrpc": self.settings.xmlrpc_port})
 
     def check_yum(self, status):
         """
@@ -179,19 +178,19 @@ class CobblerCheck(object):
             return
 
         if not os.path.exists("/usr/bin/createrepo"):
-            status.append(_("createrepo package is not installed, needed for cobbler import and cobbler reposync, install createrepo?"))
+            status.append("createrepo package is not installed, needed for cobbler import and cobbler reposync, install createrepo?")
 
         if not os.path.exists("/usr/bin/dnf") and not os.path.exists("/usr/bin/reposync"):
-            status.append(_("reposync not installed, install yum-utils"))
+            status.append("reposync not installed, install yum-utils")
 
         if os.path.exists("/usr/bin/dnf") and not os.path.exists("/usr/bin/reposync"):
-            status.append(_("reposync is not installed, install yum-utils or dnf-plugins-core"))
+            status.append("reposync is not installed, install yum-utils or dnf-plugins-core")
 
         if not os.path.exists("/usr/bin/dnf") and not os.path.exists("/usr/bin/yumdownloader"):
-            status.append(_("yumdownloader is not installed, install yum-utils"))
+            status.append("yumdownloader is not installed, install yum-utils")
 
         if os.path.exists("/usr/bin/dnf") and not os.path.exists("/usr/bin/yumdownloader"):
-            status.append(_("yumdownloader is not installed, install yum-utils or dnf-plugins-core"))
+            status.append("yumdownloader is not installed, install yum-utils or dnf-plugins-core")
 
     def check_debmirror(self, status):
         """
@@ -204,16 +203,16 @@ class CobblerCheck(object):
             return
 
         if not os.path.exists("/usr/bin/debmirror"):
-            status.append(_("debmirror package is not installed, it will be required to manage debian deployments and repositories"))
+            status.append("debmirror package is not installed, it will be required to manage debian deployments and repositories")
         if os.path.exists("/etc/debmirror.conf"):
             with open("/etc/debmirror.conf") as f:
                 re_dists = re.compile(r'@dists=')
                 re_arches = re.compile(r'@arches=')
                 for line in f.readlines():
                     if re_dists.search(line) and not line.strip().startswith("#"):
-                        status.append(_("comment out 'dists' on /etc/debmirror.conf for proper debian support"))
+                        status.append("comment out 'dists' on /etc/debmirror.conf for proper debian support")
                     if re_arches.search(line) and not line.strip().startswith("#"):
-                        status.append(_("comment out 'arches' on /etc/debmirror.conf for proper debian support"))
+                        status.append("comment out 'arches' on /etc/debmirror.conf for proper debian support")
 
     def check_name(self, status):
         """
@@ -223,9 +222,9 @@ class CobblerCheck(object):
         :param status: The status list with possible problems.
         """
         if self.settings.server == "127.0.0.1":
-            status.append(_("The 'server' field in /etc/cobbler/settings must be set to something other than localhost, or automatic installation features will not work.  This should be a resolvable hostname or IP for the boot server as reachable by all machines that will use it."))
+            status.append("The 'server' field in /etc/cobbler/settings must be set to something other than localhost, or automatic installation features will not work.  This should be a resolvable hostname or IP for the boot server as reachable by all machines that will use it.")
         if self.settings.next_server == "127.0.0.1":
-            status.append(_("For PXE to be functional, the 'next_server' field in /etc/cobbler/settings must be set to something other than 127.0.0.1, and should match the IP of the boot server on the PXE network."))
+            status.append("For PXE to be functional, the 'next_server' field in /etc/cobbler/settings must be set to something other than 127.0.0.1, and should match the IP of the boot server on the PXE network.")
 
     def check_selinux(self, status):
         """
@@ -239,7 +238,7 @@ class CobblerCheck(object):
 
         enabled = self.collection_mgr.api.is_selinux_enabled()
         if enabled:
-            status.append(_("SELinux is enabled. Please review the following wiki page for details on ensuring Cobbler works correctly in your SELinux environment:\n    https://github.com/cobbler/cobbler/wiki/Selinux"))
+            status.append("SELinux is enabled. Please review the following wiki page for details on ensuring Cobbler works correctly in your SELinux environment:\n    https://github.com/cobbler/cobbler/wiki/Selinux")
 
     def check_for_default_password(self, status):
         """
@@ -249,7 +248,7 @@ class CobblerCheck(object):
         """
         default_pass = self.settings.default_password_crypted
         if default_pass == "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac.":
-            status.append(_("The default password used by the sample templates for newly installed machines (default_password_crypted in /etc/cobbler/settings) is still set to 'cobbler' and should be changed, try: \"openssl passwd -1 -salt 'random-phrase-here' 'your-password-here'\" to generate new one"))
+            status.append("The default password used by the sample templates for newly installed machines (default_password_crypted in /etc/cobbler/settings) is still set to 'cobbler' and should be changed, try: \"openssl passwd -1 -salt 'random-phrase-here' 'your-password-here'\" to generate new one")
 
     def check_for_unreferenced_repos(self, status):
         """
@@ -270,7 +269,7 @@ class CobblerCheck(object):
             if r not in repos and r != "<<inherit>>":
                 not_found.append(r)
         if len(not_found) > 0:
-            status.append(_("One or more repos referenced by profile objects is no longer defined in Cobbler: %s") % ", ".join(not_found))
+            status.append("One or more repos referenced by profile objects is no longer defined in Cobbler: %s" % ", ".join(not_found))
 
     def check_for_unsynced_repos(self, status):
         """
@@ -285,7 +284,7 @@ class CobblerCheck(object):
                 if not os.path.exists(lookfor):
                     need_sync.append(r.name)
         if len(need_sync) > 0:
-            status.append(_("One or more repos need to be processed by cobbler reposync for the first time before automating installations using them: %s") % ", ".join(need_sync))
+            status.append("One or more repos need to be processed by cobbler reposync for the first time before automating installations using them: %s" % ", ".join(need_sync))
 
     def check_dhcpd_bin(self, status):
         """
@@ -378,7 +377,7 @@ class CobblerCheck(object):
 
         bootloc = self.settings.tftpboot_location
         if not os.path.exists(bootloc):
-            status.append(_("please create directory: %(dirname)s") % {"dirname": bootloc})
+            status.append("please create directory: %(dirname)s" % {"dirname": bootloc})
 
     def check_ctftpd_dir(self, status):
         """
@@ -391,7 +390,7 @@ class CobblerCheck(object):
 
         bootloc = self.settings.tftpboot_location
         if not os.path.exists(bootloc):
-            status.append(_("please create directory: %(dirname)s") % {"dirname": bootloc})
+            status.append("please create directory: %(dirname)s" % {"dirname": bootloc})
 
     def check_rsync_conf(self, status):
         """
@@ -404,7 +403,7 @@ class CobblerCheck(object):
 
         if os.path.exists("/usr/lib/systemd/system/rsyncd.service"):
             if not os.path.exists("/etc/systemd/system/multi-user.target.wants/rsyncd.service"):
-                status.append(_("enable and start rsyncd.service with systemctl"))
+                status.append("enable and start rsyncd.service with systemctl")
 
     def check_dhcpd_conf(self, status):
         """
@@ -429,10 +428,10 @@ class CobblerCheck(object):
                 if line.find("filename") != -1:
                     match_file = True
             if not match_next:
-                status.append(_("expecting next-server entry in %(file)s") % {"file": self.settings.dhcpd_conf})
+                status.append("expecting next-server entry in %(file)s" % {"file": self.settings.dhcpd_conf})
             if not match_file:
-                status.append(_("missing file: %(file)s") % {"file": self.settings.dhcpd_conf})
+                status.append("missing file: %(file)s" % {"file": self.settings.dhcpd_conf})
         else:
-            status.append(_("missing file: %(file)s") % {"file": self.settings.dhcpd_conf})
+            status.append("missing file: %(file)s" % {"file": self.settings.dhcpd_conf})
 
 # EOF

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -31,7 +31,6 @@ from cobbler import clogger
 from cobbler import templar
 from cobbler import tftpgen
 from cobbler import utils
-from cobbler.utils import _
 
 
 class CobblerSync(object):
@@ -228,7 +227,7 @@ class CobblerSync(object):
         try:
             template = open(template_file, "r")
         except:
-            raise CX(_("error reading template %s") % template_file)
+            raise CX("error reading template %s" % template_file)
 
         template_data = ""
         template_data = template.read()

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -39,7 +39,6 @@ from cobbler import yumgen
 from cobbler import autoinstallgen
 from cobbler import download_manager
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 ERROR = 100
@@ -1130,7 +1129,7 @@ class CobblerAPI(object):
         try:
             import dnf
         except:
-            raise CX(_("dnf is not installed"))
+            raise CX("dnf is not installed")
 
         base = dnf.Base()
         base.read_all_repos()

--- a/cobbler/autoinstallgen.py
+++ b/cobbler/autoinstallgen.py
@@ -29,7 +29,6 @@ from cobbler import templar
 from cobbler import utils
 from cobbler import validate
 from cobbler.cexceptions import FileNotFoundException, CX
-from cobbler.utils import _
 
 
 class AutoInstallationGen(object):
@@ -270,7 +269,7 @@ class AutoInstallationGen(object):
 
         p = s.get_conceptual_parent()
         if p is None:
-            raise CX(_("system %(system)s references missing profile %(profile)s") % {"system": s.name, "profile": s.profile})
+            raise CX("system %(system)s references missing profile %(profile)s" % {"system": s.name, "profile": s.profile})
 
         distro = p.get_conceptual_parent()
         if distro is None:
@@ -355,7 +354,7 @@ class AutoInstallationGen(object):
 
         distro = g.get_conceptual_parent()
         if distro is None:
-            raise CX(_("profile %(profile)s references missing distro %(distro)s")
+            raise CX("profile %(profile)s references missing distro %(distro)s"
                      % {"profile": g.name, "distro": g.distro})
 
         return self.generate_autoinstall(profile=g)

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -28,7 +28,6 @@ from threading import Lock
 from cobbler.actions import litesync
 from cobbler.items import package, system, item as item_base, image, profile, repo, mgmtclass, distro, file
 
-from cobbler.utils import _
 from cobbler.cexceptions import CX, NotImplementedException
 
 
@@ -124,7 +123,7 @@ class Collection(object):
 
         # no arguments is an error, so we don't return a false match
         if len(kargs) == 0:
-            raise CX(_("calling find with no arguments"))
+            raise CX("calling find with no arguments")
 
         # performance: if the only key is name we can skip the whole loop
         if len(kargs) == 1 and "name" in kargs and not return_list:
@@ -299,7 +298,7 @@ class Collection(object):
         kids = ref.get_children()
         for k in kids:
             if k.COLLECTION_TYPE == "distro":
-                raise CX(_("internal error, not expected to have distro child objects"))
+                raise CX("internal error, not expected to have distro child objects")
             elif k.COLLECTION_TYPE == "profile":
                 if k.parent != "":
                     k.set_parent(newname)
@@ -310,9 +309,9 @@ class Collection(object):
                 k.set_profile(newname)
                 self.api.systems().add(k, save=True, with_sync=with_sync, with_triggers=with_triggers)
             elif k.COLLECTION_TYPE == "repo":
-                raise CX(_("internal error, not expected to have repo child objects"))
+                raise CX("internal error, not expected to have repo child objects")
             else:
-                raise CX(_("internal error, unknown child type (%s), cannot finish rename" % k.COLLECTION_TYPE))
+                raise CX("internal error, unknown child type (%s), cannot finish rename" % k.COLLECTION_TYPE)
 
         # now delete the old version
         self.remove(oldname, with_delete=True, with_triggers=with_triggers)
@@ -373,7 +372,7 @@ class Collection(object):
         self.__duplication_checks(ref, check_for_duplicate_names, check_for_duplicate_netinfo)
 
         if ref.COLLECTION_TYPE != self.collection_type():
-            raise CX(_("API error: storing wrong data type in collection"))
+            raise CX("API error: storing wrong data type in collection")
 
         # failure of a pre trigger will prevent the object from being added
         if save and with_triggers:
@@ -414,7 +413,7 @@ class Collection(object):
                 elif isinstance(ref, file.File):
                     pass
                 else:
-                    print(_("Internal error. Object type not recognized: %s") % type(ref))
+                    print("Internal error. Object type not recognized: %s" % type(ref))
             if not with_sync and quick_pxe_update:
                 if isinstance(ref, system.System):
                     self.lite_sync.update_system_netboot_status(ref.name)
@@ -466,7 +465,7 @@ class Collection(object):
                 raise CX("internal error, unknown object type")
 
             if match:
-                raise CX(_("An object already exists with that name.  Try 'edit'?"))
+                raise CX("An object already exists with that name.  Try 'edit'?")
 
         # the duplicate mac/ip checks can be disabled.
         if not check_for_duplicate_netinfo:
@@ -491,13 +490,13 @@ class Collection(object):
 
                 for x in match_mac:
                     if x.name != ref.name:
-                        raise CX(_("Can't save system %s. The MAC address (%s) is already used by system %s (%s)") % (ref.name, intf["mac_address"], x.name, name))
+                        raise CX("Can't save system %s. The MAC address (%s) is already used by system %s (%s)" % (ref.name, intf["mac_address"], x.name, name))
                 for x in match_ip:
                     if x.name != ref.name:
-                        raise CX(_("Can't save system %s. The IP address (%s) is already used by system %s (%s)") % (ref.name, intf["ip_address"], x.name, name))
+                        raise CX("Can't save system %s. The IP address (%s) is already used by system %s (%s)" % (ref.name, intf["ip_address"], x.name, name))
                 for x in match_hosts:
                     if x.name != ref.name:
-                        raise CX(_("Can't save system %s.  The dns name (%s) is already used by system %s (%s)") % (ref.name, intf["dns_name"], x.name, name))
+                        raise CX("Can't save system %s.  The dns name (%s) is already used by system %s (%s)" % (ref.name, intf["dns_name"], x.name, name))
 
     def to_string(self):
         """
@@ -515,7 +514,7 @@ class Collection(object):
         if len(values) > 0:
             return "\n\n".join(results)
         else:
-            return _("No objects found")
+            return "No objects found"
 
     @staticmethod
     def collection_type() -> str:

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -26,7 +26,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import distro as distro
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Distros(collection.Collection):
@@ -60,7 +59,7 @@ class Distros(collection.Collection):
         if not recursive:
             for v in self.collection_mgr.profiles():
                 if v.distro and v.distro.lower() == name:
-                    raise CX(_("removal would orphan profile: %s") % v.name)
+                    raise CX("removal would orphan profile: %s" % v.name)
 
         obj = self.find(name=name)
 

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -22,7 +22,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import file as file
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Files(collection.Collection):
@@ -71,6 +70,6 @@ class Files(collection.Collection):
 
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -16,7 +16,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import image as image
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Images(collection.Collection):
@@ -55,7 +54,7 @@ class Images(collection.Collection):
         if not recursive:
             for v in self.collection_mgr.systems():
                 if v.image is not None and v.image.lower() == name:
-                    raise CX(_("removal would orphan system: %s") % v.name)
+                    raise CX("removal would orphan system: %s" % v.name)
 
         obj = self.find(name=name)
 
@@ -87,6 +86,6 @@ class Images(collection.Collection):
 
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -22,7 +22,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import mgmtclass as mgmtclass
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Mgmtclasses(collection.Collection):
@@ -72,6 +71,6 @@ class Mgmtclasses(collection.Collection):
 
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -22,7 +22,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import package as package
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Packages(collection.Collection):
@@ -71,6 +70,6 @@ class Packages(collection.Collection):
 
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -23,7 +23,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import profile as profile
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Profiles(collection.Collection):
@@ -57,7 +56,7 @@ class Profiles(collection.Collection):
         if not recursive:
             for v in self.collection_mgr.systems():
                 if v.profile is not None and v.profile.lower() == name:
-                    raise CX(_("removal would orphan system: %s") % v.name)
+                    raise CX("removal would orphan system: %s" % v.name)
 
         obj = self.find(name=name)
         if obj is not None:
@@ -87,6 +86,6 @@ class Profiles(collection.Collection):
                     lite_sync.remove_single_profile(name)
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -24,7 +24,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import repo as repo
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Repos(collection.Collection):
@@ -84,6 +83,6 @@ class Repos(collection.Collection):
 
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -23,7 +23,6 @@ from cobbler.cobbler_collections import collection
 from cobbler.items import system as system
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 class Systems(collection.Collection):
@@ -76,6 +75,6 @@ class Systems(collection.Collection):
 
             return
 
-        raise CX(_("cannot delete an object that does not exist: %s") % name)
+        raise CX("cannot delete an object that does not exist: %s" % name)
 
 # EOF

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -23,7 +23,6 @@ import os
 from cobbler.items import item
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 from cobbler import grub
 
 # this data structure is described in item.py
@@ -64,7 +63,7 @@ class Distro(item.Item):
     A Cobbler distribution object
     """
 
-    TYPE_NAME = _("distro")
+    TYPE_NAME = "distro"
     COLLECTION_TYPE = "distro"
 
     def __init__(self, *args, **kwargs):
@@ -217,7 +216,7 @@ class Distro(item.Item):
         if utils.find_initrd(initrd):
             self.initrd = initrd
             return
-        raise CX(_("initrd not found"))
+        raise CX("initrd not found")
 
     def set_remote_boot_initrd(self, remote_boot_initrd):
         """
@@ -273,7 +272,7 @@ class Distro(item.Item):
         :param supported_boot_loaders: The bootloaders which are available for being set.
         """
         if len(supported_boot_loaders) < 1:
-            raise CX(_("No valid supported boot loaders specified for distro '%s'" % self.name))
+            raise CX("No valid supported boot loaders specified for distro '%s'" % self.name)
         self.supported_boot_loaders = supported_boot_loaders
         self.boot_loader = supported_boot_loaders[0]
 
@@ -292,8 +291,8 @@ class Distro(item.Item):
             self.supported_boot_loaders = utils.get_supported_distro_boot_loaders(self)
             supported_distro_boot_loaders = self.supported_boot_loaders
         if name not in supported_distro_boot_loaders:
-            raise CX(_("Invalid boot loader name: %s. Supported boot loaders are: %s" %
-                       (name, ' '.join(supported_distro_boot_loaders))))
+            raise CX("Invalid boot loader name: %s. Supported boot loaders are: %s" %
+                       (name, ' '.join(supported_distro_boot_loaders)))
         self.boot_loader = name
 
     def set_redhat_management_key(self, management_key):

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -22,7 +22,6 @@ from cobbler import resource
 
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -52,7 +51,7 @@ class File(resource.Resource):
     A Cobbler file object.
     """
 
-    TYPE_NAME = _("file")
+    TYPE_NAME = "file"
     COLLECTION_TYPE = "file"
 
     #

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -193,7 +193,7 @@ class Image(item.Item):
         :param image_type: One of the four options from above.
         """
         if image_type not in self.get_valid_image_types():
-            raise CX("image type must be on of the following: %s" % string.join(self.get_valid_image_types(), ", "))
+            raise CX("image type must be on of the following: %s" % ", ".join(self.get_valid_image_types()))
         self.image_type = image_type
 
     def set_virt_cpus(self, num):

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -24,7 +24,6 @@ from cobbler import autoinstall_manager
 from cobbler.items import item
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -64,7 +63,7 @@ class Image(item.Item):
     file (autoinst) led installation.
     """
 
-    TYPE_NAME = _("image")
+    TYPE_NAME = "image"
     COLLECTION_TYPE = "image"
 
     #
@@ -153,17 +152,17 @@ class Image(item.Item):
         if filename.find(":") != -1:
             hostname, filename = filename.split(":")
         elif filename[0] != '/':
-            raise CX(_("invalid file: %s" % filename))
+            raise CX("invalid file: %s" % filename)
         # raise an exception if we don't have a valid path
         if len(filename) > 0 and filename[0] != '/':
-            raise CX(_("file contains an invalid path: %s" % filename))
+            raise CX("file contains an invalid path: %s" % filename)
         if filename.find("/") != -1:
             path, filename = filename.rsplit("/", 1)
 
         if len(filename) == 0:
-            raise CX(_("missing filename"))
+            raise CX("missing filename")
         if len(auth) > 0 and len(hostname) == 0:
-            raise CX(_("a hostname must be specified with authentication details"))
+            raise CX("a hostname must be specified with authentication details")
 
         self.file = uri
 
@@ -194,7 +193,7 @@ class Image(item.Item):
         :param image_type: One of the four options from above.
         """
         if image_type not in self.get_valid_image_types():
-            raise CX(_("image type must be on of the following: %s") % string.join(self.get_valid_image_types(), ", "))
+            raise CX("image type must be on of the following: %s" % string.join(self.get_valid_image_types(), ", "))
         self.image_type = image_type
 
     def set_virt_cpus(self, num):

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -19,7 +19,6 @@ import pprint
 from cobbler import utils
 from cobbler import validate
 from cobbler.cexceptions import CX, NotImplementedException
-from cobbler.utils import _
 
 # the fields has controls what data elements are part of each object.  To add a new field, just add a new
 # entry to the list following some conventions to be described later.  You must also add a method called
@@ -167,7 +166,7 @@ class Item(object):
                         return True
                     return False
 
-            raise CX(_("find cannot compare type: %s") % type(from_obj))
+            raise CX("find cannot compare type: %s" % type(from_obj))
 
     TYPE_NAME = "generic"
 
@@ -374,7 +373,7 @@ class Item(object):
         """
         (success, value) = utils.input_string_or_dict(options, allow_multiples=True)
         if not success:
-            raise CX(_("invalid kernel options"))
+            raise CX("invalid kernel options")
         else:
             self.kernel_options = value
 
@@ -386,7 +385,7 @@ class Item(object):
         """
         (success, value) = utils.input_string_or_dict(options, allow_multiples=True)
         if not success:
-            raise CX(_("invalid post kernel options"))
+            raise CX("invalid post kernel options")
         else:
             self.kernel_options_post = value
 
@@ -426,7 +425,7 @@ class Item(object):
             import yaml
             data = yaml.safe_load(mgmt_parameters)
             if type(data) is not dict:
-                raise CX(_("Input YAML in Puppet Parameter field must evaluate to a dictionary."))
+                raise CX("Input YAML in Puppet Parameter field must evaluate to a dictionary.")
             self.mgmt_parameters = data
 
     def set_template_files(self, template_files):
@@ -529,7 +528,7 @@ class Item(object):
             if not key_found_already:
                 if not no_errors:
                     # FIXME: removed for 2.0 code, shouldn't cause any problems to not have an exception here?
-                    # raise CX(_("searching for field that does not exist: %s" % key))
+                    # raise CX("searching for field that does not exist: %s" % key)
                     return False
             else:
                 if value is not None:       # FIXME: new?

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -21,7 +21,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 from cobbler.items import item
 from cobbler import utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -46,7 +45,7 @@ FIELDS = [
 
 class Mgmtclass(item.Item):
 
-    TYPE_NAME = _("mgmtclass")
+    TYPE_NAME = "mgmtclass"
     COLLECTION_TYPE = "mgmtclass"
 
     def __init__(self, *args, **kwargs):
@@ -112,7 +111,7 @@ class Mgmtclass(item.Item):
         """
         (success, value) = utils.input_string_or_dict(params, allow_multiples=True)
         if not success:
-            raise CX(_("invalid parameters"))
+            raise CX("invalid parameters")
         else:
             self.params = value
 
@@ -132,10 +131,10 @@ class Mgmtclass(item.Item):
         :type name: str
         """
         if not isinstance(name, str):
-            raise CX(_("class name must be a string"))
+            raise CX("class name must be a string")
         for x in name:
             if not x.isalnum() and x not in ["_", "-", ".", ":", "+"]:
-                raise CX(_("invalid characters in class name: '%s'" % name))
+                raise CX("invalid characters in class name: '%s'" % name)
         self.class_name = name
 
 # EOF

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -21,7 +21,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 from cobbler import resource
 
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -44,7 +43,7 @@ FIELDS = [
 
 class Package(resource.Resource):
 
-    TYPE_NAME = _("package")
+    TYPE_NAME = "package"
     COLLECTION_TYPE = "package"
 
     #

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -23,7 +23,6 @@ from cobbler.items import item
 from cobbler import utils
 from cobbler import validate
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -76,7 +75,7 @@ class Profile(item.Item):
     A Cobbler profile object.
     """
 
-    TYPE_NAME = _("profile")
+    TYPE_NAME = "profile"
     COLLECTION_TYPE = "profile"
 
     def __init__(self, *args, **kwargs):
@@ -159,10 +158,10 @@ class Profile(item.Item):
         if parent_name == self.name:
             # check must be done in two places as set_parent could be called before/after
             # set_name...
-            raise CX(_("self parentage is weird"))
+            raise CX("self parentage is weird")
         found = self.collection_mgr.profiles().find(name=parent_name)
         if found is None:
-            raise CX(_("profile %s not found, inheritance not possible") % parent_name)
+            raise CX("profile %s not found, inheritance not possible" % parent_name)
         self.parent = parent_name
         self.depth = found.depth + 1
         parent = self.get_parent()
@@ -182,7 +181,7 @@ class Profile(item.Item):
             self.depth = d.depth + 1    # reset depth if previously a subprofile and now top-level
             d.children[self.name] = self
             return
-        raise CX(_("distribution not found"))
+        raise CX("distribution not found")
 
     def set_name_servers(self, data):
         """

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -23,7 +23,6 @@ from cobbler.items import item
 from cobbler import utils
 from cobbler import validate
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -62,7 +61,7 @@ class Repo(item.Item):
     A Cobbler repo object.
     """
 
-    TYPE_NAME = _("repo")
+    TYPE_NAME = "repo"
     COLLECTION_TYPE = "repo"
 
     def __init__(self, *args, **kwargs):
@@ -168,7 +167,7 @@ class Repo(item.Item):
         """
         (success, value) = utils.input_string_or_dict(options, allow_multiples=False)
         if not success:
-            raise CX(_("invalid yum options"))
+            raise CX("invalid yum options")
         else:
             self.yumopts = value
 
@@ -180,7 +179,7 @@ class Repo(item.Item):
         """
         (success, value) = utils.input_string_or_dict(options, allow_multiples=False)
         if not success:
-            raise CX(_("invalid rsync options"))
+            raise CX("invalid rsync options")
         else:
             self.rsyncopts = value
 
@@ -192,7 +191,7 @@ class Repo(item.Item):
         """
         (success, value) = utils.input_string_or_dict(options, allow_multiples=False)
         if not success:
-            raise CX(_("invalid environment options"))
+            raise CX("invalid environment options")
         else:
             self.environment = value
 
@@ -205,7 +204,7 @@ class Repo(item.Item):
         try:
             priority = int(str(priority))
         except:
-            raise CX(_("invalid priority level: %s") % priority)
+            raise CX("invalid priority level: %s" % priority)
         self.priority = priority
 
     def set_rpm_list(self, rpms):

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -24,7 +24,6 @@ from cobbler import power_manager
 from cobbler import utils
 from cobbler import validate
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 # this data structure is described in item.py
@@ -121,7 +120,7 @@ class System(item.Item):
     A Cobbler system object.
     """
 
-    TYPE_NAME = _("system")
+    TYPE_NAME = "system"
     COLLECTION_TYPE = "system"
 
     def __init__(self, *args, **kwargs):
@@ -199,7 +198,7 @@ class System(item.Item):
                 # no interface here to delete
                 pass
             else:
-                raise CX(_("At least one interface needs to be defined."))
+                raise CX("At least one interface needs to be defined.")
 
     def rename_interface(self, names):
         """
@@ -207,16 +206,16 @@ class System(item.Item):
         """
         (name, newname) = names
         if name not in self.interfaces:
-            raise CX(_("Interface %s does not exist" % name))
+            raise CX("Interface %s does not exist" % name)
         if newname in self.interfaces:
-            raise CX(_("Interface %s already exists" % newname))
+            raise CX("Interface %s already exists" % newname)
         else:
             self.interfaces[newname] = self.interfaces[name]
             del self.interfaces[name]
 
     def set_boot_loader(self, name):
         if name not in utils.get_supported_system_boot_loaders():
-            raise CX(_("Invalid boot loader name: %s" % name))
+            raise CX("Invalid boot loader name: %s" % name)
         self.boot_loader = name
 
     def set_server(self, server):
@@ -447,7 +446,7 @@ class System(item.Item):
     def set_interface_type(self, type, interface):
         interface_types = ["bridge", "bridge_slave", "bond", "bond_slave", "bonded_bridge_slave", "bmc", "na", "infiniband", ""]
         if type not in interface_types:
-            raise CX(_("interface type value must be one of: %s or blank" % ",".join(interface_types)))
+            raise CX("interface type value must be one of: %s or blank" % ",".join(interface_types))
         if type == "na":
             type = ""
         intf = self.__get_interface(interface)
@@ -506,7 +505,7 @@ class System(item.Item):
             if address == "" or utils.is_ip(address):
                 secondaries.append(address)
             else:
-                raise CX(_("invalid format for IPv6 IP address (%s)") % address)
+                raise CX("invalid format for IPv6 IP address (%s)" % address)
 
         intf["ipv6_secondaries"] = secondaries
 
@@ -515,7 +514,7 @@ class System(item.Item):
         if address == "" or utils.is_ip(address):
             intf["ipv6_default_gateway"] = address.strip()
             return
-        raise CX(_("invalid format for IPv6 IP address (%s)") % address)
+        raise CX("invalid format for IPv6 IP address (%s)" % address)
 
     def set_ipv6_static_routes(self, routes, interface):
         intf = self.__get_interface(interface)
@@ -564,7 +563,7 @@ class System(item.Item):
             if isinstance(new_parent, item.Item):
                 new_parent.children[self.name] = self
             return
-        raise CX(_("invalid profile name: %s") % profile_name)
+        raise CX("invalid profile name: %s" % profile_name)
 
     def set_image(self, image_name):
         """
@@ -591,7 +590,7 @@ class System(item.Item):
             if isinstance(new_parent, item.Item):
                 new_parent.children[self.name] = self
             return
-        raise CX(_("invalid image name (%s)") % image_name)
+        raise CX("invalid image name (%s)" % image_name)
 
     def set_virt_cpus(self, num):
         return utils.set_virt_cpus(self, num)

--- a/cobbler/module_loader.py
+++ b/cobbler/module_loader.py
@@ -29,7 +29,7 @@ import os
 
 from cobbler.cexceptions import CX
 from cobbler import clogger
-from cobbler.utils import _, log_exc
+from cobbler.utils import log_exc
 
 # add cobbler/modules to python path
 import cobbler
@@ -92,7 +92,7 @@ def __import_module(module_path, modname, logger):
         blip = import_module("cobbler.modules.%s" % modname)
         if not hasattr(blip, "register"):
             if not modname.startswith("__init__"):
-                errmsg = _("%(module_path)s/%(modname)s is not a proper module")
+                errmsg = "%(module_path)s/%(modname)s is not a proper module"
                 print(errmsg % {'module_path': module_path, 'modname': modname})
             return None
         category = blip.register()
@@ -139,7 +139,7 @@ def get_module_name(category, field, fallback_module_name=None):
         if fallback_module_name is not None:
             value = fallback_module_name
         else:
-            raise CX(_("Cannot find config file setting for: %s") % field)
+            raise CX("Cannot find config file setting for: %s" % field)
     return value
 
 
@@ -160,7 +160,7 @@ def get_module_from_file(category, field, fallback_module_name=None):
     module_name = get_module_name(category, field, fallback_module_name)
     rc = MODULE_CACHE.get(module_name, None)
     if rc is None:
-        raise CX(_("Failed to load module for %s/%s") % (category, field))
+        raise CX("Failed to load module for %s/%s" % (category, field))
     return rc
 
 

--- a/cobbler/modules/authorization/ownership.py
+++ b/cobbler/modules/authorization/ownership.py
@@ -30,7 +30,6 @@ from configparser import ConfigParser
 import os
 
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 def register():
@@ -52,7 +51,7 @@ def __parse_config():
     """
     etcfile = '/etc/cobbler/users.conf'
     if not os.path.exists(etcfile):
-        raise CX(_("/etc/cobbler/users.conf does not exist"))
+        raise CX("/etc/cobbler/users.conf does not exist")
     # Make users case sensitive to handle kerberos
     config = ConfigParser()
     config.optionxform = str

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -32,7 +32,6 @@ import cobbler.clogger as clogger
 import cobbler.templar as templar
 import cobbler.utils as utils
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 def register():
@@ -324,7 +323,7 @@ zone "%(arpa)s." {
         try:
             f2 = open(template_file, "r")
         except:
-            raise CX(_("error reading template from file: %s") % template_file)
+            raise CX("error reading template from file: %s" % template_file)
         template_data = ""
         template_data = f2.read()
         f2.close()
@@ -389,7 +388,7 @@ zone "%(arpa)s." {
         try:
             f2 = open(template_file, "r")
         except:
-            raise CX(_("error reading template from file: %s") % template_file)
+            raise CX("error reading template from file: %s" % template_file)
         template_data = ""
         template_data = f2.read()
         f2.close()
@@ -542,7 +541,7 @@ zone "%(arpa)s." {
         try:
             f2 = open(default_template_file, "r")
         except:
-            raise CX(_("error reading template from file: %s") % default_template_file)
+            raise CX("error reading template from file: %s" % default_template_file)
         default_template_data = ""
         default_template_data = f2.read()
         f2.close()

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -28,7 +28,6 @@ import time
 import cobbler.templar as templar
 import cobbler.utils as utils
 
-from cobbler.utils import _
 from cobbler.cexceptions import CX
 
 
@@ -102,9 +101,8 @@ class DnsmasqManager(object):
 
         try:
             f2 = open(template_file, "r")
-        except:
-            raise CX(_("error writing template to file: %s") % template_file)
-        template_data = ""
+        except Exception:
+            raise CX("error writing template to file: %s" % template_file)
         template_data = f2.read()
         f2.close()
 

--- a/cobbler/modules/managers/genders.py
+++ b/cobbler/modules/managers/genders.py
@@ -3,7 +3,6 @@ import sys
 import os
 import time
 import cobbler.templar
-from cobbler.utils import _
 from cobbler.cexceptions import CX
 
 plib = distutils.sysconfig.get_python_lib()
@@ -36,7 +35,7 @@ def write_genders_file(config, profiles_genders, distros_genders, mgmtcls_gender
     try:
         f2 = open(template_file, "r")
     except:
-        raise CX(_("error reading template: %s") % template_file)
+        raise CX("error reading template: %s" % template_file)
     template_data = ""
     template_data = f2.read()
     f2.close()

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -30,7 +30,6 @@ import cobbler.templar as templar
 import cobbler.utils as utils
 
 from cobbler.cexceptions import CX
-from cobbler.utils import _
 
 
 def register():
@@ -79,7 +78,7 @@ class IscManager(object):
         try:
             f2 = open(template_file, "r")
         except:
-            raise CX(_("error reading template: %s") % template_file)
+            raise CX("error reading template: %s" % template_file)
         template_data = ""
         template_data = f2.read()
         f2.close()

--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -19,16 +19,11 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
-from builtins import str
-from builtins import object
 import glob
 import os.path
 import re
 
 from cobbler import utils
-from cobbler.utils import _
-
-TESTMODE = False
 
 # defaults is to be used if the config file doesn't contain the value we need
 DEFAULTS = {
@@ -233,9 +228,8 @@ class Settings(object):
         :return: The multiline string with the kernel options.
         :rtype: str
         """
-        buf = ""
-        buf += _("defaults\n")
-        buf += _("kernel options  : %s\n") % self.__dict__['kernel_options']
+        buf = "defaults\n"
+        buf += "kernel options  : %s\n" % self.__dict__['kernel_options']
         return buf
 
     def to_dict(self):
@@ -257,7 +251,7 @@ class Settings(object):
         :return: Returns the settings instance this method was called from.
         """
         if _dict is None:
-            print(_("warning: not loading empty structure for %s") % self.filename())
+            print("warning: not loading empty structure for %s" % self.filename())
             return
 
         self._clear()

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -65,11 +65,6 @@ CHEETAH_ERROR_DISCLAIMER = """
 """
 
 
-# placeholder for translation
-def _(foo):
-    return foo
-
-
 MODULE_CACHE = {}
 SIGNATURE_CACHE = {}
 
@@ -437,7 +432,7 @@ def read_file_contents(file_location, logger=None, fetch_if_remote=False):
         if not os.path.exists(file_location):
             if logger:
                 logger.warning("File does not exist: %s" % file_location)
-            raise FileNotFoundException("%s: %s" % (_("File not found"), file_location))
+            raise FileNotFoundException("%s: %s" % ("File not found", file_location))
 
         try:
             with open(file_location) as f:
@@ -462,7 +457,7 @@ def read_file_contents(file_location, logger=None, fetch_if_remote=False):
             # File likely doesn't exist
             if logger:
                 logger.warning("File does not exist: %s" % file_location)
-            raise FileNotFoundException("%s: %s" % (_("File not found"), file_location))
+            raise FileNotFoundException("%s: %s" % ("File not found", file_location))
 
 
 def remote_file_exists(file_url):
@@ -517,7 +512,7 @@ def input_string_or_list(options):
         tokens = shlex.split(options)
         return tokens
     else:
-        raise CX(_("invalid input type"))
+        raise CX("invalid input type")
 
 
 def input_string_or_dict(options, allow_multiples=True):
@@ -537,7 +532,7 @@ def input_string_or_dict(options, allow_multiples=True):
     if options is None or options == "delete":
         return True, {}
     elif isinstance(options, list):
-        raise CX(_("No idea what to do with list: %s") % options)
+        raise CX("No idea what to do with list: %s" % options)
     elif isinstance(options, str):
         new_dict = {}
         tokens = shlex.split(options)
@@ -570,7 +565,7 @@ def input_string_or_dict(options, allow_multiples=True):
         options.pop('', None)
         return True, options
     else:
-        raise CX(_("invalid input type"))
+        raise CX("invalid input type")
 
 
 def input_boolean(value):
@@ -991,7 +986,7 @@ def run_triggers(api, ref, globber, additional=[], logger=None):
             continue
 
         if rc != 0:
-            raise CX(_("Cobbler trigger failed: %(file)s returns %(code)d") % {"file": file, "code": rc})
+            raise CX("Cobbler trigger failed: %(file)s returns %(code)d" % {"file": file, "code": rc})
 
         if logger is not None:
             logger.debug("shell trigger %s finished successfully" % file)
@@ -1238,13 +1233,13 @@ def copyfile(src, dst, api=None, logger=None):
             shutil.copyfile(src, dst)
     except:
         if not os.access(src, os.R_OK):
-            raise CX(_("Cannot read: %s") % src)
+            raise CX("Cannot read: %s" % src)
         if os.path.samefile(src, dst):
             # accomodate for the possibility that we already copied
             # the file as a symlink/hardlink
             raise
             # traceback.print_exc()
-            # raise CX(_("Error copying %(src)s to %(dst)s") % { "src" : src, "dst" : dst})
+            # raise CX("Error copying %(src)s to %(dst)s" % { "src" : src, "dst" : dst})
 
 
 def copyremotefile(src, dst1, api=None, logger=None):
@@ -1263,7 +1258,7 @@ def copyremotefile(src, dst1, api=None, logger=None):
         with open(dst1, 'wb') as output:
             output.write(srcfile.read())
     except Exception as e:
-        raise CX(_("Error while getting remote file (%s -> %s):\n%s" % (src, dst1, e)))
+        raise CX("Error while getting remote file (%s -> %s):\n%s" % (src, dst1, e))
 
 
 def copyfile_pattern(pattern, dst, require_match=True, symlink_ok=False, cache=True, api=None, logger=None):
@@ -1283,7 +1278,7 @@ def copyfile_pattern(pattern, dst, require_match=True, symlink_ok=False, cache=T
     """
     files = glob.glob(pattern)
     if require_match and not len(files) > 0:
-        raise CX(_("Could not find files matching %s") % pattern)
+        raise CX("Could not find files matching %s" % pattern)
     for file in files:
         dst1 = os.path.join(dst, os.path.basename(file))
         linkfile(file, dst1, symlink_ok=symlink_ok, cache=cache, api=api, logger=logger)
@@ -1308,7 +1303,7 @@ def rmfile(path, logger=None):
         if not ioe.errno == errno.ENOENT:
             if logger is not None:
                 log_exc(logger)
-            raise CX(_("Error deleting %s") % path)
+            raise CX("Error deleting %s" % path)
         return True
 
 
@@ -1343,7 +1338,7 @@ def rmtree(path, logger=None):
         if logger is not None:
             log_exc(logger)
         if not ioe.errno == errno.ENOENT:  # doesn't exist
-            raise CX(_("Error deleting %s") % path)
+            raise CX("Error deleting %s" % path)
         return True
 
 
@@ -1364,7 +1359,7 @@ def mkdir(path, mode=0o755, logger=None):
         if not oe.errno == 17:
             if logger is not None:
                 log_exc(logger)
-            raise CX(_("Error creating %s") % path)
+            raise CX("Error creating %s" % path)
 
 
 def path_tail(apath, bpath):
@@ -1423,13 +1418,13 @@ def set_os_version(self, os_version):
         return
     self.os_version = os_version.lower()
     if not self.breed:
-        raise CX(_("cannot set --os-version without setting --breed first"))
+        raise CX("cannot set --os-version without setting --breed first")
     if self.breed not in get_valid_breeds():
-        raise CX(_("fix --breed first before applying this setting"))
+        raise CX("fix --breed first before applying this setting")
     matched = SIGNATURE_CACHE["breeds"][self.breed]
     if os_version not in matched:
         nicer = ", ".join(matched)
-        raise CX(_("--os-version for breed %s must be one of %s, given was %s") % (self.breed, nicer, os_version))
+        raise CX("--os-version for breed %s must be one of %s, given was %s" % (self.breed, nicer, os_version))
     self.os_version = os_version
 
 
@@ -1445,7 +1440,7 @@ def set_breed(self, breed):
         self.breed = breed.lower()
         return
     nicer = ", ".join(valid_breeds)
-    raise CX(_("invalid value for --breed (%s), must be one of %s, different breeds have different levels of support")
+    raise CX("invalid value for --breed (%s), must be one of %s, different breeds have different levels of support"
              % (breed, nicer))
 
 
@@ -1481,9 +1476,9 @@ def set_repo_os_version(self, os_version):
         return
     self.os_version = os_version.lower()
     if not self.breed:
-        raise CX(_("cannot set --os-version without setting --breed first"))
+        raise CX("cannot set --os-version without setting --breed first")
     if self.breed not in validate.REPO_BREEDS:
-        raise CX(_("fix --breed first before applying this setting"))
+        raise CX("fix --breed first before applying this setting")
     self.os_version = os_version
     return
 
@@ -1500,7 +1495,7 @@ def set_repo_breed(self, breed):
         self.breed = breed.lower()
         return
     nicer = ", ".join(valid_breeds)
-    raise CX(_("invalid value for --breed (%s), must be one of %s, different breeds have different levels of support")
+    raise CX("invalid value for --breed (%s), must be one of %s, different breeds have different levels of support"
              % (breed, nicer))
 
 
@@ -1530,7 +1525,7 @@ def set_repos(self, repos, bypass_check=False):
     for r in self.repos:
         # FIXME: First check this and then set the repos if the bypass check is used.
         if self.collection_mgr.repos().find(name=r) is None:
-            raise CX(_("repo %s is not defined") % r)
+            raise CX("repo %s is not defined" % r)
 
 
 def set_virt_file_size(self, num):
@@ -1563,13 +1558,13 @@ def set_virt_file_size(self, num):
     try:
         inum = int(num)
         if inum != float(num):
-            raise CX(_("invalid virt file size (%s)" % num))
+            raise CX("invalid virt file size (%s)" % num)
         if inum >= 0:
             self.virt_file_size = inum
             return
-        raise CX(_("invalid virt file size (%s)" % num))
+        raise CX("invalid virt file size (%s)" % num)
     except:
-        raise CX(_("invalid virt file size (%s)" % num))
+        raise CX("invalid virt file size (%s)" % num)
 
 
 def set_virt_disk_driver(self, driver):
@@ -1582,7 +1577,7 @@ def set_virt_disk_driver(self, driver):
     if driver in validate.VIRT_DISK_DRIVERS:
         self.virt_disk_driver = driver
     else:
-        raise CX(_("invalid virt disk driver type (%s)" % driver))
+        raise CX("invalid virt disk driver type (%s)" % driver)
 
 
 def set_virt_auto_boot(self, num):
@@ -1605,9 +1600,9 @@ def set_virt_auto_boot(self, num):
         if (inum == 0) or (inum == 1):
             self.virt_auto_boot = inum
             return
-        raise CX(_("invalid virt_auto_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % inum))
+        raise CX("invalid virt_auto_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % inum)
     except:
-        raise CX(_("invalid virt_auto_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % num))
+        raise CX("invalid virt_auto_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % num)
 
 
 def set_virt_pxe_boot(self, num):
@@ -1626,9 +1621,9 @@ def set_virt_pxe_boot(self, num):
         if (inum == 0) or (inum == 1):
             self.virt_pxe_boot = inum
             return
-        raise CX(_("invalid virt_pxe_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % inum))
+        raise CX("invalid virt_pxe_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % inum)
     except:
-        raise CX(_("invalid virt_pxe_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % num))
+        raise CX("invalid virt_pxe_boot value (%s): value must be either '0' (disabled) or '1' (enabled)" % num)
 
 
 def set_virt_ram(self, num):
@@ -1649,13 +1644,13 @@ def set_virt_ram(self, num):
     try:
         inum = int(num)
         if inum != float(num):
-            raise CX(_("invalid virt ram size (%s)" % num))
+            raise CX("invalid virt ram size (%s)" % num)
         if inum >= 0:
             self.virt_ram = inum
             return
-        raise CX(_("invalid virt ram size (%s)" % num))
+        raise CX("invalid virt ram size (%s)" % num)
     except:
-        raise CX(_("invalid virt ram size (%s)" % num))
+        raise CX("invalid virt ram size (%s)" % num)
 
 
 def set_virt_type(self, vtype):
@@ -1671,7 +1666,7 @@ def set_virt_type(self, vtype):
         return
 
     if vtype.lower() not in ["qemu", "kvm", "xenpv", "xenfv", "vmware", "vmwarew", "openvz", "auto"]:
-        raise CX(_("invalid virt type (%s)" % vtype))
+        raise CX("invalid virt type (%s)" % vtype)
     self.virt_type = vtype
 
 
@@ -1723,7 +1718,7 @@ def set_virt_cpus(self, num):
     try:
         num = int(str(num))
     except:
-        raise CX(_("invalid number of virtual CPUs (%s)" % num))
+        raise CX("invalid number of virtual CPUs (%s)" % num)
 
     self.virt_cpus = num
 
@@ -1852,7 +1847,7 @@ def set_serial_device(self, device_number):
         try:
             device_number = int(str(device_number))
         except:
-            raise CX(_("invalid value for serial device (%s)" % device_number))
+            raise CX("invalid value for serial device (%s)" % device_number)
 
     self.serial_device = device_number
     return True
@@ -1875,7 +1870,7 @@ def set_serial_baud_rate(self, baud_rate):
         try:
             baud_rate = int(str(baud_rate))
         except:
-            raise CX(_("invalid value for serial baud (%s)" % baud_rate))
+            raise CX("invalid value for serial baud (%s)" % baud_rate)
 
     self.serial_baud_rate = baud_rate
     return True
@@ -2566,7 +2561,7 @@ def link_distro(settings, distro):
             os.symlink(base, dest_link)
         except:
             # FIXME: This shouldn't happen but I've (jsabo) seen it...
-            print(_("- symlink creation failed: %(base)s, %(dest)s") % {"base": base, "dest": dest_link})
+            print("- symlink creation failed: %(base)s, %(dest)s" % {"base": base, "dest": dest_link})
 
 
 def find_distro_path(settings, distro):


### PR DESCRIPTION
Our current implementation of the multi language support will cause problems with #2530 and #2531 (and following PRs).

Since we don't use it, I vote that we remove it and find a better solution when there is time for it. This is just dead code. And implementing a multi-language application is not something which we can do in the next few releases. So better readd it at a time where we have cleaned up Cobbler a lot more.