### PR TITLE
Support for older anaconda boot line options

### DIFF
--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -371,7 +371,7 @@ class AppendLineBuilder:
         self.append_line += buildiso.add_remaining_kopts(self.data["kernel_options"])
         return self.append_line
 
-    def generate_profile(self, distro_breed: str) -> str:
+    def generate_profile(self, distro_breed: str, os_version: str) -> str:
         """
         Generate the append line for the kernel for a network installation.
         :param distro_breed: The name of the distribution breed.
@@ -509,7 +509,7 @@ class NetbootBuildiso(buildiso.BuildIso):
             )
 
         append_builder = AppendLineBuilder(distro_name=distname, data=data)
-        append_line = append_builder.generate_profile(dist.breed)
+        append_line = append_builder.generate_profile(dist.breed, dist.os_version)
         cfglines.append(append_line)
 
     def generate_netboot_iso(

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -211,7 +211,10 @@ class AppendLineBuilder:
                 self.data["proxy"],
                 self.data["proxy"],
             )
-        self.append_line += " inst.ks=%s" % self.data["autoinstall"]
+        if self.dist.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+            self.append_line += " ks=%s" % self.data["autoinstall"]
+        else:
+            self.append_line += " inst.ks=%s" % self.data["autoinstall"]
 
     def _generate_append_debian(self, system):
         """
@@ -406,7 +409,10 @@ class AppendLineBuilder:
                     self.data["proxy"],
                     self.data["proxy"],
                 )
