### PR TITLE
[RFC] Rework serial console kernel command line parameter

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -1472,7 +1472,8 @@ SYSTEM_FIELDS = [
     ],
     ["serial_device", "", 0, "Serial Device #", True, "Serial Device Number", 0, "int"],
     [
-        "serial_baud_rate",
+        "serial_driver", "", 0, "Serial Driver #", True, "Serial Kernel Driver", 0, "str"],
+    ["serial_baud_rate",
         "",
         0,
         "Serial Baud Rate",

--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -244,6 +244,17 @@ class BaudRates(enum.Enum):
     B128000 = 128000
     B256000 = 256000
 
+class SerialDrivers(enum.Enum):
+    """
+    This enum describes all serial kernel drivers as they
+    can/have to be used via console= kernel parameter
+    """
+    UNSET = "unset"
+    NONE = "none"
+    TTYS = "ttyS"
+    TTYAMA = "ttyAMA"
+    HVC = "hvc"
+    TTYUSB = "ttyUSB"
 
 class ImageTypes(ConvertableEnum):
     """

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -811,6 +811,7 @@ class System(Item):
         self._virt_pxe_boot = False
         self._virt_ram: Union[int, str] = enums.VALUE_INHERITED
         self._virt_type = enums.VirtType.INHERITED
+        self._serial_driver = enums.SerialDrivers.UNSET
         self._serial_device = -1
         self._serial_baud_rate = enums.BaudRates.DISABLED
         self._display_name = ""
@@ -2042,6 +2043,26 @@ class System(Item):
         :param baud_rate: The new value for the ``baud_rate`` property.
         """
         self._serial_baud_rate = validate.validate_serial_baud_rate(baud_rate)
+
+    @property
+    def serial_driver(self) -> enums.SerialDrivers:
+        """
+        serial_driver property.
+
+        :getter: Returns the value for ``serial_driver``.
+        :setter: Sets the value for the property ``serial_driver``.
+        :return:
+        """
+        return self._serial_driver
+
+    @serial_driver.setter
+    def serial_driver(self, driver: str):
+        """
+        Setter for the serial_driver of the System class.
+
+        :param driver:
+        """
+        self._serial_driver = validate.validate_serial_driver(driver)
 
     @property
     def children(self) -> List[str]:

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -979,6 +979,21 @@ def subprocess_get(cmd, shell: bool = True, input=None):
     return data
 
 
+def get_default_serial_drivers(arch: enums.Archs):
+    """
+    Returns the default kernel serial console driver (console= kernel param)
+    for arch
+    :return: Returns a valid default or enums.SerialDrivers.NONE if arch is unknown
+    """
+    if arch in (enums.Archs.X86_64, enums.Archs.i386):
+        return enums.SerialDrivers.TTYS
+    elif arch in (enums.Archs.PPC, enums.Archs.PPC64, enums.Archs.PPC64LE, enums.Archs.PPC64EL):
+        return enums.SerialDrivers.HVC
+    elif arch in (enums.Archs.ARM, enums.Archs.AARCH64):
+        return enums.SerialDrivers.TTYAMA
+    else:
+        enums.SerialDrivers.NONE
+
 def get_supported_system_boot_loaders() -> List[str]:
     """
     Return the list of currently supported bootloaders.

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -505,6 +505,25 @@ def validate_serial_baud_rate(
         raise ValueError("invalid value for serial baud Rate (%s)" % baud_rate)
     return baud_rate
 
+def validate_serial_driver(driver: Union[str, str, enums.SerialDrivers]) -> enums.SerialDrivers:
+    """
+    The serial kernel driver as it can/has to be used via console= kernel parameter, e.g. ttyS
+
+    :param driver: The kernel serial driver to set.
+    :return: The validated kernel serial driver.
+    """
+    if not isinstance(driver, (str, str, enums.SerialDrivers)):
+        raise TypeError("serial kernel driver needs to be of type str or enums.SerialDrivers")
+    if isinstance(driver, str):
+        try:
+            driver = enums.SerialDrivers[driver.upper()]
+        except KeyError as error:
+            raise ValueError("Serial kernel driver choices include: %s" % list(map(str, enums.SerialDrivers))) from error
+    # Now it must be of the enum Type
+    if driver not in enums.SerialDrivers:
+        raise ValueError("invalid value for serial kernel driver (%s)" % driver)
+    return driver
+
 
 def validate_boot_remote_file(value: str) -> bool:
     """

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -368,6 +368,10 @@ manage_tftpd: true
 # Default: @@tftproot@@
 tftpboot_location: "@@tftproot@@"
 
+# Always create console= kernel boot parameter in boot loader entries
+# based on some sane defaults. E.g. on x86 it would be console=ttyS0,115200
+always_enable_serial_console: false
+
 # set to true to enable Cobbler's RSYNC management features.
 manage_rsync: false
 


### PR DESCRIPTION
Rework serial console kernel command line parameter adding kernel serial driver

The previous implementation was rather x86 specific.
This is a more generic approach and allows to use serial consoles without
specifying any additional paramters by providing a global:
always_enable_serial_console
variable. This can work smoothly if all systems are sticking to serial
console defaults.