### PR TITLE
Fix local_efi.cfg

### DIFF
--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -17,18 +17,16 @@ menuentry "local" --class gnu-linux --class gnu --class os {
   else
     # ToDo: We have to know all possible local default grub.efi loaders
     search -s root -n -f /efi/boot/bootx64.efi
-    set prefix=(${root})/efi/opensuse
-    chainloader ${prefix}/grub.efi
-    boot # if it doesn't exist, go on
-    set prefix=(${root})/efi/sles
-    chainloader ${prefix}/grub.efi
+    if [ -f (${root})/efi/opensuse/grub.efi ] ; then
+      chainloader (${root})/efi/opensuse/grub.efi
+    elif [ -f (${root})/efi/sles/grub.efi ] ; then
+      chainloader (${root})/efi/sles/grub.efi
+    elif [ -f (${root})/efi/grub/grub.efi ] ; then
+      chainloader (${root})/efi/grub/grub.efi
+    else
+      chainloader (${root})/efi/boot/bootx64.efi
+    fi
     boot
-    set prefix=(${root})/efi/grub
-    chainloader ${prefix}/grub.efi
-    boot
-    set prefix=(${root})/efi/boot
-    chainloader ${prefix}/bootx64.efi
-    boot # if it doesn't exist, leave grub and enter shell
-    exit
+    exit # Exit to UEFI shell if nothing works
   fi
 }

--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -4,14 +4,14 @@ menuentry "local" --class gnu-linux --class gnu --class os {
       chainloader /efi/opensuse/grub.efi
     elif [ -f /efi/sles/shim.efi ] ; then
       chainloader /efi/sles/grub.efi
-    elif [ -f /EFI/redhat/grub.efi ]; then
-      chainloader /EFI/redhat/grub.efi
-    elif [ -f /EFI/redhat/grubx64.efi ]; then
-      chainloader /EFI/redhat/grubx64.efi
-    elif [ -f /EFI/centos/grub.efi ]; then
-      chainloader /EFI/centos/grub.efi
-    elif [ -f /EFI/centos/grubx64.efi ]; then
-      chainloader /EFI/centos/grubx64.efi
+    elif [ -f /efi/redhat/grub.efi ]; then
+      chainloader /efi/redhat/grub.efi
+    elif [ -f /efi/redhat/grubx64.efi ]; then
+      chainloader /efi/redhat/grubx64.efi
+    elif [ -f /efi/centos/grub.efi ]; then
+      chainloader /efi/centos/grub.efi
+    elif [ -f /efi/centos/grubx64.efi ]; then
+      chainloader /efi/centos/grubx64.efi
     fi
     boot
   else

--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -26,6 +26,7 @@ menuentry "local" --class gnu-linux --class gnu --class os {
     set prefix=(${root})/efi/grub
     chainloader ${prefix}/grub.efi
     boot
+    set prefix=(${root})/efi/boot
     chainloader ${prefix}/bootx64.efi
     boot # if it doesn't exist, leave grub and enter shell
     exit

--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -4,7 +4,7 @@ menuentry "local" --class gnu-linux --class gnu --class os {
       chainloader /efi/opensuse/grub.efi
     elif [ -f /efi/sles/shim.efi ] ; then
       chainloader /efi/sles/grub.efi
-      elif [ -f /EFI/redhat/grub.efi ]; then
+    elif [ -f /EFI/redhat/grub.efi ]; then
       chainloader /EFI/redhat/grub.efi
     elif [ -f /EFI/redhat/grubx64.efi ]; then
       chainloader /EFI/redhat/grubx64.efi


### PR DESCRIPTION
Highlights:

- Fix indentation
- Fallback to /efi/boot/bootx64.efi
- Unify formatting
- Consistently use lowercase paths
