### PR TITLE
fix: Append initrd path to the pxe configuration

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -649,6 +649,8 @@ class TFTPGen:
 
         if distro and distro.os_version.startswith("esxi") and filename is not None:
             append_line = "BOOTIF=%s" % (os.path.basename(filename))
+        elif "initrd_path" in metadata and arch not in [Archs.PPC, Archs.PPC64, Archs.ARM]:
+            append_line = "append initrd=%s" % (metadata["initrd_path"])
         else:
             append_line = "append "
         append_line = "%s%s" % (append_line, kernel_options)

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -649,7 +649,7 @@ class TFTPGen:
 
         if distro and distro.os_version.startswith("esxi") and filename is not None:
             append_line = "BOOTIF=%s" % (os.path.basename(filename))
-        elif "initrd_path" in metadata and arch not in [Archs.PPC, Archs.PPC64, Archs.ARM]:
+        elif "initrd_path" in metadata:
             append_line = "append initrd=%s" % (metadata["initrd_path"])
         else:
             append_line = "append "

--- a/templates/boot_loader_conf/pxe.template
+++ b/templates/boot_loader_conf/pxe.template
@@ -23,10 +23,7 @@ LABEL $menu_name
 	localboot -1
 #else
 	kernel $kernel_path
-#if $initrd_path and ($arch in ["ppc", "ppc64"] or $arch.startswith("arm"))
-	initrd $initrd_path
-	$append_line
-#elif $breed != "windows"
+#if $breed != "windows"
 	$append_line
 	ipappend 2
 #end if


### PR DESCRIPTION
Partial revert of 066678b.

Fixes: #2870

I'm not sure about the necessity to keep the `arch not in [Archs.PPC, Archs.PPC64, Archs.ARM]` condition.