### PR TITLE
fix: Cobbler distro remove

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -71,6 +71,8 @@ class CobblerSync:
         self.images_dir = os.path.join(self.bootloc, "images")
         self.ipxe_dir = os.path.join(self.bootloc, "ipxe")
         self.rendered_dir = os.path.join(self.settings.webdir, "rendered")
+        self.links = os.path.join(self.settings.webdir, "links")
+        self.distromirror_config = os.path.join(self.settings.webdir, "distro_mirror/config")
         # FIXME: See https://github.com/cobbler/cobbler/issues/2453
         # Move __create_tftpboot_dirs() outside of sync.py.
         self.__create_tftpboot_dirs()
@@ -194,6 +196,10 @@ class CobblerSync:
             utils.mkdir(self.rendered_dir)
         if not os.path.exists(self.ipxe_dir):
             utils.mkdir(self.ipxe_dir)
+        if not os.path.exists(self.links):
+            utils.mkdir(self.links)
+        if not os.path.exists(self.distromirror_config):
+            utils.mkdir(self.distromirror_config)
 
     def clean_trees(self):
         """
@@ -353,6 +359,8 @@ class CobblerSync:
         utils.rmtree(os.path.join(bootloc, "images", name))
         # delete potential symlink to tree in webdir/links
         utils.rmfile(os.path.join(self.settings.webdir, "links", name))
+        # delete potential distro config files
+        utils.rmglob_files(os.path.join(self.settings.webdir, "distro_mirror", "config"), name + "*.repo")
 
     def remove_single_image(self, name):
         """

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -508,19 +508,28 @@ def test_copyfile_pattern():
     assert False
 
 
-def test_rmfile():
+def test_rmfile(tmpdir: Path):
     # Arrange
-    filepath = "/dev/shm/testfile"
-    Path(filepath).touch()
-
-    assert os.path.exists(filepath)
+    tfile = tmpdir.join("testfile")
 
     # Act
-    result = utils.rmfile(filepath)
+    utils.rmfile(tfile)
 
     # Assert
-    assert result
-    assert not os.path.exists(filepath)
+    assert not os.path.exists(tfile)
+
+
+def test_rmglob_files(tmpdir: Path):
+    # Arrange
+    tfile1 = tmpdir.join("file1.tfile")
+    tfile2 = tmpdir.join("file2.tfile")
+
+    # Act
+    utils.rmglob_files(tmpdir, "*.tfile")
+
+    # Assert
+    assert not os.path.exists(tfile1)
+    assert not os.path.exists(tfile2)
 
 
 def test_rmtree_contents():


### PR DESCRIPTION
This PR solves the following issues:

- `cobbler distro remove` now removes the leftover *.repo files
- `distro_config` and `links` directories are now created when they were e.g. manually removed inside Cobbler's webdir
- refactor and improve `rmfile()` method
- introduce `rmglob_files()` method which deletes files in a certain path with a given glob pattern

Fixes #1370