### PR TITLE
Support for older anaconda boot line options

### DIFF
--- a/cobbler/actions/buildiso.py
+++ b/cobbler/actions/buildiso.py
@@ -217,10 +217,13 @@ class BuildIso:
                 else:
                     append_line += " autoyast=%s" % data["autoinstall"]
 
-            if dist.breed == "redhat":
+            if dist.breed in ["redhat", "redhatlegacy"]:
                 if "proxy" in data and data["proxy"] != "":
                     append_line += " proxy=%s http_proxy=%s" % (data["proxy"], data["proxy"])
-                append_line += " inst.ks=%s" % data["autoinstall"]
+                if dist.breed == "redhat":
+                    append_line += " inst.ks=%s" % data["autoinstall"]
+                else:
+                    append_line += " ks=%s" % data["autoinstall"]
 
             if dist.breed in ["ubuntu", "debian"]:
                 append_line += " auto-install/enable=true url=%s" % data["autoinstall"]
@@ -267,10 +270,13 @@ class BuildIso:
                 else:
                     append_line += " autoyast=%s" % data["autoinstall"]
 
-            if dist.breed == "redhat":
+            if dist.breed in ["redhat", "redhatlegacy"]:
                 if "proxy" in data and data["proxy"] != "":
                     append_line += " proxy=%s http_proxy=%s" % (data["proxy"], data["proxy"])
-                append_line += " inst.ks=%s" % data["autoinstall"]
+                if dist.breed == "redhat":
+                    append_line += " inst.ks=%s" % data["autoinstall"]
+                else:
+                    append_line += " ks=%s" % data["autoinstall"]
 
             if dist.breed in ["ubuntu", "debian"]:
                 append_line += " auto-install/enable=true url=%s netcfg/disable_autoconfig=true" % data["autoinstall"]
@@ -537,6 +543,8 @@ class BuildIso:
             cfg.write("  kernel %s\n" % os.path.basename(distro.kernel))
 
             append_line = "  append initrd=%s" % os.path.basename(distro.initrd)
+            if distro.breed == "redhatlegacy":
+                append_line += " ks=cdrom:/isolinux/%s.cfg" % descendant.name
             if distro.breed == "redhat":
                 append_line += " inst.ks=cdrom:/isolinux/%s.cfg" % descendant.name
             if distro.breed == "suse":

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -866,11 +866,12 @@ class TFTPGen:
 
             if distro.breed in [None, "redhat", "redhatlegacy"]:
 
-                append_line += " kssendmac"
                 if distro.breed == "redhatlegacy":
-                    append_line = "%s ks=%s" % (append_line, autoinstall_path)
+                    append_line += " kssendmac"
+                    append_line += "%s ks=%s" % (append_line, autoinstall_path)
                 else:
-                    append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
+                    append_line += " inst.ks.sendmac"
+                    append_line += "%s inst.ks=%s" % (append_line, autoinstall_path)
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -867,11 +867,9 @@ class TFTPGen:
             if distro.breed in [None, "redhat", "redhatlegacy"]:
 
                 if distro.breed == "redhatlegacy":
-                    append_line += " kssendmac"
-                    append_line += "%s ks=%s" % (append_line, autoinstall_path)
+                    append_line += " kssendmac ks=%s" % autoinstall_path
                 else:
-                    append_line += " inst.ks.sendmac"
-                    append_line += "%s inst.ks=%s" % (append_line, autoinstall_path)
+                    append_line += " inst.ks.sendmac inst.ks=%s" % autoinstall_path
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -864,10 +864,13 @@ class TFTPGen:
                     autoinstall_path = "http://%s/cblr/svc/op/autoinstall/profile/%s" \
                                        % (httpserveraddress, profile.name)
 
-            if distro.breed is None or distro.breed == "redhat":
+            if distro.breed in [None, "redhat", "redhatlegacy"]:
 
                 append_line += " kssendmac"
-                append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
+                if distro.breed == "redhatlegacy":
+                    append_line = "%s ks=%s" % (append_line, autoinstall_path)
+                else:
+                    append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -84,6 +84,33 @@
         "kernel_options": "",
         "kernel_options_post": "",
         "boot_files": []
+      },
+      "fedora16": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "(fedora)-release-16-(.*)\\.noarch\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "x86_64",
+          "ppc",
+          "ppc64"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
       }
     },
     "redhat": {
@@ -164,33 +191,6 @@
         ],
         "supported_repo_breeds": [
           "rsync",
-          "yum"
-        ],
-        "kernel_file": "vmlinuz(.*)",
-        "initrd_file": "initrd(.*)\\.img",
-        "isolinux_ok": false,
-        "default_autoinstall": "sample.ks",
-        "kernel_options": "",
-        "kernel_options_post": "",
-        "boot_files": []
-      },
-      "fedora16": {
-        "signatures": [
-          "Packages"
-        ],
-        "version_file": "(fedora)-release-16-(.*)\\.noarch\\.rpm",
-        "version_file_regex": null,
-        "kernel_arch": "kernel-(.*)\\.rpm",
-        "kernel_arch_regex": null,
-        "supported_arches": [
-          "i386",
-          "x86_64",
-          "ppc",
-          "ppc64"
-        ],
-        "supported_repo_breeds": [
-          "rsync",
-          "rhn",
           "yum"
         ],
         "kernel_file": "vmlinuz(.*)",

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -1,6 +1,6 @@
 {
   "breeds": {
-    "redhat": {
+    "redhatlegacy": {
       "rhel4": {
         "signatures": [
           "RedHat/RPMS",
@@ -84,7 +84,9 @@
         "kernel_options": "",
         "kernel_options_post": "",
         "boot_files": []
-      },
+      }
+    },
+    "redhat": {
       "rhel7": {
         "signatures": [
           "Packages"

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -32,7 +32,7 @@ def test_validate_os_version():
     utils.load_signatures("/var/lib/cobbler/distro_signatures.json")
 
     # Act
-    result = validate.validate_os_version("rhel4", "redhat")
+    result = validate.validate_os_version("rhel4", "redhatlegacy")
 
     # Assert
     assert result == "rhel4"


### PR DESCRIPTION
Prior to RHEL 7 (and Fedora 17), anaconda was using different boot line options.
Cobbler has been (partially) switched to the newer options with https://github.com/cobbler/cobbler/commit/902d0c43b861f4eae360861acf1f07ced74a0648. However, while this allows cobbler to work with anaconda versions that have removed the deprecated options (like CentOS Stream 9), this breaks anaconda versions that don't have the newer options, that is everything earlier than RHEL 7 and Fedora 17. All these distributions are indeed not supported anymore, but there are still use cases where installing these legacy distros is needed.

This PR adds a 'redhatlegacy' breed, which supports the older anaconda options.
It also converts the legacy 'kssendmac' to 'inst.ks.sendmac', where applicable.