### PR TITLE
Add explicit configgen testcases and added todos

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3560,7 +3560,7 @@ class CobblerXMLRPCInterface:
         :return: The config data as a json for Koan.
         """
         self._log("get_config_data for %s" % hostname)
-        obj = configgen.ConfigGen(hostname)
+        obj = configgen.ConfigGen(self.api, hostname)
         return obj.gen_config_data_for_koan()
 
     def clear_system_logs(self, object_id, token=None):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -574,6 +574,7 @@ def grab_tree(api_handle, item) -> list:
     """
     # TODO: Move into item.py
     results = [item]
+    # FIXME: The following line will throw an AttributeError for None because there is not get_parent() for None
     parent = item.get_parent()
     while parent is not None:
         results.append(parent)

--- a/tests/configgen_test.py
+++ b/tests/configgen_test.py
@@ -1,0 +1,111 @@
+import os
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.configgen import ConfigGen
+from cobbler.items.distro import Distro
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+
+# TODO: If the action items of the configgen class are done then the tests need to test the robustness of the class.
+
+
+@pytest.fixture
+def create_testbed(create_kernel_initrd):
+    def _create_testbed() -> CobblerAPI:
+        folder = create_kernel_initrd("vmlinux", "initrd.img")
+        test_api = CobblerAPI()
+        test_distro = Distro(test_api._collection_mgr)
+        test_distro.name = "test_configgen_distro"
+        test_distro.set_kernel(os.path.join(folder, "vmlinux"))
+        test_distro.set_initrd(os.path.join(folder, "initrd.img"))
+        test_api.add_distro(test_distro)
+        test_profile = Profile(test_api._collection_mgr)
+        test_profile.name = "test_configgen_profile"
+        test_profile.set_distro("test_configgen_distro")
+        test_api.add_profile(test_profile)
+        test_system = System(test_api._collection_mgr)
+        test_system.name = "test_configgen_system"
+        test_system.set_profile("test_configgen_profile")
+        test_system.set_hostname("testhost.test.de")
+        test_system.set_autoinstall_meta({"test": "teststring"})
+        test_api.add_system(test_system)
+        return test_api
+
+    return _create_testbed
+
+
+def test_object_value_error():
+    # Arrange
+    test_api = CobblerAPI()
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        ConfigGen(test_api, "nonexistant")
+
+
+def test_object_creation(create_testbed):
+    # Arrange
+    test_api = create_testbed()
+    # FIXME: Arrange distro, profile and system
+
+    # Act
+    test_configgen = ConfigGen(test_api, "testhost.test.de")
+
+    # Assert
+    assert isinstance(test_configgen, ConfigGen)
+
+
+def test_resolve_resource_var(create_testbed):
+    # Arrange
+    test_api = create_testbed()
+    # FIXME: Arrange distro, profile and system, package and file
+    config_gen = ConfigGen(test_api, "testhost.test.de")
+
+    # Act
+    result = config_gen.resolve_resource_var("Hello $test !")
+
+    # Assert
+    assert isinstance(result, str)
+    assert result == "Hello teststring !"
+
+
+def test_get_cobbler_resource(create_testbed):
+    # Arrange
+    test_api = create_testbed()
+    # FIXME: Arrange distro, profile and system, package and file
+    config_gen = ConfigGen(test_api, "testhost.test.de")
+
+    # Act
+    result = config_gen.get_cobbler_resource("")
+
+    # Assert
+    assert isinstance(result, (list, str, dict))
+
+
+def test_get_config_data(create_testbed):
+    # Arrange
+    test_api = create_testbed()
+    # FIXME: Arrange distro, profile and system, package and file
+    config_gen = ConfigGen(test_api, "testhost.test.de")
+
+    # Act
+    result = config_gen.gen_config_data()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_get_config_data_for_koan(create_testbed):
+    # Arrange
+    test_api = create_testbed()
+    # FIXME: Arrange distro, profile and system, package and file
+    config_gen = ConfigGen(test_api, "testhost.test.de")
+
+    # Act
+    result = config_gen.gen_config_data_for_koan()
+
+    # Assert
+    assert isinstance(result, str)


### PR DESCRIPTION
This is part of the tasks defined in #2433 

This PR tries to do the following things:

- Not be so optimistic (in regard to expected data) when generating configuration data for a system
- Have explicit tests for the `Configgen` class.

This PR will add a FIXME for obsoletion of the class since it is only acting on data of a single system. This will be left there for future consideration and thoughts/ideas/PRs.