### PR TITLE
A series of post-refactoring fixes

### DIFF
--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -30,6 +30,7 @@ from typing import Union
 
 from cobbler import utils
 from cobbler import download_manager
+from cobbler.enums import RepoArchs
 from cobbler.utils import os_release
 
 HAS_LIBREPO = True
@@ -432,12 +433,14 @@ class RepoSync:
             utils.die("ERROR: repository %(name)s needs to be renamed %(rest)s as the name of the cobbler repository "
                       "must match the name of the RHN channel" % args)
 
-        if repo.arch == "i386":
-            # Counter-intuitive, but we want the newish kernels too
-            repo.arch = "i686"
+        arch = repo.arch.value
 
-        if repo.arch != "":
-            cmd = "%s -a %s" % (cmd, repo.arch)
+        if arch == "i386":
+            # Counter-intuitive, but we want the newish kernels too
+            arch = "i686"
+
+        if arch != "":
+            cmd = "%s -a %s" % (cmd, arch)
 
         # Now regardless of whether we're doing yumdownloader or reposync or whether the repo was http://, ftp://, or
         # rhn://, execute all queued commands here. Any failure at any point stops the operation.
@@ -525,14 +528,11 @@ class RepoSync:
                   % (cmd, self.rflags, temp_file, pipes.quote(repo.name),
                      pipes.quote(self.settings.webdir + "/repo_mirror"))
             if repo.arch != "":
-                if repo.arch == "x86":
-                    # Fix potential arch errors
-                    repo.arch = "i386"
-                if repo.arch == "i386":
+                if repo.arch == RepoArchs.I386:
                     # Counter-intuitive, but we want the newish kernels too
                     cmd = "%s -a i686" % (cmd)
                 else:
-                    cmd = "%s -a %s" % (cmd, repo.arch)
+                    cmd = "%s -a %s" % (cmd, repo.arch.value)
 
         else:
             # Create the output directory if it doesn't exist
@@ -678,12 +678,10 @@ class RepoSync:
                     rflags += " %s" % x
             cmd = "%s %s %s %s" % (mirror_program, rflags, mirror_data, dest_path)
             cmd = "%s %s %s %s" % (mirror_program, rflags, mirror_data, pipes.quote(dest_path))
-            if repo.arch == "src":
+            if repo.arch == RepoArchs.SRC:
                 cmd = "%s --source" % cmd
             else:
-                arch = repo.arch
-                if arch == "x86":
-                    arch = "i386"  # FIX potential arch errors
+                arch = repo.arch.value
                 if arch == "x86_64":
                     arch = "amd64"  # FIX potential arch errors
                 cmd = "%s --nosource -a %s" % (cmd, arch)

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -452,9 +452,12 @@ class CobblerSync:
         system_record = self.systems.find(name=name)
 
         for (name, interface) in list(system_record.interfaces.items()):
