### PR TITLE
Docs: Add the mkgrub command to the CLI

### DIFF
--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -74,7 +74,7 @@ Long Usage:
 .. code-block:: shell
 
     cobbler <distro|profile|system|repo|image|mgmtclass|package|file|menu> ... [add|edit|copy|get-autoinstall*|list|remove|rename|report] [options|--help]
-    cobbler <aclsetup|buildiso|import|list|replicate|report|reposync|sync|validate-autoinstalls|version|signature|hardlink> [options|--help]
+    cobbler <aclsetup|buildiso|import|list|mkgrub|replicate|report|reposync|sync|validate-autoinstalls|version|signature|hardlink> [options|--help]
 
 Cobbler distro
 ==============
@@ -1120,6 +1120,22 @@ Example:
 .. code-block:: shell
 
     $ cobbler hardlink
+
+Cobbler mkgrub
+==============
+
+This command is used for generating UEFI bootable GRUB 2 bootloaders. This command has no options and is configured via
+the settings file of Cobbler. If available on the operating system Cobbler is running on, then this also generates
+bootloaders for different architectures then the one of the system.
+
+.. note:: This command should be executed every time the bootloader modules are being updated, running it more
+          frequently does not help, running it less frequently will cause the bootloader to be possibly vulnerable.
+
+Example:
+
+.. code-block:: shell
+
+    $ cobbler mkgrub
 
 EXIT_STATUS
 ###########


### PR DESCRIPTION
When merging #2739 we forgot to add this to the Cobbler CLI Docs. This PR fixes this.