### PR TITLE
Enums: Create general str to enum converter

### DIFF
--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -1,17 +1,46 @@
 """
-TODO
+This module is responsible for containing all enums we use in Cobbler. It should not be dependent upon any other module
+except the Python standard library.
 """
 
 import enum
+from typing import Union
 
 VALUE_INHERITED = "<<inherit>>"
 VALUE_NONE = "none"
 
 
-class ResourceAction(enum.Enum):
+class ConvertableEnum(enum.Enum):
+    """
+    Abstract class to convert the enum via our convert method.
+    """
+
+    @classmethod
+    def to_enum(cls, value: Union[str, "ConvertableEnum"]) -> "ConvertableEnum":
+        """
+        This method converts the chosen str to the corresponding enum type.
+
+        :param value: str which contains the to be converted value.
+        :returns: The enum value.
+        :raises TypeError: In case value was not of type str.
+        :raises ValueError: In case value was not in the range of valid values.
+        """
+        try:
+            if isinstance(value, str):
+                return cls[value.upper()]
+            elif isinstance(value, cls):
+                return value
+            else:
+                raise TypeError(f"{value} must be a str or Enum")
+        except KeyError:
+            raise ValueError(f"{value} must be one of {list(cls)}")
+
+
+class ResourceAction(ConvertableEnum):
     """
     This enum represents all actions a resource may execute.
     """
+
     CREATE = "create"
     REMOVE = "remove"
 
@@ -20,6 +49,7 @@ class NetworkInterfaceType(enum.Enum):
     """
     This enum represents all interface types Cobbler is able to set up on a target host.
     """
+
     NA = 0
     BOND = 1
     BOND_SLAVE = 2
@@ -30,10 +60,11 @@ class NetworkInterfaceType(enum.Enum):
     INFINIBAND = 7
 
 
-class RepoBreeds(enum.Enum):
+class RepoBreeds(ConvertableEnum):
     """
     This enum describes all repository breeds Cobbler is able to manage.
     """
+
     NONE = VALUE_NONE
     RSYNC = "rsync"
     RHN = "rhn"
@@ -42,11 +73,12 @@ class RepoBreeds(enum.Enum):
     WGET = "wget"
 
 
-class RepoArchs(enum.Enum):
+class RepoArchs(ConvertableEnum):
     """
     This enum describes all repository architectures Cobbler is able to serve in case the content of the repository is
     serving the same architecture.
     """
+
     NONE = VALUE_NONE
     I386 = "i386"
     X86_64 = "x86_64"
@@ -62,10 +94,11 @@ class RepoArchs(enum.Enum):
     SRC = "src"
 
 
-class Archs(enum.Enum):
+class Archs(ConvertableEnum):
     """
     This enum describes all system architectures which Cobbler is able to provision.
     """
+
     I386 = "i386"
     X86_64 = "x86_64"
     IA64 = "ia64"
@@ -79,11 +112,12 @@ class Archs(enum.Enum):
     AARCH64 = "aarch64"
 
 
-class VirtType(enum.Enum):
+class VirtType(ConvertableEnum):
     """
     This enum represents all known types of virtualization Cobbler is able to handle via Koan.
     """
-    INHERTIED = VALUE_INHERITED
+
+    INHERITED = VALUE_INHERITED
     QEMU = "qemu"
     KVM = "kvm"
     XENPV = "xenpv"
@@ -94,10 +128,11 @@ class VirtType(enum.Enum):
     AUTO = "auto"
 
 
-class VirtDiskDrivers(enum.Enum):
+class VirtDiskDrivers(ConvertableEnum):
     """
     This enum represents all virtual disk driver Cobbler can handle.
     """
+
     INHERTIED = VALUE_INHERITED
     RAW = "raw"
     QCOW2 = "qcow2"
@@ -110,6 +145,7 @@ class BaudRates(enum.Enum):
     """
     This enum describes all baud rates which are commonly used.
     """
+
     B0 = 0
     B110 = 110
     B300 = 300
@@ -127,29 +163,32 @@ class BaudRates(enum.Enum):
     B256000 = 256000
 
 
