### PR TITLE
Expose ports 80 and 443 of the Test container to fix CORS for Cobbler Web in the API calls

### DIFF
--- a/docker/testing/testing.dockerfile
+++ b/docker/testing/testing.dockerfile
@@ -50,5 +50,9 @@ RUN ["pip3", "install", ".[lint,test]"]
 RUN ["make", "install"]
 RUN ["cp", "/etc/cobbler/cobbler.conf", "/etc/apache2/vhosts.d/"]
 
+# Expose the Apache Webserver
+EXPOSE 80
+EXPOSE 443
+
 # Set this as an entrypoint
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisord.conf"]


### PR DESCRIPTION
This is related to PR https://github.com/cobbler/cobbler-web/pull/12