### PR TITLE
Docker: Increase build timeout for DEB

### DIFF
--- a/docker/debs/build-and-install-debs.sh
+++ b/docker/debs/build-and-install-debs.sh
@@ -49,8 +49,8 @@ $EXECUTOR exec -it cobbler bash -c 'a2enconf cobbler'
 echo "==> Start Supervisor"
 $EXECUTOR exec -it cobbler bash -c 'supervisord -c /etc/supervisord.conf'
 
-echo "==> Wait 5 sec. and show Cobbler version ..."
-$EXECUTOR exec -it cobbler bash -c 'sleep 5 && cobbler --version'
+echo "==> Wait 20 sec. and show Cobbler version ..."
+$EXECUTOR exec -it cobbler bash -c 'sleep 20 && cobbler --version'
 
 if $RUN_TESTS
 then


### PR DESCRIPTION
Locally this works, however in the CI it does not. This PR aims to find a solution for this.