### PR TITLE
Add missing schema dependencies

### DIFF
--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -35,6 +35,7 @@ of the following packages:
 - python-netaddr
 - python-simplejson
 - python-librepo
+- python-schema
 - PyYAML / python-yaml
 - rsync
 - syslinux

--- a/docs/requirements.rtd.txt
+++ b/docs/requirements.rtd.txt
@@ -7,3 +7,4 @@ pyyaml
 distro
 sphinx_rtd_theme
 file-magic
+schema


### PR DESCRIPTION
The `schema` dependency is missing in the `requirements` file and in the in prerequisities part of the documentation. This PR will fix this.