-            filename = system_record.get_config_filename(interface=name)
-            utils.rmfile(os.path.join(bootloc, "pxelinux.cfg", filename))
-            utils.rmfile(os.path.join(bootloc, "grub", filename.upper()))
+            pxe_filename = system_record.get_config_filename(interface=name, loader="pxe")
+            grub_filename = system_record.get_config_filename(interface=name, loader="grub")
+            utils.rmfile(os.path.join(bootloc, "pxelinux.cfg", pxe_filename))
+            utils.rmfile(os.path.join(bootloc, "grub", "system", grub_filename))
+            utils.rmfile(os.path.join(bootloc, "grub", "system_link", system_record.name))
+            # FIXME: No cleanup path for yaboot
 
     def remove_single_menu(self, rebuild_menu: bool = True):
         """

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -27,6 +27,7 @@ import copy
 from cobbler import utils
 from cobbler.manager import ManagerModule
 from cobbler.cexceptions import CX
+from cobbler.enums import Archs
 
 MANAGER = None
 
@@ -181,11 +182,11 @@ class _IscManager(ManagerModule):
                 # Explicitly declare filename for other (non x86) archs as in DHCP discover package mostly the
                 # architecture cannot be differed due to missing bits...
                 if distro is not None and not interface.get("filename"):
-                    if distro.arch == "ppc" or distro.arch == "ppc64":
+                    if distro.arch in [Archs.PPC,  Archs.PPC64]:
                         interface["filename"] = yaboot
-                    elif distro.arch == "ppc64le":
+                    elif distro.arch == Archs.PPC64LE:
                         interface["filename"] = "grub/grub.ppc64le"
-                    elif distro.arch == "aarch64":
+                    elif distro.arch == Archs.AARCH64:
                         interface["filename"] = "grub/grubaa64.efi"
 
                 if not self.settings.always_write_dhcp_entries:
@@ -342,13 +343,13 @@ class _IscManager(ManagerModule):
                 # Explicitly declare filename for other (non x86) archs as in DHCP discover package mostly the
                 # architecture cannot be differed due to missing bits...
                 if distro is not None and not interface.get("filename"):
-                    if distro.arch == "ppc":
+                    if distro.arch == Archs.PPC:
                         interface["filename"] = "grub/grub.ppc"
-                    elif distro.arch == "ppc64":
+                    elif distro.arch == Archs.PPC64:
                         interface["filename"] = "grub/grub.ppc64"
-                    elif distro.arch == "ppc64le":
+                    elif distro.arch == Archs.PPC64LE:
                         interface["filename"] = "grub/grub.ppc64le"
-                    elif distro.arch == "aarch64":
+                    elif distro.arch == Archs.AARCH64:
                         interface["filename"] = "grub/grubaa64.efi"
 
                 if not self.settings.always_write_dhcp_entries:

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2392,7 +2392,7 @@ class CobblerXMLRPCInterface:
         parent = obj.get_conceptual_parent()
 
         if parent and parent.COLLECTION_TYPE == "profile":
-            return parent.get_boot_loaders()
+            return parent.boot_loaders
         return self.api.get_valid_obj_boot_loaders(parent)
 
     def get_repo_config_for_profile(self, profile_name, **rest):

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -28,6 +28,7 @@ import yaml
 
 from cobbler import download_manager
 from cobbler.cobbler_collections import manager
+from cobbler.settings import Settings
 
 
 class CobblerSvc:
@@ -55,6 +56,15 @@ class CobblerSvc:
         """
         if self.remote is None:
             self.remote = xmlrpc.client.Server(self.server, allow_none=True)