-            self.append_line += " inst.ks=%s" % self.data["autoinstall"]
+            if os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+                self.append_line += " ks=%s" % self.data["autoinstall"]
+            else:
+                self.append_line += " inst.ks=%s" % self.data["autoinstall"]
         elif distro_breed in ["ubuntu", "debian"]:
             self.append_line += (
                 " auto-install/enable=true url=%s" % self.data["autoinstall"]

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -25,7 +25,10 @@ def _generate_append_line_standalone(data: dict, distro, descendant) -> str:
     """
     append_line = "  append initrd=%s" % os.path.basename(distro.initrd)
     if distro.breed == "redhat":
-        append_line += " inst.ks=cdrom:/isolinux/%s.cfg" % descendant.name
+        if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+            append_line += " ks=cdrom:/isolinux/%s.cfg" % descendant.name
+        else:
+            append_line += " inst.ks=cdrom:/isolinux/%s.cfg" % descendant.name
     elif distro.breed == "suse":
         append_line += (
             " autoyast=file:///isolinux/%s.cfg install=cdrom:///" % descendant.name

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -866,9 +866,10 @@ class TFTPGen:
                                        % (httpserveraddress, profile.name)
 
             if distro.breed is None or distro.breed == "redhat":
-
-                append_line += " kssendmac"
-                append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
+                if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+                    append_line += " kssendmac ks=%s" % autoinstall_path
+                else:
+                    append_line += " inst.ks.sendmac inst.ks=%s" % autoinstall_path
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')

--- a/tests/actions/buildiso_test.py
+++ b/tests/actions/buildiso_test.py
@@ -282,6 +282,39 @@ class TestAppendLineBuilder:
             == " append initrd=testdistro.img install=http://192.168.1.1:80/cblr/links/testdistro autoyast=default.ks"
         )
 
+        # Arrange
+        folder = create_kernel_initrd(fk_kernel, fk_initrd)
+        kernel_path = os.path.join(folder, fk_kernel)
+        initrd_path = os.path.join(folder, fk_initrd)
+        test_distro = Distro(api)
+        test_distro.name = "testdistro"
+        test_distro.breed = "redhat"
+        test_distro.kernel = kernel_path
+        test_distro.initrd = initrd_path
+        api.add_distro(test_distro)
+        test_profile = Profile(api)
+        test_profile.name = "testprofile"
+        test_profile.distro = test_distro.name
+        api.add_profile(test_profile)
+        test_system = System(api)
+        test_system.name = "testsystem"
+        test_system.profile = test_profile.name
+        api.add_system(test_system)
+        blendered_data = utils.blender(api, False, test_system)
+        test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+        # Act
+        result = test_builder.generate_system(test_distro, test_system, False)
+
+        # Assert
+        # Very basic test yes but this is the expected result atm
+        # TODO: Make tests more sophisticated
+        assert (
+            result
+            == " append initrd=testdistro.img inst.ks=default.ks"
+        )
+
+
     def test_generate_profile(
         self, api, create_kernel_initrd, fk_kernel, fk_initrd, cleanup_items
     ):
@@ -310,4 +343,58 @@ class TestAppendLineBuilder:
         assert (
             result
             == " append initrd=testdistro.img install=http://192.168.1.1:80/cblr/links/testdistro autoyast=default.ks"
+        )
+
+        # Arrange
+        folder = create_kernel_initrd(fk_kernel, fk_initrd)
+        kernel_path = os.path.join(folder, fk_kernel)
+        initrd_path = os.path.join(folder, fk_initrd)
+        test_distro = Distro(api)
+        test_distro.name = "testdistro"
+        test_distro.kernel = kernel_path
+        test_distro.initrd = initrd_path
+        api.add_distro(test_distro)
+        test_profile = Profile(api)
+        test_profile.name = "testprofile"
+        test_profile.distro = test_distro.name
+        api.add_profile(test_profile)
+        blendered_data = utils.blender(api, False, test_profile)
+        test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+        # Act
+        result = test_builder.generate_profile("redhat", "rhel7")
+
+        # Assert
+        # Very basic test yes but this is the expected result atm
+        # TODO: Make tests more sophisticated
+        assert (
+            result
+            == " append initrd=testdistro.img inst.ks=default.ks"
+        )
+
+        # Arrange
+        folder = create_kernel_initrd(fk_kernel, fk_initrd)
+        kernel_path = os.path.join(folder, fk_kernel)
+        initrd_path = os.path.join(folder, fk_initrd)
+        test_distro = Distro(api)
+        test_distro.name = "testdistro"
+        test_distro.kernel = kernel_path
+        test_distro.initrd = initrd_path
+        api.add_distro(test_distro)
+        test_profile = Profile(api)
+        test_profile.name = "testprofile"
+        test_profile.distro = test_distro.name
+        api.add_profile(test_profile)
+        blendered_data = utils.blender(api, False, test_profile)
+        test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+        # Act
+        result = test_builder.generate_profile("redhat", "rhel6")
+
+        # Assert
+        # Very basic test yes but this is the expected result atm
+        # TODO: Make tests more sophisticated
+        assert (
+            result
+            == " append initrd=testdistro.img ks=default.ks"
         )

--- a/tests/actions/buildiso_test.py
+++ b/tests/actions/buildiso_test.py
@@ -302,7 +302,7 @@ class TestAppendLineBuilder:
         test_builder = AppendLineBuilder(test_distro.name, blendered_data)
 
         # Act
-        result = test_builder.generate_profile("suse")
+        result = test_builder.generate_profile("suse", "opensuse15generic")
 
         # Assert
         # Very basic test yes but this is the expected result atm


### PR DESCRIPTION
Prior to RHEL 7 (and Fedora 17), anaconda was using different boot line options.
Cobbler has been (partially) switched to the newer options with 902d0c4. However, while this allows cobbler to work with anaconda versions that have removed the deprecated options (like CentOS Stream 9), this breaks anaconda versions that don't have the newer options, that is everything earlier than RHEL 7 and Fedora 17. All these distributions are indeed not supported anymore, but there are still use cases where installing these legacy distros is needed.

This adds checks for the distro os version in order to properly set the anaconda options.
It also takes care of the legacy 'kssendmac' which has been replaced by 'inst.ks.sendmac'.