### PR TITLE
Fix generate_bootcfg

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1088,7 +1088,7 @@ class TFTPGen(object):
         else:
             blended['img_path'] = os.path.join("/images", distro.name)
 
-        template = os.path.join(self.settings.boot_loader_conf_template_dir, "bootcfg_%s_%s.template" % (what.lower(), distro.os_version))
+        template = os.path.join(self.settings.boot_loader_conf_template_dir, "bootcfg_%s.template" % distro.os_version)
         if not os.path.exists(template):
             return "# boot.cfg template not found for the %s named %s (filename=%s)" % (what, name, template)
 

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1072,6 +1072,12 @@ class TFTPGen(object):
 
         blended = utils.blender(self.api, False, obj)
 
+        if distro.os_version.startswith("esxi"):
+            realbootcfg = open(os.path.join(os.path.dirname(distro.kernel), 'boot.cfg')).read()
+            bootmodules = re.findall(r'modules=(.*)', realbootcfg)
+            for modules in bootmodules:
+                blended['esx_modules'] = modules.replace('/', '')
+
         autoinstall_meta = blended.get("autoinstall_meta", {})
         try:
             del blended["autoinstall_meta"]

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1073,10 +1073,10 @@ class TFTPGen(object):
         blended = utils.blender(self.api, False, obj)
 
         if distro.os_version.startswith("esxi"):
-            realbootcfg = open(os.path.join(os.path.dirname(distro.kernel), 'boot.cfg')).read()
-            bootmodules = re.findall(r'modules=(.*)', realbootcfg)
-            for modules in bootmodules:
-                blended['esx_modules'] = modules.replace('/', '')
+            with open(os.path.join(os.path.dirname(distro.kernel), 'boot.cfg')) as f:
+                bootmodules = re.findall(r'modules=(.*)', f.read())
+                for modules in bootmodules:
+                    blended['esx_modules'] = modules.replace('/', '')
 
         autoinstall_meta = blended.get("autoinstall_meta", {})
         try:


### PR DESCRIPTION
This are the changes proposed by @DwayneGit in #2337 to fix generate_bootcfg.
I believe generate_bootcfg is currently only used for ESXi gpxe/ipxe.

Trying to get bootcfg for a esxi system, template path is wrong:
```
# curl http://127.0.0.1:80/cblr/svc/op/bootcfg/system/some-host
# boot.cfg template not found for the system named some-host filename=/etc/cobbler/boot_loader_conf/bootcfg_system_esxi67.template)
```

Fixing path, but esx_modules not available to template
```
# curl http://127.0.0.1:80/cblr/svc/op/bootcfg/system/some-host
bootstate=0
title=Loading ESXi installer
prefix=http://192.168.122.12:80/cobbler/links/esxi67-x86_64
kernel=b.b00
kernelopt=runweasel ks=http://192.168.122.12:80/cblr/svc/op/ks/system/some-host
modules=$esx_modules
build=
updated=0
```

