### PR TITLE
Remove leftover in the systemd file about cobbler.wsgi

### DIFF
--- a/config/service/cobblerd.service
+++ b/config/service/cobblerd.service
@@ -5,7 +5,6 @@ Wants=@@httpd_service@@
 
 [Service]
 ExecStart=/usr/bin/cobblerd -F
-ExecStartPost=-/usr/bin/touch /usr/share/cobbler/web/cobbler.wsgi
 PrivateTmp=yes
 KillMode=process
 


### PR DESCRIPTION
This was reported by @heroin-moose in the Gitter/Matrix Chat.

It is a leftover from the webinterface removal, since we don't have a WSGI application anymore for the webinterface, we don't need that touch thus.