-class ImageTypes(enum.Enum):
+class ImageTypes(ConvertableEnum):
     """
     This enum represents all image types which Cobbler can manage.
     """
+
     DIRECT = "direct"
     ISO = "iso"
     MEMDISK = "memdisk"
     VIRT_CLONE = "virt-clone"
 
 
-class MirrorType(enum.Enum):
+class MirrorType(ConvertableEnum):
     """
     This enum represents all mirror types which Cobbler can manage.
     """
+
     METALINK = "metalink"
     MIRRORLIST = "mirrorlist"
     BASEURL = "baseurl"
 
 
-class TlsRequireCert(enum.Enum):
+class TlsRequireCert(ConvertableEnum):
     """
     This enum represents all TLS validation server cert types which Cobbler can manage.
     """
+
     NEVER = "never"
     ALLOW = "allow"
     DEMAND = "demand"

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -393,7 +393,7 @@ class Distro(item.Item):
 
         :param arch: The architecture of the operating system distro.
         """
-        self._arch = validate.validate_arch(arch)
+        self._arch = enums.Archs.to_enum(arch)
 
     @property
     def supported_boot_loaders(self):

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -119,7 +119,7 @@ class Image(item.Item):
 
         :param arch: The new architecture to set.
         """
-        self._arch = validate.validate_arch(arch)
+        self._arch = enums.Archs.to_enum(arch)
 
     @property
     def autoinstall(self) -> str:
@@ -392,7 +392,7 @@ class Image(item.Item):
 
         :param driver: The virtual disk driver which will be set.
         """
-        self._virt_disk_driver = validate.validate_virt_disk_driver(driver)
+        self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
     @property
     def virt_ram(self) -> int:
@@ -430,7 +430,7 @@ class Image(item.Item):
 
         :param vtype: May be one of "qemu", "kvm", "xenpv", "xenfv", "vmware", "vmwarew", "openvz" or "auto".
         """
-        self._virt_type = validate.validate_virt_type(vtype)
+        self._virt_type = enums.VirtType.to_enum(vtype)
 
     @property
     def virt_bridge(self) -> str:

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -576,7 +576,7 @@ class Profile(item.Item):
 
         :param driver: The new driver.
         """
-        self._virt_disk_driver = validate.validate_virt_disk_driver(driver)
+        self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
     @property
     def virt_ram(self) -> int:
@@ -614,7 +614,7 @@ class Profile(item.Item):
 
         :param vtype: May be on out of "qemu", "kvm", "xenpv", "xenfv", "vmware", "vmwarew", "openvz" or "auto".
         """
-        self._virt_type = validate.validate_virt_type(vtype)
+        self._virt_type = enums.VirtType.to_enum(vtype)
 
     @property
     def virt_bridge(self) -> str:

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -356,17 +356,7 @@ class Repo(item.Item):
         :raises TypeError: In case the value was not of the corresponding enum type.
         :raises ValueError: In case a ``str`` with could not be converted to a valid breed.
         """
-        # Convert an arch which came in as a string
-        if isinstance(breed, str):
-            try:
-                breed = enums.RepoBreeds[breed.upper()]
-            except KeyError as error:
-                raise ValueError("invalid value for --breed (%s), must be one of %s, different breeds have different "
-                                 "levels of support " % (breed, list(map(str, enums.RepoBreeds)))) from error
-        # Now the arch MUST be of the type of enums.
-        if not isinstance(breed, enums.RepoBreeds):
-            raise TypeError("breed needs to be of type enums.RepoBreeds")
-        self._breed = breed
+        self._breed = enums.RepoBreeds.to_enum(breed)
 
     @property
     def os_version(self) -> str:
@@ -417,22 +407,13 @@ class Repo(item.Item):
         :raises TypeError: In case the wrong type is given.
         :raises ValueError: In case the value could not be converted from ``str`` to the enum type.
         """
-        # Convert an arch which came in as a string
-        if isinstance(arch, str):
-            try:
-                arch = enums.RepoArchs[arch.upper()]
-            except KeyError as error:
-                raise ValueError("arch choices include: %s" % list(map(str, enums.RepoArchs))) from error
         # Convert an arch which came in as an enums.Archs
         if isinstance(arch, enums.Archs):
             try:
                 arch = enums.RepoArchs[arch.name.upper()]
             except KeyError as error:
                 raise ValueError("arch choices include: %s" % list(map(str, enums.RepoArchs))) from error
