### PR TITLE
Update utils.py to include Rocky Linux

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -944,7 +944,7 @@ def get_family() -> str:
              returned.
     """
     # TODO: Refactor that this is purely reliant on the distro module or obsolete it.
-    redhat_list = ("red hat", "redhat", "scientific linux", "fedora", "centos", "virtuozzo", "almalinux")
+    redhat_list = ("red hat", "redhat", "scientific linux", "fedora", "centos", "virtuozzo", "almalinux", "rocky linux")
 
     distro_name = distro.name().lower()
     for item in redhat_list:
@@ -972,6 +972,8 @@ def os_release():
         elif "centos" in distro_name:
             make = "centos"
         elif "almalinux" in distro_name:
+            make = "centos"
+        elif "rocky linux" in distro_name:
             make = "centos"
         elif "virtuozzo" in distro_name:
             make = "virtuozzo"

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -124,7 +124,7 @@
         "signatures": [
           "BaseOS"
         ],
-        "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
+        "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,


### PR DESCRIPTION
Please add "rocky linux" into get_family() and os_release() as Centos replacement.