### PR TITLE
[RFC] Allow sync only work on specified systems

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -24,7 +24,7 @@ import os
 import random
 import tempfile
 import threading
-from typing import Optional
+from typing import Optional, List
 
 from cobbler.actions import status, hardlink, sync, buildiso, replicate, report, log, acl, check, reposync
 from cobbler import autoinstall_manager
@@ -1266,6 +1266,23 @@ class CobblerAPI:
         self.log("validate_autoinstall_files")
         autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self._collection_mgr)
         autoinstall_mgr.validate_autoinstall_files()
+
+    # ==========================================================================
+
+    def sync_systems(self, systems: List[str], verbose: bool = False):
+        """
+        Take the values currently written to the configuration files in /etc, and /var, and build out the information
+        tree found in /tftpboot. Any operations done in the API that have not been saved with serialize() will NOT be
+        synchronized with this command.
+
+        :param systems: List of specified systems that needs to be synced
+        :param verbose: If the action should be just logged as needed or (if True) as much verbose as possible.
+        """
+        self.log("sync_systems")
+        if not (systems and isinstance(systems, list) and all(isinstance(sys_name, str) for sys_name in systems)):
+            raise TypeError('Systems must be a list of one or more strings.')
+        sync_obj = self.get_sync(verbose=verbose)
+        sync_obj.run_sync_systems(systems)
 
     # ==========================================================================
 

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -344,7 +344,8 @@ class CobblerCLI:
         r"""
         Start an asynchronous task in the background.
 
-        :param name: "background\_" % name function must exist in remote.py. This function will be called in a subthread.
+        :param name: "background\_" % name function must exist in remote.py. This function will be called in a
+                      subthread.
         :param options: Dictionary of options passed to the newly started thread
         :return: Id of the newly started task
         """
@@ -726,7 +727,8 @@ class CobblerCLI:
         elif action_name == "reposync":
             self.parser.add_option("--only", dest="only", help="update only this repository name")
             self.parser.add_option("--tries", dest="tries", help="try each repo this many times", default=1)
