### PR TITLE
feat: Add initial Oracle Linux support

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -961,7 +961,8 @@ def get_family() -> str:
              returned.
     """
     # TODO: Refactor that this is purely reliant on the distro module or obsolete it.
-    redhat_list = ("red hat", "redhat", "scientific linux", "fedora", "centos", "virtuozzo", "almalinux", "rocky linux")
+    redhat_list = ("red hat", "redhat", "scientific linux", "fedora", "centos", "virtuozzo", "almalinux",
+                   "rocky linux", "oracle linux server")
 
     distro_name = distro.name().lower()
     for item in redhat_list:
@@ -994,6 +995,8 @@ def os_release():
             make = "centos"
         elif "virtuozzo" in distro_name:
             make = "virtuozzo"
+        elif "oracle linux server" in distro_name:
+            make = "centos"
         else:
             make = "redhat"
         return make, float(distro_version)

--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -25,7 +25,7 @@ if [ "$DISTRO" = "" ] && [ -r /etc/os-release ];then
 	sle*|*suse*)
 	    DISTRO="SUSE"
 	    ;;
-	fedora*|centos*|rhel*)
+	fedora*|centos*|rhel*|ol*)
 	    DISTRO="FEDORA"
 	    ;;
 	ubuntu*|debian*)


### PR DESCRIPTION
Initial Oracle Linux support. The necessary changes to the `distro_signatrues.json` were already made. 
~~The import works so far but it has to be tested further.~~

Fixes #2065, #1562

The latest signature ist the following:

```bash
$ cat /etc/os-release 
NAME="Oracle Linux Server"
VERSION="8.4"
ID="ol"
ID_LIKE="fedora"
VARIANT="Server"
VARIANT_ID="server"
VERSION_ID="8.4"
PLATFORM_ID="platform:el8"
PRETTY_NAME="Oracle Linux Server 8.4"
ANSI_COLOR="0;31"
CPE_NAME="cpe:/o:oracle:linux:8:4:server"
HOME_URL="https://linux.oracle.com/"
BUG_REPORT_URL="https://bugzilla.oracle.com/"

ORACLE_BUGZILLA_PRODUCT="Oracle Linux 8"
ORACLE_BUGZILLA_PRODUCT_VERSION=8.4
ORACLE_SUPPORT_PRODUCT="Oracle Linux"
ORACLE_SUPPORT_PRODUCT_VERSION=8.4

```