### PR TITLE
Remove field_info.py as it is empty and not used for ages

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -28,7 +28,6 @@ import traceback
 import xmlrpc.client
 from typing import Optional
 
-from cobbler import field_info
 from cobbler.items import package, system, image, profile, repo, mgmtclass, distro, file, menu
 from cobbler import settings
 from cobbler import utils
@@ -240,22 +239,12 @@ def _add_parser_option_from_field(parser, field, settings):
     # generate option string
     option_string = "--%s" % name.replace("_", "-")
 
-    # generate option aliases
-    aliases = []
-    for deprecated_field in list(field_info.DEPRECATED_FIELDS.keys()):
-        if field_info.DEPRECATED_FIELDS[deprecated_field] == name:
-            aliases.append("--%s" % deprecated_field)
-
     # add option to parser
     if isinstance(choices, list) and len(choices) != 0:
         description += " (valid options: %s)" % ",".join(choices)
         parser.add_option(option_string, dest=name, help=description, choices=choices)
-        for alias in aliases:
-            parser.add_option(alias, dest=name, help=description, choices=choices)
     else:
         parser.add_option(option_string, dest=name, help=description)
-        for alias in aliases:
-            parser.add_option(alias, dest=name, help=description)
 
 
 def add_options_from_fields(object_type, parser, fields, network_interface_fields, settings, object_action):

--- a/cobbler/field_info.py
+++ b/cobbler/field_info.py
@@ -1,7 +1,0 @@
-"""
-Deprecated fields that have been renamed, but we need to account for them appearing in older datastructs that may not
-have been saved since the code change.
-"""
-
-DEPRECATED_FIELDS = {
-}

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -45,7 +45,6 @@ import netaddr
 import json
 
 from cobbler import settings
-from cobbler import field_info
 from cobbler import validate
 from cobbler.cexceptions import CX
 
@@ -2010,9 +2009,6 @@ def from_dict_from_fields(item, item_dict: dict, fields):
                 int_fields.append(elems)
             continue
         src_k = dst_k = elems[0]
-        # deprecated field switcheroo
-        if src_k in field_info.DEPRECATED_FIELDS:
-            dst_k = field_info.DEPRECATED_FIELDS[src_k]
         if src_k in item_dict:
             setattr(item, dst_k, item_dict[src_k])
 
@@ -2022,13 +2018,7 @@ def from_dict_from_fields(item, item_dict: dict, fields):
     # special handling for interfaces
     if item.COLLECTION_TYPE == "system":
         item.interfaces = copy.deepcopy(item_dict["interfaces"])
-        # deprecated field switcheroo for interfaces
         for interface in list(item.interfaces.keys()):
-            for k in list(item.interfaces[interface].keys()):
-                if k in field_info.DEPRECATED_FIELDS:
-                    if not field_info.DEPRECATED_FIELDS[k] in item.interfaces[interface] or \
-                            item.interfaces[interface][field_info.DEPRECATED_FIELDS[k]] == "":
-                        item.interfaces[interface][field_info.DEPRECATED_FIELDS[k]] = item.interfaces[interface][k]
             # populate fields that might be missing
             for int_field in int_fields:
                 if not int_field[0][1:] in item.interfaces[interface]:

--- a/docs/code-autodoc/cobbler.rst
+++ b/docs/code-autodoc/cobbler.rst
@@ -79,14 +79,6 @@ cobbler.download\_manager module
     :undoc-members:
     :show-inheritance:
 
-cobbler.field\_info module
---------------------------
-
-.. automodule:: cobbler.field_info
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 cobbler.module\_loader module
 -----------------------------
 


### PR DESCRIPTION
The mechanism of `field_info.py` was not used in a long while and I believe it is just dead code. This PR is a splitout of #2433 