### PR TITLE
Use distro_build_configs.sh for fixing bind path

### DIFF
--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -336,7 +336,7 @@ next_server_v6: "::1"
 manage_dns: false
 
 # set to path of bind chroot to create bind-chroot compatible bind
-# configuration files.  This should be automatically detected.
+# configuration files.
 bind_chroot_path: ""
 
 # set to path where zonefiles of bind/named server are located.

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -185,8 +185,7 @@ default: ``/var/lib/cobbler/templates``
 bind_chroot_path
 ================
 
-Set to path of bind chroot to create bind-chroot compatible bind configuration files. This should be automatically
-detected.
+Set to path of bind chroot to create bind-chroot compatible bind configuration files.
 
 default: ``""``
 

--- a/tests/settings/settings_test.py
+++ b/tests/settings/settings_test.py
@@ -65,26 +65,6 @@ def test_validate_settings(parameter, expected_exception, expected_result):
         assert result == expected_result
 
 
-def test_parse_bind_config():
-    # Arrange
-
-    # Act
-    settings.parse_bind_config("/test_dir/tests/test_data/named.conf")
-
-    # Assert
-    assert True
-
-
-def test_autodect_bind_chroot():
-    # Arrange
-
-    # Act
-    settings.autodetect_bind_chroot()
-
-    # Assert
-    assert True
-
-
 def test_read_settings_file():
     # Arrange
     # Default path should be fine for the tests.

--- a/tests/test_data/V3_3_1/settings.yaml
+++ b/tests/test_data/V3_3_1/settings.yaml
@@ -336,7 +336,7 @@ next_server_v6: "::1"
 manage_dns: false
 
 # set to path of bind chroot to create bind-chroot compatible bind
-# configuration files.  This should be automatically detected.
+# configuration files.
 bind_chroot_path: ""
 
 # set to path where zonefiles of bind/named server are located.


### PR DESCRIPTION
Before we had a function which was called upon every import for the
settings module. This function was just responsible to provide a
reasonable default for the BIND chroot path. Since this rarely changes
we can set this at build time and safe ourselves the code and CPU
cycles.

Fixes #2765

@opoplawski I wasn't able to find the correct path for RH based distros. Could you maybe have a look and check if on RH based systems Bind is chrooted per default and if yes with what path please?