### PR TITLE
Add descriptions to the __init__.py files

### DIFF
--- a/cobbler/__init__.py
+++ b/cobbler/__init__.py
@@ -1,0 +1,4 @@
+"""
+This is the main Cobbler module. It contains all code related to the Cobbler server and the CLI.
+External applications should only make use of the ``cobbler.api`` module.
+"""

--- a/cobbler/actions/__init__.py
+++ b/cobbler/actions/__init__.py
@@ -1,0 +1,5 @@
+"""
+The action module is responsible for containing one Python module for each action which Cobbler offers. The code should
+never be dependent on another module or on other parts. An action should request the exact
+data it requires and nothing more.
+"""

--- a/cobbler/cobbler_collections/__init__.py
+++ b/cobbler/cobbler_collections/__init__.py
@@ -1,0 +1,4 @@
+"""
+The collections have the responsibility of ensuring the relational validity of the data present in Cobbler. Further they
+hold the data at runtime.
+"""

--- a/cobbler/items/__init__.py
+++ b/cobbler/items/__init__.py
@@ -1,0 +1,5 @@
+"""
+This package contains all data storage classes. The classes are responsible for ensuring that types of the properties
+are correct but not for logical checks. The classes should be as stupid as possible. Further they are responsible for
+returning the logic for serializing and deserializing themselves.
+"""

--- a/cobbler/modules/__init__.py
+++ b/cobbler/modules/__init__.py
@@ -1,0 +1,4 @@
+"""
+This part of Cobbler may be utilized by any plugins which are extending Cobbler and core code which can be exchanged
+through the ``modules.conf`` file.
+"""

--- a/cobbler/modules/authentication/__init__.py
+++ b/cobbler/modules/authentication/__init__.py
@@ -1,0 +1,4 @@
+"""
+This module represents all Cobbler methods of authentication. All present modules may be used through the configuration
+file ``modules.conf`` normally found at ``/etc/cobbler/``.
+"""

--- a/cobbler/modules/authorization/__init__.py
+++ b/cobbler/modules/authorization/__init__.py
@@ -1,0 +1,4 @@
+"""
+This module represents all Cobbler methods of authorization. All present modules may be used through the configuration
+file ``modules.conf`` normally found at ``/etc/cobbler/``.
+"""

--- a/cobbler/modules/installation/__init__.py
+++ b/cobbler/modules/installation/__init__.py
@@ -1,0 +1,9 @@
+"""
+This module contains Python triggers for Cobbler.
+With Cobbler one is able to add custom actions and commands after many events happening in Cobbler. The Python modules
+presented here are an example of what can be done after certain events. Custom triggers may be added in any language as
+long as Cobbler is allowed to execute them. If implemented in Python they need to follow the following specification:
+- Expose a method called ``register()`` which returns a ``str`` and returns the path of the trigger in the filesystem.
+- Expose a method called ``run(api, args)`` of type ``int``. The integer would represent the exit status of an e.g.
+  shell script. Thus 0 means success and anything else a failure.
+"""

--- a/cobbler/modules/managers/__init__.py
+++ b/cobbler/modules/managers/__init__.py
@@ -1,0 +1,6 @@
+"""
+This module contains extensions for services Cobbler is managing. The services are restarted via the ``service`` command
+or alternatively through the server executables directly. Cobbler does not announce the restarts but is expecting to be
+allowed to do this on its own at any given time. Thus all services managed by Cobbler should not be touched by any
+other tool or administrator.
+"""

--- a/cobbler/modules/serializers/__init__.py
+++ b/cobbler/modules/serializers/__init__.py
@@ -1,0 +1,4 @@
+"""
+This module contains code to persist the in memory state of Cobbler on a target. The name of the target should be the
+name of the Python file. Cobbler is currently only tested against the file serializer.
+"""


### PR DESCRIPTION
Currently these were placeholders. Let's extend them with some text to make it more describable.