### PR TITLE
Moved from the collection_mgr to the api

### DIFF
--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -60,11 +60,11 @@ class Collection:
         """
         return len(list(self.listing.values()))
 
-    def factory_produce(self, collection_mgr, seed_data):
+    def factory_produce(self, api, seed_data):
         """
         Must override in subclass. Factory_produce returns an Item object from dict.
 
-        :param collection_mgr: The collection manager to resolve all information with.
+        :param api: The collection manager to resolve all information with.
         :param seed_data: Unused Parameter in the base collection.
         """
         raise NotImplementedError()
@@ -197,7 +197,7 @@ class Collection:
         if _list is None:
             return
         for item_dict in _list:
-            item = self.factory_produce(self.collection_mgr, item_dict)
+            item = self.factory_produce(self.api, item_dict)
             self.add(item)
 
     def copy(self, ref, newname):
@@ -356,7 +356,7 @@ class Collection:
             ref.mtime = now
 
         if self.lite_sync is None:
-            self.lite_sync = self.collection_mgr.api.get_sync()
+            self.lite_sync = self.api.get_sync()
 
         # migration path for old API parameter that I've renamed.
         if with_copy and not save:

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -40,11 +40,11 @@ class Distros(collection.Collection):
     def collection_types() -> str:
         return "distros"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Distro forged from item_dict
         """
-        new_distro = distro.Distro(collection_mgr)
+        new_distro = distro.Distro(api)
         new_distro.from_dict(item_dict)
         return new_distro
 
@@ -59,7 +59,7 @@ class Distros(collection.Collection):
 
         # first see if any Groups use this distro
         if not recursive:
-            for v in self.collection_mgr.profiles():
+            for v in self.api.profiles():
                 if v.distro and v.distro.lower() == name:
                     raise CX("removal would orphan profile: %s" % v.name)
 
@@ -70,14 +70,14 @@ class Distros(collection.Collection):
             if recursive:
                 kids = obj.get_children()
                 for k in kids:
