### PR TITLE
Enums: Fix failure to convert <<inherit>>

### DIFF
--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -27,6 +27,11 @@ class ConvertableEnum(enum.Enum):
         """
         try:
             if isinstance(value, str):
+                if value == VALUE_INHERITED:
+                    try:
+                        return cls["INHERITED"]
+                    except KeyError as key_error:
+                        raise ValueError("The enum given does not support inheritance!") from key_error
                 return cls[value.upper()]
             elif isinstance(value, cls):
                 return value
@@ -133,7 +138,7 @@ class VirtDiskDrivers(ConvertableEnum):
     This enum represents all virtual disk driver Cobbler can handle.
     """
 
-    INHERTIED = VALUE_INHERITED
+    INHERITED = VALUE_INHERITED
     RAW = "raw"
     QCOW2 = "qcow2"
     QED = "qed"

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -789,7 +789,7 @@ class System(Item):
         # FIXME: The virt_* attributes don't support inheritance yet
         self._virt_auto_boot: Union[bool, str] = enums.VALUE_INHERITED
         self._virt_cpus: Union[int, str] = enums.VALUE_INHERITED
-        self._virt_disk_driver = enums.VirtDiskDrivers.INHERTIED
+        self._virt_disk_driver = enums.VirtDiskDrivers.INHERITED
         self._virt_file_size: Union[float, str] = enums.VALUE_INHERITED
         self._virt_path = enums.VALUE_INHERITED
         self._virt_pxe_boot = False

--- a/tests/enums_test.py
+++ b/tests/enums_test.py
@@ -33,6 +33,7 @@ def test_validate_arch(test_architecture, test_raise):
     ("qemu", does_not_raise()),
     ("<<inherit>>", does_not_raise()),
     (enums.VirtType.QEMU, does_not_raise()),
+    (enums.VirtType.INHERITED, does_not_raise()),
     (0, pytest.raises(TypeError))
 ])
 def test_set_virt_type(value, expected_exception):
@@ -40,7 +41,7 @@ def test_set_virt_type(value, expected_exception):
 
     # Act
     with expected_exception:
-        result = enums.VirtType.to_enum("qemu")
+        result = enums.VirtType.to_enum(value)
 
         # Assert
         if isinstance(value, str):
@@ -54,6 +55,7 @@ def test_set_virt_type(value, expected_exception):
 @pytest.mark.parametrize("value,expected_exception", [
     ("allow", does_not_raise()),
     (enums.TlsRequireCert.ALLOW, does_not_raise()),
+    (enums.VALUE_INHERITED, pytest.raises(ValueError)),
     (0, pytest.raises(TypeError))
 ])
 def test_validate_ldap_tls_reqcert(value, expected_exception):
@@ -75,7 +77,7 @@ def test_validate_ldap_tls_reqcert(value, expected_exception):
 @pytest.mark.parametrize("test_driver,test_raise", [
     (enums.VirtDiskDrivers.RAW, does_not_raise()),
     (enums.VALUE_INHERITED, does_not_raise()),
-    (enums.VirtDiskDrivers.INHERTIED, does_not_raise()),
+    (enums.VirtDiskDrivers.INHERITED, does_not_raise()),
     ("qcow2", does_not_raise()),
     ("<<inherit>>", does_not_raise()),
     ("bad_driver", pytest.raises(ValueError)),


### PR DESCRIPTION
This also fixes a typo in the VirtDiskDrivers value for INHERITED.

This is a followup (and fixup) for #2901

This should fix #2912