### PR TITLE
[Unit Testing] Added additional tftpgen.py unit test

### DIFF
--- a/tests/test_data/dummy_bootloaders/bootloader1
+++ b/tests/test_data/dummy_bootloaders/bootloader1
@@ -1,0 +1,1 @@
+i am fake bootloader data

--- a/tests/test_data/dummy_bootloaders/bootloader2
+++ b/tests/test_data/dummy_bootloaders/bootloader2
@@ -1,0 +1,1 @@
+i am fake bootloader data

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -15,7 +15,7 @@ def test_copy_bootloaders():
     generator = tftpgen.TFTPGen(test_collection_mgr)
 
     # Arrange
-    ## Dummy/empty bootloader files are staged in 'test_data'. See the below 'cp' command.
+    ## Dummy/empty bootloader files are staged in 'test_data'. See below "cp" command.
     os.system("cp -f /code/tests/test_data/dummy_bootloaders/* /var/lib/cobbler/loaders/")
     bootloader1_dst = "/srv/tftpboot/bootloader1"
     bootloader2_dst = "/srv/tftpboot/bootloader2"

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -7,6 +7,26 @@ from cobbler import tftpgen
 from cobbler.items.distro import Distro
 from tests.conftest import does_not_raise
 
+# Tests copying the bootloaders from the bootloaders_dir (setting specified in /etc/cobbler/settings.yaml) to the tftpboot directory.
+def test_copy_bootloaders():
+    # Instantiate TFTPGen class with collection_mgr parameter
+    test_api = CobblerAPI()
+    test_collection_mgr = CollectionManager(test_api)
+    generator = tftpgen.TFTPGen(test_collection_mgr)
+
+    # Arrange
+    ## Dummy/empty bootloader files are staged in 'test_data'. See the below 'cp' command.
+    os.system("cp -f /code/tests/test_data/dummy_bootloaders/* /var/lib/cobbler/loaders/")
+    bootloader1_dst = "/srv/tftpboot/bootloader1"
+    bootloader2_dst = "/srv/tftpboot/bootloader2"
+
+    # Act
+    generator.copy_bootloaders("/srv/tftpboot")
+
+    # Assert
+    assert os.path.isfile(bootloader1_dst)
+    assert os.path.isfile(bootloader2_dst)
+
 # Tests copy_single_distro_file() method using a sample initrd file pulled from Centos 8
 def test_copy_single_distro_file():
     # Instantiate TFTPGen class with collection_mgr parameter


### PR DESCRIPTION
Wrote another unit test for tftpgen.py, specifically covering the "copy_bootloaders()" method.

Running pytest results in the dummy bootloader files being copied from the staging area, to /var/lib/cobbler/loaders (defined in /etc/cobbler/settings.yaml) then rsync'd over to the tftpboot directory (also defined in settings.yaml).

![image](https://user-images.githubusercontent.com/43251403/134753705-5d6c57ee-29fa-4a43-99de-d4f04db5db68.png)