-        # Now the arch MUST be of the type of enums.RepoArchs
-        if not isinstance(arch, enums.RepoArchs):
-            raise TypeError("arch needs to be of type enums.RepoArchs")
-        self._arch = arch
+        self._arch = enums.RepoArchs.to_enum(arch)
 
     @property
     def mirror_locally(self) -> bool:

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -89,16 +89,7 @@ class Resource(item.Item):
         :raise ValueError: Raised in case wrong value is provided.
         :raise TypeError: Raised in case ``action`` is no ``enums.ResourceAction``.
         """
-        # Convert an action which came in as a string
-        if isinstance(action, str):
-            try:
-                action = enums.ResourceAction[action.upper()]
-            except KeyError as error:
-                raise ValueError("action choices include: %s" % list(map(str, enums.ResourceAction))) from error
-        # Now the action MUST be of the type of enums.
-        if not isinstance(action, enums.ResourceAction):
-            raise TypeError("action needs to be of type enums.ResourceAction")
-        self._action = action
+        self._action = enums.ResourceAction.to_enum(action)
 
     @property
     def group(self) -> str:

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -399,8 +399,7 @@ class NetworkInterface:
         """
         Setter for the interface_type of the NetworkInterface class.
 
-
-        :param intf_type:
+        :param intf_type: The interface type to be set. Will be autoconverted to the enum type if possible.
         """
         if not isinstance(intf_type, (enums.NetworkInterfaceType, int, str)):
             raise TypeError("interface intf_type type must be of int, str or enums.NetworkInterfaceType")
@@ -795,7 +794,7 @@ class System(Item):
         self._virt_path = enums.VALUE_INHERITED
         self._virt_pxe_boot = False
         self._virt_ram : Union[int, str] = enums.VALUE_INHERITED
-        self._virt_type = enums.VirtType.INHERTIED
+        self._virt_type = enums.VirtType.INHERITED
         self._serial_device = 0
         self._serial_baud_rate = enums.BaudRates.B0
 
@@ -1582,7 +1581,7 @@ class System(Item):
 
         :param driver:
         """
-        self._virt_disk_driver = validate.validate_virt_disk_driver(driver)
+        self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
     @property
     def virt_auto_boot(self) -> bool:
@@ -1666,7 +1665,7 @@ class System(Item):
 
         :param vtype:
         """
-        self._virt_type = validate.validate_virt_type(vtype)
+        self._virt_type = enums.VirtType.to_enum(vtype)
 
     @property
     def virt_path(self) -> str:

--- a/cobbler/modules/authentication/ldap.py
+++ b/cobbler/modules/authentication/ldap.py
@@ -23,7 +23,6 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import traceback
 
 from cobbler.cexceptions import CX
-from cobbler import validate
 from cobbler import enums
 
 
@@ -106,7 +105,7 @@ def authenticate(api_handle, username, password) -> bool:
         if tls_certfile:
             ldaps_tls.set_option(ldap.OPT_X_TLS_CERTFILE, tls_certfile)
         if tls_reqcert:
-            req_cert = validate.validate_ldap_tls_reqcert(tls_reqcert)
+            req_cert = enums.TlsRequireCert.to_enum(tls_reqcert)
             reqcert_types = {enums.TlsRequireCert.NEVER: ldap.OPT_X_TLS_NEVER,
                              enums.TlsRequireCert.ALLOW: ldap.OPT_X_TLS_ALLOW,
                              enums.TlsRequireCert.DEMAND: ldap.OPT_X_TLS_DEMAND,

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -208,7 +208,7 @@ def name_servers_search(search: Union[str, list], for_item: bool = True) -> Unio
     Validate nameservers search domains.
 
     :param search: One or more search domains to validate.
-    :param for_item: (enable/disable special handling for Item objects)
+    :param for_item: enable/disable special handling for Item objects
     :return: The list of valid nameservers.
     :raises TypeError: Raised if ``search`` is not a string or list.
     """
