### PR TITLE
Fix gitstamp, gitdate in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ def gen_build_version():
                                stdout=subprocess.PIPE)
         data = cmd.communicate()[0].strip()
         if cmd.returncode == 0:
-            gitstamp, gitdate = data.split(b"\n")
+            gitstamp, gitdate = data.decode("utf8").split("\n")
 
     fd = open(os.path.join(OUTPUT_DIR, "version"), "w+")
     config = ConfigParser()


### PR DESCRIPTION
After building cobbler from source and testing it afterwards I found out that the output of `cobbler version` ist not correct:

```shell
$ cobbler version    
Cobbler 3.2.0
  source: b'f52bdd86', b'Sat Feb 13 13:39:50 2021 +0100'
  build time: Mon Feb 15 12:22:01 2021
```
This PR coverts the `bytes` objets to a normal `string` and corrects the output:

```shell
cobbler version
Cobbler 3.2.0
source: e1ea7367, Mon Feb 15 14:34:55 2021 +0100
  build time: Mon Feb 15 13:27:41 2021
```
Source and build date now look correct again.