### PR TITLE
Do not warn users about missing files during removal

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -1239,9 +1239,9 @@ def rmfile(path: str):
         os.remove(path)
         logger.info("Successfully removed \"%s\"", path)
     except FileNotFoundError:
-        logger.warning("File to remove not found \"%s\"", path)
-    except OSError:
-        logger.warning("Could not remove file \"%s\"", path)
+        pass
+    except OSError as ioe:
+        logger.warning("Could not remove file \"%s\": %s", path, ioe.strerror)
 
 
 def rmtree_contents(path: str):


### PR DESCRIPTION
There is really no point to log the fact that the file we are trying to
remove is already gone, especially as a warning. I believe that this
logic was lost during the refactoring in 4d6faeb980d2b6f6726d319e3f418217def20023.

This bites me during the initial system creation, I see tons of error
messages like this:

  [2021-10-04_215834_sync] 2021-10-04T21:58:36 - WARNING | File to remove not found "/var/lib/tftpboot/grub/system_link/fili"
  [2021-10-04_215834_sync] 2021-10-04T21:58:36 - INFO | mkdir: /var/lib/tftpboot/grub/system_link

While there, log the reason of every other failure.