And making esx_modules available to template:
```
# curl http://127.0.0.1:80/cblr/svc/op/bootcfg/system/some-host
bootstate=0
title=Loading ESXi installer
prefix=http://192.168.122.12:80/cobbler/links/esxi67-x86_64
kernel=b.b00
kernelopt=runweasel ks=http://192.168.122.12:80/cblr/svc/op/ks/system/some-host
modules=jumpstrt.gz --- useropts.gz --- features.gz --- k.b00 --- chardevs.b00 --- user.b00 --- procfs.b00 --- uc_intel.b00 --- uc_amd.b00 --- uc_hygon.b00 --- vmx.v00 --- vim.v00 --- sb.v00 --- s.v00 --- ata_liba.v00 --- ata_pata.v00 --- ata_pata.v01 --- ata_pata.v02 --- ata_pata.v03 --- ata_pata.v04 --- ata_pata.v05 --- ata_pata.v06 --- ata_pata.v07 --- block_cc.v00 --- bnxtnet.v00 --- bnxtroce.v00 --- brcmfcoe.v00 --- char_ran.v00 --- ehci_ehc.v00 --- elxiscsi.v00 --- elxnet.v00 --- hid_hid.v00 --- i40en.v00 --- iavmd.v00 --- igbn.v00 --- ima_qla4.v00 --- ipmi_ipm.v00 --- ipmi_ipm.v01 --- ipmi_ipm.v02 --- iser.v00 --- ixgben.v00 --- lpfc.v00 --- lpnic.v00 --- lsi_mr3.v00 --- lsi_msgp.v00 --- lsi_msgp.v01 --- lsi_msgp.v02 --- misc_cni.v00 --- misc_dri.v00 --- mtip32xx.v00 --- ne1000.v00 --- nenic.v00 --- net_bnx2.v00 --- net_bnx2.v01 --- net_cdc_.v00 --- net_cnic.v00 --- net_e100.v00 --- net_e100.v01 --- net_enic.v00 --- net_fcoe.v00 --- net_forc.v00 --- net_igb.v00 --- net_ixgb.v00 --- net_libf.v00 --- net_mlx4.v00 --- net_mlx4.v01 --- net_nx_n.v00 --- net_tg3.v00 --- net_usbn.v00 --- net_vmxn.v00 --- nfnic.v00 --- nhpsa.v00 --- nmlx4_co.v00 --- nmlx4_en.v00 --- nmlx4_rd.v00 --- nmlx5_co.v00 --- nmlx5_rd.v00 --- ntg3.v00 --- nvme.v00 --- nvmxnet3.v00 --- nvmxnet3.v01 --- ohci_usb.v00 --- pvscsi.v00 --- qcnic.v00 --- qedentv.v00 --- qfle3.v00 --- qfle3f.v00 --- qfle3i.v00 --- qflge.v00 --- sata_ahc.v00 --- sata_ata.v00 --- sata_sat.v00 --- sata_sat.v01 --- sata_sat.v02 --- sata_sat.v03 --- sata_sat.v04 --- scsi_aac.v00 --- scsi_adp.v00 --- scsi_aic.v00 --- scsi_bnx.v00 --- scsi_bnx.v01 --- scsi_fni.v00 --- scsi_hps.v00 --- scsi_ips.v00 --- scsi_isc.v00 --- scsi_lib.v00 --- scsi_meg.v00 --- scsi_meg.v01 --- scsi_meg.v02 --- scsi_mpt.v00 --- scsi_mpt.v01 --- scsi_mpt.v02 --- scsi_qla.v00 --- sfvmk.v00 --- shim_isc.v00 --- shim_isc.v01 --- shim_lib.v00 --- shim_lib.v01 --- shim_lib.v02 --- shim_lib.v03 --- shim_lib.v04 --- shim_lib.v05 --- shim_vmk.v00 --- shim_vmk.v01 --- shim_vmk.v02 --- smartpqi.v00 --- uhci_usb.v00 --- usb_stor.v00 --- usbcore_.v00 --- vmkata.v00 --- vmkfcoe.v00 --- vmkplexe.v00 --- vmkusb.v00 --- vmw_ahci.v00 --- xhci_xhc.v00 --- elx_esx_.v00 --- btldr.t00 --- esx_dvfi.v00 --- esx_ui.v00 --- esxupdt.v00 --- weaselin.t00 --- lsu_hp_h.v00 --- lsu_inte.v00 --- lsu_lsi_.v00 --- lsu_lsi_.v01 --- lsu_lsi_.v02 --- lsu_lsi_.v03 --- lsu_lsi_.v04 --- lsu_smar.v00 --- native_m.v00 --- qlnative.v00 --- rste.v00 --- vmware_e.v00 --- vsan.v00 --- vsanheal.v00 --- vsanmgmt.v00 --- tools.t00 --- xorg.v00 --- imgdb.tgz --- imgpayld.tgz
build=
updated=0
```

code to make esx_modules available is adapted from write_templates (where it generates the distro cobbler-boot.cfg file).
