### PR TITLE
Update quickstart-guide: correct filename path

### DIFF
--- a/docs/quickstart-guide.rst
+++ b/docs/quickstart-guide.rst
@@ -33,7 +33,7 @@ Changing settings
 
 Before starting the `cobblerd` service, there are a few things you should modify.
 
-Settings are stored in ``/etc/cobbler/settings.yaml``. This file is a YAML formatted data file, so be sure to take care
+Settings are stored in ``/etc/cobbler/settings``. This file is a YAML formatted data file, so be sure to take care
 when editing this file as an incorrectly formatted file will prevent `cobblerd` from running.
 
 


### PR DESCRIPTION
Hi,

I was following this guide for the installation of cobbler and seems that the path + name file specified in the documentation (**/etc/cobbler/settings.yaml**) for define the settings, is different from the default name file that are created after the installation (**/etc/cobbler/settings**).

My current environment is

```
CentOS Linux release 8.3.2011
Linux 4.18.0-240.22.1.el8_3.x86_64
```

And the version of cobbler:

```
Installed Packages
Name         : cobbler
Version      : 3.2.0
Release      : 2.module_el8+10474+71f42bad
Architecture : noarch
Size         : 2.3 M
Source       : cobbler-3.2.0-2.module_el8+10474+71f42bad.src.rpm
Repository   : @System
From repo    : epel-modular
Summary      : Boot server configurator
URL          : https://cobbler.github.io/
License      : GPLv2+
Description  : Cobbler is a network install server.  Cobbler supports PXE, ISO
             : virtualized installs, and re-installing existing Linux machines.
             : The last two modes use a helper tool, 'koan', that integrates with
             : cobbler.  There is also a web interface 'cobbler-web'.  Cobbler's
             : advanced features include importing distributions from DVDs and rsync
             : mirrors, kickstart templating, integrated yum mirroring, and built-in
             : DHCP/DNS Management.  Cobbler has a XML-RPC API for integration with
```

Could you check if please?

I know that is a minor change, but after define some settings on **/etc/cobbler/settings.yaml** following the documentation path and after run a cobbler check, I obtained this warning advising about some parameter definitions that are not correctly reached.

```
1: The 'server' field in /etc/cobbler/settings must be set to something other than localhost, or automatic installation features will not work.  This should be a resolvable hostname or IP for the boot server as reachable by all machines that will use it.
```

```
6: The default password used by the sample templates for newly installed machines (default_password_crypted in /etc/cobbler/settings) is still set to 'cobbler' and should be changed, try: "openssl passwd -1 -salt 'random-phrase-here' 'your-password-here'" to generate new one
```

Don't hesitate on any suggestion, correction or comment.

Thanks.