### PR TITLE
ipmilanplus shall be the new default fence-agent

### DIFF
--- a/cobbler/settings.py
+++ b/cobbler/settings.py
@@ -113,7 +113,7 @@ DEFAULTS = {
     "nsupdate_log": ["/var/log/cobbler/nsupdate.log", "str"],
     "nsupdate_tsig_algorithm": ["hmac-sha512", "str"],
     "nsupdate_tsig_key": [[], "list"],
-    "power_management_default_type": ["ipmilan", "str"],
+    "power_management_default_type": ["ipmilanplus", "str"],
     "proxy_url_ext": ["", "str"],
     "proxy_url_int": ["", "str"],
     "puppet_auto_setup": [False, "bool"],

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -270,8 +270,8 @@ next_server_v6: "::1"
 # see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
 # choices (refer to codes.py):
 #    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
-#    ipmilan lpar rsa virsh wti
-power_management_default_type: 'ipmilan'
+#    ipmilan ipmilanplus lpar rsa virsh wti
+power_management_default_type: 'ipmilanplus'
 
 # if this setting is set to true, Cobbler systems that pxe boot
 # will request at the end of their installation to toggle the

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -78,7 +78,7 @@ class TestSystem:
         ("virt_path", "/path/to/test"),
         ("virt_pxe_boot", True),
         ("virt_pxe_boot", False),
-        ("power_type", "ipmilan"),
+        ("power_type", "ipmilanplus"),
         ("power_address", "127.0.0.1"),
         ("power_id", "pmachine:lpar1"),
         ("power_pass", "pass"),


### PR DESCRIPTION
./docs/quickstart-guide.rst already describes this.
Since fence-agents git commit (4.7.1):
commit 08a4521f9361c7ca4877e691fa82cc0e8f51d707 (origin/fence_ipmitool)

    Add fence_ipmilanplus as fence_ipmilan wrapper always enabling lanplus

this fence exists and should support all new IPMI v2.0 and newer
BMC implementations.