### PR TITLE
Basic pytests for module file.py

### DIFF
--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -77,8 +77,6 @@ def serialize_item(collection, item):
     filename = os.path.join(libpath, collection_types, item.name + ".json")
     __find_double_json_files(filename)
 
-    _dict = item.to_dict()
-
     if capi.CobblerAPI().settings().serializer_pretty_json:
         sort_keys = True
         indent = 4
@@ -116,13 +114,12 @@ def serialize(collection):
     """
 
     # do not serialize settings
-    ctype = collection.collection_type()
-    if ctype != "settings":
+    if collection.collection_type() != "setting":
         for x in collection:
             serialize_item(collection, x)
 
 
-def deserialize_raw(collection_types):
+def deserialize_raw(collection_types: str):
     """
     Loads a collection from the disk.
 
@@ -145,20 +142,19 @@ def deserialize_raw(collection_types):
         return results
 
 
-def deserialize(collection, topological=True):
+def deserialize(collection, topological: bool = True):
     """
     Load a collection from file system.
 
     :param collection: The collection to deserialize.
     :param topological: If the collection list should be sorted by the
-                        collection dict depth value or not.
-    :type topological: bool
+                        collection dict key 'depth' value or not.
     """
 
     datastruct = deserialize_raw(collection.collection_types())
-    if topological and type(datastruct) == list:
-        datastruct.sort(key=lambda x: x["depth"])
-    if type(datastruct) == dict:
+    if topological and isinstance(datastruct, list):
+        datastruct.sort(key=lambda x: x.get("depth", 1))
+    if isinstance(datastruct, dict):
         collection.from_dict(datastruct)
-    elif type(datastruct) == list:
+    elif isinstance(datastruct, list):
         collection.from_list(datastruct)

--- a/setup.py
+++ b/setup.py
@@ -527,7 +527,10 @@ if __name__ == "__main__":
             "file-magic",
             "schema"
         ],
