### PR TITLE
move postrotate to systemd

### DIFF
--- a/config/rotate/cobblerd_rotate
+++ b/config/rotate/cobblerd_rotate
@@ -10,7 +10,7 @@
    weekly
    create 644 root root
    postrotate
-      /sbin/service cobblerd condrestart > /dev/null 2>&1
+      /usr/bin/systemctl try-reload-or-restart cobblerd
    endscript
 }
 


### PR DESCRIPTION
As systemd is the only supported system, convert the restart request to
systemctl. Adjust it such that a non-running cobblerd is handled
gracefully.

Signed-off-by: Olaf Hering <olaf@aepfle.de>