### PR TITLE
Decrease log output

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -256,9 +256,8 @@ class CobblerAPI:
         :param name: The name of the item to retrieve.
         :return: An item of the desired type.
         """
-        self.log("get_item", [what, name], debug=True)
+        # self.log("get_item", [what, name], debug=True)
         item = self._collection_mgr.get_items(what).get(name)
-        self.log("done with get_item", [what, name], debug=True)
         return item
 
     def get_items(self, what: str):
@@ -268,9 +267,8 @@ class CobblerAPI:
         :param what: The collection to query.
         :return: The items which were queried. May return no items.
         """
-        self.log("get_items", [what], debug=True)
+        # self.log("get_items", [what], debug=True)
         items = self._collection_mgr.get_items(what)
-        self.log("done with get_items", [what], debug=True)
         return items
 
     def distros(self):
@@ -868,8 +866,7 @@ class CobblerAPI:
         :param no_errors: Silence some errors which would raise if this turned to False.
         :return: The list of items witch match the search criteria.
         """
-        self.log("find_items", [what])
-
+        # self.log("find_items", [what])
         if criteria is None:
             criteria = {}
 

--- a/cobbler/grub.py
+++ b/cobbler/grub.py
@@ -33,5 +33,5 @@ def parse_grub_remote_file(file_location: str) -> Optional[str]:
             raise ValueError("Invalid remote file format %s\n%s is not a valid IP address" % (file_location, server))
 
     res = '(%s,%s)/%s' % (prot, server, path)
-    logging.info("Found remote grub file. Converted [%s] to [%s]", file_location, res)
+    # logging.info("Found remote grub file. Converted [%s] to [%s]", file_location, res)
     return res

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -960,7 +960,7 @@ class CobblerXMLRPCInterface:
         """
         if criteria is None:
             criteria = {}
-        self._log("find_items(%s); criteria(%s); sort(%s)" % (what, criteria, sort_field))
+        # self._log("find_items(%s); criteria(%s); sort(%s)" % (what, criteria, sort_field))
         if "name" in criteria:
             name = criteria.pop("name")
             items = self.api.find_items(what, criteria=criteria, name=name)
@@ -2318,7 +2318,7 @@ class CobblerXMLRPCInterface:
         :param rest: Unused parameter.
         :return: Get the settings which are currently in Cobbler present.
         """
-        self._log("get_settings", token=token)
+        # self._log("get_settings", token=token)
         results = self.api.settings().to_dict()
         # self._log("my settings are: %s" % results, debug=True)
         return self.xmlrpc_hacks(results)

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -612,7 +612,7 @@ def blender(api_handle, remove_dicts: bool, root_obj):
     if "children" in results:
         child_names = results["children"]
         results["children"] = {}
-        logger.info("Children: %s", child_names)
+        # logger.info("Children: %s", child_names)
         for key in child_names:
             child = api_handle.find_items("", name=key, return_list=False)
             if child is None:


### PR DESCRIPTION
If one adds some hundred items, logs raise quickly in size to some hundred MBs.
These seem to be leftovers from recent debugging sessions.