### PR TITLE
Handle files with double .json ending (fixes #2529)

### DIFF
--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -59,7 +59,7 @@ def __find_double_json_files(filename: str):
             os.rename(filename + ".json", filename)
     else:
         if os.path.isfile(filename + ".json"):
-            raise FileExistsError("Both JSON files exist!")
+            raise FileExistsError("Both JSON files (%s) exist!" % filename)
 
 
 def serialize_item(collection, item):

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -145,26 +145,6 @@ def deserialize_raw(collection_types):
         return results
 
 
-def filter_upgrade_duplicates(file_list) -> list:
-    """
-    In a set of files, some ending with .json, some not, return the list of files with the .json ones taking priority
-    over the ones that are not.
-
-    :param file_list: The list of files to remove duplicates from.
-    :return: The filtered list of files. Normally this should only return ``.json``-Files.
-    """
-    bases = {}
-    for f in file_list:
-        basekey = f.replace(".json", "")
-        if f.endswith(".json"):
-            bases[basekey] = f
-        else:
-            lookup = bases.get(basekey, "")
-            if not lookup.endswith(".json"):
-                bases[basekey] = f
-    return list(bases.values())
-
-
 def deserialize(collection, topological=True):
     """
     Load a collection from file system.

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -33,14 +33,14 @@ from cobbler.cexceptions import CX
 libpath = "/var/lib/cobbler/collections"
 
 
-def register():
+def register() -> str:
     """
     The mandatory Cobbler module registration hook.
     """
     return "serializer"
 
 
-def what():
+def what() -> str:
     """
     Module identification function
     """
@@ -145,7 +145,7 @@ def deserialize_raw(collection_types):
         return results
 
 
-def filter_upgrade_duplicates(file_list):
+def filter_upgrade_duplicates(file_list) -> list:
     """
     In a set of files, some ending with .json, some not, return the list of files with the .json ones taking priority
     over the ones that are not.

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -47,6 +47,21 @@ def what():
     return "serializer/file"
 
 
+def __find_double_json_files(filename: str):
+    """
+    Finds a file with duplicate .json ending and renames it.
+    :param filename: Filename to be checked
+    :raises FileExistsError: If both JSON files exist
+    """
+
+    if not os.path.isfile(filename):
+        if os.path.isfile(filename + ".json"):
+            os.rename(filename + ".json", filename)
+    else:
+        if os.path.isfile(filename + ".json"):
+            raise FileExistsError("Both JSON files exist!")
+
+
 def serialize_item(collection, item):
     """
     Save a collection item to file system
@@ -60,6 +75,7 @@ def serialize_item(collection, item):
 
     collection_types = collection.collection_types()
     filename = os.path.join(libpath, collection_types, item.name + ".json")
+    __find_double_json_files(filename)
 
     _dict = item.to_dict()
 
@@ -86,6 +102,7 @@ def serialize_delete(collection, item):
 
     collection_types = collection.collection_types()
     filename = os.path.join(libpath, collection_types, item.name + ".json")
+    __find_double_json_files(filename)
 
     if os.path.exists(filename):
         os.remove(filename)


### PR DESCRIPTION
This PR fixes the issues described in #2529. Futhermore I added function annotations as mentioned in [PEP 3107](https://www.python.org/dev/peps/pep-3107/). I will write some test cases for `file.py` in a seperate PR.