### PR TITLE
docker: add build of debs for Debian 11 Bullseye

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -45,7 +45,7 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           ./docker/rpms/build-and-install-rpms.sh opensuse-tumbleweed docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
-  build-debian-debs:
+  build-debian10-debs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -53,3 +53,11 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           ./docker/debs/build-and-install-debs.sh deb10 docker/debs/Debian_10/Debian10.dockerfile
+  build-debian11-debs:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build a Debian 11 Package
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          ./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile

--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,9 @@ test-fedora34: ## Executes the testscript for testing cobbler in a docker contai
 test-debian10: ## Executes the testscript for testing cobbler in a docker container on Debian 10.
 	./docker/debs/build-and-install-debs.sh deb10 docker/debs/Debian_10/Debian10.dockerfile
 
+test-debian11: ## Executes the testscript for testing cobbler in a docker container on Debian 11.
+	./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile
+
 system-test: ## Runs the system tests
 	$(MAKE) -C system-tests
 

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -101,6 +101,12 @@
 %define grub2_x64_efi_pkg grub-efi-amd64
 %define grub2_ia32_efi_pkg grub-efi-ia32
 %define system_release_pkg base-files
+
+# Debian 11 moved to the C implementation of createrepo
+%if 0%{?debian} == 11
+%define createrepo_pkg createrepo-c
+%endif
+
 #endif UBUNTU
 %endif
 

--- a/docker/debs/Debian_11/Debian11.dockerfile
+++ b/docker/debs/Debian_11/Debian11.dockerfile
@@ -1,0 +1,80 @@
+# vim: ft=dockerfile
+
+FROM debian:11
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# TERM=screen is fairly neutral and works with xterm for example, for others
+# you might need to pass -e TERM=<terminal>, like rxvt-unicode.
+ENV TERM screen
+ENV OSCODENAME bullseye
+
+# Add repo for debbuild and install all packages required
+# hadolint ignore=DL3008,DL3015,DL4006
+RUN apt-get update -qq && \
+    apt-get install -qqy gnupg curl && \
+    /bin/sh -c "echo 'deb http://download.opensuse.org/repositories/Debian:/debbuild/Debian_11/ /' > /etc/apt/sources.list.d/debbuild.list" && \
+    curl -sL http://download.opensuse.org/repositories/Debian:/debbuild/Debian_11/Release.key | apt-key add - && \
+    apt-get update -qq && \
+    apt-get install -qqy \
+    debbuild \
+    debbuild-macros \
+    wget \
+    pycodestyle \
+    pyflakes3 \
+    python3-cheetah  \
+    python3-coverage \
+    python3-wheel   \
+    python3-distro \
+    python3-distutils \
+    python3-dnspython \
+    python3-dns  \
+    python3-dnsq  \
+    python3-magic  \
+    python3-ldap3 \
+    python3-netaddr \
+    python3-pip \
+    python3-pycodestyle \
+    python3-pytest \
+    python3-setuptools \
+    python3-simplejson  \
+    python3-sphinx \
+    python3-tz \
+    python3-yaml \
+    python3-schema \
+    liblocale-gettext-perl \
+    lsb-release \
+    xz-utils \
+    bzip2 \
+    dpkg-dev \
+    tftpd-hpa \
+    createrepo-c \
+    rsync \
+    xorriso\
+    fence-agents\
+    fakeroot \
+    patch \
+    pax \
+    git \
+    hardlink \
+    apache2 \
+    libapache2-mod-wsgi-py3 \
+    systemd \
+    systemd-sysv \
+    supervisor && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Make /bin/sh point to bash, not dash
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
+
+COPY ./docker/debs/Debian_11/supervisord/supervisord.conf /etc/supervisord.conf
+COPY ./docker/debs/Debian_11/supervisord/conf.d /etc/supervisord/conf.d
+
+COPY . /usr/src/cobbler
+WORKDIR /usr/src/cobbler
+
+VOLUME /usr/src/cobbler/deb-build
+
+CMD ["/bin/bash", "-c", "make debs"]

--- a/docker/debs/Debian_11/supervisord/conf.d/apache2.conf
+++ b/docker/debs/Debian_11/supervisord/conf.d/apache2.conf
@@ -1,0 +1,10 @@
+[program:apache2]
+command=/usr/sbin/apache2 -D FOREGROUND
+redirect_stderr=true
+environment=
+    APACHE_RUN_USER=www-data,
+    APACHE_RUN_GROUP=www-data,
+    APACHE_PID_FILE=/var/run/apache2/apache2.pid,
+    APACHE_RUN_DIR=/var/run/apache2,
+    APACHE_LOCK_DIR=/var/lock/apache2,
+    APACHE_LOG_DIR=/var/log/apache2,

--- a/docker/debs/Debian_11/supervisord/conf.d/cobblerd.conf
+++ b/docker/debs/Debian_11/supervisord/conf.d/cobblerd.conf
@@ -1,0 +1,3 @@
+[program:cobblerd]
+command=cobblerd -F
+redirect_stderr=true

--- a/docker/debs/Debian_11/supervisord/conf.d/tftpd.conf
+++ b/docker/debs/Debian_11/supervisord/conf.d/tftpd.conf
@@ -1,0 +1,3 @@
+[program:tftpd]
+command=/usr/sbin/in.tftpd -L -u root -s /srv/tftpboot
+redirect_stderr=true

--- a/docker/debs/Debian_11/supervisord/supervisord.conf
+++ b/docker/debs/Debian_11/supervisord/supervisord.conf
@@ -1,0 +1,15 @@
+[supervisord]
+loglevel=debug
+logfile=/var/log/supervisor/supervisor.log
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[unix_http_server]
+file=/run/supervisord.sock
+
+[include]
+files=/etc/supervisord/conf.d/*.conf
+
+[supervisorctl]
+serverurl=unix:///run/supervisord.sock

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -103,6 +103,7 @@ However we provide docker files for
 - Fedora 34
 - CentOS 8
 - Debian 10 Buster
+- Debian 11 Bullseye
 
 which will give you packages which will work better then building from source yourself.
 
@@ -114,6 +115,7 @@ To build the packages you to need to execute the following in the root folder of
 - Fedora 34: ``./docker/rpms/build-and-install-rpms.sh fc34 docker/rpms/Fedora_34/Fedora34.dockerfile``
 - CentOS 8: ``./docker/rpms/build-and-install-rpms.sh el8 docker/rpms/CentOS_8/CentOS8.dockerfile``
 - Debian 10: ``./docker/debs/build-and-install-debs.sh deb10 docker/debs/Debian_10/Debian10.dockerfile``
+- Debian 11: ``./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile``
 
 After executing the scripts you should have one folder owned by ``root`` which was created during the build. It is
 either called ``rpm-build`` or ``deb-build``. In these directories you should find the built packages. They are


### PR DESCRIPTION
This commit adds a Dockerfile to build the debs for Debian 11. For the
build to succeed, update the file cobbler.spec to define the correct
package name in createrepo_pkg since Debian 11 moved to the C
implementation of createrepo.

Update the installation guide to provide the build and install command
for Debian 11. Also add Debian 11 to the Makefile and GH Action jobs.