### PR TITLE
Added signature for fedora34

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -737,6 +737,38 @@
           ]
         }
       },
+      "fedora34": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "(fedora)-release-34-(.*)\\.noarch\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "aarch64",
+          "i386",
+          "x86_64",
+          "ppc64le"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "repo=$tree",
+        "kernel_options_post": "",
+        "boot_files": [],
+        "boot_loaders": {
+          "ppc64": [
+            "grub"
+          ]
+        }
+      },
       "cloudlinux6": {
         "signatures": [
           "Packages"


### PR DESCRIPTION
Added signature for fedora34 and tested with a cobbler import
```Found a candidate signature: breed=redhat, version=fedora30
Found a candidate signature: breed=redhat, version=fedora31
Found a candidate signature: breed=redhat, version=fedora32
Found a candidate signature: breed=redhat, version=fedora33
Found a candidate signature: breed=redhat, version=fedora34
Found a matching signature: breed=redhat, version=fedora34
Adding distros from path /var/www/cobbler/distro_mirror/fedora34-x86_64:
creating new distro: fedora34-x86_64
trying symlink: /var/www/cobbler/distro_mirror/fedora34-x86_64 -> /var/www/cobbler/links/fedora34-x86_64
creating new profile: fedora34-x86_64
associating repos
checking for rsync repo(s)
checking for rhn repo(s)
checking for yum repo(s)
starting descent into /var/www/cobbler/distro_mirror/fedora34-x86_64 for fedora34-x86_64
processing repo at : /var/www/cobbler/distro_mirror/fedora34-x86_64
need to process repo/comps: /var/www/cobbler/distro_mirror/fedora34-x86_64
looking for /var/www/cobbler/distro_mirror/fedora34-x86_64/repodata/*comps*.xml
Keeping repodata as-is :/var/www/cobbler/distro_mirror/fedora34-x86_64/repodata
*** TASK COMPLETE ***
```