### PR TITLE
System: Fix serial_device and serial_baud_rate

### DIFF
--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -151,6 +151,7 @@ class BaudRates(enum.Enum):
     This enum describes all baud rates which are commonly used.
     """
 
+    DISABLED = -1
     B0 = 0
     B110 = 110
     B300 = 300

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -793,10 +793,10 @@ class System(Item):
         self._virt_file_size: Union[float, str] = enums.VALUE_INHERITED
         self._virt_path = enums.VALUE_INHERITED
         self._virt_pxe_boot = False
-        self._virt_ram : Union[int, str] = enums.VALUE_INHERITED
+        self._virt_ram: Union[int, str] = enums.VALUE_INHERITED
         self._virt_type = enums.VirtType.INHERITED
-        self._serial_device = 0
-        self._serial_baud_rate = enums.BaudRates.B0
+        self._serial_device = -1
+        self._serial_baud_rate = enums.BaudRates.DISABLED
 
         # Overwrite defaults from item.py
         self._owners = enums.VALUE_INHERITED
@@ -1963,11 +1963,10 @@ class System(Item):
     @property
     def serial_device(self) -> int:
         """
-        serial_device property.
+        serial_device property. "-1" disables the serial device functionality completely.
 
         :getter: Returns the value for ``serial_device``.
         :setter: Sets the value for the property ``serial_device``.
-        :return:
         """
         return self._serial_device
 
@@ -1976,19 +1975,17 @@ class System(Item):
         """
         Setter for the serial_device of the System class.
 
-
-        :param device_number:
+        :param device_number: The number of the device which is going
         """
         self._serial_device = validate.validate_serial_device(device_number)
 
     @property
     def serial_baud_rate(self) -> enums.BaudRates:
         """
-        serial_baud_rate property.
+        serial_baud_rate property. The value "disabled" will disable the functionality completely.
 
         :getter: Returns the value for ``serial_baud_rate``.
         :setter: Sets the value for the property ``serial_baud_rate``.
-        :return:
         """
         return self._serial_baud_rate
 

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -658,15 +658,15 @@ class TFTPGen:
 
         # store variables for templating
         if system:
-            if system.serial_device or system.serial_baud_rate:
-                if system.serial_device:
-                    serial_device = system.serial_device
-                else:
+            if system.serial_device > -1 or system.serial_baud_rate != enums.BaudRates.DISABLED:
+                if system.serial_device == -1:
                     serial_device = 0
-                if system.serial_baud_rate:
-                    serial_baud_rate = system.serial_baud_rate.value
                 else:
+                    serial_device = system.serial_device
+                if system.serial_baud_rate == enums.BaudRates.DISABLED:
                     serial_baud_rate = 115200
+                else:
+                    serial_baud_rate = system.serial_baud_rate.value
 
                 if format == "pxe":
                     buffer += "serial %d %d\n" % (serial_device, serial_baud_rate)

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -466,8 +466,8 @@ def validate_serial_device(value: Union[str, int]) -> int:
         value = int(value)
     if not isinstance(value, int):
         raise TypeError("serial_device needs to be an integer")
-    if value < 0:
-        raise ValueError("serial_device needs to be 0 or greater")
+    if value < -1:
+        raise ValueError("serial_device needs to be -1 or greater")
     return int(value)
 
 
@@ -484,7 +484,10 @@ def validate_serial_baud_rate(baud_rate: Union[int, str, enums.BaudRates]) -> en
     # Convert the baud rate which came in as an int or str
     if isinstance(baud_rate, (int, str)):
         try:
-            baud_rate = enums.BaudRates["B" + str(baud_rate)]
+            if str(baud_rate).upper() == "DISABLED" or baud_rate == -1:
+                baud_rate = enums.BaudRates.DISABLED
+            else:
+                baud_rate = enums.BaudRates["B" + str(baud_rate)]
         except KeyError as key_error:
             raise ValueError("vtype choices include: %s" % list(map(str, enums.BaudRates))) from key_error
     # Now it must be of the enum Type


### PR DESCRIPTION
It was not possible with the new properties and enums to disable the
serial console, and it was not possible to stick to reasonable
defaults. This patch fixes this problem and does the following:

- Introduces a new state for
  - serial_device: -1 means disabled
  - serial_baud_rate: "disabled" or enums.BaudRate.DISABLED
- Only if BOTH are disabled no serial console information is not
  generated.
- If one is set then we use the following default for the other:
  - serial_device: 0
  - serial_baud_rate: 115200

Fixes #2922 