### PR TITLE
Fixed python3-magic dependency for RHEL

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -110,7 +110,9 @@
 %define grub2_x64_efi_pkg grub2-efi-x64
 %define grub2_ia32_efi_pkg grub2-efi-ia32
 %define system_release_pkg system-release
+%if 0%{?fedora}
 %define py3_module_file python%{python3_pkgversion}-file-magic
+%endif
 #endif FEDORA
 %endif
 


### PR DESCRIPTION
RHEL wants python3-magic instead of python3-file-magic.

Build tested successfully on copr for

epel-8-x86_64
fedora-33-x86_64
fedora-rawhide-x86_64
opensuse-leap-15.3-x86_64

