### PR TITLE
Fix CVE-2021-45082 and CVE-2021-45083

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -361,6 +361,20 @@ fi
 %else
 %post
 %systemd_post cobblerd.service
+# Fixup permission for world readable settings files
+chmod 640 %{_sysconfdir}/cobbler/settings.yaml
+chmod 600 %{_sysconfdir}/cobbler/mongodb.conf
+chmod 600 %{_sysconfdir}/cobbler/modules.conf
+chmod 640 %{_sysconfdir}/cobbler/users.conf
+chmod 640 %{_sysconfdir}/cobbler/users.digest
+chmod 750 %{_sysconfdir}/cobbler/settings.d
+chmod 640 %{_sysconfdir}/cobbler/settings.d/*
+chgrp %{apache_group} %{_sysconfdir}/cobbler/settings
+chgrp %{apache_group} %{_sysconfdir}/cobbler/users.conf
+chgrp %{apache_group} %{_sysconfdir}/cobbler/users.digest
+chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.d
+chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.d/*
+
 
 %preun
 %systemd_preun cobblerd.service
@@ -395,8 +409,8 @@ fi
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf
-%config(noreplace) %{_sysconfdir}/cobbler/modules.conf
-%config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf
+%attr(600, root, root) %config(noreplace) %{_sysconfdir}/cobbler/modules.conf
+%attr(600, root, root) %config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf
 %config(noreplace) %{_sysconfdir}/cobbler/named.template
 %config(noreplace) %{_sysconfdir}/cobbler/ndjbdns.template
 %dir %{_sysconfdir}/cobbler/reporting
@@ -404,14 +418,14 @@ fi
 %config(noreplace) %{_sysconfdir}/cobbler/rsync.exclude
 %config(noreplace) %{_sysconfdir}/cobbler/rsync.template
 %config(noreplace) %{_sysconfdir}/cobbler/secondary.template
-%config(noreplace) %{_sysconfdir}/cobbler/settings.yaml
-%dir %{_sysconfdir}/cobbler/settings.d
-%config(noreplace) %{_sysconfdir}/cobbler/settings.d/bind_manage_ipmi.settings
-%config(noreplace) %{_sysconfdir}/cobbler/settings.d/manage_genders.settings
-%config(noreplace) %{_sysconfdir}/cobbler/settings.d/nsupdate.settings
-%config(noreplace) %{_sysconfdir}/cobbler/settings.d/windows.settings
-%config(noreplace) %{_sysconfdir}/cobbler/users.conf
-%config(noreplace) %{_sysconfdir}/cobbler/users.digest
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/settings.yaml
+%attr(750, root, %{apache_group}) %dir %{_sysconfdir}/cobbler/settings.d
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/bind_manage_ipmi.settings
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/manage_genders.settings
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/nsupdate.settings
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/settings.d/windows.settings
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/users.conf
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/users.digest
 %config(noreplace) %{_sysconfdir}/cobbler/version
 %config(noreplace) %{_sysconfdir}/cobbler/zone.template
 %dir %{_sysconfdir}/cobbler/zone_templates

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -75,10 +75,10 @@ class Templar:
         """
         lines = data.split("\n")
         for line in lines:
-            if line.find("#import") != -1:
-                rest = line.replace("#import", "").replace(" ", "").strip()
+            if "#import" in line or "#from" in line:
+                rest = line.replace("#import", "").replace("#from", "").replace("import", ".").replace(" ", "").strip()
                 if self.settings and rest not in self.settings.cheetah_import_whitelist:
-                    raise CX("potentially insecure import in template: %s" % rest)
+                    raise CX(f"Potentially insecure import in template: {rest}")
 
     def render(self, data_input: Union[TextIO, str], search_table: dict, out_path: Optional[str],
                template_type="default") -> str:


### PR DESCRIPTION
Two patches for CVE-2021-45082 and  CVE-2021-45083. One of them only touches the file permission that are being set up in the spec file, the other tightens the cheetah template sanitization.