### PR TITLE
Fix arch comparison

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1001,7 +1001,7 @@ class TFTPGen:
             append_line = "%s suite=%s" % (append_line, distro.os_version)
 
         # append necessary kernel args for arm architectures
-        if arch is not None and arch.startswith("arm"):
+        if arch is enums.Archs.ARM:
             append_line = "%s fixrtc vram=48M omapfb.vram=0:24M" % append_line
 
         # do variable substitution on the append line


### PR DESCRIPTION
The Enum class does not support string operations like startswith(), but
TFTP code still checks the CPU arch this way. Rewrite the check.

Fixes #2678.