@@ -282,26 +282,6 @@ def validate_os_version(os_version: str, breed: str) -> str:
     return os_version
 
 
-def validate_arch(arch: Union[str, enums.Archs]) -> enums.Archs:
-    """
-    This is a validator for system architectures. If the arch is not valid then an exception is raised.
-
-    :param arch: The desired architecture to set for the object.
-    :raises TypeError: In case the any type other then str or enums.Archs was supplied.
-    :raises ValueError: In case the supplied str could not be converted.
-    """
-    # Convert an arch which came in as a string
-    if isinstance(arch, str):
-        try:
-            arch = enums.Archs[arch.upper()]
-        except KeyError as error:
-            raise ValueError("arch choices include: %s" % list(map(str, enums.Archs))) from error
-    # Now the arch MUST be from the type for the enum.
-    if not isinstance(arch, enums.Archs):
-        raise TypeError("arch needs to be of type enums.Archs")
-    return arch
-
-
 def validate_repos(repos: list, api, bypass_check: bool = False):
     """
     This is a setter for the repository.
@@ -363,28 +343,6 @@ def validate_virt_file_size(num: Union[str, int, float]):
     return num
 
 
-def validate_virt_disk_driver(driver: Union[enums.VirtDiskDrivers, str]):
-    """
-    For Virt only. Specifies the on-disk format for the virtualized disk
-
-    :param driver: The virt driver to set.
-    """
-    if not isinstance(driver, (str, enums.VirtDiskDrivers)):
-        raise TypeError("driver needs to be of type str or enums.VirtDiskDrivers")
-    # Convert an driver which came in as a string
-    if isinstance(driver, str):
-        if driver == enums.VALUE_INHERITED:
-            return enums.VirtDiskDrivers.INHERTIED
-        try:
-            driver = enums.VirtDiskDrivers[driver.upper()]
-        except KeyError as error:
-            raise ValueError("driver choices include: %s" % list(map(str, enums.VirtDiskDrivers))) from error
-    # Now the arch MUST be from the type for the enum.
-    if driver not in enums.VirtDiskDrivers:
-        raise ValueError("invalid virt disk driver type (%s)" % driver)
-    return driver
-
-
 def validate_virt_auto_boot(value: bool) -> bool:
     """
     For Virt only.
@@ -439,28 +397,6 @@ def validate_virt_ram(value: Union[int, str]) -> Union[str, int]:
         raise ValueError("The virt_ram needs to have a value greater or equal to zero. Zero means default RAM."
                          % str(value))
     return interger_number
-
-
-def validate_virt_type(vtype: Union[enums.VirtType, str]):
-    """
-    Virtualization preference, can be overridden by koan.
-
-    :param vtype: May be one of "qemu", "kvm", "xenpv", "xenfv", "vmware", "vmwarew", "openvz" or "auto"
-    """
-    if not isinstance(vtype, (str, enums.VirtType)):
-        raise TypeError("driver needs to be of type str or enums.VirtDiskDrivers")
-    # Convert an arch which came in as a string
-    if isinstance(vtype, str):
-        if vtype == enums.VALUE_INHERITED:
-            return enums.VALUE_INHERITED
-        try:
-            vtype = enums.VirtType[vtype.upper()]
-        except KeyError as error:
-            raise ValueError("vtype choices include: %s" % list(map(str, enums.VirtType))) from error
-    # Now it must be of the enum Type
-    if vtype not in enums.VirtType:
-        raise ValueError("invalid virt type (%s)" % vtype)
-    return vtype
 
 
 def validate_virt_bridge(vbridge: str) -> str:
@@ -677,23 +613,3 @@ def validate_obj_id(object_id: str) -> bool:
         object_id = object_id[9:]
     (otype, oname) = object_id.split("::", 1)
     return validate_obj_type(otype) and validate_obj_name(oname)
