### PR TITLE
Fixes issue #2828 by converting arch from enums.Archs to enums.RepoArchs

### DIFF
--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -423,7 +423,13 @@ class Repo(item.Item):
                 arch = enums.RepoArchs[arch.upper()]
             except KeyError as error:
                 raise ValueError("arch choices include: %s" % list(map(str, enums.RepoArchs))) from error
-        # Now the arch MUST be of the type of enums.
+        # Convert an arch which came in as an enums.Archs
+        if isinstance(arch, enums.Archs):
+            try:
+                arch = enums.RepoArchs[arch.name.upper()]
+            except KeyError as error:
+                raise ValueError("arch choices include: %s" % list(map(str, enums.RepoArchs))) from error
+        # Now the arch MUST be of the type of enums.RepoArchs
         if not isinstance(arch, enums.RepoArchs):
             raise TypeError("arch needs to be of type enums.RepoArchs")
         self._arch = arch


### PR DESCRIPTION
Ubuntu 20.04 now imports

Fixes #2828 