-                    self.collection_mgr.api.remove_profile(k.name, recursive=recursive, delete=with_delete,
+                    self.api.remove_profile(k.name, recursive=recursive, delete=with_delete,
                                                            with_triggers=with_triggers)
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/distro/pre/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/distro/pre/*", [])
                 if with_sync:
-                    lite_sync = self.collection_mgr.api.get_sync()
+                    lite_sync = self.api.get_sync()
                     lite_sync.remove_single_distro(name)
             self.lock.acquire()
             try:
@@ -89,12 +89,12 @@ class Distros(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/distro/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/distro/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
             # look through all mirrored directories and find if any directory is holding
             # this particular distribution's kernel and initrd
-            settings = self.collection_mgr.settings()
+            settings = self.api.settings()
             possible_storage = glob.glob(settings.webdir + "/distro_mirror/*")
             path = None
             for storage in possible_storage:

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -37,11 +37,11 @@ class Files(collection.Collection):
     def collection_types() -> str:
         return "files"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a File forged from item_dict
         """
-        new_file = file.File(collection_mgr)
+        new_file = file.File(api)
         new_file.from_dict(item_dict)
         return new_file
 
@@ -57,7 +57,7 @@ class Files(collection.Collection):
         if obj is not None:
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/file/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/file/*", [])
 
             self.lock.acquire()
             try:
@@ -68,8 +68,8 @@ class Files(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/file/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/file/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
             return
 

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -31,11 +31,11 @@ class Images(collection.Collection):
     def collection_types() -> str:
         return "images"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Distro forged from item_dict
         """
-        new_image = image.Image(collection_mgr)
+        new_image = image.Image(api)
         new_image.from_dict(item_dict)
         return new_image
 
@@ -54,7 +54,7 @@ class Images(collection.Collection):
 
         # first see if any Groups use this distro
         if not recursive:
-            for v in self.collection_mgr.systems():
+            for v in self.api.systems():
                 if v.image is not None and v.image.lower() == name:
                     raise CX("removal would orphan system: %s" % v.name)
 
@@ -65,13 +65,13 @@ class Images(collection.Collection):
             if recursive:
                 kids = obj.get_children()
                 for k in kids:
-                    self.collection_mgr.api.remove_system(k, recursive=True)
+                    self.api.remove_system(k, recursive=True)
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/image/pre/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/image/pre/*", [])
                 if with_sync:
-                    lite_sync = self.collection_mgr.api.get_sync()
+                    lite_sync = self.api.get_sync()
                     lite_sync.remove_single_image(name)
 
             self.lock.acquire()
@@ -83,8 +83,8 @@ class Images(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/image/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/image/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
             return
 

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -37,15 +37,15 @@ class Menus(collection.Collection):
     def collection_types() -> str:
         return "menus"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Menu forged from item_dict
 
-        :param collection_mgr: TODO
+        :param api: TODO
         :param item_dict: TODO
         :return:
         """
-        new_menu = menu.Menu(collection_mgr)
+        new_menu = menu.Menu(api)
         new_menu.from_dict(item_dict)
         return new_menu
 
@@ -62,10 +62,10 @@ class Menus(collection.Collection):
         :raises CX
         """
         name = name.lower()
-        for profile in self.collection_mgr.profiles():
+        for profile in self.api.profiles():
             if profile.menu and profile.menu.lower() == name:
                 profile.set_menu(None)
-        for image in self.collection_mgr.images():
+        for image in self.api.images():
             if image.menu and image.menu.lower() == name:
                 image.set_menu(None)
 
@@ -78,7 +78,7 @@ class Menus(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/menu/pre/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/menu/pre/*", [])
             self.lock.acquire()
             try:
                 del self.listing[name]
@@ -87,10 +87,10 @@ class Menus(collection.Collection):
             self.collection_mgr.serialize_delete(self, obj)
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/menu/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/menu/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
                 if with_sync:
-                    lite_sync = self.collection_mgr.api.get_sync()
+                    lite_sync = self.api.get_sync()
                     lite_sync.remove_single_menu()
             return
         raise CX("cannot delete an object that does not exist: %s" % name)

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -37,11 +37,15 @@ class Mgmtclasses(collection.Collection):
     def collection_types() -> str:
         return "mgmtclasses"
 
-    def factory_produce(self, config, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a mgmtclass forged from item_dict
+
+        :param api: TODO
+        :param item_dict: TODO
+        :returns: TODO
         """
-        new_mgmtclass = mgmtclass.Mgmtclass(config)
+        new_mgmtclass = mgmtclass.Mgmtclass(api)
         new_mgmtclass.from_dict(item_dict)
         return new_mgmtclass
 
@@ -58,7 +62,7 @@ class Mgmtclasses(collection.Collection):
         if obj is not None:
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/mgmtclass/pre/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/mgmtclass/pre/*", [])
 
             self.lock.acquire()
             try:
@@ -69,8 +73,8 @@ class Mgmtclasses(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/mgmtclass/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/mgmtclass/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
             return
 

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -37,11 +37,11 @@ class Packages(collection.Collection):
     def collection_types() -> str:
         return "packages"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Package forged from item_dict
         """
-        new_package = package.Package(collection_mgr)
+        new_package = package.Package(api)
         new_package.from_dict(item_dict)
         return new_package
 
@@ -57,7 +57,7 @@ class Packages(collection.Collection):
         if obj is not None:
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/package/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/package/*", [])
 
             self.lock.acquire()
             try:
@@ -68,8 +68,8 @@ class Packages(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/package/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/package/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
             return
 

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -26,8 +26,7 @@ from cobbler.cexceptions import CX
 
 class Profiles(collection.Collection):
     """
-    A profile represents a distro paired with an automatic OS installation
-    template file.
+    A profile represents a distro paired with an automatic OS installation template file.
     """
 
     @staticmethod
@@ -38,11 +37,11 @@ class Profiles(collection.Collection):
     def collection_types() -> str:
         return "profiles"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Distro forged from item_dict
         """
-        new_profile = profile.Profile(collection_mgr)
+        new_profile = profile.Profile(api)
         new_profile.from_dict(item_dict)
         return new_profile
 
@@ -55,7 +54,7 @@ class Profiles(collection.Collection):
         """
         name = name.lower()
         if not recursive:
-            for v in self.collection_mgr.systems():
+            for v in self.api.systems():
                 if v.profile is not None and v.profile.lower() == name:
                     raise CX("removal would orphan system: %s" % v.name)
 
@@ -65,16 +64,15 @@ class Profiles(collection.Collection):
                 kids = obj.get_children()
                 for k in kids:
                     if k.COLLECTION_TYPE == "profile":
-                        self.collection_mgr.api.remove_profile(k.name, recursive=recursive, delete=with_delete,
+                        self.api.remove_profile(k.name, recursive=recursive, delete=with_delete,
                                                                with_triggers=with_triggers)
                     else:
-                        self.collection_mgr.api.remove_system(k.name, recursive=recursive, delete=with_delete,
+                        self.api.remove_system(k.name, recursive=recursive, delete=with_delete,
                                                               with_triggers=with_triggers)
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/profile/pre/*",
-                                       [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/profile/pre/*", [])
             self.lock.acquire()
             try:
                 del self.listing[name]
@@ -83,11 +81,10 @@ class Profiles(collection.Collection):
             self.collection_mgr.serialize_delete(self, obj)
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/profile/post/*",
-                                       [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/profile/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
                 if with_sync:
-                    lite_sync = self.collection_mgr.api.get_sync()
+                    lite_sync = self.api.get_sync()
                     lite_sync.remove_single_profile(name)
             return
 

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -40,11 +40,11 @@ class Repos(collection.Collection):
     def collection_types() -> str:
         return "repos"
 
-    def factory_produce(self, config, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Distro forged from item_dict
         """
-        new_repo = repo.Repo(config)
+        new_repo = repo.Repo(api)
         new_repo.from_dict(item_dict)
         return new_repo
 
@@ -62,7 +62,7 @@ class Repos(collection.Collection):
         if obj is not None:
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/repo/pre/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/repo/pre/*", [])
 
             self.lock.acquire()
             try:
@@ -73,8 +73,8 @@ class Repos(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/repo/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/repo/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
                 # FIXME: better use config.settings() webdir?
                 path = "/var/www/cobbler/repo_mirror/%s" % obj.name

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -38,11 +38,15 @@ class Systems(collection.Collection):
     def collection_types() -> str:
         return "systems"
 
-    def factory_produce(self, collection_mgr, item_dict):
+    def factory_produce(self, api, item_dict):
         """
         Return a Distro forged from item_dict
+
+        :param api: TODO
+        :param item_dict: TODO
+        :returns: TODO
         """
-        new_system = system.System(collection_mgr)
+        new_system = system.System(api)
         new_system.from_dict(item_dict)
         return new_system
 
@@ -60,9 +64,9 @@ class Systems(collection.Collection):
 
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/system/pre/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/system/pre/*", [])
                 if with_sync:
-                    lite_sync = self.collection_mgr.api.get_sync()
+                    lite_sync = self.api.get_sync()
                     lite_sync.remove_single_system(name)
             self.lock.acquire()
             try:
@@ -72,8 +76,8 @@ class Systems(collection.Collection):
             self.collection_mgr.serialize_delete(self, obj)
             if with_delete:
                 if with_triggers:
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/delete/system/post/*", [])
-                    utils.run_triggers(self.collection_mgr.api, obj, "/var/lib/cobbler/triggers/change/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/system/post/*", [])
+                    utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/change/*", [])
 
             return
 

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -66,14 +66,14 @@ class Distro(item.Item):
 
     COLLECTION_TYPE = "distro"
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, api, *args, **kwargs):
         """
         This creates a Distro object.
 
         :param args: Place for extra parameters in this distro object.
         :param kwargs: Place for extra parameters in this distro object.
         """
-        super(Distro, self).__init__(*args, **kwargs)
+        super().__init__(api, *args, **kwargs)
         self.kernel_options = {}
         self.kernel_options_post = {}
         self.autoinstall_meta = {}
@@ -100,7 +100,7 @@ class Distro(item.Item):
         :return: The cloned object. Not persisted on the disk or in a database.
         """
         _dict = self.to_dict()
-        cloned = Distro(self.collection_mgr)
+        cloned = Distro(self.api)
         cloned.from_dict(_dict)
         return cloned
 
@@ -123,9 +123,9 @@ class Distro(item.Item):
         if self.name is None:
             raise CX("name is required")
         if self.kernel is None:
-            raise CX("Error with distro %s - kernel is required" % (self.name))
+            raise CX("Error with distro %s - kernel is required" % self.name)
         if self.initrd is None:
-            raise CX("Error with distro %s - initrd is required" % (self.name))
+            raise CX("Error with distro %s - initrd is required" % self.name)
 
         # self.remote_grub_kernel has to be set in set_remote_boot_kernel and here
         # in case the distro is read from json file (setters are not called).

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -54,6 +54,16 @@ class File(resource.Resource):
     TYPE_NAME = "file"
     COLLECTION_TYPE = "file"
 
+    def __init__(self, api, *args, **kwargs):
+        """
+        TODO
+
+        :param api:
+        :param args:
+        :param kwargs:
+        """
+        super().__init__(api, *args, **kwargs)
+
     #
     # override some base class methods first (item.Item)
     #
@@ -65,7 +75,7 @@ class File(resource.Resource):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
-        cloned = File(self.collection_mgr)
+        cloned = File(self.api)
         cloned.from_dict(_dict)
         return cloned
 

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -67,8 +67,8 @@ class Image(item.Item):
     TYPE_NAME = "image"
     COLLECTION_TYPE = "image"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, api, *args, **kwargs):
+        super().__init__(api, *args, **kwargs)
         self.boot_loaders = []
         self.menu = ""
 
@@ -88,7 +88,7 @@ class Image(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
-        cloned = Image(self.collection_mgr)
+        cloned = Image(self.api)
         cloned.from_dict(_dict)
         return cloned
 
@@ -132,7 +132,7 @@ class Image(item.Item):
         :param autoinstall: local automatic installation template file path
         """
 
-        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.collection_mgr)
+        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.api._collection_mgr)
         self.autoinstall = autoinstall_mgr.validate_autoinstall_template_file_path(autoinstall)
 
     def set_file(self, filename):
@@ -303,7 +303,7 @@ class Image(item.Item):
         """
 
         if menu and menu != "":
-            menu_list = self.collection_mgr.menus()
+            menu_list = self.api.menus()
             if not menu_list.find(name=menu):
                 raise CX("menu %s not found" % menu)
 

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -173,7 +173,7 @@ class Item:
 
     TYPE_NAME = "generic"
 
-    def __init__(self, collection_mgr, is_subobject: bool = False):
+    def __init__(self, api, is_subobject: bool = False):
         """
         Constructor.  Requires a back reference to the CollectionManager object.
 
@@ -196,12 +196,11 @@ class Item:
         use False for is_subobject and the parent object will (therefore) have a different type.
         """
 
-        self.collection_mgr = collection_mgr
-        self.settings = self.collection_mgr._settings
+        self.api = api
+        self.settings = self.api.settings()
         self.clear(is_subobject)        # reset behavior differs for inheritance cases
         self.parent = ''                # all objects by default are not subobjects
         self.children = {}              # caching for performance reasons, not serialized
-        self.log_func = self.collection_mgr.api.log
         self.ctime = 0                  # to be filled in by collection class
         self.mtime = 0                  # to be filled in by collection class
         self.uid = ""                   # to be filled in by collection class
@@ -554,7 +553,7 @@ class Item:
         :param format: Whether to format the output or not.
         :return: The raw or formatted data.
         """
-        raw = utils.blender(self.collection_mgr.api, False, self)
+        raw = utils.blender(self.api, False, self)
         if format:
             return pprint.pformat(raw)
         else:

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -45,8 +45,8 @@ class Menu(item.Item):
 
     COLLECTION_TYPE = "menu"
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, api, *args, **kwargs):
+        super().__init__(api, *args, **kwargs)
         self.display_name = ""
 
     #
@@ -60,7 +60,7 @@ class Menu(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
-        cloned = Menu(self.collection_mgr)
+        cloned = Menu(self.api)
         cloned.from_dict(_dict)
         return cloned
 
@@ -79,7 +79,7 @@ class Menu(item.Item):
         if not self.parent or self.parent == '':
             return None
 
-        return self.collection_mgr.menus().find(name=self.parent)
+        return self.api.menus().find(name=self.parent)
 
     def check_if_valid(self):
         """
@@ -119,7 +119,7 @@ class Menu(item.Item):
             # check must be done in two places as set_parent could be called before/after
             # set_name...
             raise CX("self parentage is weird")
-        found = self.collection_mgr.menus().find(name=parent_name)
+        found = self.api.menus().find(name=parent_name)
         if found is None:
             raise CX("menu %s not found" % parent_name)
         self.parent = parent_name

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -49,8 +49,8 @@ class Mgmtclass(item.Item):
     TYPE_NAME = "mgmtclass"
     COLLECTION_TYPE = "mgmtclass"
 
-    def __init__(self, *args, **kwargs):
-        super(Mgmtclass, self).__init__(*args, **kwargs)
+    def __init__(self, api, *args, **kwargs):
+        super().__init__(api, *args, **kwargs)
         self.params = {}
 
     #
@@ -65,7 +65,7 @@ class Mgmtclass(item.Item):
         """
 
         _dict = self.to_dict()
-        cloned = Mgmtclass(self.collection_mgr)
+        cloned = Mgmtclass(self.api)
         cloned.from_dict(_dict)
         return cloned
 

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -46,6 +46,16 @@ class Package(resource.Resource):
     TYPE_NAME = "package"
     COLLECTION_TYPE = "package"
 
+    def __init__(self, api, *args, **kwargs):
+        """
+        TODO
+
+        :param api:
+        :param args:
+        :param kwargs:
+        """
+        super().__init__(api, *args, **kwargs)
+
     #
     # override some base class methods first (item.Item)
     #
@@ -57,7 +67,7 @@ class Package(resource.Resource):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
-        cloned = Package(self.collection_mgr)
+        cloned = Package(self.api)
         cloned.from_dict(_dict)
         return cloned
 

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -84,8 +84,8 @@ class Profile(item.Item):
     TYPE_NAME = "profile"
     COLLECTION_TYPE = "profile"
 
-    def __init__(self, *args, **kwargs):
-        super(Profile, self).__init__(*args, **kwargs)
+    def __init__(self, api, *args, **kwargs):
+        super().__init__(api, *args, **kwargs)
         self.kernel_options = {}
         self.kernel_options_post = {}
         self.autoinstall_meta = {}
@@ -111,7 +111,7 @@ class Profile(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
-        cloned = Profile(self.collection_mgr)
+        cloned = Profile(self.api)
         cloned.from_dict(_dict)
         return cloned
 
@@ -130,9 +130,9 @@ class Profile(item.Item):
         if not self.parent:
             if self.distro is None:
                 return None
-            result = self.collection_mgr.distros().find(name=self.distro)
+            result = self.api.distros().find(name=self.distro)
         else:
-            result = self.collection_mgr.profiles().find(name=self.parent)
+            result = self.api.profiles().find(name=self.parent)
         return result
 
     def check_if_valid(self):
@@ -175,7 +175,7 @@ class Profile(item.Item):
             # check must be done in two places as set_parent could be called before/after
             # set_name...
             raise CX("self parentage is weird")
-        found = self.collection_mgr.profiles().find(name=parent_name)
+        found = self.api.profiles().find(name=parent_name)
         if found is None:
             raise CX("profile %s not found, inheritance not possible" % parent_name)
         self.parent = parent_name
@@ -188,7 +188,7 @@ class Profile(item.Item):
         """
         Sets the distro. This must be the name of an existing Distro object in the Distros collection.
         """
-        d = self.collection_mgr.distros().find(name=distro_name)
+        d = self.api.distros().find(name=distro_name)
         if d is not None:
             old_parent = self.get_parent()
             if isinstance(old_parent, item.Item):
@@ -305,7 +305,7 @@ class Profile(item.Item):
         :param autoinstall: local automatic installation template path
         """
 
-        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.collection_mgr)
+        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.api._collection_mgr)
         self.autoinstall = autoinstall_mgr.validate_autoinstall_template_file_path(autoinstall)
 
     def set_virt_auto_boot(self, num: int):
@@ -455,7 +455,7 @@ class Profile(item.Item):
         """
 
         if menu and menu != "":
-            menu_list = self.collection_mgr.menus()
+            menu_list = self.api.menus()
             if not menu_list.find(name=menu):
                 raise CX("menu %s not found" % menu)
 

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -64,8 +64,8 @@ class Repo(item.Item):
     TYPE_NAME = "repo"
     COLLECTION_TYPE = "repo"
 
-    def __init__(self, *args, **kwargs):
-        super(Repo, self).__init__(*args, **kwargs)
+    def __init__(self, api, *args, **kwargs):
+        super().__init__(api, *args, **kwargs)
         self.breed = None
         self.arch = None
         self.environment = {}
@@ -84,7 +84,7 @@ class Repo(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
-        cloned = Repo(self.collection_mgr)
+        cloned = Repo(self.api)
         cloned.from_dict(_dict)
         return cloned
 

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -125,8 +125,8 @@ class System(Item):
 
     COLLECTION_TYPE = "system"
 
-    def __init__(self, *args, **kwargs):
-        super(System, self).__init__(*args, **kwargs)
+    def __init__(self, api, *args, **kwargs):
+        super().__init__(api, *args, **kwargs)
         self.interfaces = {}
         self.kernel_options = {}
         self.kernel_options_post = {}
@@ -151,7 +151,7 @@ class System(Item):
 
     def make_clone(self):
         _dict = self.to_dict()
-        cloned = System(self.collection_mgr)
+        cloned = System(self.api)
         cloned.from_dict(_dict)
         return cloned
 
@@ -166,11 +166,11 @@ class System(Item):
         :raises CX
         """
         if (self.parent is None or self.parent == '') and self.profile:
-            return self.collection_mgr.profiles().find(name=self.profile)
+            return self.api.profiles().find(name=self.profile)
         elif (self.parent is None or self.parent == '') and self.image:
-            return self.collection_mgr.images().find(name=self.image)
+            return self.api.images().find(name=self.image)
         else:
-            return self.collection_mgr.systems().find(name=self.parent)
+            return self.api.systems().find(name=self.parent)
 
     def check_if_valid(self):
         """
@@ -246,10 +246,10 @@ class System(Item):
             boot_loaders_split = utils.input_string_or_list(boot_loaders)
 
             if self.profile and self.profile != "":
-                profile = self.collection_mgr.profiles().find(name=self.profile)
+                profile = self.api.profiles().find(name=self.profile)
                 parent_boot_loaders = profile.get_boot_loaders()
             elif self.image and self.image != "":
-                image = self.collection_mgr.images().find(name=self.image)
+                image = self.api.images().find(name=self.image)
                 parent_boot_loaders = image.get_boot_loaders()
             else:
                 parent_boot_loaders = []
@@ -267,10 +267,10 @@ class System(Item):
         boot_loaders = self.boot_loaders
         if boot_loaders == '<<inherit>>':
             if self.profile and self.profile != "":
-                profile = self.collection_mgr.profiles().find(name=self.profile)
+                profile = self.api.profiles().find(name=self.profile)
                 return profile.get_boot_loaders()
             if self.image and self.image != "":
-                image = self.collection_mgr.images().find(name=self.image)
+                image = self.api.images().find(name=self.image)
                 return image.get_boot_loaders()
         return boot_loaders
 
@@ -406,8 +406,8 @@ class System(Item):
         :raises CX
         """
         dns_name = validate.hostname(dns_name)
-        if dns_name != "" and self.collection_mgr.settings().allow_duplicate_hostnames is False:
-            matched = self.collection_mgr.api.find_items("system", {"dns_name": dns_name})
+        if dns_name != "" and self.api.settings().allow_duplicate_hostnames is False:
+            matched = self.api.find_items("system", {"dns_name": dns_name})
             for x in matched:
                 if x.name != self.name:
                     raise CX("DNS name duplicated: %s" % dns_name)
@@ -433,8 +433,8 @@ class System(Item):
         :raises CX
         """
         address = validate.ipv4_address(address)
-        if address != "" and self.collection_mgr.settings().allow_duplicate_ips is False:
-            matched = self.collection_mgr.api.find_items("system", {"ip_address": address})
+        if address != "" and self.api.settings().allow_duplicate_ips is False:
+            matched = self.api.find_items("system", {"ip_address": address})
             for x in matched:
                 if x.name != self.name:
                     raise CX("IP address duplicated: %s" % address)
@@ -452,9 +452,9 @@ class System(Item):
         """
         address = validate.mac_address(address)
         if address == "random":
-            address = utils.get_random_mac(self.collection_mgr.api)
-        if address != "" and self.collection_mgr.settings().allow_duplicate_macs is False:
-            matched = self.collection_mgr.api.find_items("system", {"mac_address": address})
+            address = utils.get_random_mac(self.api)
+        if address != "" and self.api.settings().allow_duplicate_macs is False:
+            matched = self.api.find_items("system", {"mac_address": address})
             for x in matched:
                 if x.name != self.name:
                     raise CX("MAC address duplicated: %s" % address)
@@ -558,8 +558,8 @@ class System(Item):
         :raises CX
         """
         address = validate.ipv6_address(address)
-        if address != "" and self.collection_mgr.settings().allow_duplicate_ips is False:
-            matched = self.collection_mgr.api.find_items("system", {"ipv6_address": address})
+        if address != "" and self.api.settings().allow_duplicate_ips is False:
+            matched = self.api.find_items("system", {"ipv6_address": address})
             for x in matched:
                 if x.name != self.name:
                     raise CX("IP address duplicated: %s" % address)
@@ -632,7 +632,7 @@ class System(Item):
 
         self.image = ""         # mutual exclusion rule
 
-        p = self.collection_mgr.profiles().find(name=profile_name)
+        p = self.api.profiles().find(name=profile_name)
         if p is not None:
             self.profile = profile_name
             self.depth = p.depth + 1            # subprofiles have varying depths.
@@ -660,7 +660,7 @@ class System(Item):
 
         self.profile = ""       # mutual exclusion rule
 
-        img = self.collection_mgr.images().find(name=image_name)
+        img = self.api.images().find(name=image_name)
 
         if img is not None:
             self.image = image_name
@@ -720,7 +720,7 @@ class System(Item):
         :param autoinstall: local automatic installation template file path
         """
 
-        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.collection_mgr)
+        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.api._collection_mgr)
         self.autoinstall = autoinstall_mgr.validate_autoinstall_template_file_path(autoinstall)
 
     def set_power_type(self, power_type):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1557,23 +1557,23 @@ class CobblerXMLRPCInterface:
         self._log("new_item(%s)" % what, token=token)
         self.check_access(token, "new_%s" % what)
         if what == "distro":
-            d = distro.Distro(self.api._collection_mgr, is_subobject=is_subobject)
+            d = distro.Distro(self.api, is_subobject=is_subobject)
         elif what == "profile":
-            d = profile.Profile(self.api._collection_mgr, is_subobject=is_subobject)
+            d = profile.Profile(self.api, is_subobject=is_subobject)
         elif what == "system":
-            d = system.System(self.api._collection_mgr, is_subobject=is_subobject)
+            d = system.System(self.api, is_subobject=is_subobject)
         elif what == "repo":
-            d = repo.Repo(self.api._collection_mgr, is_subobject=is_subobject)
+            d = repo.Repo(self.api, is_subobject=is_subobject)
         elif what == "image":
-            d = image.Image(self.api._collection_mgr, is_subobject=is_subobject)
+            d = image.Image(self.api, is_subobject=is_subobject)
         elif what == "mgmtclass":
-            d = mgmtclass.Mgmtclass(self.api._collection_mgr, is_subobject=is_subobject)
+            d = mgmtclass.Mgmtclass(self.api, is_subobject=is_subobject)
         elif what == "package":
-            d = package.Package(self.api._collection_mgr, is_subobject=is_subobject)
+            d = package.Package(self.api, is_subobject=is_subobject)
         elif what == "file":
-            d = file.File(self.api._collection_mgr, is_subobject=is_subobject)
+            d = file.File(self.api, is_subobject=is_subobject)
         elif what == "menu":
-            d = menu.Menu(self.api._collection_mgr, is_subobject=is_subobject)
+            d = menu.Menu(self.api, is_subobject=is_subobject)
         else:
             raise CX("internal error, collection name is %s" % what)
         key = "___NEW___%s::%s" % (what, self.__get_random(25))

--- a/cobbler/resource.py
+++ b/cobbler/resource.py
@@ -22,6 +22,16 @@ class Resource(item.Item):
     Base Class for management resources.
     """
 
+    def __init__(self, api, *args, **kwargs):
+        """
+        TODO
+
+        :param api:
+        :param args:
+        :param kwargs:
+        """
+        super().__init__(api, *args, **kwargs)
+
     def set_action(self, action: str):
         """
         All management resources have an action. Action determine weather a most resources should be created or removed,

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -883,7 +883,7 @@ def run_this(cmd: str, args: str):
         die("Command failed")
 
 
-def run_triggers(api, ref, globber, additional: list = []):
+def run_triggers(api, ref, globber, additional: list = None):
     """Runs all the trigger scripts in a given directory.
     Example: ``/var/lib/cobbler/triggers/blah/*``
 
@@ -898,9 +898,10 @@ def run_triggers(api, ref, globber, additional: list = []):
     :param additional: Additional arguments to run the triggers with.
     :raises CX
     """
-
     logger.debug("running python triggers from %s", globber)
     modules = api.get_modules_in_category(globber)
+    if additional is None:
+        additional = []
     for m in modules:
         arglist = []
         if ref:


### PR DESCRIPTION
The collection mgr is more often used to access the API then the collection_mgr itself. Thus I changed this. Some lines are shorter and we have more control over the data flowing inside Cobbler.