+
+    def settings(self) -> Settings:
+        """
+        Get the application configuration.
+
+        :return: Settings object.
+        """
+        self.__xmlrpc_setup()
+        return Settings().from_dict(self.remote.get_settings())
 
     def index(self, **args) -> str:
         """

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -483,10 +483,10 @@ class TFTPGen:
         for image in image_list:
             if os.path.exists(image.file):
                 arch = image.arch
-                boot_loaders = image.get_boot_loaders()
+                boot_loaders = image.boot_loaders
 
                 for boot_loader in boot_loaders:
-                    if boot_loader not in image.get_boot_loaders():
+                    if boot_loader not in image.boot_loaders:
                         continue
                     contents = self.write_pxe_file(filename=None, system=None, profile=None, distro=None, arch=arch,
                                                    image=image, format=boot_loader)
@@ -627,7 +627,7 @@ class TFTPGen:
 
         boot_loaders = None
         if system:
-            boot_loaders = system.get_boot_loaders()
+            boot_loaders = system.boot_loaders
             metadata["menu_label"] = system.name
             metadata["menu_name"] = system.name
         elif profile:
@@ -635,7 +635,7 @@ class TFTPGen:
             metadata["menu_label"] = profile.name
             metadata["menu_name"] = profile.name
         elif image:
-            boot_loaders = image.get_boot_loaders()
+            boot_loaders = image.boot_loaders
             metadata["menu_label"] = image.name
             metadata["menu_name"] = image.name
         if boot_loaders is None or format not in boot_loaders:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -294,10 +294,8 @@ class TFTPGen:
                                             working_arch, format="grub")
                         # Generate a link named after system to the mac file for easier lookup
                         link_path = os.path.join(self.bootloc, "grub", "system_link", system.name)
-                        if os.path.exists(link_path):
-                            utils.rmfile(link_path)
-                        if not os.path.exists(os.path.dirname(link_path)):
-                            utils.mkdir(os.path.dirname(link_path))
+                        utils.rmfile(link_path)
+                        utils.mkdir(os.path.dirname(link_path))
                         os.symlink(os.path.join("..", "system", grub_name), link_path)
                 else:
                     self.write_pxe_file(pxe_path, system, None, None, working_arch, image=profile,

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -770,15 +770,10 @@ class TFTPGen:
         if image is None:
             # not image based, it's something normalish
             img_path = os.path.join("/images", distro.name)
-            if boot_loader == "grub":
-                if distro.remote_grub_kernel:
-                    kernel_path = distro.remote_grub_kernel
-                if distro.remote_grub_initrd:
-                    initrd_path = distro.remote_grub_initrd
-            if boot_loader == "ipxe":
-                if distro.remote_grub_kernel:
+            if boot_loader in ["grub", "ipxe"]:
+                if distro.remote_boot_kernel:
                     kernel_path = distro.remote_boot_kernel
-                if distro.remote_grub_initrd:
+                if distro.remote_boot_initrd:
                     initrd_path = distro.remote_boot_initrd
 
             if 'http' in distro.kernel and 'http' in distro.initrd:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -236,7 +236,10 @@ class TFTPGen:
         # generate one record for each described NIC ..
         for (name, _) in list(system.interfaces.items()):
 
-            pxe_name = system.get_config_filename(interface=name)
+            # Passing "pxe" here is a hack, but we need to make sure that
+            # get_config_filename() will return a filename in the pxelinux
+            # format.
+            pxe_name = system.get_config_filename(interface=name, loader="pxe")
             grub_name = system.get_config_filename(interface=name, loader="grub")
 
             if pxe_name is not None:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -30,6 +30,7 @@ from typing import Optional, List
 from cobbler import enums, templar
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.enums import Archs
 
 
 class TFTPGen:
@@ -261,11 +262,12 @@ class TFTPGen:
                 raise CX("internal error, invalid arch supplied")
 
             # for tftp only ...
-            if working_arch in ["i386", "x86", "x86_64", "arm", "aarch64", "ppc64le", "ppc64el", "standard"]:
+            if working_arch in [Archs.I386, Archs.X86_64, Archs.ARM, Archs.AARCH64,
+                                Archs.PPC64LE, Archs.PPC64EL]:
                 # ToDo: This is old, move this logic into item_system.get_config_filename()
                 pass
 
-            elif working_arch == "ppc" or working_arch == "ppc64":
+            elif working_arch in [Archs.PPC, Archs.PPC64]:
                 # Determine filename for system-specific bootloader config
                 filename = "%s" % system.get_config_filename(interface=name).lower()
                 # to inherit the distro and system's boot_loader values correctly
@@ -285,9 +287,11 @@ class TFTPGen:
             if system.is_management_supported():
                 if not image_based:
                     if pxe_path:
-                        self.write_pxe_file(pxe_path, system, profile, distro, working_arch, metadata=pxe_metadata)
+                        self.write_pxe_file(pxe_path, system, profile, distro,
+                                            working_arch, metadata=pxe_metadata)
                     if grub_path:
-                        self.write_pxe_file(grub_path, system, profile, distro, working_arch, format="grub")
+                        self.write_pxe_file(grub_path, system, profile, distro,
+                                            working_arch, format="grub")
                         # Generate a link named after system to the mac file for easier lookup
                         link_path = os.path.join(self.bootloc, "grub", "system_link", system.name)
                         if os.path.exists(link_path):
@@ -594,7 +598,7 @@ class TFTPGen:
         metadata["menu_labels"] = menu_labels
         return metadata
 
-    def write_pxe_file(self, filename, system, profile, distro, arch: str, image=None, metadata=None,
+    def write_pxe_file(self, filename, system, profile, distro, arch: Archs, image=None, metadata=None,
                        format: str = "pxe") -> str:
         """
         Write a configuration file for the boot loader(s).
@@ -649,42 +653,40 @@ class TFTPGen:
         # just some random variables
         buffer = ""
 
-        if system and format in ['pxe', 'yaboot'] and not system.netboot_enabled and arch in ['ppc', 'ppc64']:
-            # local booting on ppc requires removing the system-specific dhcpd.conf filename
-            if arch is not None and (arch == "ppc" or arch == "ppc64"):
-                # Disable yaboot network booting for all interfaces on the system
-                for (name, interface) in list(system.interfaces.items()):
+        if system and format in ['pxe', 'yaboot'] and not system.netboot_enabled and arch in [Archs.PPC, Archs.PPC64]:
+            # Disable yaboot network booting for all interfaces on the system
+            for (name, interface) in list(system.interfaces.items()):
 
-                    filename = "%s" % system.get_config_filename(interface=name).lower()
+                filename = "%s" % system.get_config_filename(interface=name).lower()
 
-                    # Remove symlink to the yaboot binary
-                    f3 = os.path.join(self.bootloc, "ppc", filename)
-                    if os.path.lexists(f3):
-                        utils.rmfile(f3)
-                    f3 = os.path.join(self.bootloc, "etc", filename)
-                    if os.path.lexists(f3):
-                        utils.rmfile(f3)
+                # Remove symlink to the yaboot binary
+                f3 = os.path.join(self.bootloc, "ppc", filename)
+                if os.path.lexists(f3):
+                    utils.rmfile(f3)
+                f3 = os.path.join(self.bootloc, "etc", filename)
+                if os.path.lexists(f3):
+                    utils.rmfile(f3)
 
