### PR TITLE
Fix cobbler mkgrub

### DIFF
--- a/cobbler/actions/grubimage.py
+++ b/cobbler/actions/grubimage.py
@@ -3,6 +3,7 @@
 This action calls grub2-mkimage for all bootloader formats configured in
 Cobbler's settings. See man(1) grub2-mkimage for available formats.
 """
+import os.path
 import pathlib
 import subprocess
 import typing
@@ -41,6 +42,8 @@ class GrubImage:
     ):
         """Run GrubImages action."""
 
+        self.create_directories()
+
         for target, link in GrubImage.COMMON_LINKS.items():
             symlink(target, self.bootloaders_dir.joinpath(link), skip_existing=True)
 
@@ -67,6 +70,17 @@ class GrubImage:
                 self.grub2_mod_dir.joinpath(bl_mod_dir),
                 self.bootloaders_dir.joinpath("grub", bl_mod_dir),
             )
+
+    def create_directories(self):
+        """
+        Create the required directories so that this succeeds. If existing, do nothing.
+        """
+        if not self.bootloaders_dir.exists():
+            raise FileNotFoundError("Main bootloader directory not found! Please create it yourself!")
+
+        grub_dir = self.bootloaders_dir.joinpath("grub")
+        if not grub_dir.exists():
+            os.mkdir(grub_dir, 0o644)
 
 
 # NOTE: move this to cobbler.utils?

--- a/cobbler/actions/grubimage.py
+++ b/cobbler/actions/grubimage.py
@@ -18,8 +18,7 @@ class GrubImage:
     COMMON_LINKS = {
         pathlib.Path("/usr/share/efi/x86_64/shim.efi"): pathlib.Path("grub/shim.efi"),
         pathlib.Path("/usr/share/efi/x86_64/grub.efi"): pathlib.Path("grub/grub.efi"),
-        # TODO: do this properly if still used
-        pathlib.Path("/usr/share/*pxe/undionly.kpxe"): pathlib.Path("undionly.pxe"),
+        pathlib.Path("/usr/share/ipxe/undionly.kpxe"): pathlib.Path("undionly.pxe"),
     }
 
     def __init__(self, api):

--- a/cobbler/actions/grubimage.py
+++ b/cobbler/actions/grubimage.py
@@ -60,7 +60,7 @@ class GrubImage:
             try:
                 mkimage(
                     image_format,
-                    self.bootloaders_dir.joinpath(options["binary_name"]),
+                    self.bootloaders_dir.joinpath("grub", options["binary_name"]),
                     self.modules + options.get("extra_modules", []),
                 )
             except subprocess.CalledProcessError:

--- a/cobbler/actions/grubimage.py
+++ b/cobbler/actions/grubimage.py
@@ -11,8 +11,7 @@ import typing
 from cobbler import utils
 
 
-# NOTE: does not warrant being a class, but all Cobbler actions use a class's
-# .run() as the entrypoint
+# NOTE: does not warrant being a class, but all Cobbler actions use a class's ".run()" as the entrypoint
 class GrubImage:
     """Action to create bootable GRUB 2 images."""
 
@@ -37,9 +36,7 @@ class GrubImage:
             for f in ["pxelinux.0", "menu.c32", "ldlinux.c32", "memdisk"]
         }
 
-    def run(
-        self,
-    ):
+    def run(self):
         """Run GrubImages action."""
 
         self.create_directories()
@@ -86,9 +83,7 @@ class GrubImage:
 # NOTE: move this to cobbler.utils?
 # cobbler.utils.linkfile does a lot of things, it might be worth it to have a
 # function just for symbolic links
-def symlink(
-    target: pathlib.Path, link: pathlib.Path, skip_existing: bool = False
-) -> None:
+def symlink(target: pathlib.Path, link: pathlib.Path, skip_existing: bool = False):
     """Create a symlink LINK pointing to TARGET.
 
     :param target: File/directory that the link will point to. The file/directory must exist.
