### PR TITLE
Security: Validate the data before logging it

### DIFF
--- a/cobbler/modules/installation/post_log.py
+++ b/cobbler/modules/installation/post_log.py
@@ -21,6 +21,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 
 import time
 
+from cobbler import validate
+
 
 def register() -> str:
     """
@@ -33,16 +35,31 @@ def register() -> str:
 
 def run(api, args) -> int:
     """
+    The method runs the trigger, meaning this logs that an installation has ended.
+
+    The list of args should have three elements:
+        - 0: system or profile
+        - 1: the name of the system or profile
+        - 2: the ip or a "?"
 
     :param api: This parameter is unused currently.
     :param args: An array of three elements. Type (system/profile), name and ip. If no ip is present use a ``?``.
     :return: Always 0
     """
-    # FIXME: make everything use the logger, no prints, use util.subprocess_call, etc
+    objtype = args[0]
+    name = args[1]
+    ip = args[2]
 
-    objtype = args[0]   # "system" or "profile"
-    name = args[1]      # name of system or profile
-    ip = args[2]        # ip or "?"
+    if not validate.validate_obj_type(objtype):
+        return 1
+
+    if not api.find_items(objtype, name=name, return_list=False):
+        return 1
+
+    if not (ip == "?" or validate.ipv4_address(ip) or validate.ipv6_address(ip)):
+        return 1
+
+    # FIXME: use the logger
 
     with open("/var/log/cobbler/install.log", "a+") as fd:
         fd.write("%s\t%s\t%s\tstop\t%s\n" % (objtype, name, ip, time.time()))

--- a/cobbler/modules/installation/post_power.py
+++ b/cobbler/modules/installation/post_power.py
@@ -35,22 +35,19 @@ def run(api, args) -> int:
 
     :param api: The api to resolve information with.
     :param args: This is an array containing two objects.
-                 0: String with the content "target" or "profile".
-                 1: The name of target or profile
+                 0: The str "system". All other content will result in an early exit of the trigger.
+                 1: The name of the target system.
     :return: ``0`` on success.
     """
-    # FIXME: make everything use the logger
-
     objtype = args[0]
     name = args[1]
-    # boot_ip = args[2] # ip or "?"
 
     if objtype == "system":
         target = api.find_system(name)
     else:
         return 0
 
-    if target and 'postreboot' in target.autoinstall_meta:
+    if target and "postreboot" in target.autoinstall_meta:
         # Run this in a thread so the system has a chance to finish and umount the filesystem
         current = reboot(api, target)
         current.start()

--- a/cobbler/modules/installation/post_puppet.py
+++ b/cobbler/modules/installation/post_puppet.py
@@ -4,7 +4,7 @@ puppet master server is running on the same machine as the Cobbler
 server.
 
 Based on:
-http://www.ithiriel.com/content/2010/03/29/writing-install-triggers-cobbler
+https://www.ithiriel.com/content/2010/03/29/writing-install-triggers-cobbler
 """
 import logging
 import re
@@ -27,13 +27,12 @@ def run(api, args) -> int:
     The obligatory Cobbler modules hook.
 
     :param api: The api to resolve all information with.
-    :param args: This is an array with two items. The first may be ``system`` or ``profile`` and the second is the name
-                 of this system or profile.
+    :param args: This is an array with two items. The first must be ``system``, if the value is different we do an
+                 early and the second is the name of this system or profile.
     :return: ``0`` or nothing.
     """
     objtype = args[0]
     name = args[1]
-    # ip = args[2]          # ip or "?"
 
     if objtype != "system":
         return 0
@@ -49,12 +48,12 @@ def run(api, args) -> int:
     system = api.find_system(name)
     system = utils.blender(api, False, system)
     hostname = system["hostname"]
-    if not re.match(r'[\w-]+\..+', hostname):
-        search_domains = system['name_servers_search']
+    if not re.match(r"[\w-]+\..+", hostname):
+        search_domains = system["name_servers_search"]
         if search_domains:
-            hostname += '.' + search_domains[0]
+            hostname += "." + search_domains[0]
     puppetca_path = settings.puppetca_path
-    cmd = [puppetca_path, 'cert', 'sign', hostname]
+    cmd = [puppetca_path, "cert", "sign", hostname]
 
     rc = 0
 

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -30,7 +30,7 @@ def run(api, args) -> int:
 
     :param api: The api to resolve information with.
     :param args: This is an array with three elements.
