### PR TITLE
docs: update URL to official Ansible integration

### DIFF
--- a/docs/user-guide/configuration-management-integrations.rst
+++ b/docs/user-guide/configuration-management-integrations.rst
@@ -212,7 +212,7 @@ Ansible
 
 Official integration:
 
-- https://github.com/cobbler/ansible
+- https://docs.ansible.com/ansible/latest/collections/community/general/cobbler_inventory.html#ansible-collections-community-general-cobbler-inventory
 
 Community provided integration:
 


### PR DESCRIPTION
The cobbler module for Ansible is now part of `community.general`.