@@ -110,9 +105,7 @@ def symlink(
             raise
 
 
-def mkimage(
-    image_format: str, image_filename: pathlib.Path, modules: typing.List
-) -> None:
+def mkimage(image_format: str, image_filename: pathlib.Path, modules: typing.List):
     """Create a bootable image of GRUB using grub2-mkimage.
 
     :param image_format: Format of the image that is being created. See man(1)

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -59,7 +59,7 @@ class MkLoaders:
             return
         symlink(
             pathlib.Path("/usr/share/efi/x86_64/shim.efi"),
-            self.bootloaders_dir.joinpath(pathlib.Path("undionly.pxe")),
+            self.bootloaders_dir.joinpath(pathlib.Path("grub/shim.efi")),
             skip_existing=True
         )
 
@@ -72,7 +72,7 @@ class MkLoaders:
             return
         symlink(
             pathlib.Path("/usr/share/ipxe/undionly.kpxe"),
-            self.bootloaders_dir.joinpath(pathlib.Path("grub/shim.efi")),
+            self.bootloaders_dir.joinpath(pathlib.Path("undionly.pxe")),
             skip_existing=True
         )
 
@@ -135,6 +135,7 @@ class MkLoaders:
             symlink(
                 mod_dir,
                 self.bootloaders_dir.joinpath("grub", bl_mod_dir),
+                skip_existing=True
             )
 
     def create_directories(self):
@@ -203,6 +204,7 @@ def get_syslinux_version() -> int:
     This calls syslinux and asks for the version number.
 
     :return: The major syslinux release number.
+    :raises subprocess.CalledProcessError: Error raised by ``subprocess.run`` in case syslinux does not return zero.
     """
     # Example output: "syslinux 4.04  Copyright 1994-2011 H. Peter Anvin et al"
     cmd = ["syslinux", "-v"]

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -53,7 +53,7 @@ class MkLoaders:
         """
         TODO
         """
-        if not utils.command_existing("shim-install --help", 0):
+        if not utils.command_existing("shim-install"):
             self.logger.info("shim-install missing. This means we are probably also missing the file we require. "
                              "Bailing out of linking the shim!")
             return
@@ -80,7 +80,7 @@ class MkLoaders:
         """
         TODO
         """
-        if not utils.command_existing("syslinux", 64):
+        if not utils.command_existing("syslinux"):
             self.logger.info("syslinux command not available. Bailing out of syslinux setup!")
             return
         for target, link in self.syslinux_links.items():
@@ -101,7 +101,7 @@ class MkLoaders:
             skip_existing=True
         )
 
