### PR TITLE
CI: Add entrypoint script to develop container

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Build Docker Test Container
+      - name: Build Docker test container
         run: docker build -t cobbler -f docker/develop/develop.dockerfile .
-      - name: Run previously built Docker Container
-        run: docker run -t -d -v $PWD:/code --name cobbler cobbler
+      - name: Run previously built Docker container
+        run: docker run -t -e CI -d -v $PWD:/code --name cobbler cobbler
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
           docker exec -u 0 -it cobbler bash -c "./docker/develop/scripts/setup-supervisor.sh"
-      - name: Run the Tests inside the Docker Container
+      - name: Run the tests inside the Docker container
         shell: 'script -q -e -c "bash {0}"'
         run: |
           docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -82,4 +82,4 @@ VOLUME ["/code"]
 WORKDIR "/code"
 
 # Set this as an entrypoint
-CMD ["/bin/bash"]
+CMD ["./docker/develop/scripts/setup-supervisor.sh"]

--- a/docker/develop/scripts/setup-supervisor.sh
+++ b/docker/develop/scripts/setup-supervisor.sh
@@ -14,3 +14,8 @@ sleep 2
 
 echo "Show Cobbler version"
 cobbler version
+
+# only execute locally and not in the CI
+if [ ! "$CI" ]; then
+    /bin/bash
+fi


### PR DESCRIPTION
This will start the `setup_supervisor.sh` script automatically when running the docker container. This saves the developer one manual step.

The GitHub Actions testing workflow has to be testet here.