### PR TITLE
Systems: Re-enable the modify_interface call

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
-      - name: Build a CentOS 8 Package
+      - name: Build a Rocky Linux 8 Package
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          ./docker/rpms/build-and-install-rpms.sh el8 docker/rpms/CentOS_8/CentOS8.dockerfile
+          ./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
   build-fedora34-rpms:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run the test suite
-        run: ./docker/rpms/build-and-install-rpms.sh --with-system-tests el8 docker/rpms/CentOS_8/CentOS8.dockerfile
+        run: ./docker/rpms/build-and-install-rpms.sh --with-system-tests rl8 docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
 
       - name: Publish the test results
         uses: actions/upload-artifact@v2

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -941,18 +941,33 @@ class System(Item):
         raise ValueError("The values of the interfaces must be fully of type dict (one level with values) or "
                          "NetworkInterface objects")
 
-    def delete_interface(self, name: str):
+    def modify_interface(self, interface_values: dict):
+        """
+        Modifies a magic interface dictionary in the form of: {"macaddress-eth0" : "aa:bb:cc:dd:ee:ff"}
+        """
+        for key in interface_values.keys():
+            (_, interface) = key.split("-", 1)
+            if interface not in self.interfaces:
+                self.__create_interface(interface)
+            self.interfaces[interface].modify_interface({key: interface_values[key]})
+
+    def delete_interface(self, name: Union[str, dict]):
         """
         Used to remove an interface.
 
-        :raises TypeError: If the name of the interface is not of type str
+        :raises TypeError: If the name of the interface is not of type str or dict.
         """
-        if not isinstance(name, str):
-            raise TypeError("The name of the interface must be of type str")
-        if not name:
+        if isinstance(name, str):
+            if not name:
+                return
+            if name in self.interfaces:
+                self.interfaces.pop(name)
+                return
+        if isinstance(name, dict):
+            interface_name = name.get("interface", "")
+            self.interfaces.pop(interface_name)
             return
-        if name in self.interfaces:
-            self.interfaces.pop(name)
+        raise TypeError("The name of the interface must be of type str or dict")
 
     def rename_interface(self, old_name: str, new_name: str):
         r"""

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1718,7 +1718,7 @@ class CobblerXMLRPCInterface:
         """
         return self.new_item("menu", token)
 