-                 0: "target" or "profile"
+                 0: "system" or "profile"
                  1: name of target or profile
                  2: ip or "?"
     :return: ``0`` or ``1``.
@@ -50,8 +50,10 @@ def run(api, args) -> int:
 
     if objtype == "system":
         target = api.find_system(name)
-    else:
+    elif objtype == "profile":
         target = api.find_profile(name)
+    else:
+        return 1
 
     # collapse the object down to a rendered datastructure
     target = utils.blender(api, False, target)
@@ -75,32 +77,34 @@ def run(api, args) -> int:
 
     subject = settings.build_reporting_subject
     if subject == "":
-        subject = '[Cobbler] install complete '
+        subject = "[Cobbler] install complete "
 
     to_addr = ",".join(to_addr)
     metadata = {
         "from_addr": from_addr,
         "to_addr": to_addr,
         "subject": subject,
-        "boot_ip": boot_ip
+        "boot_ip": boot_ip,
     }
     metadata.update(target)
 
     with open("/etc/cobbler/reporting/build_report_email.template") as input_template:
         input_data = input_template.read()
 
-        message = templar.Templar(api._collection_mgr).render(input_data, metadata, None)
+        message = templar.Templar(api._collection_mgr).render(
+            input_data, metadata, None
+        )
 
         sendmail = True
         for prefix in settings.build_reporting_ignorelist:
-            if prefix != '' and name.lower().startswith(prefix):
+            if prefix != "" and name.lower().startswith(prefix):
                 sendmail = False
 
         if sendmail:
             # Send the mail
             # FIXME: on error, return non-zero
             server_handle = smtplib.SMTP(smtp_server)
-            server_handle.sendmail(from_addr, to_addr.split(','), message)
+            server_handle.sendmail(from_addr, to_addr.split(","), message)
             server_handle.quit()
 
     return 0

--- a/cobbler/modules/installation/pre_clear_anamon_logs.py
+++ b/cobbler/modules/installation/pre_clear_anamon_logs.py
@@ -20,9 +20,16 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 
 import glob
+import logging
 import os
 
+from cobbler import utils
 from cobbler.cexceptions import CX
+
+
+PATH_PREFIX = "/var/log/cobbler/anamon/"
+
+logger = logging.getLogger()
 
 
 def register() -> str:
@@ -45,9 +52,6 @@ def run(api, args) -> int:
     :return: "0" on success.
     :raises CX: Raised in case of missing arguments.
     """
-
-    # FIXME: use the logger
-
     if len(args) < 3:
         raise CX("invalid invocation")
 
@@ -59,15 +63,12 @@ def run(api, args) -> int:
     def unlink_files(globex):
         for f in glob.glob(globex):
             if os.path.isfile(f):
-                try:
-                    os.unlink(f)
-                except OSError:
-                    pass
+                utils.rmfile(f)
 
     if settings.anamon_enabled:
-        dirname = "/var/log/cobbler/anamon/%s" % name
+        dirname = os.path.join(PATH_PREFIX, name)
         if os.path.isdir(dirname):
             unlink_files(os.path.join(dirname, "*"))
 
-    # TODO - log somewhere that we cleared a systems anamon logs
+    logger.info('Cleared Anamon logs for "%s".', name)
     return 0

--- a/cobbler/modules/installation/pre_log.py
+++ b/cobbler/modules/installation/pre_log.py
@@ -1,5 +1,7 @@
 import time
 
+from cobbler import validate
+
 
 def register() -> str:
     """
@@ -28,10 +30,18 @@ def run(api, args: list) -> int:
     name = args[1]
     ip = args[2]
 
+    if not validate.validate_obj_type(objtype):
+        return 1
+
+    if not api.find_items(objtype, name=name, return_list=False):
+        return 1
+
+    if not (ip == "?" or validate.ipv4_address(ip) or validate.ipv6_address(ip)):
+        return 1
+
     # FIXME: use the logger
 
