### PR TITLE
fix: OBS build in pull requests

### DIFF
--- a/.obs/workflows.yml
+++ b/.obs/workflows.yml
@@ -3,3 +3,4 @@ workflow:
     - branch_package:
         source_project: systemsmanagement:orthos2:github_master_ci
         source_package: cobbler-master
+        target_project: home:dgedon

--- a/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
@@ -6,9 +6,6 @@ FROM registry.opensuse.org/opensuse/leap:15.3
 ENV container docker
 ENV DISTRO SUSE
 
-# Update Leap to most current packages
-RUN zypper update -y
-
 # Runtime & dev dependencies
 RUN zypper install -y          \
     acl                        \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -6,9 +6,6 @@ FROM registry.opensuse.org/opensuse/tumbleweed:latest
 ENV container docker
 ENV DISTRO SUSE
 
-# Update Leap to most current packages
-RUN zypper dup -y
-
 # Runtime & dev dependencies
 RUN zypper install -y          \
     acl                        \


### PR DESCRIPTION
This will fix the the missing builds in the OBS when creating a pull request (in the future).

See https://openbuildservice.org/2021/09/28/support-for-push-events