-
-
-def validate_ldap_tls_reqcert(ldap_tls_reqcert: Union[enums.TlsRequireCert, str]) -> enums.TlsRequireCert:
-    """
-    Validation strategy for server cert
-
-    :param ldap_tls_reqcert: May be one of "never", "allow", "demand" or "hard"
-    """
-    if not isinstance(ldap_tls_reqcert, (str, enums.TlsRequireCert)):
-        raise TypeError("TLS require cert needs to be of type str or enums.TlsRequireCert")
-    # Convert an tls_reqcert which came in as a string
-    if isinstance(ldap_tls_reqcert, str):
-        try:
-            ldap_tls_reqcert = enums.TlsRequireCert[ldap_tls_reqcert.upper()]
-        except KeyError as error:
-            raise ValueError("ldap_tls_reqcert choices include: %s" % list(map(str, enums.TlsRequireCert))) from error
-    # Now it must be of the enum Type
-    if ldap_tls_reqcert not in enums.TlsRequireCert:
-        raise ValueError("invalid TLS require cert type (%s)" % ldap_tls_reqcert)
-    return ldap_tls_reqcert

--- a/tests/enums_test.py
+++ b/tests/enums_test.py
@@ -1,0 +1,97 @@
+import pytest
+
+from cobbler import enums
+from tests.conftest import does_not_raise
+
+
+@pytest.mark.parametrize(
+    "test_architecture,test_raise",
+    [
+        (enums.Archs.X86_64, does_not_raise()),
+        ("x86_64", does_not_raise()),
+        ("abc", pytest.raises(ValueError)),
+        (0, pytest.raises(TypeError)),
+    ],
+)
+def test_validate_arch(test_architecture, test_raise):
+    # Arrange
+
+    # Act
+    with test_raise:
+        result = enums.Archs.to_enum(test_architecture)
+
+        # Assert
+        if isinstance(test_architecture, str):
+            assert result.value == test_architecture
+        elif isinstance(test_architecture, enums.Archs):
+            assert result == test_architecture
+        else:
+            raise TypeError("result had a non expected result")
+
+
+@pytest.mark.parametrize("value,expected_exception", [
+    ("qemu", does_not_raise()),
+    ("<<inherit>>", does_not_raise()),
+    (enums.VirtType.QEMU, does_not_raise()),
+    (0, pytest.raises(TypeError))
+])
+def test_set_virt_type(value, expected_exception):
+    # Arrange
+
+    # Act
+    with expected_exception:
+        result = enums.VirtType.to_enum("qemu")
+
+        # Assert
+        if isinstance(value, str):
+            assert result.value == value
+        elif isinstance(value, enums.VirtType):
+            assert result == value
+        else:
+            raise TypeError("Unexpected type for value!")
+
+
+@pytest.mark.parametrize("value,expected_exception", [
+    ("allow", does_not_raise()),
+    (enums.TlsRequireCert.ALLOW, does_not_raise()),
+    (0, pytest.raises(TypeError))
+])
+def test_validate_ldap_tls_reqcert(value, expected_exception):
+    # Arrange
+
+    # Act
+    with expected_exception:
+        result = enums.TlsRequireCert.to_enum(value)
+
+        # Assert
+        if isinstance(value, str):
+            assert result.value == value
+        elif isinstance(value, enums.TlsRequireCert):
+            assert result == value
+        else:
+            raise TypeError("Unexpected type for value!")
+
+
+@pytest.mark.parametrize("test_driver,test_raise", [
+    (enums.VirtDiskDrivers.RAW, does_not_raise()),
+    (enums.VALUE_INHERITED, does_not_raise()),
+    (enums.VirtDiskDrivers.INHERTIED, does_not_raise()),
+    ("qcow2", does_not_raise()),
+    ("<<inherit>>", does_not_raise()),
+    ("bad_driver", pytest.raises(ValueError)),
+    (0, pytest.raises(TypeError))
+])
+def test_set_virt_disk_driver(test_driver, test_raise):
+    # Arrange
+
+    # Act
+    with test_raise:
+        result = enums.VirtDiskDrivers.to_enum(test_driver)
+
+        # Assert
+        if isinstance(test_driver, str):
+            assert result.value == test_driver
+        elif isinstance(test_driver, enums.VirtDiskDrivers):
+            assert result == test_driver
+        else:
+            raise TypeError("Unexpected type for value!")

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -5,28 +5,6 @@ from cobbler.api import CobblerAPI
 from tests.conftest import does_not_raise
 
 