-    def modify_item(self, what, object_id, attribute, arg, token: str) -> bool:
+    def modify_item(self, what: str, object_id, attribute, arg, token: str) -> bool:
         """
         Adjusts the value of a given field, specified by 'what' on a given object id. Allows modification of certain
         attributes on newly created or existing distro object handle.
@@ -1733,6 +1733,20 @@ class CobblerXMLRPCInterface:
         self._log("modify_item(%s)" % what, object_id=object_id, attribute=attribute, token=token)
         obj = self.__get_object(object_id)
         self.check_access(token, "modify_%s" % what, obj, attribute)
+
+        if what == "system":
+            if attribute == "modify_interface":
+                obj.modify_interface(arg)
+                return True
+            elif attribute == "delete_interface":
+                obj.delete_interface(arg)
+                return True
+            elif attribute == "rename_interface":
+                obj.rename_interface(
+                    old_name=arg.get("interface", ""),
+                    new_name=arg.get("rename_interface", "")
+                )
+                return True
 
         if hasattr(obj, attribute):
             setattr(obj, attribute, arg)

--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -32,7 +32,7 @@ if [ "$DISTRO" = "" ] && [ -r /etc/os-release ];then
 	sle*|*suse*)
 	    DISTRO="SUSE"
 	    ;;
-	fedora*|ol*|centos*|rhel*)
+	fedora*|ol*|centos*|rhel*|rocky*)
 	    DISTRO="FEDORA"
 	    ;;
 	ubuntu*|debian*)

--- a/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
+++ b/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
@@ -1,6 +1,6 @@
 # vim: ft=dockerfile
 
-FROM centos:8
+FROM rockylinux:8
 
 RUN dnf makecache && \
     dnf install -y epel-release dnf-utils && \
@@ -17,6 +17,7 @@ RUN dnf makecache && \
 # Dev dependencies
 RUN touch /var/lib/rpm/* &&   \
     dnf install -y            \
+    iproute                   \
     git                       \
     rsync                     \
     make                      \

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -21,70 +21,82 @@ class TestSystem:
         # Assert
         assert result == []
 
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_testprofile", "remove_testdistro",
-                             "remove_testmenu", "remove_testprofile", "remove_testsystem")
-    @pytest.mark.parametrize("field_name,field_value", [
-        ("comment", "test comment"),
-        ("enable_ipxe", True),
-        ("enable_ipxe", False),
-        ("kernel_options", "a=1 b=2 c=3 c=4 c=5 d e"),
-        ("kernel_options_post", "a=1 b=2 c=3 c=4 c=5 d e"),
-        ("autoinstall", "test.ks"),
-        ("autoinstall", "test.xml"),
-        ("autoinstall", "test.seed"),
-        ("autoinstall_meta", "a=1 b=2 c=3 c=4 c=5 d e"),
-        ("mgmt_classes", "one two three"),
-        ("mgmt_parameters", "<<inherit>>"),
-        ("name", "testsystem0"),
-        ("netboot_enabled", True),
-        ("netboot_enabled", False),
-        ("owners", "user1 user2 user3"),
-        ("profile", "testprofile0"),
-        ("repos_enabled", True),
-        ("repos_enabled", False),
-        ("status", "development"),
-        ("status", "testing"),
-        ("status", "acceptance"),
-        ("status", "production"),
-        ("proxy", "testproxy"),
-        ("server", "1.1.1.1"),
-        # ("boot_loaders", "pxe ipxe grub"), FIXME: This raises currently but it did not in the past
-        ("virt_auto_boot", True),
-        ("virt_auto_boot", False),
-        ("virt_auto_boot", "yes"),
-        ("virt_auto_boot", "no"),
-        ("virt_cpus", "<<inherit>>"),
-        ("virt_cpus", 1),
-        ("virt_cpus", 2),
-        ("virt_cpus", "<<inherit>>"),
-        ("virt_file_size", "<<inherit>>"),
-        ("virt_file_size", 5),
-        ("virt_file_size", 10),
-        ("virt_disk_driver", "<<inherit>>"),
-        ("virt_disk_driver", "raw"),
-        ("virt_disk_driver", "qcow2"),
-        ("virt_disk_driver", "vdmk"),
-        ("virt_ram", "<<inherit>>"),
-        ("virt_ram", 256),
-        ("virt_ram", 1024),
-        ("virt_type", "<<inherit>>"),
-        ("virt_type", "xenpv"),
-        ("virt_type", "xenfv"),
-        ("virt_type", "qemu"),
-        ("virt_type", "kvm"),
-        ("virt_type", "vmware"),
-        ("virt_type", "openvz"),
-        ("virt_path", "<<inherit>>"),
-        ("virt_path", "/path/to/test"),
-        ("virt_pxe_boot", True),
-        ("virt_pxe_boot", False),
-        ("power_type", "ipmilanplus"),
-        ("power_address", "127.0.0.1"),
-        ("power_id", "pmachine:lpar1"),
-        ("power_pass", "pass"),
-        ("power_user", "user")
-    ])
-    def test_create_system_positive(self, remote, token, template_files, field_name, field_value):
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
+    @pytest.mark.parametrize(
+        "field_name,field_value",
+        [
+            ("comment", "test comment"),
+            ("enable_ipxe", True),
+            ("enable_ipxe", False),
+            ("kernel_options", "a=1 b=2 c=3 c=4 c=5 d e"),
+            ("kernel_options_post", "a=1 b=2 c=3 c=4 c=5 d e"),
+            ("autoinstall", "test.ks"),
+            ("autoinstall", "test.xml"),
+            ("autoinstall", "test.seed"),
+            ("autoinstall_meta", "a=1 b=2 c=3 c=4 c=5 d e"),
+            ("mgmt_classes", "one two three"),
+            ("mgmt_parameters", "<<inherit>>"),
+            ("name", "testsystem0"),
+            ("netboot_enabled", True),
+            ("netboot_enabled", False),
+            ("owners", "user1 user2 user3"),
+            ("profile", "testprofile0"),
+            ("repos_enabled", True),
+            ("repos_enabled", False),
+            ("status", "development"),
+            ("status", "testing"),
+            ("status", "acceptance"),
+            ("status", "production"),
+            ("proxy", "testproxy"),
+            ("server", "1.1.1.1"),
+            # ("boot_loaders", "pxe ipxe grub"), FIXME: This raises currently but it did not in the past
+            ("virt_auto_boot", True),
+            ("virt_auto_boot", False),
+            ("virt_auto_boot", "yes"),
+            ("virt_auto_boot", "no"),
+            ("virt_cpus", "<<inherit>>"),
+            ("virt_cpus", 1),
+            ("virt_cpus", 2),
+            ("virt_cpus", "<<inherit>>"),
+            ("virt_file_size", "<<inherit>>"),
+            ("virt_file_size", 5),
+            ("virt_file_size", 10),
+            ("virt_disk_driver", "<<inherit>>"),
+            ("virt_disk_driver", "raw"),
+            ("virt_disk_driver", "qcow2"),
+            ("virt_disk_driver", "vdmk"),
+            ("virt_ram", "<<inherit>>"),
+            ("virt_ram", 256),
+            ("virt_ram", 1024),
+            ("virt_type", "<<inherit>>"),
+            ("virt_type", "xenpv"),
+            ("virt_type", "xenfv"),
+            ("virt_type", "qemu"),
+            ("virt_type", "kvm"),
+            ("virt_type", "vmware"),
+            ("virt_type", "openvz"),
+            ("virt_path", "<<inherit>>"),
+            ("virt_path", "/path/to/test"),
+            ("virt_pxe_boot", True),
+            ("virt_pxe_boot", False),
+            ("power_type", "ipmilanplus"),
+            ("power_address", "127.0.0.1"),
+            ("power_id", "pmachine:lpar1"),
+            ("power_pass", "pass"),
+            ("power_user", "user"),
+        ],
+    )
+    def test_create_system_positive(
+        self, remote, token, template_files, field_name, field_value
+    ):
         """
         Test: create/edit a system object
         """
@@ -99,19 +111,29 @@ class TestSystem:
         # Assert
         assert result
 
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_testprofile", "remove_testdistro",
-                             "remove_testmenu", "remove_testprofile", "remove_testsystem")
-    @pytest.mark.parametrize("field_name,field_value", [
-        ("autoinstall", "/path/to/bad/autoinstall"),
-        ("mgmt_parameters", "badyaml"),
-        ("profile", "badprofile"),
-        ("boot_loaders", "badloader"),
-        ("virt_cpus", "a"),
-        ("virt_file_size", "a"),
-        ("virt_ram", "a"),
-        ("virt_type", "bad"),
-        ("power_type", "bla")
-    ])
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
+    @pytest.mark.parametrize(
+        "field_name,field_value",
+        [
+            ("autoinstall", "/path/to/bad/autoinstall"),
+            ("mgmt_parameters", "badyaml"),
+            ("profile", "badprofile"),
+            ("boot_loaders", "badloader"),
+            ("virt_cpus", "a"),
+            ("virt_file_size", "a"),
+            ("virt_ram", "a"),
+            ("virt_type", "bad"),
+            ("power_type", "bla"),
+        ],
+    )
     def test_create_system_negative(self, remote, token, field_name, field_value):
         """
         Test: create/edit a system object
