### PR TITLE
Remove import cgi

### DIFF
--- a/svc/services.py
+++ b/svc/services.py
@@ -28,7 +28,6 @@ import urllib.request
 import urllib.parse
 import urllib.error
 import xmlrpc.server
-import cgi
 
 from cobbler import settings
 


### PR DESCRIPTION
commit 5170d70f77a32d3b4f2196fe5ed47e8d669c98c2
    cgi.parse_qs is deprecated
removed the last cgi module user:
svc/services.py:31:1: F401 'cgi' imported but unused