### PR TITLE
Move first argument of kopts_overwrite to the end and make it optional

### DIFF
--- a/cobbler/actions/buildiso.py
+++ b/cobbler/actions/buildiso.py
@@ -189,7 +189,8 @@ class BuildIso:
             data = utils.blender(self.api, False, profile)
 
             # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-            utils.kopts_overwrite(None, dist, data['kernel_options'], self.api.settings())
+            if dist is not None:
+                utils.kopts_overwrite(data['kernel_options'], self.api.settings().server, dist.breed)
 
             if not re.match(r"[a-z]+://.*", data["autoinstall"]):
                 data["autoinstall"] = "http://%s:%s/cblr/svc/op/autoinstall/profile/%s" % (
@@ -525,7 +526,8 @@ class BuildIso:
             data = utils.blender(self.api, False, descendant)
 
             # SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
-            utils.kopts_overwrite(None, distro, data['kernel_options'], self.settings)
+            if distro is not None:
+                utils.kopts_overwrite(data['kernel_options'], self.settings.server, distro.breed)
 
             cfg.write("\n")
             cfg.write("LABEL %s\n" % descendant.name)

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -839,8 +839,12 @@ class TFTPGen:
         kopts = blended.get("kernel_options", dict())
         kopts = utils.revert_strip_none(kopts)
 
-        # SUSE and other distro specific kernel additions or modificatins
-        utils.kopts_overwrite(system, distro, kopts, self.settings)
+        # SUSE and other distro specific kernel additions or modifications
+        if distro is not None:
+            if system is None:
+                utils.kopts_overwrite(kopts, self.settings.server, distro.breed)
+            else:
+                utils.kopts_overwrite(kopts, self.settings.server, distro.breed, system.name)
 
         # since network needs to be configured again (it was already in netboot) when kernel boots
         # and we choose to do it dinamically, we need to set 'ksdevice' to one of

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -2456,21 +2456,31 @@ def compare_versions_gt(ver1, ver2) -> bool:
     return versiontuple(ver1) > versiontuple(ver2)
 
 
-def kopts_overwrite(system, distro, kopts, settings):
+def kopts_overwrite(kopts: dict, cobbler_server_hostname: str = "", distro_breed: str = "", system_name: str = ""):
     """
     SUSE is not using 'text'. Instead 'textmode' is used as kernel option.
 
-    :param system: The system to overwrite the kopts for.
-    :param distro: The distro for the system to change to kopts for.
     :param kopts: The kopts of the system.
-    :param settings: The settings instance of Cobbler.
+    :param cobbler_server_hostname: The server setting from our Settings.
+    :param distro_breed: The distro for the system to change to kopts for.
+    :param system_name: The system to overwrite the kopts for.
     """
-    if distro and distro.breed == "suse":
+    # Type checks
+    if not isinstance(kopts, dict):
+        raise TypeError("kopts needs to be of type dict")
+    if not isinstance(cobbler_server_hostname, str):
+        raise TypeError("cobbler_server_hostname needs to be of type str")
+    if not isinstance(distro_breed, str):
+        raise TypeError("distro_breed needs to be of type str")
+    if not isinstance(system_name, str):
+        raise TypeError("system_name needs to be of type str")
+    # Function logic
+    if distro_breed == "suse":
         if 'textmode' in list(kopts.keys()):
             kopts.pop('text', None)
         elif 'text' in list(kopts.keys()):
             kopts.pop('text', None)
             kopts['textmode'] = ['1']
-        if system and settings:
+        if system_name and cobbler_server_hostname:
             # only works if pxe_just_once is enabled in global settings
-            kopts['info'] = 'http://%s/cblr/svc/op/nopxe/system/%s' % (settings.server, system.name)
+            kopts['info'] = 'http://%s/cblr/svc/op/nopxe/system/%s' % (cobbler_server_hostname, system_name)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1228,19 +1228,12 @@ def test_compare_version_gt(test_input_v1, test_input_v2, expected_output, error
 
 def test_kopts_overwrite():
     # Arrange
-    test_api = CobblerAPI()
-    test_manager = CollectionManager(test_api)
-    test_distro = Distro(test_manager)
-    test_distro.set_breed("suse")
-    test_distro.name = "kopts_test_distro"
-    test_profile = Profile(test_manager)
-    test_profile.distro = test_distro.name
-    test_system = System(test_manager)
-    test_system.name = "kopts_test_system"
+    distro_breed = "suse"
+    system_name = "kopts_test_system"
     kopts = {"textmode": False, "text": True}
 
     # Act
-    utils.kopts_overwrite(test_system, test_distro, kopts, test_api.settings())
+    utils.kopts_overwrite(kopts, "servername", distro_breed, system_name)
 
     # Assert
     assert "textmode" in kopts


### PR DESCRIPTION
I did this because passing the whole object is not desired since we only need the name I changed the method signature.