### PR TITLE
Cobbler-settings: Change options order

### DIFF
--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -18,9 +18,6 @@ from cobbler.settings import migrations
 from cobbler.settings.migrations import EMPTY_VERSION, helper
 from cobbler.utils import input_boolean, input_string_or_dict, input_string_or_list
 
-# https://docs.python.org/3.6/howto/argparse.html#id1
-# https://docs.python.org/3.6/library/argparse.html
-
 
 # TODO: Transform this into a lamda/list comprehension
 def __generate_version_choices() -> List[str]:
@@ -135,14 +132,14 @@ def modify(args: argparse.Namespace) -> int:
 
 
 parser = argparse.ArgumentParser(description="Manage the settings of Cobbler without a running daemon.")
-parser.add_argument("--config", "-c",
+parser.add_argument("-c", "--config",
                     help="The location of the Cobbler configuration file.",
                     default="/etc/cobbler/settings.yaml")
 subparsers = parser.add_subparsers(title="Subcommands", help="One of these commands is required.")
 parser_validate = subparsers.add_parser("validate",
                                         description="Validates if Cobbler would start with the current settings file.")
 parser_validate.set_defaults(func=validate)
-parser_validate.add_argument("--version", "-v",
+parser_validate.add_argument("-v", "--version",
                              help="The version to validate against.",
                              choices=sorted(__generate_version_choices()),
                              default=sorted(__generate_version_choices())[-1])
@@ -155,7 +152,7 @@ parser_migrate.set_defaults(func=migrate)
 #                            help="Whether to produce a diff output or not.",
 #                            action="store_true",
 #                            default=False)
-parser_migrate.add_argument("--target", "-t",
+parser_migrate.add_argument("-t", "--target",
                             help="Write the resulting settings to the target path given in this argument.")
 parser_migrate.add_argument("--new",
                             help="The new version to migrate to, e.g. 3.3.0",
@@ -166,21 +163,21 @@ parser_automigrate = subparsers.add_parser("automigrate",
                                            description="Enables or disables the automigration on startup of the daemon. "
                                                        'If no flag is provided, the default is "--disable".')
 parser_automigrate.set_defaults(func=automigrate)
-parser_automigrate.add_argument("--enable", "-e",
+parser_automigrate.add_argument("-e", "--enable",
                                 help="Enables settings automigration.",
                                 dest="enable_automigration",
                                 action="store_true")
-parser_automigrate.add_argument("--disable", "-d",
+parser_automigrate.add_argument("-d", "--disable",
                                 help="Disables settings automigration.",
                                 dest="enable_automigration",
                                 action="store_false")
 parser_modify = subparsers.add_parser("modify", description="Modify the value of a key in the config file.")
 parser_modify.set_defaults(func=modify)
-parser_modify.add_argument("--key", "-k",
+parser_modify.add_argument("-k", "--key",
                            help='The name of the key in file to edit. If the key is nested use the format '
                                 '"parent_key.key".',
                            required=True)
-parser_modify.add_argument("--value", "-v",
+parser_modify.add_argument("-v", "--value",
                            help="The new value of the key.",
                            required=True)
 


### PR DESCRIPTION
This PR unifies the order of the arguments in `cobbler-settings`.