### PR TITLE
Use a real boolean instead of a str one in snippets

### DIFF
--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -14,14 +14,14 @@
 #set os_version = $getVar('os_version','')
 #set srv = $getVar('http_server','')
 #set autoinstall = $getVar('autoinstall','')
-#set run_install_triggers = $str($getVar('run_install_triggers',''))
-#set pxe_just_once = $str($getVar('pxe_just_once',''))
+#set run_install_triggers = $getVar('run_install_triggers','')
+#set pxe_just_once = $getVar('pxe_just_once','')
 #set nopxe = ""
 #set save_autoinstall = ""
 #set runpost = ""
 #if $system_name != ''
     ## PXE JUST ONCE
-    #if $pxe_just_once == "True"
+    #if $pxe_just_once
         #if $breed == 'redhat'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
@@ -47,7 +47,7 @@
         #end if
     #end if
     ## RUN POST TRIGGER
-    #if $run_install_triggers == "True"
+    #if $run_install_triggers
         #if $breed == 'redhat'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'

--- a/autoinstall_snippets/autoinstall_start
+++ b/autoinstall_snippets/autoinstall_start
@@ -12,11 +12,11 @@
 #end if
 #set breed = $getVar('breed','')
 #set srv = $getVar('http_server','')
-#set run_install_triggers = $str($getVar('run_install_triggers',''))
+#set run_install_triggers = $getVar('run_install_triggers','')
 #set runpre = ""
 #if $object_type != ''
     ## RUN PRE TRIGGER
-    #if $run_install_triggers == "True"
+    #if $run_install_triggers
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else


### PR DESCRIPTION
Fixes #2783 

This PR adjusts the `autoinstall_done` and `autoinstall_start` snippets to work as intended with the boolean values instead with string ones.