### PR TITLE
Improve devel Docker image

### DIFF
--- a/docker/debs/Debian_10/Debian10.dockerfile
+++ b/docker/debs/Debian_10/Debian10.dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update -qq && \
     python3-pycodestyle \
     python3-pytest \
     python3-setuptools \
-    python3-simplejson  \
     python3-sphinx \
     python3-tz \
     python3-yaml \

--- a/docker/debs/build-and-install-debs.sh
+++ b/docker/debs/build-and-install-debs.sh
@@ -47,7 +47,7 @@ then
     # Also on Debian mod_wsgi is installed as "libapache2-mod-wsgi-py3"
     echo "==> Running tests ..."
     docker exec -it cobbler bash -c 'pip3 install coverage distro future setuptools sphinx requests future'
-    docker exec -it cobbler bash -c 'pip3 install pyyaml simplejson netaddr Cheetah3 pymongo distro ldap3 librepo'
+    docker exec -it cobbler bash -c 'pip3 install pyyaml netaddr Cheetah3 pymongo distro ldap3 librepo'
     docker exec -it cobbler bash -c 'pip3 install dnspython pyflakes pycodestyle pytest pytest-cov codecov'
     docker exec -it cobbler bash -c 'pytest-3'
 fi

--- a/docker/debs/install-debs.sh
+++ b/docker/debs/install-debs.sh
@@ -26,7 +26,7 @@ then
     # Most of these requirement are already satisfied in the Dockerfiles!
     # Also on Debian mod_wsgi is installed as "libapache2-mod-wsgi-py3"
     docker exec -it cobbler bash -c 'pip3 install coverage distro future setuptools sphinx requests future'
-    docker exec -it cobbler bash -c 'pip3 install pyyaml simplejson netaddr Cheetah3 pymongo distro ldap3 librepo'
+    docker exec -it cobbler bash -c 'pip3 install pyyaml netaddr Cheetah3 pymongo distro ldap3 librepo'
     docker exec -it cobbler bash -c 'pip3 install dnspython pyflakes pycodestyle pytest pytest-cov codecov'
     docker exec -it cobbler bash -c 'pytest-3'
 fi

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -55,6 +55,9 @@ RUN zypper install --no-recommends -y \
 # Add Testuser for the PAM tests
 RUN useradd -p $(perl -e 'print crypt("test", "password")') test
 
+# Add Developer scripts to PATH
+ENV PATH="/code/docker/develop/scripts:${PATH}"
+
 # Update pip
 RUN pip3 install --upgrade pip
 

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -43,6 +43,15 @@ RUN zypper install --no-recommends -y \
     which                      \
     xorriso
 
+# Add bootloader packages
+RUN zypper install --no-recommends -y \
+    syslinux \
+    shim \
+    ipxe-bootimgs \
+    grub2 \
+    grub2-i386-efi \
+    grub2-x86_64-efi
+
 # Add Testuser for the PAM tests
 RUN useradd -p $(perl -e 'print crypt("test", "password")') test
 

--- a/docker/rpms/CentOS_8/CentOS8.dockerfile
+++ b/docker/rpms/CentOS_8/CentOS8.dockerfile
@@ -44,7 +44,6 @@ RUN touch /var/lib/rpm/* &&   \
     python3-mod_wsgi          \
     python3-pyyaml            \
     python3-netaddr           \
-    python3-simplejson        \
     python3-cheetah           \
     python3-magic             \
     python3-dns               \

--- a/docker/rpms/Fedora_34/Fedora34.dockerfile
+++ b/docker/rpms/Fedora_34/Fedora34.dockerfile
@@ -32,7 +32,6 @@ RUN yum install -y          \
     python3-PyYAML          \
     python3-cheetah         \
     python3-netaddr         \
-    python3-simplejson      \
     python3-dns             \
     python3-file-magic      \
     python3-ldap3           \

--- a/docker/rpms/build-and-install-rpms.sh
+++ b/docker/rpms/build-and-install-rpms.sh
@@ -57,7 +57,7 @@ if $RUN_TESTS
 then
     echo "==> Running tests ..."
     docker exec -it cobbler bash -c 'pip3 install coverage distro future setuptools sphinx mod_wsgi requests future'
-    docker exec -it cobbler bash -c 'pip3 install pyyaml simplejson netaddr Cheetah3 pymongo distro ldap3 librepo'
+    docker exec -it cobbler bash -c 'pip3 install pyyaml netaddr Cheetah3 pymongo distro ldap3 librepo'
     docker exec -it cobbler bash -c 'pip3 install dnspython pyflakes pycodestyle pytest pytest-cov codecov'
     docker exec -it cobbler bash -c 'pytest'
 fi

--- a/docker/rpms/install-rpms.sh
+++ b/docker/rpms/install-rpms.sh
@@ -26,7 +26,7 @@ if $RUN_TESTS
 then
     echo "==> Running tests ..."
     docker exec -it cobbler bash -c 'pip3 install coverage distro future setuptools sphinx mod_wsgi requests future'
-    docker exec -it cobbler bash -c 'pip3 install pyyaml simplejson netaddr Cheetah3 pymongo distro ldap3'
+    docker exec -it cobbler bash -c 'pip3 install pyyaml netaddr Cheetah3 pymongo distro ldap3'
     docker exec -it cobbler bash -c 'pip3 install dnspython pyflakes pycodestyle pytest pytest-cov codecov'
     docker exec -it cobbler bash -c 'pytest'
 fi

--- a/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
@@ -43,7 +43,6 @@ RUN zypper install -y          \
     python3-pycodestyle        \
     python3-schema             \
     python3-setuptools         \
-    python3-simplejson         \
     python3-pip                \
     python3-PyYAML             \
     python3-wheel              \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -44,7 +44,6 @@ RUN zypper install -y          \
     python3-pycodestyle        \
     python3-schema             \
     python3-setuptools         \
-    python3-simplejson         \
     python3-pip                \
     python3-PyYAML             \
     python3-wheel              \


### PR DESCRIPTION
This PR is a splitout of #2416 and tries to improve the Docker container in a way that it is more convenient to use. This is achieved through three things:

- Remove the unrequired `python3-simplejson`
- Add the bootloaders for testing functionallity related to this
- Add the scripts directory to the PATH so they can be easier used