-        if not utils.command_existing("grub2-mkimage --help", 0):
+        if not utils.command_existing("grub2-mkimage"):
             self.logger.info("grub2-mkimage command not available. Bailing out of GRUB2 generation!")
             return
 

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -51,7 +51,7 @@ class MkLoaders:
 
     def make_shim(self):
         """
-        TODO
+        Create symlink of the shim bootloader in case it is available on the system.
         """
         if not utils.command_existing("shim-install"):
             self.logger.info("shim-install missing. This means we are probably also missing the file we require. "
@@ -65,7 +65,7 @@ class MkLoaders:
 
     def make_ipxe(self):
         """
-        TODO
+        Create symlink of the iPXE bootloader in case it is available on the system.
         """
         if not pathlib.Path("/usr/share/ipxe").exists():
             self.logger.info("ipxe directory did not exist. Bailing out of iPXE setup!")
@@ -78,7 +78,7 @@ class MkLoaders:
 
     def make_syslinux(self):
         """
-        TODO
+        Create symlink of the important syslinux bootloader files in case they are available on the system.
         """
         if not utils.command_existing("syslinux"):
             self.logger.info("syslinux command not available. Bailing out of syslinux setup!")
@@ -93,7 +93,8 @@ class MkLoaders:
 
     def make_grub(self):
         """
-        TODO
+        Create symlink of the GRUB 2 bootloader in case it is available on the system. Additionally build the loaders
+        for other architectures if the modules to do so are available.
         """
         symlink(
             pathlib.Path("/usr/share/efi/x86_64/grub.efi"),
@@ -138,7 +139,8 @@ class MkLoaders:
 
     def create_directories(self):
         """
-        Create the required directories so that this succeeds. If existing, do nothing.
+        Create the required directories so that this succeeds. If existing, do nothing. This should create the tree for
+        all supported bootloaders, regardless of the capabilities to symlink/install/build them.
         """
         if not self.bootloaders_dir.exists():
             raise FileNotFoundError("Main bootloader directory not found! Please create it yourself!")
@@ -159,7 +161,6 @@ def symlink(target: pathlib.Path, link: pathlib.Path, skip_existing: bool = Fals
     :param skip_existing: Controls if existing links are skipped, defaults to False.
     :raises FileNotFoundError: ``target`` is not an existing file.
     :raises FileExistsError: ``skip_existing`` is False and ``link`` already exists.
-    :return: None
     """
 
     if not target.exists():
@@ -181,7 +182,6 @@ def mkimage(image_format: str, image_filename: pathlib.Path, modules: typing.Lis
     :param image_filename: Location of the image that is being created.
     :param modules: List of GRUB modules to include into the image
     :raises subprocess.CalledProcessError: Error raised by ``subprocess.run``.
-    :return: None
     """
 
     if not image_filename.parent.exists():

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -14,7 +14,7 @@ from cobbler import utils
 
 
 # NOTE: does not warrant being a class, but all Cobbler actions use a class's ".run()" as the entrypoint
-class GrubImage:
+class MkLoaders:
     """Action to create bootable GRUB 2 images."""
 
     COMMON_LINKS = {
@@ -24,7 +24,7 @@ class GrubImage:
     }
 
     def __init__(self, api):
-        """GrubImage constructor.
+        """MkLoaders constructor.
 
         :param api: CobblerAPI instance for accessing settings
         """
@@ -44,7 +44,7 @@ class GrubImage:
 
         self.create_directories()
 
-        for target, link in GrubImage.COMMON_LINKS.items():
+        for target, link in MkLoaders.COMMON_LINKS.items():
             symlink(target, self.bootloaders_dir.joinpath(link), skip_existing=True)
 
         for target, link in self.syslinux_links.items():

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -28,7 +28,7 @@ from configparser import ConfigParser
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
-from cobbler.actions import status, hardlink, sync, buildiso, replicate, report, log, acl, check, reposync, grubimage
+from cobbler.actions import status, hardlink, sync, buildiso, replicate, report, log, acl, check, reposync, mkloaders
 from cobbler import autoinstall_manager, autoinstallgen, download_manager, enums, module_loader, power_manager
 from cobbler import settings, tftpgen, utils, yumgen
 from cobbler.cobbler_collections import manager
@@ -1850,9 +1850,9 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    def create_grub_images(self):
+    def mkloaders(self):
         """
         Create the GRUB installer images via this API call. It utilizes ``grub2-mkimage`` behind the curtain.
         """
-        action = grubimage.GrubImage(self)
+        action = mkloaders.MkLoaders(self)
         action.run()

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -53,7 +53,7 @@ OBJECT_ACTIONS = []
 for actions in list(OBJECT_ACTIONS_MAP.values()):
     OBJECT_ACTIONS += actions
 DIRECT_ACTIONS = ["aclsetup", "buildiso", "import", "list", "replicate", "report", "reposync", "sync",
-                  "validate-autoinstalls", "version", "signature", "hardlink", "mkgrub"]
+                  "validate-autoinstalls", "version", "signature", "hardlink", "mkloaders"]
 
 ####################################################
 
@@ -1250,9 +1250,9 @@ class CobblerCLI:
             list_items(self.remote, "file")
             print("\nmenus:")
             list_items(self.remote, "menu")
-        elif action_name == "mkgrub":
+        elif action_name == "mkloaders":
             (options, _) = self.parser.parse_args(self.args)
-            task_id = self.start_task("mkgrub", options)
+            task_id = self.start_task("mkloaders", options)
         else:
             print("No such command: %s" % action_name)
             return 1

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -165,13 +165,13 @@ class CobblerXMLRPCInterface:
                 self.options.get("iso", webdir + "/pub/generated.iso"),
                 self.options.get("profiles", None),
                 self.options.get("systems", None),
-                self.options.get("buildisodir", None),
+                self.options.get("buildisodir", ""),
                 self.options.get("distro", None),
                 self.options.get("standalone", False),
                 self.options.get("airgapped", False),
                 self.options.get("source", None),
                 self.options.get("exclude_dns", False),
-                self.options.get("xorrisofs_opts", None),
+                self.options.get("xorrisofs_opts", ""),
             )
 
         def on_done(self):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -396,12 +396,12 @@ class CobblerXMLRPCInterface:
         self.check_access(token, "sigupdate")
         return self.__start_task(runner, token, "sigupdate", "Updating Signatures", options)
 
-    def background_mkgrub(self, options, token) -> str:
+    def background_mkloaders(self, options: dict, token: str) -> str:
         def runner(self):
-            return self.api.create_grub_images()
+            return self.api.mkloaders()
 
         return self.__start_task(
-            runner, token, "create_grub_images", "Create bootable GRUB images", options
+            runner, token, "mkloaders", "Create bootable bootloader images", options
         )
 
     def get_events(self, for_user: str = "") -> dict:

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1504,30 +1504,15 @@ def is_remote_file(file) -> bool:
         return False
 
 
-def command_existing(cmd: str, expected_return_code: Optional[int]) -> bool:
+def command_existing(cmd: str) -> bool:
     r"""
     This takes a command which should be known to the system and checks if it is available.
 
-    Bash defines the exit code 127 if the command is not known to the system, so this function checks if the return
-    code is NOT 127 and then returns ``True``.
-
-    All subprocess errors are interpreted as "command not found", thus ``False`` is returned.
-
-    .. warning:: Do not use this command for things with user input. Only use hardcoded fixed commands for security
-                 reasons!
-
     :param cmd: The executable to check
-    :param expected_return_code: If this is an integer it will be checked if the int is equal to the return code by the
-                                 shell.
     :return: If the binary does not exist ``False``, otherwhise ``True``.
     """
-    try:
-        result = subprocess.run(cmd, shell=True)
-        if expected_return_code is not None and isinstance(expected_return_code, int):
-            return result.returncode == expected_return_code
-        return result.returncode != 127
-    except subprocess.SubprocessError:
-        return False
+    # https://stackoverflow.com/a/28909933
+    return shutil.which(cmd) is not None
 
 
 def subprocess_sp(cmd, shell: bool = True, input=None):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1509,7 +1509,7 @@ def command_existing(cmd: str) -> bool:
     This takes a command which should be known to the system and checks if it is available.
 
     :param cmd: The executable to check
-    :return: If the binary does not exist ``False``, otherwhise ``True``.
+    :return: If the binary does not exist ``False``, otherwise ``True``.
     """
     # https://stackoverflow.com/a/28909933
     return shutil.which(cmd) is not None

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1504,6 +1504,32 @@ def is_remote_file(file) -> bool:
         return False
 
 
+def command_existing(cmd: str, expected_return_code: Optional[int]) -> bool:
+    r"""
+    This takes a command which should be known to the system and checks if it is available.
+
+    Bash defines the exit code 127 if the command is not known to the system, so this function checks if the return
+    code is NOT 127 and then returns ``True``.
+
+    All subprocess errors are interpreted as "command not found", thus ``False`` is returned.
+
+    .. warning:: Do not use this command for things with user input. Only use hardcoded fixed commands for security
+                 reasons!
+
+    :param cmd: The executable to check
+    :param expected_return_code: If this is an integer it will be checked if the int is equal to the return code by the
+                                 shell.
+    :return: If the binary does not exist ``False``, otherwhise ``True``.
+    """
+    try:
+        result = subprocess.run(cmd, shell=True)
+        if expected_return_code is not None and isinstance(expected_return_code, int):
+            return result.returncode == expected_return_code
+        return result.returncode != 127
+    except subprocess.SubprocessError:
+        return False
+
+
 def subprocess_sp(cmd, shell: bool = True, input=None):
     """
     Call a shell process and redirect the output for internal usage.

--- a/config/bash/completion/cobbler
+++ b/config/bash/completion/cobbler
@@ -10,7 +10,7 @@ _cobbler_completions()
     cobbler_type=${COMP_WORDS[1]}
     COMPREPLY=()
     TYPE="distro profile system repo image mgmtclass package file aclsetup buildiso import list replicate report reposync sync validateks version signature hardlink"
-    ACTION="add edit copy list remove rename report"
+    ACTION="add edit copy list remove rename report mkloaders"
     opts=(
         [distro]="--ctime --depth --mtime --source-repos --tree-build-time --uid --arch --autoinstall-meta --boot-files --boot-loaders --breed --comment --fetchable-files --initrd --kernel --kernel-options --kernel-options-post --mgmt-classes --name --os-version --owners --redhat-management-key --template-files --in-place --help"
         [profile]="--ctime --depth --mtime --uid --autoinstall --autoinstall-meta --boot-files --comment --dhcp-tag --distro --enable-ipxe --enable-menu --fetchable-files --kernel-options --kernel-options-post --mgmt-classes --mgmt-parameters --name --name-servers --name-servers-search --next-server --owners --parent --proxy --redhat-management-key --repos --server --template-files --virt-auto-boot --virt-bridge --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-ram --virt-type --in-place --help"

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -55,7 +55,7 @@ bootloaders_formats:
     binary_name: grubaa64.efi
     extra_modules:
       - efinet
-  i386:
+  i386-efi:
     binary_name: bootia32.efi
   i386-pc-pxe:
     binary_name: grub.0

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -50,7 +50,8 @@ RUN zypper install --no-recommends -y \
     ipxe-bootimgs \
     grub2 \
     grub2-i386-efi \
-    grub2-x86_64-efi
+    grub2-x86_64-efi \
+    grub2-arm64-efi
 
 # Add Testuser for the PAM tests
 RUN useradd -p $(perl -e 'print crypt("test", "password")') test

--- a/tests/actions/grubimage_test.py
+++ b/tests/actions/grubimage_test.py
@@ -102,3 +102,11 @@ def test_symlink_target_missing(tmp_path):
     # Act & Assert
     with pytest.raises(FileNotFoundError):
         grubimage.symlink(target, link)
+
+
+def test_get_syslinux_version():
+    # Arrange & Act
+    result = grubimage.get_syslinux_version()
+
+    # Assert
+    assert result == 4

--- a/tests/actions/grubimage_test.py
+++ b/tests/actions/grubimage_test.py
@@ -32,8 +32,8 @@ def test_grubimage_run(api, mocker):
     test_image_creator.run()
 
     # Assert
-    # 3 common formats, 4 syslinux links and 9 common bootloader formats
-    assert grubimage.symlink.call_count == 16
+    # 3 common formats, 4 syslinux links (three in case we have syslinux 4 or less) and 9 common bootloader formats
+    assert grubimage.symlink.call_count == 15
     # 9 common bootloader formats
     assert grubimage.mkimage.call_count == 9
 
@@ -58,6 +58,7 @@ def test_mkimage(mocker):
             mkimage_args["image_format"],
             "--output",
             str(mkimage_args["image_filename"]),
+            "--prefix=",
             *mkimage_args["modules"],
         ],
         check=True,

--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -25,17 +25,18 @@ def test_grubimage_object(api):
 def test_grubimage_run(api, mocker):
     # Arrange
     test_image_creator = mkloaders.MkLoaders(api)
-    mocker.patch("cobbler.actions.grubimage.symlink", spec=cobbler.actions.mkloaders.symlink)
-    mocker.patch("cobbler.actions.grubimage.mkimage", spec=cobbler.actions.mkloaders.mkimage)
+    mocker.patch("cobbler.actions.mkloaders.symlink", spec=cobbler.actions.mkloaders.symlink)
+    mocker.patch("cobbler.actions.mkloaders.mkimage", spec=cobbler.actions.mkloaders.mkimage)
 
     # Act
     test_image_creator.run()
 
     # Assert
-    # 3 common formats, 4 syslinux links (three in case we have syslinux 4 or less) and 9 common bootloader formats
-    assert mkloaders.symlink.call_count == 15
-    # 9 common bootloader formats
-    assert mkloaders.mkimage.call_count == 9
+    # On a full install: 3 common formats, 4 syslinux links and 9 bootloader formats
+    # In our test container we have: shim (1x), ipxe (1x), syslinux v4 (3x) and 4 grubs (5x)
+    assert mkloaders.symlink.call_count == 10
+    # In our test container we have: x86_64, arm64-efi, i386-efi & i386-pc-pxe
+    assert mkloaders.mkimage.call_count == 4
 
 
 def test_mkimage(mocker):
@@ -45,7 +46,7 @@ def test_mkimage(mocker):
         "image_filename": pathlib.Path("/var/cobbler/loaders/grub/grubx64.efi"),
         "modules": ["btrfs", "ext2", "luks", "serial"],
     }
-    mocker.patch("cobbler.actions.grubimage.subprocess.run", spec=subprocess.run)
+    mocker.patch("cobbler.actions.mkloaders.subprocess.run", spec=subprocess.run)
 
     # Act
     mkloaders.mkimage(**mkimage_args)

--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -3,8 +3,8 @@ import subprocess
 
 import pytest
 
-import cobbler.actions.grubimage
-from cobbler.actions import grubimage
+import cobbler.actions.mkloaders
+from cobbler.actions import mkloaders
 from cobbler.api import CobblerAPI
 
 
@@ -15,27 +15,27 @@ def api():
 
 def test_grubimage_object(api):
     # Arrange & Act
-    test_image_creator = grubimage.GrubImage(api)
+    test_image_creator = mkloaders.MkLoaders(api)
 
     # Assert
-    assert isinstance(test_image_creator, grubimage.GrubImage)
+    assert isinstance(test_image_creator, mkloaders.MkLoaders)
     assert str(test_image_creator.syslinux_dir) == "/usr/share/syslinux"
 
 
 def test_grubimage_run(api, mocker):
     # Arrange
-    test_image_creator = grubimage.GrubImage(api)
-    mocker.patch("cobbler.actions.grubimage.symlink", spec=cobbler.actions.grubimage.symlink)
-    mocker.patch("cobbler.actions.grubimage.mkimage", spec=cobbler.actions.grubimage.mkimage)
+    test_image_creator = mkloaders.MkLoaders(api)
+    mocker.patch("cobbler.actions.grubimage.symlink", spec=cobbler.actions.mkloaders.symlink)
+    mocker.patch("cobbler.actions.grubimage.mkimage", spec=cobbler.actions.mkloaders.mkimage)
 
     # Act
     test_image_creator.run()
 
     # Assert
     # 3 common formats, 4 syslinux links (three in case we have syslinux 4 or less) and 9 common bootloader formats
-    assert grubimage.symlink.call_count == 15
+    assert mkloaders.symlink.call_count == 15
     # 9 common bootloader formats
-    assert grubimage.mkimage.call_count == 9
+    assert mkloaders.mkimage.call_count == 9
 
 
 def test_mkimage(mocker):
@@ -48,10 +48,10 @@ def test_mkimage(mocker):
     mocker.patch("cobbler.actions.grubimage.subprocess.run", spec=subprocess.run)
 
     # Act
-    grubimage.mkimage(**mkimage_args)
+    mkloaders.mkimage(**mkimage_args)
 
     # Assert
-    grubimage.subprocess.run.assert_called_once_with(
+    mkloaders.subprocess.run.assert_called_once_with(
         [
             "grub2-mkimage",
             "--format",
@@ -72,7 +72,7 @@ def test_symlink(tmp_path: pathlib.Path):
     link = tmp_path / "link"
 
     # Run
-    grubimage.symlink(target, link)
+    mkloaders.symlink(target, link)
 
     # Assert
     assert link.exists()
@@ -89,10 +89,10 @@ def test_symlink_link_exists(tmp_path):
 
     # Act
     with pytest.raises(FileExistsError):
-        grubimage.symlink(link, target, skip_existing=False)
+        mkloaders.symlink(link, target, skip_existing=False)
 
     # Assert: must not raise an exception
-    grubimage.symlink(link, target, skip_existing=True)
+    mkloaders.symlink(link, target, skip_existing=True)
 
 
 def test_symlink_target_missing(tmp_path):
@@ -102,12 +102,12 @@ def test_symlink_target_missing(tmp_path):
 
     # Act & Assert
     with pytest.raises(FileNotFoundError):
-        grubimage.symlink(target, link)
+        mkloaders.symlink(target, link)
 
 
 def test_get_syslinux_version():
     # Arrange & Act
-    result = grubimage.get_syslinux_version()
+    result = mkloaders.get_syslinux_version()
 
     # Assert
     assert result == 4

--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -106,8 +106,19 @@ def test_symlink_target_missing(tmp_path):
         mkloaders.symlink(target, link)
 
 
-def test_get_syslinux_version():
-    # Arrange & Act
+def test_get_syslinux_version(mocker):
+    # Arrange
+    mocker.patch(
+        "cobbler.actions.mkloaders.subprocess.run",
+        autospec=True,
+        return_value=subprocess.CompletedProcess(
+            "",
+            0,
+            stdout="syslinux 4.04  Copyright 1994-2011 H. Peter Anvin et al"
+        )
+    )
+
+    # Act
     result = mkloaders.get_syslinux_version()
 
     # Assert

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -645,14 +645,13 @@ def test_is_remote_file():
     assert not result
 
 
-@pytest.mark.parametrize("input_cmd,input_exit_code,expected_result", [
-    ("foobaz", None, False),
-    ("echo", None, True),
-    ("echo", -1, False),
+@pytest.mark.parametrize("input_cmd,expected_result", [
+    ("foobaz", False),
+    ("echo", True)
 ])
-def test_command_existing(input_cmd, input_exit_code, expected_result):
+def test_command_existing(input_cmd, expected_result):
     # Arrange & Act
-    result = utils.command_existing(input_cmd, input_exit_code)
+    result = utils.command_existing(input_cmd)
 
     # Assert
     assert result == expected_result

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -645,6 +645,19 @@ def test_is_remote_file():
     assert not result
 
 
+@pytest.mark.parametrize("input_cmd,input_exit_code,expected_result", [
+    ("foobaz", None, False),
+    ("echo", None, True),
+    ("echo", -1, False),
+])
+def test_command_existing(input_cmd, input_exit_code, expected_result):
+    # Arrange & Act
+    result = utils.command_existing(input_cmd, input_exit_code)
+
+    # Assert
+    assert result == expected_result
+
+
 def test_subprocess_sp():
     # Arrange
 


### PR DESCRIPTION
Currently `cobbler mkgrub` would not work correctly. This PR mainly does the following things:

- Skip `ldlinux.c32` when syslinux 4 or less is installed
- Improve logging for building GRUB2 loaders
- Add missing prefix option to the command