-        extras_require={"lint": ["pyflakes", "pycodestyle"], "test": ["pytest", "pytest-cov", "codecov"]},
+        extras_require={
+            "lint": ["pyflakes", "pycodestyle"],
+            "test": ["pytest", "pytest-cov", "codecov", "pytest-mock"]
+        },
         packages=find_packages(exclude=["*tests*"]),
         scripts=[
             "bin/cobbler",

--- a/tests/modules/serializer/file_test.py
+++ b/tests/modules/serializer/file_test.py
@@ -1,0 +1,183 @@
+import json
+import os
+import pathlib
+
+from unittest.mock import Mock, MagicMock
+import pytest
+from cobbler.cobbler_collections.collection import Collection
+from cobbler.modules.serializers import file
+from cobbler.cexceptions import CX
+from cobbler.settings import Settings
+
+
+def test_register():
+    # Arrange
+    # Act
+    result = file.register()
+
+    # Assert
+    assert isinstance(result, str)
+    assert result == "serializer"
+
+
+def test_what():
+    # Arrange
+    # Act
+    result = file.what()
+
+    # Assert
+    assert isinstance(result, str)
+    assert result == "serializer/file"
+
+
+def test_find_double_json_files_1(tmpdir: pathlib.Path):
+    # Arrange
+    file_one = tmpdir.join("double.json")
+    file_double = tmpdir.join("double.json.json")
+    with open(file_double, "w") as duplicate:
+        duplicate.write('double\n')
+
+    # Act
+    file.__find_double_json_files(file_one)
+
+    # Assert
+    assert os.path.isfile(file_one)
+
+
+def test_find_double_json_files_raise(tmpdir: pathlib.Path):
+    # Arrange
+    file_one = tmpdir.join("double.json")
+    file_double = tmpdir.join("double.json.json")
+    with open(file_one, "w") as duplicate:
+        duplicate.write('one\n')
+    with open(file_double, "w") as duplicate:
+        duplicate.write('double\n')
+
+    # Act and assert
+    with pytest.raises(FileExistsError):
+        file.__find_double_json_files(file_one)
+
+
+def test_serialize_item_raise():
+    # Arrange
+    mitem = Mock()
+    mcollection = Mock()
+    mitem.name = ""
+
+    # Act and assert
+    with pytest.raises(CX):
+        file.serialize_item(mcollection, mitem)
+
+
+def test_serialize_item(tmpdir: pathlib.Path):
+    # Arrange
+    file.libpath = tmpdir
+    os.mkdir(os.path.join(tmpdir, "distros"))
+    expected_file = os.path.join(tmpdir, "distros", "test_serializer.json")
+    mitem = Mock()
+    mitem.name = "test_serializer"
+    mcollection = Mock()
+    mcollection.collection_types.return_value = "distros"
+    mitem.to_dict.return_value = {"name": mitem.name}
+
+    # Act
+    file.serialize_item(mcollection, mitem)
+
+    # Assert
+    assert os.path.exists(expected_file)
+    with open(expected_file, "r") as json_file:
+        assert json.load(json_file) == mitem.to_dict()
+
+
+def test_serialize_delete(tmpdir: pathlib.Path):
+    # Arrange
+    mitem = Mock()
+    mitem.name = "test_serializer_del"
+    mcollection = Mock()
+    file.libpath = tmpdir
+    mcollection.collection_types.return_value = "distros"
+    os.mkdir(os.path.join(tmpdir, mcollection.collection_types()))
+    expected_path = os.path.join(tmpdir, mcollection.collection_types(), mitem.name + ".json")
+    pathlib.Path(expected_path).touch()
+
+    # Act
+    file.serialize_delete(mcollection, mitem)
+
+    # Assert
+    assert not os.path.exists(expected_path)
+
+
+@pytest.mark.parametrize("input_collection_type,input_collection", [
+    ("settings", {}),
+    ("distros", MagicMock())
+])
+def test_serialize(input_collection_type, input_collection, mocker):
+    # Arrange
+    stub = mocker.stub()
+    mocker.patch("cobbler.modules.serializers.file.serialize_item", new=stub)
+    if input_collection_type == "settings":
+        mock = Settings()
+    else:
+        mocker.patch("cobbler.cobbler_collections.collection.Collection.collection_types",
+                     return_value=input_collection_type)
+        mocker.patch("cobbler.cobbler_collections.collection.Collection.collection_type",
+                     return_value="")
+        mock = Collection(MagicMock())
+        mock.listing["test"] = input_collection
+
+    # Act
+    file.serialize(mock)
+
+    # Assert
+    if input_collection_type == "settings":
+        assert not stub.called
+    else:
+        assert stub.called
+        stub.assert_called_with(mock, input_collection)
+
+
+@pytest.mark.parametrize("input_collection_type,expected_result,settings_read", [
+    ("settings", {}, True),
+    ("distros", [], False),
+])
+def test_deserialize_raw(input_collection_type, expected_result, settings_read, mocker):
+    # Arrange
+    mocker.patch("cobbler.settings.read_settings_file", return_value=expected_result)
+
+    # Act
+    result = file.deserialize_raw(input_collection_type)
+
+    # Assert
+    assert result == expected_result
+
+
+@pytest.mark.parametrize("input_collection_type,input_collection,input_topological,expected_result", [
+    ("settings", {}, True, {}),
+    ("settings", {}, False, {}),
+    ("distros", [{'depth': 2, 'name': False}, {'depth': 1, 'name': True}], True,
+     [{'depth': 1, 'name': True}, {'depth': 2, 'name': False}]),
+    ("distros", [{'depth': 2, 'name': False}, {'depth': 1, 'name': True}], False,
+     [{'depth': 2, 'name': False}, {'depth': 1, 'name': True}]),
+    ("distros", [{'name': False}, {'name': True}], True, [{'name': False}, {'name': True}]),
+    ("distros", [{'name': False}, {'name': True}], False, [{'name': False}, {'name': True}]),
+])
+def test_deserialize(input_collection_type, input_collection, input_topological, expected_result, mocker):
+    # Arrange
+    mocker.patch("cobbler.modules.serializers.file.deserialize_raw", return_value=input_collection)
+    if input_collection_type == "settings":
+        stub_from = mocker.stub(name="from_dict_stub")
+        mocker.patch.object(Settings, "from_dict", new=stub_from)
+        mock = Settings()
+    else:
+        stub_from = mocker.stub(name="from_list_stub")
+        mocker.patch.object(Collection, "from_list", new=stub_from)
+        mock = Collection(MagicMock())
+        mocker.patch("cobbler.cobbler_collections.collection.Collection.collection_types",
+                     return_value=input_collection_type)
+
+    # Act
+    file.deserialize(mock, input_topological)
+
+    # Assert
+    assert stub_from.called
+    stub_from.assert_called_with(expected_result)


### PR DESCRIPTION
Adds testing for [file.py](https://github.com/cobbler/cobbler/blob/master/cobbler/modules/serializers/file.py) and fixes some issues with it.