### PR TITLE
fix: `fixed-address6` field in DHCPv6 template

### DIFF
--- a/templates/etc/dhcp6.template
+++ b/templates/etc/dhcp6.template
@@ -68,11 +68,7 @@ group {
         #end if
         ##
         ## fixed-address6
-        #if $iface.dns_name:
-        fixed-address6 $iface.dns_name;
-        #else if $iface.ipv6_address:
         fixed-address6 $iface.ipv6_address;
-        #end if
         ##
         ## host-name
         #if $iface.hostname:


### PR DESCRIPTION
This will fix the DHCPv6 template file according to the fixed IPv6 addresses. The `fixed-address6` should always contain the IP
address an not FQDN. I found the issue while testing DHCPv6 in our Orthos network.