### PR TITLE
Switch to build system according to PEP 518

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["coverage", "distro", "sphinx", "setuptools", "wheel"]

--- a/setup.py
+++ b/setup.py
@@ -505,12 +505,6 @@ if __name__ == "__main__":
             'Tracker': 'https://github.com/cobbler/cobbler/issues'
         },
         license="GPLv2+",
-        setup_requires=[
-            "coverage",
-            "distro",
-            "setuptools",
-            "sphinx",
-        ],
         install_requires=[
             "mod_wsgi",
             "requests",


### PR DESCRIPTION
This PR will fix #2415. I had to add the `wheels` package, otherwise pip would not stop complaining:

```shell
$ pip install .    
Processing /home/dom/git/work/cobbler   
  Installing build dependencies ... done 
  WARNING: Missing build requirements in pyproject.toml for file:///home/dom/git/work/cobbler.   
  WARNING: The project does not specify a build backend, and pip cannot fall back to setuptools without 'wheel'.
(...)
```
The [pip documentation](https://pip.pypa.io/en/stable/reference/pip/#pep-517-and-518-support) confirms that.
> If a project has [build-system], but no build-backend, pip will also use setuptools.build_meta:__legacy__, but will expect the project requirements to include setuptools and wheel (and will report an error if the installed version of setuptools is not recent enough).

Furthermore the [setuptools documentation](https://setuptools.readthedocs.io/en/latest/references/keywords.html) states the following:
> Using setup_requires is discouraged in favor of PEP-518.