### PR TITLE
IP address goes into the hosts file without associated hostname

### DIFF
--- a/autoinstall_snippets/SuSE/hosts.xml
+++ b/autoinstall_snippets/SuSE/hosts.xml
@@ -10,12 +10,15 @@
       #set $ikeys = $interfaces.keys()
       #for $iface in $ikeys
       #set $idata = $interfaces[$iface]
-      #if $idata["interface_type"].lower() in ["","na","bridge","bond"]
+      #if $idata["interface_type"].lower() in ["","na","bridge","bond"] and $idata["dns_name"] != ""
       <hosts_entry>
         <host_address>$idata["ip_address"]</host_address>
         <names config:type="list">
+          <name>$idata["dns_name"]</name>
           #set $my_interface_hostname_short = $idata["dns_name"].split('.',1)[:1][0]
-          <name>$idata["dns_name"].lower() $my_interface_hostname_short.lower()</name>
+          #if $my_interface_hostname_short != $idata["dns_name"]
+          <name>$my_interface_hostname_short</name>
+          #end if
         </names>
       </hosts_entry>
       #end if


### PR DESCRIPTION
If IP address is defined but no DNS name for a system's interface, the `hosts.xml` snippet creates a hosts entry only with IP address alone without name. The proper way would be not to create hosts entry. This bug stops the installation of `Tumbleweed`. The `autoyast.xml` file syntactically correct, however the installation is suspended with error message when the file `/etc/hosts` is actually created (probably by yast2).

This is a **tested** fix, it fixes the following:

1. If no DNS name is defined, no hosts entry is added into the `autoyast.xml` for that interface
2. If the DNS name was not fully qualified, the same, unqualified name was printed twice on the line. With this change, if the name is unqualified, it is printed only once
3. The two names was printed in between one single `<name>` `</name>` tags pair. The change seems only cosmetic, however one day a syntax check improvement (no other than surrounding whitespace is allowed inside the tags) may invalidate this. With this fix, each name is printed in between his own `<name>` `</name>` tags individually
4. There is no case conversion of the names to lower case any more. It is just nice to preserve the case if it does not heart