### PR TITLE
Also disable ONBOOT if it is enclosed in quotation marks.

### DIFF
--- a/autoinstall_snippets/post_install_network_config
+++ b/autoinstall_snippets/post_install_network_config
@@ -357,7 +357,7 @@ echo "nameserver $nameserver" >>/etc/resolv.conf
 ## the old files with the new ones in the working directory
 ## This stops unneccesary (and time consuming) DHCP queries
 ## during the network initialization
-sed -i 's/ONBOOT=yes/ONBOOT=no/g' /etc/sysconfig/network-scripts/ifcfg-eth*
+sed -i 's/ONBOOT=\("\)\?yes\("\)\?/ONBOOT=\1no\2/g' /etc/sysconfig/network-scripts/ifcfg-eth*
 
 ## Move all staged files to their final location
     #for $iname in $ikeys


### PR DESCRIPTION
Some of the ifcfg generated by Anaconda may be enclosed in quotation marks.
The quotes will not match the sed in post_install_network_config when disabling ONBOOT for all interfaces.
In this PR will fix it so that ONBOOT is disabled with or without quotes.