@@ -142,8 +164,15 @@ class TestSystem:
         # Assert --> A not exiting system returns an empty list
         assert result == []
 
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_testprofile", "remove_testdistro",
-                             "remove_testmenu", "remove_testprofile", "remove_testsystem")
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
     def test_add_interface_to_system(self, remote, token):
         """
         Test: add an interface to a system
@@ -155,14 +184,114 @@ class TestSystem:
         remote.modify_system(system, "profile", "testprofile0", token)
 
         # Act
-        result = remote.modify_system(system, "modify_interface", {"macaddress-eth0": "aa:bb:cc:dd:ee:ff"}, token)
+        result = remote.modify_system(
+            system, "modify_interface", {"macaddress-eth0": "aa:bb:cc:dd:ee:ff"}, token
+        )
+        remote.save_system(system, token)
 
         # Assert --> returns true if successful
         assert result
+        assert (
+            remote.get_system("testsystem0")
+            .get("interfaces", {})
+            .get("eth0", {})
+            .get("mac_address")
+            == "aa:bb:cc:dd:ee:ff"
+        )
 
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_testprofile", "create_testsystem",
-                             "remove_testdistro",
-                             "remove_testmenu", "remove_testprofile", "remove_testsystem")
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
+    def test_remove_interface_from_system(self, remote, token):
+        """
+        Test: remove an interface from a system
+        """
+
+        # Arrange
+        system = remote.new_system(token)
+        remote.modify_system(system, "name", "testsystem0", token)
+        remote.modify_system(system, "profile", "testprofile0", token)
+        remote.modify_system(
+            system, "modify_interface", {"macaddress-eth0": "aa:bb:cc:dd:ee:ff"}, token
+        )
+        remote.save_system(system, token)
+
+        # Act
+        result = remote.modify_system(
+            system, "delete_interface", {"interface": "eth0"}, token
+        )
+        remote.save_system(system, token)
+
+        # Assert --> returns true if successful
+        assert result
+        assert (
+            remote.get_system("testsystem0").get("interfaces", {}).get("eth0", None)
+            is None
+        )
+
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
+    def test_rename_interface(self, remote, token):
+        """
+        Test: rename an interface on a system
+        """
+
+        # Arrange
+        system = remote.new_system(token)
+        remote.modify_system(system, "name", "testsystem0", token)
+        remote.modify_system(system, "profile", "testprofile0", token)
+        result_add = remote.modify_system(
+            system, "modify_interface", {"macaddress-eth0": "aa:bb:cc:dd:ee:ff"}, token
+        )
+        remote.save_system(system, token)
+
+        # Act
+        result_rename = remote.modify_system(
+            system,
+            "rename_interface",
+            {"interface": "eth0", "rename_interface": "eth_new"},
+            token,
+        )
+        remote.save_system(system, token)
+
+        # Assert --> returns true if successful
+        assert result_add
+        assert result_rename
+        assert (
+            remote.get_system("testsystem0").get("interfaces", {}).get("eth0", None)
+            is None
+        )
+        assert (
+            remote.get_system("testsystem0")
+            .get("interfaces", {})
+            .get("eth_new", {})
+            .get("mac_address")
+            == "aa:bb:cc:dd:ee:ff"
+        )
+
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "create_testsystem",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
     def test_copy_system(self, remote, token):
         """
         Test: copy a system object
@@ -180,9 +309,16 @@ class TestSystem:
         # Cleanup
         remote.remove_system("testsytemcopy", token)
 
-    @pytest.mark.usefixtures("create_testdistro", "create_testmenu", "create_testprofile", "create_testsystem",
-                             "remove_testdistro",
-                             "remove_testmenu", "remove_testprofile", "remove_testsystem")
+    @pytest.mark.usefixtures(
+        "create_testdistro",
+        "create_testmenu",
+        "create_testprofile",
+        "create_testsystem",
+        "remove_testdistro",
+        "remove_testmenu",
+        "remove_testprofile",
+        "remove_testsystem",
+    )
     def test_rename_system(self, remote, token):
         """
         Test: rename a system object


### PR DESCRIPTION
This reintroduces modify_interface to the System object. It is a
compatibility function. The way to do this now is:

    system.interfaces[<name>].property = value

The old way was:

    system.modify_interface({"property-<name>": value})

However since the new way is not yet supported by all consumers of
the API this compatibility layer.

This fixes #2846