-    fd = open("/var/log/cobbler/install.log", "a+")
-    fd.write("%s\t%s\t%s\tstart\t%s\n" % (objtype, name, ip, time.time()))
-    fd.close()
+    with open("/var/log/cobbler/install.log", "a+") as fd:
+        fd.write("%s\t%s\t%s\tstart\t%s\n" % (objtype, name, ip, time.time()))
 
     return 0

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -33,6 +33,15 @@ RUN zypper install --no-recommends -y \
     python3-setuptools         \
     python3-pip                \
     python3-wheel              \
+    python3-Cheetah3           \
+    python3-distro             \
+    python3-dnspython          \
+    python3-Jinja2             \
+    python3-requests           \
+    python3-PyYAML             \
+    python3-pykickstart        \
+    python3-netaddr            \
+    python3-pymongo            \
     rpm-build                  \
     rsync                      \
     supervisor                 \
@@ -59,6 +68,13 @@ RUN zypper install --no-recommends -y \
     system-user-nobody                \
     sysvinit-tools
 
+# Required for ldap tests
+RUN zypper install --no-recommends -y \
+    openldap2                         \
+    openldap2-client                  \
+    hostname                          \
+    python3-ldap
+
 # Dependencies for system-tests
 RUN zypper install --no-recommends -y \
     dhcp-server                       \
@@ -80,23 +96,14 @@ RUN pip3 install --upgrade pip
 
 # Install packages and dependencies via pip
 RUN pip3 install      \
-    Cheetah3          \
     codecov           \
-    distro            \
-    dnspython         \
     file-magic        \
-    Jinja2            \
-    netaddr           \
     pycodestyle       \
     pyflakes          \
-    pykickstart       \
-    pymongo           \
     pytest            \
     pytest-cov        \
     pytest-mock       \
-    pytest-pythonpath \
-    pyyaml            \
-    requests
+    pytest-pythonpath
 
 # Enable the Apache Modules
 RUN ["a2enmod", "version"]

