### PR TITLE
Fix some detected issues with installation logger

### DIFF
--- a/cobbler/modules/installation/post_log.py
+++ b/cobbler/modules/installation/post_log.py
@@ -53,7 +53,7 @@ def run(api, args) -> int:
     if not validate.validate_obj_type(objtype):
         return 1
 
-    if not api.find_items(objtype, name=name, return_list=False):
+    if not validate.validate_obj_name(name):
         return 1
 
     if not (ip == "?" or validate.ipv4_address(ip) or validate.ipv6_address(ip)):

--- a/cobbler/modules/installation/pre_clear_anamon_logs.py
+++ b/cobbler/modules/installation/pre_clear_anamon_logs.py
@@ -29,6 +29,8 @@ from cobbler.cexceptions import CX
 
 PATH_PREFIX = "/var/log/cobbler/anamon/"
 
+logger = logging.getLogger()
+
 
 def register() -> str:
     """

--- a/cobbler/modules/installation/pre_clear_anamon_logs.py
+++ b/cobbler/modules/installation/pre_clear_anamon_logs.py
@@ -29,8 +29,6 @@ from cobbler.cexceptions import CX
 
 PATH_PREFIX = "/var/log/cobbler/anamon/"
 
-logger = logging.getLogger()
-
 
 def register() -> str:
     """
@@ -70,5 +68,5 @@ def run(api, args) -> int:
         if os.path.isdir(dirname):
             unlink_files(os.path.join(dirname, "*"))
 
-    logger.info('Cleared Anamon logs for "%s".', name)
+    logger.info('Cleared Anamon logs for "' + name + '".')
     return 0

--- a/cobbler/modules/installation/pre_log.py
+++ b/cobbler/modules/installation/pre_log.py
@@ -33,7 +33,7 @@ def run(api, args: list) -> int:
     if not validate.validate_obj_type(objtype):
         return 1
 
-    if not api.find_items(objtype, name=name, return_list=False):
+    if not validate.validate_obj_name(name):
         return 1
 
     if not (ip == "?" or validate.ipv4_address(ip) or validate.ipv6_address(ip)):


### PR DESCRIPTION
This PR fixes some issues we have identifies in our testsuite related to logger usage in installation module:

```python
=================================== FAILURES ===================================
_________________ TestMiscellaneous.test_run_install_triggers __________________

self = <tests.xmlrpcapi.miscellaneous_test.TestMiscellaneous object at 0x7f99a8c7c9e8>
remote = <ServerProxy for 127.0.0.1:80/cobbler_api>
token = 'JamAiTV8ZEbTZ2MJnVjJe7A8Vak5Bw6U7g=='

    def test_run_install_triggers(self, remote, token):
        # Arrange
        # TODO: Needs a system as a target
    
        # Act
>       result_pre = remote.run_install_triggers("pre", "system", "systemname", "10.0.0.2", token)
```
---

We have noticed few issues related with this failure:


1) Custom logger is not accepting multiple arguments:

```console
2022-02-14T13:12:23 - DEBUG | running python trigger cobbler.modules.installation.pre_clear_anamon_logs
2022-02-14T13:12:23 - INFO | Exception occured: <class 'TypeError'>
2022-02-14T13:12:23 - INFO | Exception value: info() takes 2 positional arguments but 3 were given
2022-02-14T13:12:23 - INFO | Exception Info:
  File "/usr/lib/python3.6/site-packages/cobbler/remote.py", line 3525, in _dispatch
    return method_handle(*params)

  File "/usr/lib/python3.6/site-packages/cobbler/remote.py", line 2572, in run_install_triggers
    additional=[objtype, name, ip], logger=self.logger)

  File "/usr/lib/python3.6/site-packages/cobbler/utils.py", line 973, in run_triggers
    rc = m.run(api, arglist, logger)

  File "/usr/lib/python3.6/site-packages/cobbler/modules/installation/pre_clear_anamon_logs.py", line 76, in run
    logger.info('Cleared Anamon logs for "%s".', name)
```

Once this above one was fixed, we discover this other one: 

2) Use proper validation function for object name in installations logs. The current approach is expecting the object exist to validate the input but this is not correct.

```console
2022-02-14T13:17:56 - DEBUG | running python trigger cobbler.modules.installation.pre_clear_anamon_logs
2022-02-14T13:17:56 - INFO | Cleared Anamon logs for "systemname".
2022-02-14T13:17:56 - DEBUG | running python trigger cobbler.modules.installation.pre_log
2022-02-14T13:17:56 - INFO | find_items; ['system']
2022-02-14T13:17:56 - INFO | Exception occured: <class 'cobbler.cexceptions.CX'>
2022-02-14T13:17:56 - INFO | Exception value: 'Cobbler trigger failed: cobbler.modules.installation.pre_log'
2022-02-14T13:17:56 - INFO | Exception Info:
  File "/usr/lib/python3.6/site-packages/cobbler/remote.py", line 3525, in _dispatch
    return method_handle(*params)

  File "/usr/lib/python3.6/site-packages/cobbler/remote.py", line 2572, in run_install_triggers
    additional=[objtype, name, ip], logger=self.logger)

  File "/usr/lib/python3.6/site-packages/cobbler/utils.py", line 975, in run_triggers
    raise CX("Cobbler trigger failed: %s" % m.__name__)
```

This PR is fixing those 2 issues.