### PR TITLE
Update utils.py to include Almalinux

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -944,7 +944,7 @@ def get_family() -> str:
              returned.
     """
     # TODO: Refactor that this is purely reliant on the distro module or obsolete it.
-    redhat_list = ("red hat", "redhat", "scientific linux", "fedora", "centos", "virtuozzo")
+    redhat_list = ("red hat", "redhat", "scientific linux", "fedora", "centos", "virtuozzo", "almalinux")
 
     distro_name = distro.name().lower()
     for item in redhat_list:
@@ -970,6 +970,8 @@ def os_release():
         if "fedora" in distro_name:
             make = "fedora"
         elif "centos" in distro_name:
+            make = "centos"
+        elif "almalinux" in distro_name:
             make = "centos"
         elif "virtuozzo" in distro_name:
             make = "virtuozzo"


### PR DESCRIPTION
Add "almalinux" into get_family so it is recognised as a replacement for Centos

(I hope I've done this correctly - it is the first "fix" I have suggested ... ever!)