### PR TITLE
Fix docs generation error from Sphinx

### DIFF
--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -29,8 +29,7 @@ import time
 from cobbler import remote, utils
 from cobbler.api import CobblerAPI
 
-# FIXME: Fix the absolute path and logging dependency on it.
-if os.geteuid() == 0:
+if os.geteuid() == 0 and os.path.exists('/etc/cobbler/logging_config.conf'):
     logging.config.fileConfig('/etc/cobbler/logging_config.conf')
 
 

--- a/cobbler/template_api.py
+++ b/cobbler/template_api.py
@@ -21,6 +21,7 @@ along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
+import logging
 import os.path
 import re
 from typing import Match, Optional, TextIO, Tuple, Union
@@ -34,6 +35,8 @@ from cobbler.cexceptions import FileNotFoundException
 # This class is defined using the Cheetah language. Using the 'compile' function we can compile the source directly into
 # a Python class. This class will allow us to define the cheetah builtins.
 
+logger = logging.getLogger()
+
 
 def read_macro_file(location='/etc/cobbler/cheetah_macros'):
     if not os.path.exists(location):
@@ -43,10 +46,15 @@ def read_macro_file(location='/etc/cobbler/cheetah_macros'):
 
 
 def generate_cheetah_macros():
-    return Template.compile(
-        source=read_macro_file(),
-        moduleName="cobbler.template_api",
-        className="CheetahMacros")
+    try:
+        macro_file = read_macro_file()
+        return Template.compile(
+            source=macro_file,
+            moduleName="cobbler.template_api",
+            className="CheetahMacros")
+    except FileNotFoundException:
+        logger.warning("Cheetah Macros file note found. Using empty template.")
+        return Template.compile(source="")
 
 
 class CobblerTemplate(generate_cheetah_macros()):

--- a/docs/code-autodoc/cobbler.actions.rst
+++ b/docs/code-autodoc/cobbler.actions.rst
@@ -36,14 +36,6 @@ cobbler.actions.hardlink module
     :undoc-members:
     :show-inheritance:
 
-cobbler.actions.litesync module
--------------------------------
-
-.. automodule:: cobbler.actions.litesync
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 cobbler.actions.log module
 --------------------------
 

--- a/docs/code-autodoc/cobbler.modules.managers.rst
+++ b/docs/code-autodoc/cobbler.modules.managers.rst
@@ -60,14 +60,6 @@ cobbler.modules.managers.ndjbdns module
     :undoc-members:
     :show-inheritance:
 
-cobbler.modules.managers.tftpd\_py module
------------------------------------------
-
-.. automodule:: cobbler.modules.managers.tftpd_py
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 
 Module contents
 ---------------


### PR DESCRIPTION
This will fix the missing modules error when generating the documentation using Sphinx e.g. when using the Makefile and doing an installation from source.
Furtheremore Sphinx complained about 2 missing modules which we do not use anymore so I removed them from the docs. Litesync got refactored into the sync module and the tftp module got completly removed. 