### PR TITLE
fix/windows

### DIFF
--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -169,7 +169,7 @@ def run(api, args):
 
         if is_wimboot:
             distro_path = os.path.join(settings.webdir, "distro_mirror", distro.name)
-            kernel_path = os.path.join(distro_path, "Boot")
+            kernel_path = os.path.join(distro_path, "boot")
 
             if "kernel" in meta and "wimboot" not in distro.kernel:
                 tgen.copy_single_distro_file(os.path.join(settings.tftpboot_location, kernel_name), distro_dir, False)
@@ -301,7 +301,7 @@ def run(api, args):
             wim_pl_name = os.path.join(kernel_path, "winpe.wim")
 
             cmd = ["/usr/bin/cp", "--reflink=auto", wim_pl_name, ps_file_name]
-            utils.subprocess_call(logger, cmd, shell=False)
+            utils.subprocess_call(cmd, shell=False)
             tgen.copy_single_distro_file(ps_file_name, web_dir, True)
 
             if os.path.exists(wimupdate):
@@ -309,7 +309,9 @@ def run(api, args):
                 pi_file = tempfile.NamedTemporaryFile()
                 pi_file.write(bytes(data, 'utf-8'))
                 pi_file.flush()
-                cmd = [wimupdate, ps_file_name, "--command=add " + pi_file.name + " /Windows/System32/startnet.cmd"]
+                cmd = ["/usr/bin/wimdir %s 1 | /usr/bin/grep -i '^/Windows/System32/startnet.cmd$'" % ps_file_name]
+                startnet_path = utils.subprocess_get(cmd, shell=True)[0:-1]
+                cmd = [wimupdate, ps_file_name, "--command=add %s %s" % (pi_file.name, startnet_path)]
                 utils.subprocess_call(cmd, shell=False)
                 pi_file.close()
 

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -67,8 +67,8 @@ CHEETAH_ERROR_DISCLAIMER = """
 MODULE_CACHE = {}
 SIGNATURE_CACHE = {}
 
-_re_kernel = re.compile(r'(vmlinu[xz]|(kernel|linux(\.img)?))')
-_re_initrd = re.compile(r'(initrd(.*)\.img|ramdisk\.image\.gz)')
+_re_kernel = re.compile(r'(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot)')
+_re_initrd = re.compile(r'(initrd(.*)\.img|ramdisk\.image\.gz|boot\.sdi)')
 
 
 class DHCP(enum.Enum):
@@ -1580,11 +1580,11 @@ def get_supported_distro_boot_loaders(distro, api_handle=None):
     """
     try:
         # Try to read from the signature
-        return api_handle.get_signatures()["breeds"][distro.breed][distro.os_version]["boot_loaders"][distro.arch]
+        return api_handle.get_signatures()["breeds"][distro.breed][distro.os_version]["boot_loaders"][distro.arch.value]
     except:
         try:
             # Try to read directly from the cache
-            return SIGNATURE_CACHE["breeds"][distro.breed][distro.os_version]["boot_loaders"][distro.arch]
+            return SIGNATURE_CACHE["breeds"][distro.breed][distro.os_version]["boot_loaders"][distro.arch.value]
         except:
             try:
                 # Else use some well-known defaults
@@ -1594,7 +1594,7 @@ def get_supported_distro_boot_loaders(distro, api_handle=None):
                         "ppc64el": ["grub", "pxe"],
                         "aarch64": ["grub"],
                         "i386": ["grub", "pxe", "ipxe"],
-                        "x86_64": ["grub", "pxe", "ipxe"]}[distro.arch]
+                        "x86_64": ["grub", "pxe", "ipxe"]}[distro.arch.value]
             except:
                 # Else return the globally known list
                 return get_supported_system_boot_loaders()

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -2880,48 +2880,183 @@
     },
     "windows": {
       "2003": {
+        "signatures": [
+          "amd64",
+          "i386",
+          "autorun.inf"
+        ],
+        "version_file": "relnotes\\.htm",
+        "version_file_regex": "^.*Microsoft Windows Server 2003.*$",
+        "kernel_arch": "(amd64|i386)",
+        "kernel_arch_regex": null,
         "supported_arches":["i386","x86_64"],
         "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
         "boot_files": [
           "i386/*.*",
           "amd64/*.*"
         ]
       },
       "2008": {
-        "supported_arches":["i386","x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
-      },
-      "2012": {
-        "supported_arches":["x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
-      },
-      "2016": {
-        "supported_arches":["x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
-      },
-      "2019": {
-        "supported_arches":["x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
-      },
-      "XP": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows Server 2008.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["i386","x86_64"],
         "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "2012": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows Server 2012.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
+        "supported_arches":["x86_64"],
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "2016": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows Server 2016.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
+        "supported_arches":["x86_64"],
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "2019": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows Server 2019.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
+        "supported_arches":["x86_64"],
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "XP": {
+        "signatures": [
+          "amd64",
+          "i386",
+          "autorun.inf"
+        ],
+        "version_file": "readme\\.htm",
+        "version_file_regex": "^Version of Microsoft Windows&nbsp;XP.*$",
+        "kernel_arch": "(amd64|i386)",
+        "kernel_arch_regex": null,
+        "supported_arches":["i386","x86_64"],
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
         "boot_files": [
           "i386/*.*",
           "amd64/*.*"
         ]
       },
       "7": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows 7.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["i386","x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       },
       "8": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows 8.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["i386","x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       },
       "10": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows 10.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["i386","x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]}
+        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       }
     },
     "powerkvm": {


### PR DESCRIPTION
- the lack of mandatory attributes for windows distros in `distro_signatures.json` breaks the `cobbler import`, even if the import is not done for windows distro.
- added support for import windows distros. It simplifies the preparation of installation and eliminates the need to do part of the preparation on windows.
- fixed some small bugs.