### PR TITLE
Fix trail stripping in case of using UTF symbols

### DIFF
--- a/svc/services.py
+++ b/svc/services.py
@@ -115,9 +115,11 @@ def application(environ, start_response):
         status = "500 SERVER ERROR"
         content = err.faultString
 
+    content = content.encode('utf-8')
+
     # req.content_type = "text/plain;charset=utf-8"
     response_headers = [('Content-type', 'text/plain;charset=utf-8'),
                         ('Content-Length', str(len(content)))]
     start_response(status, response_headers)
 
-    return [content.encode('utf-8')]
+    return [content]


### PR DESCRIPTION
The Content-Length calculated prior encoding the response to UTF-8 it leads to stipping the trailing part of the response in case if there are UTF-8 symbols in the response.