--- a/docker/develop/scripts/setup-openldap.sh
+++ b/docker/develop/scripts/setup-openldap.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Dependencies for LDAP tests
-zypper install -y openldap2 openldap2-client hostname openssl-1_1 python38-ldap
-
 echo "Copy openLDAP confiuration file"
 cp  /code/docker/develop/openldap/slapd.conf /etc/openldap
 

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -13,8 +13,18 @@ class TestMiscellaneous:
     Class to test remote calls to cobbler which do not belong into a specific category.
     """
 
-    def test_clear_system_logs(self, remote, token, create_kernel_initrd, create_distro, create_profile, create_system,
-                               remove_distro, remove_profile, remove_system):
+    def test_clear_system_logs(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+        create_system,
+        remove_distro,
+        remove_profile,
+        remove_system,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -40,8 +50,18 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_disable_netboot(self, remote, token, create_distro, remove_distro, create_profile, remove_profile,
-                             create_system, remove_system, create_kernel_initrd):
+    def test_disable_netboot(
+        self,
+        remote,
+        token,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_system,
+        remove_system,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -79,7 +99,9 @@ class TestMiscellaneous:
         assert type(result.get("version_tuple")) == list
         assert [3, 3, 1] == result.get("version_tuple")
 
-    def test_find_items_paged(self, remote, token, create_distro, remove_distro, create_kernel_initrd):
+    def test_find_items_paged(
+        self, remote, token, create_distro, remove_distro, create_kernel_initrd
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -115,10 +137,22 @@ class TestMiscellaneous:
         assert "pages" in result["pageinfo"]
         assert result["pageinfo"]["pages"] == [1, 2]
 
-    @pytest.mark.skip("This functionality was implemented very quickly. The test for this needs to be fixed at a "
-                      "later point!")
-    def test_find_system_by_dns_name(self, remote, token, create_distro, remove_distro, create_profile, remove_profile,
-                                     create_system, remove_system, create_kernel_initrd):
+    @pytest.mark.skip(
+        "This functionality was implemented very quickly. The test for this needs to be fixed at a "
+        "later point!"
+    )
+    def test_find_system_by_dns_name(
+        self,
+        remote,
+        token,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_system,
+        remove_system,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -146,8 +180,17 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_generate_script(self, remote, create_distro, remove_distro, create_profile, remove_profile,
-                             create_system, remove_system, create_kernel_initrd):
+    def test_generate_script(
+        self,
+        remote,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_system,
+        remove_system,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -171,7 +214,9 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_get_item_as_rendered(self, remote, token, create_distro, remove_distro, create_kernel_initrd):
+    def test_get_item_as_rendered(
+        self, remote, token, create_distro, remove_distro, create_kernel_initrd
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -190,7 +235,9 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_get_s_since(self, remote, create_distro, remove_distro, create_kernel_initrd):
+    def test_get_s_since(
+        self, remote, create_distro, remove_distro, create_kernel_initrd
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -223,8 +270,17 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_get_blended_data(self, remote, create_distro, remove_distro, create_profile, remove_profile,
-                              create_system, remove_system, create_kernel_initrd):
+    def test_get_blended_data(
+        self,
+        remote,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_system,
+        remove_system,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -249,8 +305,18 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_get_config_data(self, remote, token, create_distro, remove_distro, create_profile, remove_profile,
-                             create_system, remove_system, create_kernel_initrd):
+    def test_get_config_data(
+        self,
+        remote,
+        token,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_system,
+        remove_system,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -278,8 +344,18 @@ class TestMiscellaneous:
         # Assert
         assert json.loads(result)
 
-    def test_get_repos_compatible_with_profile(self, remote, token, create_distro, remove_distro, create_profile,
-                                               remove_profile, create_repo, remove_repo, create_kernel_initrd):
+    def test_get_repos_compatible_with_profile(
+        self,
+        remote,
+        token,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_repo,
+        remove_repo,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -293,7 +369,9 @@ class TestMiscellaneous:
         create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
         create_profile(name_profile, name_distro, "text")
         repo_compatible = create_repo(name_repo_compatible, "http://localhost", False)
-        repo_incompatible = create_repo(name_repo_incompatible, "http://localhost", False)
+        repo_incompatible = create_repo(
+            name_repo_incompatible, "http://localhost", False
+        )
         remote.modify_repo(repo_compatible, "arch", "x86_64", token)
         remote.save_repo(repo_compatible, token)
         remote.modify_repo(repo_incompatible, "arch", "ppc64le", token)
@@ -320,10 +398,20 @@ class TestMiscellaneous:
         # Assert
         assert result == {}
 
-    @pytest.mark.skip("The function under test appears to have a bug. For now we skip the test.")
-    def test_get_template_file_for_profile(self, remote, create_distro, remove_distro, create_profile, remove_profile,
-                                           create_autoinstall_template, remove_autoinstall_template,
-                                           create_kernel_initrd):
+    @pytest.mark.skip(
+        "The function under test appears to have a bug. For now we skip the test."
+    )
+    def test_get_template_file_for_profile(
+        self,
+        remote,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_autoinstall_template,
+        remove_autoinstall_template,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -350,9 +438,19 @@ class TestMiscellaneous:
         # Assert
         assert result == content_template
 
-    def test_get_template_file_for_system(self, remote, create_distro, remove_distro, create_profile, remove_profile,
-                                          create_system, remove_system, create_autoinstall_template,
-                                          remove_autoinstall_template, create_kernel_initrd):
+    def test_get_template_file_for_system(
+        self,
+        remote,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_system,
+        remove_system,
+        create_autoinstall_template,
+        remove_autoinstall_template,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -381,8 +479,16 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_is_autoinstall_in_use(self, remote, token, create_distro, remove_distro, create_profile, remove_profile,
-                                   create_kernel_initrd):
+    def test_is_autoinstall_in_use(
+        self,
+        remote,
+        token,
+        create_distro,
+        remove_distro,
+        create_profile,
+        remove_profile,
+        create_kernel_initrd,
+    ):
         # Arrange
         fk_kernel = "vmlinuz1"
         fk_initrd = "initrd1.img"
@@ -426,7 +532,9 @@ class TestMiscellaneous:
         # Assert
         assert result == 1
 
-    def test_read_autoinstall_template(self, remote, token, create_autoinstall_template, remove_autoinstall_template):
+    def test_read_autoinstall_template(
+        self, remote, token, create_autoinstall_template, remove_autoinstall_template
+    ):
         # Arrange
         name = "test_template_name"
         create_autoinstall_template(name, "# Testtemplate")
@@ -440,7 +548,9 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_write_autoinstall_template(self, remote, token, remove_autoinstall_template):
+    def test_write_autoinstall_template(
+        self, remote, token, remove_autoinstall_template
+    ):
         # Arrange
         name = "testtemplate"
 
@@ -453,7 +563,9 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_remove_autoinstall_template(self, remote, token, create_autoinstall_template):
+    def test_remove_autoinstall_template(
+        self, remote, token, create_autoinstall_template
+    ):
         # Arrange
         name = "test_template_remove"
         create_autoinstall_template(name, "# Testtemplate")
@@ -464,7 +576,9 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_read_autoinstall_snippet(self, remote, token, testsnippet, snippet_add, snippet_remove):
+    def test_read_autoinstall_snippet(
+        self, remote, token, testsnippet, snippet_add, snippet_remove
+    ):
         # Arrange
         snippet_name = "testsnippet_read"
         snippet_add(snippet_name, testsnippet)
@@ -478,7 +592,9 @@ class TestMiscellaneous:
         # Cleanup
         snippet_remove(snippet_name)
 
-    def test_write_autoinstall_snippet(self, remote, token, testsnippet, snippet_remove):
+    def test_write_autoinstall_snippet(
+        self, remote, token, testsnippet, snippet_remove
+    ):
         # Arrange
         # See fixture: testsnippet
         name = "testsnippet_write"
@@ -503,13 +619,44 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    def test_run_install_triggers(self, remote, token):
+    def test_run_install_triggers(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+        create_system,
+        remove_distro,
+        remove_profile,
+        remove_system,
+    ):
         # Arrange
-        # TODO: Needs a system as a target
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        name_distro = "testdistro_run_install_triggers"
+        name_profile = "testprofile_run_install_triggers"
+        name_system = "testsystem_run_install_triggers"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+
+        distro = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        profile = create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+        system = create_system(name_system, name_profile)
 
         # Act
-        result_pre = remote.run_install_triggers("pre", "system", "systemname", "10.0.0.2", token)
-        result_post = remote.run_install_triggers("post", "system", "systemname", "10.0.0.2", token)
+        result_pre = remote.run_install_triggers(
+            "pre", "system", name_system, "10.0.0.2", token
+        )
+        result_post = remote.run_install_triggers(
+            "post", "system", name_system, "10.0.0.2", token
+        )
+
+        # Cleanup
+        remove_distro(name_distro)
+        remove_profile(name_profile)
+        remove_system(name_system)
 
         # Assert
         assert result_pre
@@ -535,9 +682,19 @@ class TestMiscellaneous:
         name = "testdistro_xapi_edit"
 
         # Act
-        result = remote.xapi_object_edit("distro", name, "add",
-                                         {"name": name, "arch": "x86_64", "breed": "suse", "kernel": path_kernel,
-                                          "initrd": path_initrd}, token)
+        result = remote.xapi_object_edit(
+            "distro",
+            name,
+            "add",
+            {
+                "name": name,
+                "arch": "x86_64",
+                "breed": "suse",
+                "kernel": path_kernel,
+                "initrd": path_initrd,
+            },
+            token,
+        )
 
         # Cleanup
         remove_distro(name)
@@ -545,8 +702,14 @@ class TestMiscellaneous:
         # Assert
         assert result
 
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_profile", "remove_testdistro",
-                             "remove_testmenu", "remove_testprofile")
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_profile",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+    )
     def test_render_vars(self, remote, token):
         """
         Test: string replacements for @@xyz@@
@@ -564,13 +727,23 @@ class TestMiscellaneous:
         assert True
 
     @pytest.mark.skip("Functionality is broken!")
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_testprofile", "create_testsystem",
-                             "remove_testdistro", "remove_testmenu", "remove_testprofile", "remove_testsystem")
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "create_testsystem",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
     def test_upload_log_data(self, remote):
         # Arrange
 
         # Act
-        result = remote.upload_log_data("testsystem0", "testinstall.log", 0, 0, b"asdas")
+        result = remote.upload_log_data(
+            "testsystem0", "testinstall.log", 0, 0, b"asdas"
+        )
 
         # Assert
         assert isinstance(result, bool)


### PR DESCRIPTION
This is required so that we don't create an opportunity for log file
pollution.

Scenario is the following: You issue an arbitrary HTTP request that
a system has finished installing. For this you don't need to be
authenticated and any valid str would be passed to the pre & post
install triggers. The validation now introduced will secure the
triggers.

Additionally I included some cosmetic changes.

Fixes #2910