### PR TITLE
Add OBS workflows file

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -1,0 +1,5 @@
+workflow:
+  steps:
+    - branch_package:
+        source_project: systemsmanagement:orthos2:github_master_ci
+        source_package: cobbler-master


### PR DESCRIPTION
This PR add a workflows file for automatically building the master branch of Cobbler in the OBS when PRs are opened against master or commits are added to it. This is basically for testing the most recent Cobbler version in OBS for Orthos 2. The necessary webhooks are already enabled in the settings for Cobbler.
CC @watologo1 