### PR TITLE
Fix trigger stacktraces in cobbler.log

### DIFF
--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -60,7 +60,7 @@ class Files(collection.Collection):
 
         if with_delete:
             if with_triggers:
-                utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/file/*", [])
+                utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/file/pre/*", [])
 
         self.lock.acquire()
         try:

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -59,7 +59,7 @@ class Packages(collection.Collection):
 
         if with_delete:
             if with_triggers:
-                utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/package/*", [])
+                utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/package/pre/*", [])
 
         self.lock.acquire()
         try:

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -966,7 +966,7 @@ def run_triggers(api, ref, globber, additional: list = None):
 
     :param api: The api object to use for resolving the actions.
     :param ref: Can be a Cobbler object, if not None, the name will be passed to the script. If ref is None, the script
-                will be called with no argumenets.
+                will be called with no arguments.
     :param globber: is a wildcard expression indicating which triggers to run.
     :param additional: Additional arguments to run the triggers with.
     :raises CX: Raised in case the trigger failed.


### PR DESCRIPTION
The glob to the triggers was wrong. After fixing this the stacktraces
disappeared and triggers now behave for files and packages as
expected.

Typo fix for utils.run_triggers() is included for this change