-@pytest.mark.parametrize("test_architecture,test_raise", [
-    (enums.Archs.X86_64, does_not_raise()),
-    ("x86_64", does_not_raise()),
-    ("abc", pytest.raises(ValueError)),
-    (0, pytest.raises(TypeError))
-])
-def test_validate_arch(test_architecture, test_raise):
-    # Arrange
-
-    # Act
-    with test_raise:
-        result = validate.validate_arch(test_architecture)
-
-        # Assert
-        if isinstance(test_architecture, str):
-            assert result.value == test_architecture
-        elif isinstance(test_architecture, enums.Archs):
-            assert result == test_architecture
-        else:
-            raise TypeError("result had a non expected result")
-
-
 def test_validate_os_version():
     # Arrange
     utils.load_signatures("/var/lib/cobbler/distro_signatures.json")
@@ -71,30 +49,6 @@ def test_set_virt_file_size():
     # Assert
     assert isinstance(result, float)
     assert result == 8
-
-
-@pytest.mark.parametrize("test_driver,test_raise", [
-    (enums.VirtDiskDrivers.RAW, does_not_raise()),
-    (enums.VALUE_INHERITED, does_not_raise()),
-    (enums.VirtDiskDrivers.INHERTIED, does_not_raise()),
-    ("qcow2", does_not_raise()),
-    ("bad_driver", pytest.raises(ValueError)),
-    (0, pytest.raises(TypeError))
-])
-def test_set_virt_disk_driver(test_driver, test_raise):
-    # Arrange
-
-    # Act
-    with test_raise:
-        result = validate.validate_virt_disk_driver(test_driver)
-
-        # Assert
-        if isinstance(test_driver, str):
-            assert result.value == test_driver
-        elif isinstance(test_driver, enums.VirtDiskDrivers):
-            assert result == test_driver
-        else:
-            raise TypeError("Unexpected type for value!")
 
 
 @pytest.mark.parametrize("test_autoboot,expectation", [
@@ -145,27 +99,6 @@ def test_set_virt_ram():
 
     # Assert
     assert result == 1024
-
-
-@pytest.mark.parametrize("value,expected_exception", [
-    ("qemu", does_not_raise()),
-    (enums.VirtType.QEMU, does_not_raise()),
-    (0, pytest.raises(TypeError))
-])
-def test_set_virt_type(value, expected_exception):
-    # Arrange
-
-    # Act
-    with expected_exception:
-        result = validate.validate_virt_type("qemu")
-
-        # Assert
-        if isinstance(value, str):
-            assert result.value == value
-        elif isinstance(value, enums.VirtType):
-            assert result == value
-        else:
-            raise TypeError("Unexpected type for value!")
 
 
 def test_set_virt_bridge():
@@ -276,23 +209,3 @@ def test_validate_grub_remote_file(test_value, expected_result):
 
     # Assert
     assert expected_result == result
-
-@pytest.mark.parametrize("value,expected_exception", [
-    ("allow", does_not_raise()),
-    (enums.TlsRequireCert.ALLOW, does_not_raise()),
-    (0, pytest.raises(TypeError))
-])
-def test_validate_ldap_tls_reqcert(value, expected_exception):
-    # Arrange
-
-    # Act
-    with expected_exception:
-        result = validate.validate_ldap_tls_reqcert("allow")
-
-        # Assert
-        if isinstance(value, str):
-            assert result.value == value
-        elif isinstance(value, enums.TlsRequireCert):
-            assert result == value
-        else:
-            raise TypeError("Unexpected type for value!")


### PR DESCRIPTION
This commit deduplicates code and introduces a new method called
"to_enum(value)" which accepts str or enum type values and converts
them to enum type values.

Tests were moved from "validate_test.py" to "enums_test.py" and more
cases were added to check that the "<<inherits>>" logic works.

This effort is needed because we do need to stay Python 3.6
compatible. If we had been able to use Python 3.10, then we could
have just used StrEnum.

The second reason we need this, is that we don't know what type the
value might have. From the CLI it might be a str, from the demon
itself it might be a typed value already.

This PR shall be rebased after #2900 was merged.