### PR TITLE
Fix RHEL / Fedora arches in signatures

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -12,9 +12,11 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "i386",
-          "x86_64",
+          "ia64",
           "ppc",
-          "ppc64"
+          "s390",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -42,9 +42,10 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "i386",
-          "x86_64",
+          "ia64",
           "ppc",
-          "ppc64"
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -129,11 +129,10 @@
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
-          "i386",
-          "x86_64",
-          "ppc",
-          "ppc64",
-          "ppc64le"
+          "aarch64",
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -208,10 +208,14 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "arm",
+          "armhfp",
           "i386",
           "x86_64",
           "ppc",
-          "ppc64"
+          "ppc64",
+          "s390",
+          "s390x"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -235,10 +239,14 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "arm",
+          "armhfp",
           "i386",
-          "x86_64",
           "ppc",
-          "ppc64"
+          "ppc64",
+          "x86_64",
+          "s390",
+          "s390x"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -262,10 +270,13 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "arm",
           "i386",
-          "x86_64",
           "ppc",
-          "ppc64"
+          "ppc64",
+          "s390",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -289,10 +300,13 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "armhfp",
           "i386",
-          "x86_64",
           "ppc",
-          "ppc64"
+          "ppc64",
+          "s390",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -321,11 +335,14 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -354,11 +371,14 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -387,11 +407,14 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -420,11 +443,13 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -453,11 +478,13 @@
         "kernel_arch": "kernel-(.*)\\.rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
+          "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -487,10 +514,12 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -520,10 +549,12 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -553,10 +584,12 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -586,10 +619,11 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -619,9 +653,11 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
+          "armhfp",
           "i386",
-          "x86_64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -651,9 +687,10 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
-          "i386",
-          "x86_64",
-          "ppc64le"
+          "armhfp",
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -683,9 +720,10 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
-          "i386",
-          "x86_64",
-          "ppc64le"
+          "armhfp",
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -715,9 +753,10 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
-          "i386",
-          "x86_64",
-          "ppc64le"
+          "armhfp",
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",
@@ -747,9 +786,10 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "aarch64",
-          "i386",
-          "x86_64",
-          "ppc64le"
+          "armhfp",
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -94,10 +94,12 @@
         "kernel_arch": "kernel-(.*).rpm",
         "kernel_arch_regex": null,
         "supported_arches": [
-          "i386",
-          "x86_64",
+          "aarch64",
+          "ppc",
           "ppc64",
-          "ppc64le"
+          "ppc64le",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -69,8 +69,9 @@
         "kernel_arch_regex": null,
         "supported_arches": [
           "i386",
-          "x86_64",
-          "ppc64"
+          "ppc64",
+          "s390x",
+          "x86_64"
         ],
         "supported_repo_breeds": [
           "rsync",


### PR DESCRIPTION
While looking at adding Fedora 35 and RHEL 9 signatures (#2894), I noticed the arches list for older Fedora and RHEL releases are like ly not correct, so here's a try at fixing this. I'm not sure this is 100% correct for RHEL 4, 5 and 6, so please double check I did not got anything wrong.