### PR TITLE
Use a base class ManagerModule for all modules/manager/*.py module cl…

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -118,7 +118,7 @@ class CobblerSync:
         if self.settings.manage_dns:
             self.logger.info("rendering DNS files")
             self.dns.regen_hosts()
-            self.dns.write_dns_files()
+            self.dns.write_configs()
 
         if self.settings.manage_tftpd:
             # copy in boot_files
@@ -193,7 +193,7 @@ class CobblerSync:
         Write all files which are associated to DHCP.
         """
         self.logger.info("rendering DHCP files")
-        self.dhcp.write_dhcp_file()
+        self.dhcp.write_configs()
         self.dhcp.regen_ethers()
 
     def sync_dhcp(self):

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -720,7 +720,13 @@ class CobblerCLI:
                 print("No configuration problems found.  All systems go.")
 
         elif action_name == "sync":
-            self.parser.add_option("--verbose", dest="verbose", action="store_true", help="run sync with more output")
+            self.parser.add_option("--verbose", dest="verbose", action="store_true",
+                                   help="run sync with more output")
+            self.parser.add_option("--dhcp", dest="dhcp", action="store_true",
+                                   help="Write DHCP config files and restart service")
+            self.parser.add_option("--dns", dest="dns", action="store_true",
+                                   help="Write DNS config files and restart service")
+            # ToDo: Add tftp syncing when it's cleaned up
             (options, args) = self.parser.parse_args(self.args)
             task_id = self.start_task("sync", options)
         elif action_name == "report":

--- a/cobbler/manager.py
+++ b/cobbler/manager.py
@@ -1,0 +1,86 @@
+"""
+Base class for modules.managers.* classes
+
+Copyright 2021 SUSE LLC
+Thomas Renninger <trenn@suse.de>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301  USA
+"""
+import logging
+import cobbler.templar as templar
+
+
+class ManagerModule():
+    """
+    Base class for Manager modules located in modules/manager/*.py
+
+    These are typically, but not necessarily used to manage systemd services.
+    Enabling can be done via settings manage_* (e.g. manage_dhcp) and restart_*
+    (e.g. restart_dhcp).
+    Different modules could manage same functionality like dhcp can be
+    managed via isc.py or dnsmasq.py (compare with /etc/cobbler/modules.py)
+    """
+
+    @staticmethod
+    def what():
+        """
+        Static method to identify the manager module.
+        Must be overwritten by the inheriting class
+        """
+        return "undefined"
+
+    def __init__(self, collection_mgr):
+        """
+        Constructor
+
+        :param collection_mgr: The collection manager to resolve all information with.
+        """
+        self.logger = logging.getLogger()
+        self.collection_mgr = collection_mgr
+        self.api = collection_mgr.api
+        self.distros = collection_mgr.distros()
+        self.profiles = collection_mgr.profiles()
+        self.systems = collection_mgr.systems()
+        self.settings = collection_mgr.settings()
+        self.repos = collection_mgr.repos()
+        self.templar = templar.Templar(collection_mgr)
+
+    def write_configs(self):
+        """
+        Write module specific config files.
+        E.g. dhcp manager would write /etc/dhcpd.conf here
+        """
+
+    def restart_service(self):
+        """
+        Write module specific config files.
+        E.g. dhcp manager would write /etc/dhcpd.conf here
+        """
+
+    def regen_ethers(self):
+        """
+        ISC/BIND doesn't use this. It is there for compability reasons with other managers.
+        """
+
+    def sync(self):
+        """
+        This syncs the manager's server (systemd service) with it's new config files.
+        Basically this restarts the service to apply the changes.
+
+        :return: Integer return value of restart_service - 0 on success
+        """
+        self.write_configs()
+        return self.restart_service()

--- a/cobbler/manager.py
+++ b/cobbler/manager.py
@@ -19,6 +19,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
+
 import logging
 import cobbler.templar as templar
 

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -20,15 +20,15 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
-import logging
 import re
 import socket
 import time
 
-from cobbler import templar
 from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler.manager import ManagerModule
+
+MANAGER = None
 
 
 def register() -> str:
@@ -615,7 +615,6 @@ zone "%(arpa)s." {
             self.logger.error("%s service failed", named_service_name)
         return ret
 
-manager = None
 
 def get_manager(collection_mgr):
     """
@@ -624,8 +623,9 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager to resolve all information with.
     :return: The BindManger object to manage bind with.
     """
-    global manager
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
 
-    if not manager:
-        manager = _BindManager(collection_mgr)
-    return manager
+    if not MANAGER:
+        MANAGER = _BindManager(collection_mgr)
+    return MANAGER

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -20,14 +20,15 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
-import logging
+
 import time
 
-import cobbler.templar as templar
 import cobbler.utils as utils
 from cobbler.manager import ManagerModule
 
 from cobbler.cexceptions import CX
+
+MANAGER = None
 
 
 def register() -> str:
@@ -192,8 +193,6 @@ class _DnsmasqManager(ManagerModule):
                 raise CX(error_msg)
 
 
-manager = None
-
 def get_manager(collection_mgr):
     """
     Creates a manager object to manage a dnsmasq server.
@@ -201,8 +200,9 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager to resolve all information with.
     :return: The object generated from the class.
     """
-    global manager
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
 
-    if not manager:
-        manager = _DnsmasqManager(collection_mgr)
-    return manager
+    if not MANAGER:
+        MANAGER = _DnsmasqManager(collection_mgr)
+    return MANAGER

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -25,6 +25,7 @@ import time
 
 import cobbler.templar as templar
 import cobbler.utils as utils
+from cobbler.manager import ManagerModule
 
 from cobbler.cexceptions import CX
 
@@ -38,28 +39,13 @@ def register() -> str:
     return "manage"
 
 
-class DnsmasqManager:
+class _DnsmasqManager(ManagerModule):
     """
     Handles conversion of internal state to the tftpboot tree layout.
     """
 
-    def __init__(self, collection_mgr):
-        """
-        Constructor
-
-        :param collection_mgr: The collection manager to resolve all information with.
-        """
-        self.logger = logging.getLogger()
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
-
-    def what(self) -> str:
+    @staticmethod
+    def what() -> str:
         """
         This identifies the module.
 
@@ -67,27 +53,7 @@ class DnsmasqManager:
         """
         return "dnsmasq"
 
-    def write_dhcp_lease(self, port, host, ip, mac):
-        """
-        Not used
-
-        :param port: Unused in this module implementation.
-        :param host: Unused in this module implementation.
-        :param ip: Unused in this module implementation.
-        :param mac: Unused in this module implementation.
-        """
-        pass
-
-    def remove_dhcp_lease(self, port, host):
-        """
-        Not used
-
-        :param port: Unused in this module implementation.
-        :param host: Unused in this module implementation.
-        """
-        pass
-
-    def write_dhcp_file(self):
+    def write_configs(self):
         """
         DHCP files are written when ``manage_dhcp`` is set in our settings.
         """
@@ -214,14 +180,7 @@ class DnsmasqManager:
                     fh.write(ip + "\t" + host + "\n")
         fh.close()
 
-    def write_dns_files(self):
-        """
-        Not used
-        """
-        # already taken care of by the regen_hosts()
-        pass
-
-    def sync_dhcp(self):
+    def restart_service(self):
         """
         This restarts the dhcp server and thus applied the newly written config files.
         """
@@ -233,6 +192,8 @@ class DnsmasqManager:
                 raise CX(error_msg)
 
 
+manager = None
+
 def get_manager(collection_mgr):
     """
     Creates a manager object to manage a dnsmasq server.
@@ -240,4 +201,8 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager to resolve all information with.
     :return: The object generated from the class.
     """
-    return DnsmasqManager(collection_mgr)
+    global manager
+
+    if not manager:
+        manager = _DnsmasqManager(collection_mgr)
+    return manager

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -35,6 +35,7 @@ from cobbler import templar
 from cobbler.items import profile, distro
 from cobbler.cexceptions import CX
 from cobbler import utils
+from cobbler.manager import ManagerModule
 
 import cobbler.items.repo as item_repo
 
@@ -46,7 +47,6 @@ try:
     apt_available = True
 except:
     apt_available = False
-
 
 def register() -> str:
     """
@@ -86,32 +86,9 @@ def import_walker(top: str, func: Callable, arg: Any):
             import_walker(name, func, arg)
 
 
-class ImportSignatureManager:
-    """
-    This class contains most of the magic behind the ``cobbler import`` command. It uses the signatures as a data source
-    and then automatically adds the detected distro to Cobbler.
-    """
+class _ImportSignatureManager(ManagerModule):
 
-    def __init__(self, collection_mgr):
-        """
-        Main constructor for our class.
-
-        :param collection_mgr: This is the collection manager which has every information in Cobbler available.
-        """
-        self.logger = logging.getLogger()
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
-
-        self.signature = None
-        self.found_repos = {}
-
-    # required function for import modules
+    @staticmethod
     def what(self) -> str:
         """
         Identifies what service this manages.
@@ -119,6 +96,12 @@ class ImportSignatureManager:
         :return: Always will return ``import/signatures``.
         """
         return "import/signatures"
+
+    def __init__(self, collection_mgr):
+        super().__init__(collection_mgr)
+
+        self.signature = None
+        self.found_repos = {}
 
     def get_file_lines(self, filename: str):
         """
@@ -807,11 +790,17 @@ class ImportSignatureManager:
 # ==========================================================================
 
 
-def get_import_manager(config):
+manager = None
+
+def get_import_manager(collection_mgr):
     """
     Get an instance of the import manager which enables you to import various things.
 
     :param config: The configuration for the import manager.
     :return: The object to import data with.
     """
-    return ImportSignatureManager(config)
+    global manager
+
+    if not manager:
+        manager = _ImportSignatureManager(collection_mgr)
+    return manager

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -18,7 +18,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
-import logging
+
 from typing import List, Callable, Any, Optional
 
 import glob
@@ -31,7 +31,6 @@ import stat
 
 import magic
 
-from cobbler import templar
 from cobbler.items import profile, distro
 from cobbler.cexceptions import CX
 from cobbler import utils
@@ -47,6 +46,9 @@ try:
     apt_available = True
 except:
     apt_available = False
+
+MANAGER = None
+
 
 def register() -> str:
     """
@@ -790,8 +792,6 @@ class _ImportSignatureManager(ManagerModule):
 # ==========================================================================
 
 
-manager = None
-
 def get_import_manager(collection_mgr):
     """
     Get an instance of the import manager which enables you to import various things.
@@ -799,8 +799,9 @@ def get_import_manager(collection_mgr):
     :param config: The configuration for the import manager.
     :return: The object to import data with.
     """
-    global manager
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
 
-    if not manager:
-        manager = _ImportSignatureManager(collection_mgr)
-    return manager
+    if not MANAGER:
+        MANAGER = _ImportSignatureManager(collection_mgr)
+    return MANAGER

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -27,7 +27,7 @@ from cobbler import utils
 from cobbler import tftpgen
 
 from cobbler.cexceptions import CX
-
+from cobbler.manager import ManagerModule
 
 def register() -> str:
     """
@@ -36,9 +36,10 @@ def register() -> str:
     return "manage"
 
 
-class InTftpdManager:
+class _InTftpdManager(ManagerModule):
 
-    def what(self) -> str:
+    @staticmethod
+    def what() -> str:
         """
         Static method to identify the manager.
 
@@ -47,30 +48,10 @@ class InTftpdManager:
         return "in_tftpd"
 
     def __init__(self, collection_mgr):
-        """
-        Constructor
+        super().__init__(collection_mgr)
 
-        :param collection_mgr: The collection manager to resolve all information with.
-        """
-        self.logger = logging.getLogger()
-
-        self.collection_mgr = collection_mgr
-        self.templar = templar.Templar(collection_mgr)
         self.tftpgen = tftpgen.TFTPGen(collection_mgr)
-        self.systems = collection_mgr.systems()
         self.bootloc = collection_mgr.settings().tftpboot_location
-
-    def regen_hosts(self):
-        """
-        Not used
-        """
-        pass
-
-    def write_dns_files(self):
-        """
-        Not used
-        """
-        pass
 
     def write_boot_files_distro(self, distro):
         # Collapse the object down to a rendered datastructure.
@@ -181,6 +162,8 @@ class InTftpdManager:
         self.tftpgen.make_pxe_menu()
 
 
+manager = None
+
 def get_manager(collection_mgr):
     """
     Creates a manager object to manage an in_tftp server.
@@ -188,4 +171,8 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
     :return: The object to manage the server with.
     """
-    return InTftpdManager(collection_mgr)
+    global manager
+
+    if not manager:
+        manager = _InTftpdManager(collection_mgr)
+    return manager

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -18,7 +18,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 
 import glob
-import logging
 import os.path
 import shutil
 
@@ -28,6 +27,9 @@ from cobbler import tftpgen
 
 from cobbler.cexceptions import CX
 from cobbler.manager import ManagerModule
+
+MANAGER = None
+
 
 def register() -> str:
     """
@@ -162,8 +164,6 @@ class _InTftpdManager(ManagerModule):
         self.tftpgen.make_pxe_menu()
 
 
-manager = None
-
 def get_manager(collection_mgr):
     """
     Creates a manager object to manage an in_tftp server.
@@ -171,8 +171,9 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
     :return: The object to manage the server with.
     """
-    global manager
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
 
-    if not manager:
-        manager = _InTftpdManager(collection_mgr)
-    return manager
+    if not MANAGER:
+        MANAGER = _InTftpdManager(collection_mgr)
+    return MANAGER

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -21,13 +21,14 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-import logging
 import time
 import copy
 
 import cobbler.utils as utils
 from cobbler.manager import ManagerModule
 from cobbler.cexceptions import CX
+
+MANAGER = None
 
 
 def register() -> str:
@@ -237,8 +238,6 @@ class _IscManager(ManagerModule):
         return ret
 
 
-manager = None
-
 def get_manager(collection_mgr):
     """
     Creates a manager object to manage an isc dhcp server.
@@ -246,8 +245,9 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
     :return: The object to manage the server with.
     """
-    global manager
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
 
-    if not manager:
-        manager = _IscManager(collection_mgr)
-    return manager
+    if not MANAGER:
+        MANAGER = _IscManager(collection_mgr)
+    return MANAGER

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -20,13 +20,13 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
+
 import logging
 import time
 import copy
 
-from cobbler import templar
-from cobbler import utils
-
+import cobbler.utils as utils
+from cobbler.manager import ManagerModule
 from cobbler.cexceptions import CX
 
 
@@ -37,9 +37,10 @@ def register() -> str:
     return "manage"
 
 
-class IscManager:
+class _IscManager(ManagerModule):
 
-    def what(self) -> str:
+    @staticmethod
+    def what() -> str:
         """
         Static method to identify the manager.
 
@@ -48,23 +49,11 @@ class IscManager:
         return "isc"
 
     def __init__(self, collection_mgr):
-        """
-        Constructor
+        super().__init__(collection_mgr)
 
-        :param collection_mgr: The collection manager to resolve all information with.
-        """
-        self.logger = logging.getLogger()
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
         self.settings_file = utils.dhcpconf_location()
 
-    def write_dhcp_file(self):
+    def write_configs(self):
         """
         DHCP files are written when ``manage_dhcp`` is set in our settings.
         """
@@ -74,8 +63,10 @@ class IscManager:
 
         try:
             f2 = open(template_file, "r")
-        except:
+
+        except Exception:
             raise CX("error reading template: %s" % template_file)
+
         template_data = ""
         template_data = f2.read()
         f2.close()
@@ -228,30 +219,25 @@ class IscManager:
         self.logger.info("generating %s", self.settings_file)
         self.templar.render(template_data, metadata, self.settings_file)
 
-    def regen_ethers(self):
+    def restart_service(self):
         """
-        ISC/BIND doesn't use this. It is there for compability reasons with other managers.
-        """
-        pass
-
-    def sync_dhcp(self):
-        """
-        This syncs the dhcp server with it's new config files. Basically this restarts the service to apply the changes.
+        This syncs the dhcp server with it's new config files.
+        Basically this restarts the service to apply the changes.
         """
         service_name = utils.dhcp_service_name()
+        ret = 0
         if self.settings.restart_dhcp:
-            rc = utils.subprocess_call("dhcpd -t -q", shell=True)
-            if rc != 0:
-                error_msg = "dhcpd -t failed"
-                self.logger.error(error_msg)
-                raise CX(error_msg)
+            ret = utils.subprocess_call("dhcpd -t -q", shell=True)
+            if ret != 0:
+                self.logger.error("dhcpd -t failed")
             service_restart = "service %s restart" % service_name
-            rc = utils.subprocess_call(service_restart, shell=True)
-            if rc != 0:
-                error_msg = "%s failed" % service_name
-                self.logger.error(error_msg)
-                raise CX(error_msg)
+            ret = utils.subprocess_call(service_restart, shell=True)
+            if ret != 0:
+                self.logger.error("%s service failed", service_name)
+        return ret
 
+
+manager = None
 
 def get_manager(collection_mgr):
     """
@@ -260,4 +246,8 @@ def get_manager(collection_mgr):
     :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
     :return: The object to manage the server with.
     """
-    return IscManager(collection_mgr)
+    global manager
+
+    if not manager:
+        manager = _IscManager(collection_mgr)
+    return manager

--- a/cobbler/modules/managers/ndjbdns.py
+++ b/cobbler/modules/managers/ndjbdns.py
@@ -26,6 +26,8 @@ import subprocess
 
 from cobbler.manager import ManagerModule
 
+MANAGER = None
+
 
 def register() -> str:
     """
@@ -84,18 +86,16 @@ class _NDjbDnsManager(ManagerModule):
             raise Exception('Could not regenerate tinydns data file.')
 
 
-manager = None
-
 def get_manager(collection_mgr):
     """
     Creates a manager object to manage an isc dhcp server.
 
     :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
-    :param logger: The logger to audit all actions with.
     :return: The object to manage the server with.
     """
-    global manager
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
 
-    if not manager:
-        manager = _NDjbDnsManager(collection_mgr)
-    return manager
+    if not MANAGER:
+        MANAGER = _NDjbDnsManager(collection_mgr)
+    return MANAGER

--- a/cobbler/modules/managers/ndjbdns.py
+++ b/cobbler/modules/managers/ndjbdns.py
@@ -24,7 +24,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import os
 import subprocess
 
-from cobbler import templar
+from cobbler.manager import ManagerModule
 
 
 def register() -> str:
@@ -34,29 +34,9 @@ def register() -> str:
     return "manage"
 
 
-def get_manager(config):
-    """
-    Get the DNS Manger object.
+class _NDjbDnsManager(ManagerModule):
 
-    :param config: Unused parameter.
-    :return: The manager object.
-    """
-    return NDjbDnsManager(config)
-
-
-class NDjbDnsManager:
-
-    def __init__(self, config):
-        """
-        This class can manage a New-DJBDNS server.
-
-        :param config: Currently an usused parameter.
-        """
-
-        self.config = config
-        self.systems = config.systems()
-        self.templar = templar.Templar(config)
-
+    @staticmethod
     def what(self) -> str:
         """
         Static method to identify the manager.
@@ -65,13 +45,10 @@ class NDjbDnsManager:
         """
         return "ndjbdns"
 
-    def regen_hosts(self):
-        """
-        Empty stub method to have compability with other dns managers who need this.
-        """
+    def __init__(self, collection_mgr):
         pass
 
-    def write_dns_files(self):
+    def write_configs(self):
         """
         This writes the new dns configuration file to the disc.
         """
@@ -105,3 +82,20 @@ class NDjbDnsManager:
 
         if p.returncode != 0:
             raise Exception('Could not regenerate tinydns data file.')
+
+
+manager = None
+
+def get_manager(collection_mgr):
+    """
+    Creates a manager object to manage an isc dhcp server.
+
+    :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
+    :param logger: The logger to audit all actions with.
+    :return: The object to manage the server with.
+    """
+    global manager
+
+    if not manager:
+        manager = _NDjbDnsManager(collection_mgr)
+    return manager

--- a/cobbler/modules/managers/ndjbdns.py
+++ b/cobbler/modules/managers/ndjbdns.py
@@ -39,7 +39,7 @@ def register() -> str:
 class _NDjbDnsManager(ManagerModule):
 
     @staticmethod
-    def what(self) -> str:
+    def what() -> str:
         """
         Static method to identify the manager.
 
@@ -48,7 +48,7 @@ class _NDjbDnsManager(ManagerModule):
         return "ndjbdns"
 
     def __init__(self, collection_mgr):
-        pass
+        super().__init__(collection_mgr)
 
     def write_configs(self):
         """

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -199,12 +199,17 @@ class CobblerXMLRPCInterface:
         """
         Run a full Cobbler sync in the background.
 
-        :param options: Not known what this parameter does.
+        :param options: Possible options: verbose, dhcp, dns
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :return: The id of the task which was started.
         """
         def runner(self):
-            self.remote.api.sync(self.options.get("verbose", False))
+            what = []
+            if self.options.get("dhcp", False):
+                what.append('dhcp')
+            if self.options.get("dns", False):
+                what.append('dns')
+            self.remote.api.sync(self.options.get("verbose", False), what=what)
         return self.__start_task(runner, token, "sync", "Sync", options)
 
     def background_hardlink(self, options, token) -> str:

--- a/tests/api_test.py
+++ b/tests/api_test.py
@@ -1,0 +1,102 @@
+import pytest
+from unittest.mock import Mock, MagicMock, create_autospec, PropertyMock
+
+import cobbler.actions.sync
+import cobbler.modules.managers.bind
+import cobbler.modules.managers.isc
+from cobbler.api import CobblerAPI
+from tests.conftest import does_not_raise
+
+
+@pytest.mark.parametrize("input_verbose,input_what,expected_exception", [
+    (None, None, does_not_raise()),
+    (True, [], does_not_raise()),
+    (False, [], does_not_raise()),
+    (True, ["dhcp"], does_not_raise()),
+    (True, ["dns"], does_not_raise()),
+    (True, ["dns", "dhcp"], does_not_raise())
+])
+def test_sync(input_verbose, input_what, expected_exception, mocker):
+    # Arrange
+    stub = create_autospec(spec=cobbler.actions.sync.CobblerSync)
+    stub_dhcp = mocker.stub()
+    stub_dns = mocker.stub()
+    mocker.patch.object(CobblerAPI, "get_sync", return_value=stub)
+    mocker.patch.object(CobblerAPI, "sync_dhcp", new=stub_dhcp)
+    mocker.patch.object(CobblerAPI, "sync_dns", new=stub_dns)
+    test_api = CobblerAPI()
+
+    # Act
+    with expected_exception:
+        test_api.sync(input_verbose, input_what)
+
+    # Assert
+    if not input_what:
+        stub.run.assert_called_once()
+    if input_what and "dhcp" in input_what:
+        stub_dhcp.assert_called_once()
+    if input_what and "dns" in input_what:
+        stub_dns.assert_called_once()
+
+
+@pytest.mark.parametrize("input_manage_dns", [
+    (True),
+    (False)
+])
+def test_sync_dns(input_manage_dns, mocker):
+    # Arrange
+    mock = MagicMock()
+    m_property = PropertyMock(return_value=input_manage_dns)
+    type(mock).manage_dns = m_property
+    mocker.patch.object(CobblerAPI, "settings", return_value=mock)
+
+    # mock get_manager() and ensure mock object has the same api as the object it is replacing.
+    # see https://docs.python.org/3/library/unittest.mock.html#unittest.mock.create_autospec
+    stub = create_autospec(spec=cobbler.modules.managers.bind._BindManager)
+    mocker.patch("cobbler.modules.managers.bind.get_manager", return_value=stub)
+    test_api = CobblerAPI()
+
+    # Act
+    test_api.sync_dns()
+
+    # Assert
+    m_property.assert_called_once()
+    assert stub.sync.called == input_manage_dns
+
+
+@pytest.mark.parametrize("input_manager_dhcp", [
+    (True),
+    (False)
+])
+def test_sync_dhcp(input_manager_dhcp, mocker):
+    # Arrange
+    mock = MagicMock()
+    m_property = PropertyMock(return_value=input_manager_dhcp)
+    type(mock).manage_dhcp = m_property
+    mocker.patch.object(CobblerAPI, "settings", return_value=mock)
+
+    stub = create_autospec(spec=cobbler.modules.managers.isc._IscManager)
+    mocker.patch("cobbler.modules.managers.isc.get_manager", return_value=stub)
+    test_api = CobblerAPI()
+
+    # Act
+    test_api.sync_dhcp()
+
+    # Assert
+    m_property.assert_called_once()
+    assert stub.sync.called == input_manager_dhcp
+
+
+def test_get_sync(mocker):
+    # Arrange
+    stub = Mock()
+    mocker.patch.object(CobblerAPI, "get_module_from_file", new=stub)
+    test_api = CobblerAPI()
+
+    # Act
+    result = test_api.get_sync()
+
+    # Assert
+    # has to be called 3 times by the method
+    assert stub.call_count == 3
+    assert isinstance(result, cobbler.actions.sync.CobblerSync)

--- a/tests/cli/cobbler_cli_direct_test.py
+++ b/tests/cli/cobbler_cli_direct_test.py
@@ -72,6 +72,24 @@ class TestCobblerCliTestDirect:
         lines = outputstd.split("\n")
         assert "*** TASK COMPLETE ***" == get_last_line(lines)
 
+    def test_cobbler_sync_dns(self, run_cmd, get_last_line):
+        """Runs 'cobbler sync --dns'"""
+        (outputstd, outputerr) = run_cmd(cmd=["sync", "--dns"])
+        lines = outputstd.split("\n")
+        assert "*** TASK COMPLETE ***" == get_last_line(lines)
+
+    def test_cobbler_sync_dhcp(self, run_cmd, get_last_line):
+        """Runs 'cobbler sync --dhcp'"""
+        (outputstd, outputerr) = run_cmd(cmd=["sync", "--dhcp"])
+        lines = outputstd.split("\n")
+        assert "*** TASK COMPLETE ***" == get_last_line(lines)
+
+    def test_cobbler_sync_dhcp_dns(self, run_cmd, get_last_line):
+        """Runs 'cobbler sync --dhcp --dns'"""
+        (outputstd, outputerr) = run_cmd(cmd=["sync", "--dhcp", "--dns"])
+        lines = outputstd.split("\n")
+        assert "*** TASK COMPLETE ***" == get_last_line(lines)
+
     def test_cobbler_signature_report(self, run_cmd, get_last_line):
         """Runs 'cobbler signature report'"""
         (outputstd, outputerr) = run_cmd(cmd=["signature", "report"])


### PR DESCRIPTION
…asses

By this cleanup, also split up cobbler sync into dhcp and dns only sync
capabilities.

Now there are:
```
cobbler sync -> same as before
```
and:
```
cobbler sync --dhcp
cobbler sync --dns
cobbler sync --dhcp --dns
```
to only sync dhcp and dns or only one of these.

This allows a huge speed-up if syncing is only needed, if a host got
added or deleted or a network interface and cobbler shall only re-create
dns and/or dhcp configs.

`get_manager()` now returns a single (Singleton) instance of a module, instead of creating new objects every time.
`module_loader.py:get_module_from_file()` is called by `cobbler/api.py`
