### PR TITLE
Remove simplejson dependency

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -212,7 +212,6 @@ Requires:       %{apache_mod_wsgi}
 Requires:       python%{python3_pkgversion}-netaddr
 Requires:       %{py3_module_pyyaml}
 Requires:       python%{python3_pkgversion}-requests
-Requires:       python%{python3_pkgversion}-simplejson
 Requires:       python%{python3_pkgversion}-distro
 Requires:       python%{python3_pkgversion}-schema
 Requires:       %{py3_module_file}

--- a/cobbler/configgen.py
+++ b/cobbler/configgen.py
@@ -23,7 +23,7 @@ module for generating configuration manifest using autoinstall_meta data,
 mgmtclasses, resources, and templates for a given system (hostname)
 """
 
-import simplejson as json
+import json
 import string
 
 from cobbler.cexceptions import CX

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 import os
 import glob
-import simplejson
+import json
 
 import cobbler.api as capi
 from cobbler import settings
@@ -86,7 +86,7 @@ def serialize_item(collection, item):
 
     _dict = item.to_dict()
     with open(filename, "w+") as file_descriptor:
-        data = simplejson.dumps(_dict, encoding="utf-8", sort_keys=sort_keys, indent=indent)
+        data = json.dumps(_dict, sort_keys=sort_keys, indent=indent)
         file_descriptor.write(data)
 
 
@@ -137,7 +137,7 @@ def deserialize_raw(collection_types: str):
         for f in all_files:
             with open(f) as file_descriptor:
                 json_data = file_descriptor.read()
-                _dict = simplejson.loads(json_data, encoding='utf-8')
+                _dict = json.loads(json_data)
                 results.append(_dict)
         return results
 

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-import simplejson
+import json
 import time
 import xmlrpc.client
 import yaml
@@ -177,7 +177,7 @@ class CobblerSvc:
             nowtime = time.time()
             if ((nowtime - etime) < 30):
                 results.append([k, data[k][0], data[k][1], data[k][2]])
-        return simplejson.dumps(results)
+        return json.dumps(results)
 
     def template(self, profile=None, system=None, path=None, **rest) -> str:
         """

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -39,7 +39,7 @@ from typing import List, Optional, Union
 
 import distro
 import netaddr
-import simplejson
+import json
 
 from cobbler import clogger, settings
 from cobbler import field_info
@@ -1062,7 +1062,7 @@ def hashfile(fn, lcache=None, logger=None):
     dbfile = os.path.join(lcache, 'link_cache.json')
     try:
         if os.path.exists(dbfile):
-            db = simplejson.load(open(dbfile, 'r'))
+            db = json.load(open(dbfile, 'r'))
     except:
         pass
 
@@ -1078,7 +1078,7 @@ def hashfile(fn, lcache=None, logger=None):
         if lcache is not None:
             db[fn] = (mtime, key)
             # TODO: Safeguard this against above mentioned directory does not exist error.
-            simplejson.dump(db, open(dbfile, 'w'))
+            json.dump(db, open(dbfile, 'w'))
         return key
     else:
         return None
@@ -2175,7 +2175,7 @@ def load_signatures(filename, cache: bool = True):
 
     with open(filename, "r") as f:
         sigjson = f.read()
-    sigdata = simplejson.loads(sigjson)
+    sigdata = json.loads(sigjson)
     if cache:
         SIGNATURE_CACHE = sigdata
 

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -33,7 +33,6 @@ of the following packages:
 - mod_ssl / libapache2-mod-ssl
 - python-cheetah
 - python-netaddr
-- python-simplejson
 - python-librepo
 - python-schema
 - PyYAML / python-yaml
@@ -70,7 +69,6 @@ Installation from source requires the following additional software:
 - make
 - python3-devel (on Debian based distributions ``python3-dev``)
 - python3-Cheetah3
-- python3-future
 - python3-Sphinx
 - python3-coverage
 - openssl

--- a/docs/requirements.rtd.txt
+++ b/docs/requirements.rtd.txt
@@ -1,6 +1,5 @@
 netaddr
 Cheetah3
-simplejson
 dnspython
 pyyaml
 distro

--- a/setup.py
+++ b/setup.py
@@ -510,7 +510,6 @@ if __name__ == "__main__":
             "mod_wsgi",
             "requests",
             "pyyaml",
-            "simplejson",
             "netaddr",
             "Cheetah3",
             "pymongo",


### PR DESCRIPTION
The PyPi `simplejson` package was integrated into the Python standard library (see: <https://github.com/simplejson/simplejson>). Thus I removed it since Py 2.6 is already a while in the past now.