-                # Yaboot/OF doesn't support booting locally once you've booted off the network, so nothing left
-                # to do
-                return None
+            # Yaboot/OF doesn't support booting locally once you've booted off the network, so nothing left
+            # to do
+            return None
 
         template = os.path.join(self.settings.boot_loader_conf_template_dir, format + ".template")
         self.build_kernel(metadata, system, profile, distro, image, format)
 
         # generate the kernel options and append line:
         kernel_options = self.build_kernel_options(system, profile, distro,
-                                                   image, arch, metadata["autoinstall"])
+                                                   image, arch.value, metadata["autoinstall"])
         metadata["kernel_options"] = kernel_options
 
         if distro and distro.os_version.startswith("esxi") and filename is not None:
             append_line = "BOOTIF=%s" % (os.path.basename(filename))
-        elif "initrd_path" in metadata and (not arch or arch not in ["ppc", "ppc64", "arm"]):
+        elif "initrd_path" in metadata and arch not in [Archs.PPC, Archs.PPC64, Archs.ARM]:
             append_line = "append initrd=%s" % (metadata["initrd_path"])
         else:
             append_line = "append "
         append_line = "%s%s" % (append_line, kernel_options)
-        if arch == "ppc" or arch == "ppc64":
+        if arch in [Archs.PPC, Archs.PPC64]:
             # remove the prefix "append"
             # TODO: this looks like it's removing more than append, really not sure what's up here...
             append_line = append_line[7:]
@@ -1014,7 +1016,7 @@ class TFTPGen:
         # This could get enhanced for profile/distro via utils.blender (inheritance)
         # This also is architecture specific. E.g: Some ARM consoles need: console=ttyAMAx,BAUDRATE
         # I guess we need a serial_kernel_dev = param, that can be set to "ttyAMA" if needed.
-        if system and arch == "x86_64":
+        if system and arch == Archs.X86_64:
             if system.serial_device or system.serial_baud_rate:
                 if system.serial_device:
                     serial_device = system.serial_device

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -700,7 +700,7 @@ class TFTPGen:
                 else:
                     serial_device = 0
                 if system.serial_baud_rate:
-                    serial_baud_rate = system.serial_baud_rate
+                    serial_baud_rate = system.serial_baud_rate.value
                 else:
                     serial_baud_rate = 115200
 
@@ -1021,7 +1021,7 @@ class TFTPGen:
                 else:
                     serial_device = 0
                 if system.serial_baud_rate:
-                    serial_baud_rate = system.serial_baud_rate
+                    serial_baud_rate = system.serial_baud_rate.value
                 else:
                     serial_baud_rate = 115200
 

--- a/templates/etc/dhcp.template
+++ b/templates/etc/dhcp.template
@@ -117,24 +117,18 @@ subnet 192.168.1.0 netmask 255.255.255.0 {
             #else if $iface.gateway:
                 option routers $iface.gateway;
             #end if
-            #if "filename" in $iface.keys() and $iface.filename:
-                #if $iface.enable_ipxe:
-                    if exists user-class and option user-class = "iPXE" {
-                        filename "http://$cobbler_server/cblr/svc/op/ipxe/system/$iface.owner";
-                    } else if exists user-class and option user-class = "iPXE" {
-                        filename "http://$cobbler_server/cblr/svc/op/ipxe/system/$iface.owner";
-                    } else {
-                        filename "undionly.kpxe";
-                    }
-                #else
-                    filename "$iface.filename";
-                #end if
+            #if $iface.enable_ipxe:
+                if exists user-class and option user-class = "iPXE" {
+                    filename "http://$cobbler_server/cblr/svc/op/ipxe/system/$iface.owner";
+                } else {
+                    filename "undionly.kpxe";
+                }
             #end if
             #if $iface.next_server_v4:
                 next-server $iface.next_server_v4;
             #end if
             #if $iface.filename:
-                filename $filename
+                filename "$iface.filename";
             #end if
             #if $iface.name_servers:
                 #set $mynameservers = ','.join($iface.name_servers)


### PR DESCRIPTION
Highlights:

- Remove the last of get\_boot\_loaders() invocations
- Fix BaudRates usage
- Use Archs and RepoArchs enums instead of str
- Do not check if a file exists before removing
- Fix bootloader cleanup during system removal
- Fix dhcpd template for iPXE
- Fix incorrect PXELINUX filename
- Use distro.remote_boot_* instead of distro.remote_grub_*
- Unbreak iPXE

While the most of the changes are trivial, there are some pieces I'm kinda
worried about. Please take a carefull look at the patches that remove code
branches related to x86 (not x86\_64) and replace global state (like
repo.arch) with local.
