### PR TITLE
Test: Introduce system-test for cobbler buildiso

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -40,6 +40,7 @@ RUN zypper install --no-recommends -y \
     tree                       \
     util-linux                 \
     vim                        \
+    wget                       \
     which                      \
     xorriso
 

--- a/system-tests/tests/basic-buildiso
+++ b/system-tests/tests/basic-buildiso
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Check that Cobbler is able to build customized ISOs by the "cobbler buildiso" command
+
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+# Preparations
+cobbler distro add --name fake --arch x86_64 --kernel ${fake_kernel} --initrd ${fake_initramfs}
+
+cobbler profile add --name fake --distro fake
+
+cobbler system add --name testbed --profile fake
+
+# Tmp: Create "/var/cache/cobbler" because it does not exist per default
+mkdir -p /var/cache/cobbler/buildiso
+
+# Real test
+cobbler buildiso --tempdir="/var/cache/cobbler/buildiso" --iso ${tmp}/autoinst.iso
+
+# Check ISO exists
+[ -f ${tmp}/autoinst.iso ]
+
+# Check ISO is bootable
+cat >${tmp}/a <<-EOF
+BIOS
+UEFI
+EOF
+xorriso -indev ${tmp}/autoinst.iso -report_el_torito 2>/dev/null | awk '/^El Torito boot img[[:space:]]+:[[:space:]]+[0-9]+[[:space:]]+[a-zA-Z]+[[:space:]]+y/{print $7}' >> ${tmp}/b
+
+diff ${tmp}/{a,b}

--- a/system-tests/tests/buildiso-@
+++ b/system-tests/tests/buildiso-@
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Check that Cobbler is able to build customized ISOs by the "cobbler buildiso" command with the addition of the
+# airgapped flag
+
+source ${SYSTESTS_PRELUDE} && prepare
+
+build_iso_test=${TEST_NAME#buildiso-}
+
+trap cleanup EXIT
+
+cleanup() {
+	mountpoint -q ${mp} && umount ${mp}
+	rmdir ${mp}
+}
+
+set -x -e -o pipefail
+
+wget -P "${tmp}/" https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-x86_64-Current.iso
+mp=$(mktemp -dt leap-mp-XXX)
+mount -o loop,ro "${tmp}/openSUSE-Leap-15.3-DVD-x86_64-Current.iso" "${mp}"
+cobbler import --name leap --path "${mp}"
+
+# Preparations
+cobbler system add --name testbed --profile leap-x86_64
+
+# Tmp: Create "/var/cache/cobbler" because it does not exist per default
+mkdir -p /var/cache/cobbler/buildiso
+
+# Real test
+case ${build_iso_test} in
+    airgapped)
+        cobbler buildiso --airgapped \
+                         --distro=leap-x86_64 \
+                         --tempdir="/var/cache/cobbler/buildiso" \
+                         --iso ${tmp}/autoinst.iso
+        ;;
+    full)
+        cobbler buildiso --standalone \
+                         --distro=leap-x86_64 \
+                         --tempdir="/var/cache/cobbler/buildiso" \
+                         --iso ${tmp}/autoinst.iso
+        ;;
+    net)
+        cobbler buildiso --tempdir="/var/cache/cobbler/buildiso" --iso ${tmp}/autoinst.iso
+        ;;
+esac
+
+# Check ISO exists & is bootable
+cat >${tmp}/a <<-EOF
+BIOS
+UEFI
+EOF
+xorriso -indev ${tmp}/autoinst.iso -report_el_torito 2>/dev/null \
+    | awk '/^El Torito boot img[[:space:]]+:[[:space:]]+[0-9]+[[:space:]]+[a-zA-Z]+[[:space:]]+y/{print $7}' >>${tmp}/b
+
+diff ${tmp}/{a,b}

--- a/system-tests/tests/buildiso-airgapped
+++ b/system-tests/tests/buildiso-airgapped
@@ -1,0 +1,1 @@
+buildiso-@

--- a/system-tests/tests/buildiso-full
+++ b/system-tests/tests/buildiso-full
@@ -1,0 +1,1 @@
+buildiso-@

--- a/system-tests/tests/buildiso-net
+++ b/system-tests/tests/buildiso-net
@@ -1,0 +1,1 @@
+buildiso-@


### PR DESCRIPTION
This test is currently very basic and only checks for the existence of the ISO. In the future we should also check for the validity of
the content of the ISO. This is not yet possible as the tool for this (parti) is not yet available everywhere.

What is missing with this basic test is also the different use-cases for the buildiso command: Airgapped, Offline and Online media creation.

TODO:

- [x] ~~Make parti available everywhere~~
  - [x] ~~Debian~~
  - [x] ~~Fedora/CentOS~~
  - [x] ~~Ubuntu~~
  - [x] ~~TBD~~
- [x] Produce system test for full media (DVD image style)
- [x] Produce system test for online media (net installer style)
- [x] Produce system test for airgapped media (include all custom repos etc in the image)