-            self.parser.add_option("--no-fail", dest="nofail", help="don't stop reposyncing if a failure occurs", action="store_true")
+            self.parser.add_option("--no-fail", dest="nofail", help="don't stop reposyncing if a failure occurs",
+                                   action="store_true")
             (options, args) = self.parser.parse_args(self.args)
             task_id = self.start_task("reposync", options)
         elif action_name == "check":

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -299,6 +299,28 @@ def add_options_from_fields(object_type, parser, fields, network_interface_field
     #    parser.add_option("--no-sync",     action="store_true", dest="nosync", help="suppress sync for speed")
 
 
+def get_comma_separated_args(option: optparse.Option, opt_str, value: str, parser: optparse.OptionParser):
+    """
+    Simple callback function to achieve option split with comma.
+
+    Reference for the method signature can be found at:
+      https://docs.python.org/3/library/optparse.html#defining-a-callback-option
+
+    :param option: The option the callback is executed for
+    :param opt_str: Unused for this callback function. Would be the extended option if the user used the short version.
+    :param value: The value which should be split by comma.
+    :param parser: The optparse instance which the callback should be added to.
+    """
+    # TODO: Migrate to argparse
+    if not isinstance(option, optparse.Option):
+        raise optparse.OptionValueError("Option is not an optparse.Option object!")
+    if not isinstance(value, str):
+        raise optparse.OptionValueError("Value is not a string!")
+    if not isinstance(parser, optparse.OptionParser):
+        raise optparse.OptionValueError("Parser is not an optparse.OptionParser object!")
+    setattr(parser.values, option.dest, value.split(','))
+
+
 class CobblerCLI:
     """
     Main CLI Class which contains the logic to communicate with the Cobbler Server.
@@ -723,12 +745,18 @@ class CobblerCLI:
             self.parser.add_option("--verbose", dest="verbose", action="store_true",
                                    help="run sync with more output")
             self.parser.add_option("--dhcp", dest="dhcp", action="store_true",
-                                   help="Write DHCP config files and restart service")
+                                   help="write DHCP config files and restart service")
             self.parser.add_option("--dns", dest="dns", action="store_true",
-                                   help="Write DNS config files and restart service")
+                                   help="write DNS config files and restart service")
+            self.parser.add_option("--systems", dest="systems", type='string', action="callback",
+                                   callback=get_comma_separated_args,
+                                   help="run a sync only on specified systems")
             # ToDo: Add tftp syncing when it's cleaned up
             (options, args) = self.parser.parse_args(self.args)
-            task_id = self.start_task("sync", options)
+            if options.systems is not None:
+                task_id = self.start_task("syncsystems", options)
+            else:
+                task_id = self.start_task("sync", options)
         elif action_name == "report":
             (options, args) = self.parser.parse_args(self.args)
             print("distros:\n==========")

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -174,7 +174,7 @@ class _InTftpdManager(ManagerModule):
         # directory that's no longer mounted)
         for d in self.collection_mgr.distros():
             try:
-                self.logger.info("copying files for distro: %s" % d.name)
+                self.logger.info("copying files for distro: %s", d.name)
                 self.tftpgen.copy_single_distro_files(d, self.bootloc, False)
             except CX as e:
                 self.logger.error(e.value)

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import glob
 import os.path
 import shutil
+from typing import List
 
 from cobbler import templar
 from cobbler import utils
@@ -129,6 +130,33 @@ class _InTftpdManager(ManagerModule):
     def add_single_distro(self, distro):
         self.tftpgen.copy_single_distro_files(distro, self.bootloc, False)
         self.write_boot_files_distro(distro)
+
+    def sync_systems(self, systems: List[str], verbose: bool = True):
+        """
+        Write out specified systems as separate files to /tftpdboot
+
+        :param systems: List of systems to write PXE configuration files for.
+        :param verbose: Whether the TFTP server should log this verbose or not.
+        """
+        self.tftpgen.verbose = verbose
+
+        system_objs = []
+        for system_name in systems:
+            # get the system object:
+            system_obj = self.systems.find(name=system_name)
+            if system_obj is None:
+                self.logger.info("did not find any system named %s", system_name)
+                continue
+            system_objs.append(system_obj)
+
+        # the actual pxelinux.cfg files, for each interface
+        self.logger.info("generating PXE configuration files")
+        menu_items = self.tftpgen.get_menu_items()['pxe']
+        for system in system_objs:
+            self.tftpgen.write_all_system_files(system, menu_items)
+
+        self.logger.info("generating PXE menu structure")
+        self.tftpgen.make_pxe_menu()
 
     def sync(self, verbose: bool = True):
         """

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -212,6 +212,18 @@ class CobblerXMLRPCInterface:
             self.remote.api.sync(self.options.get("verbose", False), what=what)
         return self.__start_task(runner, token, "sync", "Sync", options)
 
+    def background_syncsystems(self, options, token) -> str:
+        """
+        Run a lite Cobbler sync in the background with only systems specified.
+
+        :param options: Unknown what this parameter does.
+        :param token: The API-token obtained via the login() method.
+        :return: The id of the task that was started.
+        """
+        def runner(self):
+            self.remote.api.sync_systems(self.options.get("systems", []), self.options.get("verbose", False))
+        return self.__start_task(runner, token, "syncsystems", "Syncsystems", options)
+
     def background_hardlink(self, options, token) -> str:
         """
         Hardlink all files as a background task.

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -89,7 +89,8 @@ class CobblerThread(Thread):
         """
         time.sleep(1)
         try:
-            if utils.run_triggers(self.api, None, "/var/lib/cobbler/triggers/task/%s/pre/*" % self.task_name, self.options):
+            if utils.run_triggers(self.api, None, "/var/lib/cobbler/triggers/task/%s/pre/*" % self.task_name,
+                                  self.options):
                 self.remote._set_task_state(self, self.event_id, EVENT_FAILED)
                 return False
             rc = self._run(self)
@@ -98,7 +99,8 @@ class CobblerThread(Thread):
             else:
                 self.remote._set_task_state(self, self.event_id, EVENT_COMPLETE)
                 self.on_done()
-                utils.run_triggers(self.api, None, "/var/lib/cobbler/triggers/task/%s/post/*" % self.task_name, self.options)
+                utils.run_triggers(self.api, None, "/var/lib/cobbler/triggers/task/%s/post/*" % self.task_name,
+                                   self.options)
             return rc
         except:
             utils.log_exc()
@@ -246,7 +248,8 @@ class CobblerXMLRPCInterface:
         """
         def runner(self):
             return self.remote.api.validate_autoinstall_files()
-        return self.__start_task(runner, token, "validate_autoinstall_files", "Automated installation files validation", options)
+        return self.__start_task(runner, token, "validate_autoinstall_files", "Automated installation files validation",
+                                 options)
 
     def background_replicate(self, options, token) -> str:
         """
@@ -2372,7 +2375,8 @@ class CobblerXMLRPCInterface:
         :param rest: This is dropped in this method since it is not needed here.
         :return: True if everything succeeded.
         """
-        self._log("upload_log_data (file: '%s', size: %s, offset: %s)" % (file, size, offset), token=token, name=sys_name)
+        self._log("upload_log_data (file: '%s', size: %s, offset: %s)" % (file, size, offset), token=token,
+                  name=sys_name)
 
         # Check if enabled in self.api.settings()
         if not self.api.settings().anamon_enabled:
@@ -2384,7 +2388,8 @@ class CobblerXMLRPCInterface:
         obj = systems.find(name=sys_name)
         if obj is None:
             # system not found!
-            self._log("upload_log_data - WARNING - system '%s' not found in Cobbler" % sys_name, token=token, name=sys_name)
+            self._log("upload_log_data - WARNING - system '%s' not found in Cobbler" % sys_name, token=token,
+                      name=sys_name)
 
         return self.__upload_file(sys_name, file, size, offset, data)
 

--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -1034,7 +1034,15 @@ settings file) or when making changes to automatic installation files. In practi
 running sync too many times does not cause any adverse effects.
 
 If using Cobbler to manage a DHCP and/or DNS server (see the advanced section of this manpage), sync does need to be run
-after systems are added to regenerate and reload the DHCP/DNS configurations.
+after systems are added to regenerate and reload the DHCP/DNS configurations. If you want to trigger the DHCP/DNS
+regeneration only and do not want a complete sync, you can use ``cobbler sync --dhcp`` or ``cobbler sync --dns`` or the
+combination of both.
+
+``cobbler sync --systems`` is used to only write specific systems (must exists in backend storage) to the TFTP folder.
+The expected pattern is a comma separated list of systems e.g. ``sys1.internal,sys2.internal,sys3.internal``.
+
+.. note::
+    Please note that at least once a full sync has to be run beforehand.
 
 The sync process can also be kicked off from the web interface.
 
@@ -1043,6 +1051,10 @@ Example:
 .. code-block:: shell
 
     $ cobbler sync
+    $ cobbler sync [--systems=sys1.internal,sys2.internal,sys3.internal]
+    $ cobbler sync [--dns]
+    $ cobbler sync [--dhcp]
+    $ cobbler sync [--dns --dhcp]
 
 Cobbler validate-autoinstalls
 =============================

--- a/tests/actions/sync_test.py
+++ b/tests/actions/sync_test.py
@@ -1,0 +1,40 @@
+from unittest.mock import Mock
+
+import pytest
+
+from cobbler.actions import sync
+
+
+@pytest.mark.skip("TODO")
+def test_run_sync_systems():
+    # Arrange
+    mcollection = Mock()
+    # mock os.path.exists()
+    # mock file access (run_triggers)
+    # mock collections (distro, profile, etc.)
+    # mock tftpd module
+    # mock dns module
+    # mock dhcp module
+    test_sync = sync.CobblerSync()
+
+    # Act
+    test_sync.run_sync_systems(["t1.systems.de"])
+    # Assert
+    # correct order with correct parameters
+    assert False
+
+
+@pytest.mark.skip("TODO")
+def test_clean_link_cache():
+    # Arrange
+    # Act
+    # Assert
+    assert False
+
+
+@pytest.mark.skip("TODO")
+def test_rsync_gen():
+    # Arrange
+    # Act
+    # Assert
+    assert False

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -100,3 +100,25 @@ def test_get_sync(mocker):
     # has to be called 3 times by the method
     assert stub.call_count == 3
     assert isinstance(result, cobbler.actions.sync.CobblerSync)
+
+
+@pytest.mark.parametrize("input_verbose,input_systems,expected_exception", [
+    (None, ["t1.systems.de"], does_not_raise()),
+    (True, ["t1.systems.de"], does_not_raise()),
+    (False, ["t1.systems.de"], does_not_raise()),
+    (False, [42], pytest.raises(TypeError)),
+    (False, "t1.systems.de", pytest.raises(TypeError))
+])
+def test_sync_systems(input_systems, input_verbose, expected_exception, mocker):
+    # Arrange
+    stub = create_autospec(spec=cobbler.actions.sync.CobblerSync)
+    mocker.patch.object(CobblerAPI, "get_sync", return_value=stub)
+    test_api = CobblerAPI()
+
+    # Act
+    with expected_exception:
+        test_api.sync_systems(input_systems, input_verbose)
+
+        # Assert
+        stub.run_sync_systems.assert_called_once()
+        stub.run_sync_systems.assert_called_with(input_systems)

--- a/tests/cli/cli_unit_test.py
+++ b/tests/cli/cli_unit_test.py
@@ -1,0 +1,58 @@
+import optparse
+
+import pytest
+
+from cobbler import cli
+from unittest.mock import patch, MagicMock
+
+
+@pytest.mark.parametrize("input_data,expected_result", [
+    ("", ""),
+    (0, 0),
+    (None, "")
+])
+def test_n2s(input_data, expected_result):
+    # Arrange
+    # Act
+    result = cli.n2s(input_data)
+
+    # Assert
+    assert result == expected_result
+
+
+@pytest.mark.skip("TODO: Does not work yet.")
+@pytest.mark.parametrize("input_options,input_k,expected_result", [
+    (None, None, None),
+    ("--dns", "name", ""),
+    ("--dhcp", "name", ""),
+    ("--system", "name", "")
+])
+def test_opt(input_options, input_k, expected_result, mocker):
+    # Arrange
+    # TODO: Create Mock which replaces n2s
+    # mocker.patch.object(cli, "n2s")
+
+    # Act
+    print(cli.opt(input_options, input_k))
+
+    # Assert
+    # TODO: Assert args for n2s not the function return
+    assert False
+
+
+@pytest.mark.parametrize("input_parser,expected_result", [
+    (["--systems=a.b.c"], {'systems': ['a.b.c']}),
+    (["--systems=a.b.c,a.d.c"], {'systems': ['a.b.c', 'a.d.c']}),
+    (["--systems=t1.example.de"], {'systems': ['t1.example.de']})
+])
+def test_get_comma_separated_args(input_parser, expected_result):
+    # Arrange
+    parser_obj = optparse.OptionParser()
+    parser_obj.add_option("--systems", dest="systems", type='string', action="callback",
+                          callback=cli.get_comma_separated_args)
+
+    # Act
+    (options, args) = parser_obj.parse_args(args=input_parser)
+
+    # Assert
+    assert expected_result == parser_obj.values.__dict__

--- a/tests/cli/cobbler_cli_direct_test.py
+++ b/tests/cli/cobbler_cli_direct_test.py
@@ -90,6 +90,12 @@ class TestCobblerCliTestDirect:
         lines = outputstd.split("\n")
         assert "*** TASK COMPLETE ***" == get_last_line(lines)
 
+    def test_cobbler_sync_systems(self, run_cmd, get_last_line):
+        """Runs 'cobbler sync'"""
+        (outputstd, outputerr) = run_cmd(cmd=["sync", "--systems=a.b.c,a.d.c"])
+        lines = outputstd.split("\n")
+        assert "*** TASK COMPLETE ***" == get_last_line(lines)
+
     def test_cobbler_signature_report(self, run_cmd, get_last_line):
         """Runs 'cobbler signature report'"""
         (outputstd, outputerr) = run_cmd(cmd=["signature", "report"])

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -1,0 +1,34 @@
+from unittest.mock import Mock
+
+import pytest
+
+from cobbler.modules.managers import in_tftpd
+
+
+def test_tftpd_singleton():
+    # Arrange
+    mcollection = Mock()
+
+    # Act
+    manager_1 = in_tftpd.get_manager(mcollection)
+    manager_2 = in_tftpd.get_manager(mcollection)
+
+    # Assert
+    assert manager_1 == manager_2
+
+
+@pytest.mark.skip("TODO")
+@pytest.mark.parametrize("input_systems, input_verbose, expected_output", [
+    ("t1.example.org", True, "t1.example.org")
+])
+def test_sync_systems(input_systems, input_verbose, expected_output):
+    # Arrange
+    mcollection = Mock()
+    manager_obj = in_tftpd.get_manager(mcollection)
+    # mock tftpgen
+
+    # Act
+    # .sync_systems(input_systems, input_verbose)
+
+    # Assert
+    assert False


### PR DESCRIPTION
**Problem:** if number of systems a single cobbler instance manage gets over couple of thousands, the cobbler sync will take very long time to finish (we usually see a sync takes over 10 mins)

**Observation:** the process of writing pxe config files for every systems to /tftpboot take 90% of the sync time

**Solution:** in here, i am trying to introduce an option after regular `cobbler sync` as `cobbler sync --systems a.b.c,a.x.c` and API will result a call as `sync_systems(systems)`, if no `--systems` get passed after `cobbler sync`, it will default to run regular `cobbler sync`

the function/command name can be changed, or we can make it a standalone command with options

**please be note that i haven't test PR code**
this is just a preliminary idea and code change, if we can agree on this change, i can make up all the piece including unit test