### PR TITLE
Fix wrong usage of the collection manager

### DIFF
--- a/cobbler/actions/acl.py
+++ b/cobbler/actions/acl.py
@@ -30,15 +30,14 @@ from cobbler.cexceptions import CX
 
 class AclConfig:
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The collection manager which holds all information about Cobbler.
+        :param api: The API which holds all information about Cobbler.
         """
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.settings = collection_mgr.settings()
+        self.api = api
+        self.settings = api.settings()
 
     def run(self, adduser: Optional[str] = None, addgroup: Optional[str] = None, removeuser: Optional[str] = None,
             removegroup: Optional[str] = None):

--- a/cobbler/actions/check.py
+++ b/cobbler/actions/check.py
@@ -35,14 +35,14 @@ class CobblerCheck:
     serving up content. This is the code behind 'cobbler check'.
     """
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The collection manager which holds all information.
+        :param api: The API which holds all information.
         """
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
+        self.api = api
+        self.settings = api.settings()
         self.logger = logging.getLogger()
         self.checked_family = ""
 
@@ -58,7 +58,7 @@ class CobblerCheck:
         self.check_name(status)
         self.check_selinux(status)
         if self.settings.manage_dhcp:
-            mode = self.collection_mgr.api.get_sync().dhcp.what()
+            mode = self.api.get_sync().dhcp.what()
             if mode == "isc":
                 self.check_dhcpd_bin(status)
                 self.check_dhcpd_conf(status)
@@ -68,7 +68,7 @@ class CobblerCheck:
                 self.check_service(status, "dnsmasq")
 
         if self.settings.manage_dns:
-            mode = self.collection_mgr.api.get_sync().dns.what()
+            mode = self.api.get_sync().dns.what()
             if mode == "bind":
                 self.check_bind_bin(status)
                 self.check_service(status, "named")
@@ -76,7 +76,7 @@ class CobblerCheck:
                 self.check_dnsmasq_bin(status)
                 self.check_service(status, "dnsmasq")
 
-        mode = self.collection_mgr.api.get_sync().tftpd.what()
+        mode = self.api.get_sync().tftpd.what()
         if mode == "in_tftpd":
             self.check_tftpd_dir(status)
         elif mode == "tftpd_py":
@@ -260,7 +260,7 @@ class CobblerCheck:
         if self.checked_family == "debian":
             return
 
-        enabled = self.collection_mgr.api.is_selinux_enabled()
+        enabled = self.api.is_selinux_enabled()
         if enabled:
             status.append("SELinux is enabled. Please review the following wiki page for details on ensuring Cobbler "
                           "works correctly in your SELinux environment:\n    "
@@ -288,9 +288,9 @@ class CobblerCheck:
         repos = []
         referenced = []
         not_found = []
-        for r in self.collection_mgr.api.repos():
+        for r in self.api.repos():
             repos.append(r.name)
-        for p in self.collection_mgr.api.profiles():
+        for p in self.api.profiles():
             my_repos = p.repos
             if my_repos != "<<inherit>>":
                 referenced.extend(my_repos)
@@ -308,7 +308,7 @@ class CobblerCheck:
         :param status: The status list with possible problems.
         """
         need_sync = []
-        for r in self.collection_mgr.repos():
+        for r in self.api.repos():
             if r.mirror_locally == 1:
                 lookfor = os.path.join(self.settings.webdir, "repo_mirror", r.name)
                 if not os.path.exists(lookfor):

--- a/cobbler/actions/log.py
+++ b/cobbler/actions/log.py
@@ -23,6 +23,7 @@ import glob
 import os
 import os.path
 import logging
+import pathlib
 
 
 class LogTool:
@@ -30,23 +31,22 @@ class LogTool:
     Helpers for dealing with System logs, anamon, etc..
     """
 
-    def __init__(self, collection_mgr, system, api):
+    def __init__(self, system, api):
         """
         Log library constructor requires a Cobbler system object.
         """
         self.system = system
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
         self.api = api
+        self.settings = api.settings()
         self.logger = logging.getLogger()
 
     def clear(self):
         """
         Clears the system logs
         """
-        anamon_dir = '/var/log/cobbler/anamon/%s' % self.system.name
-        if os.path.isdir(anamon_dir):
-            logs = list(filter(os.path.isfile, glob.glob('%s/*' % anamon_dir)))
+        anamon_dir = pathlib.Path('/var/log/cobbler/anamon/').joinpath(self.system.name)
+        if anamon_dir.is_dir():
+            logs = list(filter(os.path.isfile, glob.glob(str(anamon_dir.joinpath('*')))))
         else:
             logs = []
             logging.info("No log-files found to delete for system: %s", self.system.name)

--- a/cobbler/actions/replicate.py
+++ b/cobbler/actions/replicate.py
@@ -37,15 +37,14 @@ class Replicate:
     This class contains the magic to replicate a Cobbler instance to another Cobbler instance.
     """
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The collection manager which holds all information available in Cobbler.
+        :param api: The API which holds all information available in Cobbler.
         """
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
-        self.api = collection_mgr.api
+        self.settings = api.settings()
+        self.api = api
         self.remote = None
         self.uri = None
         self.logger = logging.getLogger()

--- a/cobbler/actions/report.py
+++ b/cobbler/actions/report.py
@@ -22,15 +22,14 @@ from cobbler import utils
 
 class Report:
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The collection manager to hold all information in Cobbler available.
+        :param api: The API to hold all information in Cobbler available.
         """
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
-        self.api = collection_mgr.api
+        self.settings = api.settings()
+        self.api = api
         self.report_type = None
         self.report_what = None
         self.report_name = None

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -78,28 +78,23 @@ class RepoSync:
 
     # ==================================================================================
 
-    def __init__(self, collection_mgr, tries: int = 1, nofail: bool = False):
+    def __init__(self, api, tries: int = 1, nofail: bool = False):
         """
         Constructor
 
-        :param collection_mgr: The object which holds all information in Cobbler.
+        :param api: The object which holds all information in Cobbler.
         :param tries: The number of tries before the operation fails.
         :param nofail: This sets the strictness of the reposync result handling.
-        :param logger: The logger to audit all actions with.
         """
         self.verbose = True
-        self.api = collection_mgr.api
-        self.collection_mgr = collection_mgr
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
+        self.api = api
+        self.settings = api.settings()
+        self.repos = api.repos()
         self.rflags = self.settings.reposync_flags
         self.tries = tries
         self.nofail = nofail
         self.logger = logging.getLogger()
-        self.dlmgr = download_manager.DownloadManager(self.collection_mgr)
+        self.dlmgr = download_manager.DownloadManager(self.api)
 
         self.logger.info("hello, reposync")
 

--- a/cobbler/actions/status.py
+++ b/cobbler/actions/status.py
@@ -37,16 +37,15 @@ STATE = 5
 
 class CobblerStatusReport:
 
-    def __init__(self, collection_mgr, mode: str):
+    def __init__(self, api, mode: str):
         """
         Constructor
 
-        :param collection_mgr: The collection manager which holds all information.
+        :param api: The API which holds all information.
         :param mode: This describes how Cobbler should report. Currently there only the option ``text`` can be set
                      explicitly.
         """
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
+        self.settings = api.settings()
         self.ip_data = {}
         self.mode = mode
 

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -38,11 +38,11 @@ class CobblerSync:
     Handles conversion of internal state to the tftpboot tree layout
     """
 
-    def __init__(self, collection_mgr, verbose: bool = True, dhcp=None, dns=None, tftpd=None):
+    def __init__(self, api, verbose: bool = True, dhcp=None, dns=None, tftpd=None):
         """
         Constructor
 
-        :param collection_mgr: The collection manager instance which holds all information about cobbler.
+        :param api: The API instance which holds all information about cobbler.
         :param verbose: Whether to log the actions performed in this module verbose or not.
         :param dhcp: The DHCP manager which can update the DHCP config.
         :param dns: The DNS manager which can update the DNS config.
@@ -51,16 +51,15 @@ class CobblerSync:
         self.logger = logging.getLogger()
 
         self.verbose = verbose
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.images = collection_mgr.images()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
-        self.tftpgen = tftpgen.TFTPGen(collection_mgr)
+        self.api = api
+        self.distros = api.distros()
+        self.profiles = api.profiles()
+        self.systems = api.systems()
+        self.images = api.images()
+        self.settings = api.settings()
+        self.repos = api.repos()
+        self.templar = templar.Templar(self.api)
+        self.tftpgen = tftpgen.TFTPGen(api)
         self.dns = dns
         self.dhcp = dhcp
         self.tftpd = tftpd
@@ -89,11 +88,11 @@ class CobblerSync:
         # run pre-triggers...
         utils.run_triggers(self.api, None, "/var/lib/cobbler/triggers/sync/pre/*")
 
-        self.distros = self.collection_mgr.distros()
-        self.profiles = self.collection_mgr.profiles()
-        self.systems = self.collection_mgr.systems()
-        self.settings = self.collection_mgr.settings()
-        self.repos = self.collection_mgr.repos()
+        self.distros = self.api.distros()
+        self.profiles = self.api.profiles()
+        self.systems = self.api.systems()
+        self.settings = self.api.settings()
+        self.repos = self.api.repos()
 
         # Have the tftpd module handle copying bootloaders, distros, images, and all_system_files
         self.tftpd.sync_systems(systems)
@@ -130,11 +129,11 @@ class CobblerSync:
         # run pre-triggers...
         utils.run_triggers(self.api, None, "/var/lib/cobbler/triggers/sync/pre/*")
 
-        self.distros = self.collection_mgr.distros()
-        self.profiles = self.collection_mgr.profiles()
-        self.systems = self.collection_mgr.systems()
-        self.settings = self.collection_mgr.settings()
-        self.repos = self.collection_mgr.repos()
+        self.distros = self.api.distros()
+        self.profiles = self.api.profiles()
+        self.systems = self.api.systems()
+        self.settings = self.api.settings()
+        self.repos = self.api.repos()
 
         # execute the core of the sync operation
         self.logger.info("cleaning trees")

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -122,10 +122,10 @@ class CobblerAPI:
             # FIXME: pass more loggers around, and also see that those using things via tasks construct their own
             #  yumgen/tftpgen versus reusing this one, which has the wrong logger (most likely) for background tasks.
 
-            self.autoinstallgen = autoinstallgen.AutoInstallationGen(self._collection_mgr)
-            self.yumgen = yumgen.YumGen(self._collection_mgr)
-            self.tftpgen = tftpgen.TFTPGen(self._collection_mgr)
-            self.power_mgr = power_manager.PowerManager(self, self._collection_mgr)
+            self.autoinstallgen = autoinstallgen.AutoInstallationGen(self)
+            self.yumgen = yumgen.YumGen(self)
+            self.tftpgen = tftpgen.TFTPGen(self)
+            self.power_mgr = power_manager.PowerManager(self)
             self.logger.debug("API handle initialized")
             self.perms_ok = True
 
@@ -668,7 +668,7 @@ class CobblerAPI:
         :return: An empty Distro object.
         """
         self.log("new_distro", [is_subobject])
-        return distro.Distro(self._collection_mgr, is_subobject=is_subobject)
+        return distro.Distro(self, is_subobject=is_subobject)
 
     def new_profile(self, is_subobject: bool = False):
         """
@@ -679,7 +679,7 @@ class CobblerAPI:
         :return: An empty Profile object.
         """
         self.log("new_profile", [is_subobject])
-        return profile.Profile(self._collection_mgr, is_subobject=is_subobject)
+        return profile.Profile(self, is_subobject=is_subobject)
 
     def new_system(self, is_subobject: bool = False):
         """
@@ -690,7 +690,7 @@ class CobblerAPI:
         :return: An empty System object.
         """
         self.log("new_system", [is_subobject])
-        return system.System(self._collection_mgr, is_subobject=is_subobject)
+        return system.System(self, is_subobject=is_subobject)
 
     def new_repo(self, is_subobject: bool = False):
         """
@@ -701,7 +701,7 @@ class CobblerAPI:
         :return: An empty repo object.
         """
         self.log("new_repo", [is_subobject])
-        return repo.Repo(self._collection_mgr, is_subobject=is_subobject)
+        return repo.Repo(self, is_subobject=is_subobject)
 
     def new_image(self, is_subobject: bool = False):
         """
@@ -712,7 +712,7 @@ class CobblerAPI:
         :return: An empty image object.
         """
         self.log("new_image", [is_subobject])
-        return image.Image(self._collection_mgr, is_subobject=is_subobject)
+        return image.Image(self, is_subobject=is_subobject)
 
     def new_mgmtclass(self, is_subobject: bool = False):
         """
@@ -723,7 +723,7 @@ class CobblerAPI:
         :return: An empty mgmtclass object.
         """
         self.log("new_mgmtclass", [is_subobject])
-        return mgmtclass.Mgmtclass(self._collection_mgr, is_subobject=is_subobject)
+        return mgmtclass.Mgmtclass(self, is_subobject=is_subobject)
 
     def new_package(self, is_subobject: bool = False):
         """
@@ -734,7 +734,7 @@ class CobblerAPI:
         :return: An empty Package object.
         """
         self.log("new_package", [is_subobject])
-        return package.Package(self._collection_mgr, is_subobject=is_subobject)
+        return package.Package(self, is_subobject=is_subobject)
 
     def new_file(self, is_subobject: bool = False):
         """
@@ -745,7 +745,7 @@ class CobblerAPI:
         :return: An empty File object.
         """
         self.log("new_file", [is_subobject])
-        return file.File(self._collection_mgr, is_subobject=is_subobject)
+        return file.File(self, is_subobject=is_subobject)
 
     def new_menu(self, is_subobject: bool = False):
         """
@@ -756,7 +756,7 @@ class CobblerAPI:
         :return: An empty File object.
         """
         self.log("new_menu", [is_subobject])
-        return menu.Menu(self._collection_mgr, is_subobject=is_subobject)
+        return menu.Menu(self, is_subobject=is_subobject)
 
     # ==========================================================================
 
@@ -1150,7 +1150,7 @@ class CobblerAPI:
         """
         try:
             url = self.settings().signature_url
-            dlmgr = download_manager.DownloadManager(self._collection_mgr)
+            dlmgr = download_manager.DownloadManager(self)
             # write temp json file
             tmpfile = tempfile.NamedTemporaryFile()
             sigjson = dlmgr.urlread(url)
@@ -1357,7 +1357,7 @@ class CobblerAPI:
         :return: None or a list of things to address.
         """
         self.log("check")
-        action_check = check.CobblerCheck(self._collection_mgr)
+        action_check = check.CobblerCheck(self)
         return action_check.run()
 
     # ==========================================================================
@@ -1368,7 +1368,7 @@ class CobblerAPI:
 
         """
         self.log("validate_autoinstall_files")
-        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self._collection_mgr)
+        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self)
         autoinstall_mgr.validate_autoinstall_files()
 
     # ==========================================================================
@@ -1428,7 +1428,7 @@ class CobblerAPI:
             "module",
             "managers.bind"
         )
-        dns = dns_module.get_manager(self._collection_mgr)
+        dns = dns_module.get_manager(self)
         dns.sync()
 
     # ==========================================================================
@@ -1446,7 +1446,7 @@ class CobblerAPI:
             "module",
             "managers.isc"
         )
-        dhcp = dhcp_module.get_manager(self._collection_mgr)
+        dhcp = dhcp_module.get_manager(self)
         dhcp.sync()
 
     # ==========================================================================
@@ -1464,19 +1464,19 @@ class CobblerAPI:
             "dhcp",
             "module",
             "managers.isc"
-        ).get_manager(self._collection_mgr)
+        ).get_manager(self)
         dns = self.get_module_from_file(
             "dns",
             "module",
             "managers.bind"
-        ).get_manager(self._collection_mgr)
+        ).get_manager(self)
         tftpd = self.get_module_from_file(
             "tftpd",
             "module",
             "managers.in_tftpd",
-        ).get_manager(self._collection_mgr)
+        ).get_manager(self)
 
-        return sync.CobblerSync(self._collection_mgr, dhcp=dhcp, dns=dns, tftpd=tftpd, verbose=verbose)
+        return sync.CobblerSync(self, dhcp=dhcp, dns=dns, tftpd=tftpd, verbose=verbose)
 
     # ==========================================================================
 
@@ -1491,7 +1491,7 @@ class CobblerAPI:
                        ``tries`` parameter.
         """
         self.log("reposync", [name])
-        action_reposync = reposync.RepoSync(self._collection_mgr, tries=tries, nofail=nofail)
+        action_reposync = reposync.RepoSync(self, tries=tries, nofail=nofail)
         action_reposync.run(name)
 
     # ==========================================================================
@@ -1503,7 +1503,7 @@ class CobblerAPI:
         :param mode: "text" or anything else. Meaning whether the output is thought for the terminal or not.
         :return: The current status of Cobbler.
         """
-        statusifier = status.CobblerStatusReport(self._collection_mgr, mode)
+        statusifier = status.CobblerStatusReport(self, mode)
         return statusifier.run()
 
     # ==========================================================================
@@ -1605,7 +1605,7 @@ class CobblerAPI:
                     return False
 
         import_module = self.get_module_by_name("managers.import_signatures") \
-            .get_import_manager(self._collection_mgr)
+            .get_import_manager(self)
         import_module.run(path, mirror_name, network_root, autoinstall_file, arch, breed, os_version)
         return True
 
@@ -1622,7 +1622,7 @@ class CobblerAPI:
         :param removeuser:
         :param removegroup:
         """
-        action_acl = acl.AclConfig(self._collection_mgr)
+        action_acl = acl.AclConfig(self)
         action_acl.run(
             adduser=adduser,
             addgroup=addgroup,
@@ -1795,7 +1795,7 @@ class CobblerAPI:
                          if False then only some things are synced.
         :param use_ssl: Whether SSL should be used (True) or not (False).
         """
-        replicator = replicate.Replicate(self._collection_mgr)
+        replicator = replicate.Replicate(self)
         return replicator.run(
             cobbler_master=cobbler_master, port=port, distro_patterns=distro_patterns,
             profile_patterns=profile_patterns, system_patterns=system_patterns, repo_patterns=repo_patterns,
@@ -1817,7 +1817,7 @@ class CobblerAPI:
         :param report_fields: Specify "all" or the fields you want to be reported.
         :param report_noheaders: If the column headers should be included in the output or not.
         """
-        reporter = report.Report(self._collection_mgr)
+        reporter = report.Report(self)
         return reporter.run(report_what=report_what, report_name=report_name, report_type=report_type,
                             report_fields=report_fields, report_noheaders=report_noheaders)
 
@@ -1855,7 +1855,7 @@ class CobblerAPI:
 
         :param system: The system to clear logs of.
         """
-        log.LogTool(self._collection_mgr, system, self).clear()
+        log.LogTool(system, self).clear()
 
     # ==========================================================================
 

--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -18,17 +18,16 @@ class AutoInstallationManager:
     Manage automatic installation templates, snippets and final files
     """
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor for the autoinstall manager.
 
-        :param collection_mgr: The collection manager which has all objects.
+        :param api: The collection manager which has all objects.
         """
-
-        self.collection_mgr = collection_mgr
-        self.snippets_base_dir = self.collection_mgr.settings().autoinstall_snippets_dir
-        self.templates_base_dir = self.collection_mgr.settings().autoinstall_templates_dir
-        self.autoinstallgen = autoinstallgen.AutoInstallationGen(self.collection_mgr)
+        self.api = api
+        self.snippets_base_dir = api.settings().autoinstall_snippets_dir
+        self.templates_base_dir = api.settings().autoinstall_templates_dir
+        self.autoinstallgen = autoinstallgen.AutoInstallationGen(api)
         self.logger = logging.getLogger()
 
     def validate_autoinstall_template_file_path(self, autoinstall: str, for_item: bool = True,
@@ -245,10 +244,10 @@ class AutoInstallationManager:
         :param name: The name of the system.
         :return: Whether the system is in install mode or not.
         """
-        for x in self.collection_mgr.profiles():
+        for x in self.api.profiles():
             if x.autoinstall is not None and x.autoinstall == name:
                 return True
-        for x in self.collection_mgr.systems():
+        for x in self.api.systems():
             if x.autoinstall is not None and x.autoinstall == name:
                 return True
         return False
@@ -293,7 +292,7 @@ class AutoInstallationManager:
         :returns: [bool, int, list] list with validation result, errors type and list of errors
         """
 
-        blended = utils.blender(self.collection_mgr.api, False, obj)
+        blended = utils.blender(self.api, False, obj)
 
         # get automatic installation template
         autoinstall = blended["autoinstall"]
@@ -325,13 +324,13 @@ class AutoInstallationManager:
         """
         overall_success = True
 
-        for x in self.collection_mgr.profiles():
+        for x in self.api.profiles():
             (success, errors_type, errors) = self.validate_autoinstall_file(x, True)
             if not success:
                 overall_success = False
             if len(errors) > 0:
                 self.log_autoinstall_validation_errors(errors_type, errors)
-        for x in self.collection_mgr.systems():
+        for x in self.api.systems():
             (success, errors_type, errors) = self.validate_autoinstall_file(x, False)
             if not success:
                 overall_success = False

--- a/cobbler/autoinstallgen.py
+++ b/cobbler/autoinstallgen.py
@@ -34,21 +34,16 @@ class AutoInstallationGen:
     """
     Handles conversion of internal state to the tftpboot tree layout
     """
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The collection manager instance which is used for this object. Normally there is only one
+        :param api: The API instance which is used for this object. Normally there is only one
                                instance of the collection manager.
         """
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
+        self.api = api
+        self.settings = api.settings()
+        self.templar = templar.Templar(self.api)
 
     def createAutoYaSTScript(self, document, script, name):
         """

--- a/cobbler/download_manager.py
+++ b/cobbler/download_manager.py
@@ -25,14 +25,13 @@ import requests
 
 class DownloadManager:
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: This is the current collection manager instance which holds the settings.
+        :param api: This is the current API instance which holds the settings.
         """
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
+        self.settings = api.settings()
         self.logger = logging.getLogger()
         self.cert = ()
         if self.settings.proxy_url_ext:

--- a/cobbler/manager.py
+++ b/cobbler/manager.py
@@ -24,7 +24,7 @@ import logging
 import cobbler.templar as templar
 
 
-class ManagerModule():
+class ManagerModule:
     """
     Base class for Manager modules located in ``modules/manager/*.py``
 
@@ -42,21 +42,20 @@ class ManagerModule():
         """
         return "undefined"
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The collection manager to resolve all information with.
+        :param api: The API instance to resolve all information with.
         """
         self.logger = logging.getLogger()
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
+        self.api = api
+        self.distros = self.api.distros()
+        self.profiles = self.api.profiles()
+        self.systems = self.api.systems()
+        self.settings = self.api.settings()
+        self.repos = self.api.repos()
+        self.templar = templar.Templar(self.api)
 
     def write_configs(self):
         """

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -91,7 +91,7 @@ def run(api, args) -> int:
     with open("/etc/cobbler/reporting/build_report_email.template") as input_template:
         input_data = input_template.read()
 
-        message = templar.Templar(api._collection_mgr).render(
+        message = templar.Templar(api).render(
             input_data, metadata, None
         )
 

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -49,8 +49,8 @@ class _BindManager(ManagerModule):
         """
         return "bind"
 
-    def __init__(self, collection_mgr):
-        super().__init__(collection_mgr)
+    def __init__(self, api):
+        super().__init__(api)
 
         self.settings_file = utils.namedconf_location()
         self.zonefile_base = self.settings.bind_zonefile_path + "/"
@@ -619,16 +619,16 @@ zone "%(arpa)s." {
         return ret
 
 
-def get_manager(collection_mgr):
+def get_manager(api):
     """
     This returns the object to manage a BIND server located locally on the Cobbler server.
 
-    :param collection_mgr: The collection manager to resolve all information with.
+    :param api: The API to resolve all information with.
     :return: The BindManger object to manage bind with.
     """
     # Singleton used, therefore ignoring 'global'
     global MANAGER  # pylint: disable=global-statement
 
     if not MANAGER:
-        MANAGER = _BindManager(collection_mgr)
+        MANAGER = _BindManager(api)
     return MANAGER

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -199,16 +199,16 @@ class _DnsmasqManager(ManagerModule):
                 raise CX(error_msg)
 
 
-def get_manager(collection_mgr):
+def get_manager(api):
     """
     Creates a manager object to manage a dnsmasq server.
 
-    :param collection_mgr: The collection manager to resolve all information with.
+    :param api: The API to resolve all information with.
     :return: The object generated from the class.
     """
     # Singleton used, therefore ignoring 'global'
     global MANAGER  # pylint: disable=global-statement
 
     if not MANAGER:
-        MANAGER = _DnsmasqManager(collection_mgr)
+        MANAGER = _DnsmasqManager(api)
     return MANAGER

--- a/cobbler/modules/managers/genders.py
+++ b/cobbler/modules/managers/genders.py
@@ -28,7 +28,7 @@ def write_genders_file(config, profiles_genders, distros_genders, mgmtcls_gender
     """
     Genders file is over-written when ``manage_genders`` is set in our settings.
 
-    :param config: The config file to template with the data.
+    :param config: The API instance to template the data with.
     :param profiles_genders: The profiles which should be included.
     :param distros_genders: The distros which should be included.
     :param mgmtcls_genders: The management classes which should be included.
@@ -115,5 +115,5 @@ def run(api, args) -> int:
         logger.info("Please run: touch " + settings_file + " as root and try again.")
         return 1
 
-    write_genders_file(api._collection_mgr, profiles_genders, distros_genders, mgmtcls_genders)
+    write_genders_file(api, profiles_genders, distros_genders, mgmtcls_genders)
     return 0

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -106,8 +106,8 @@ class _ImportSignatureManager(ManagerModule):
         """
         return "import/signatures"
 
-    def __init__(self, collection_mgr):
-        super().__init__(collection_mgr)
+    def __init__(self, api):
+        super().__init__(api)
 
         self.signature = None
         self.found_repos = {}
@@ -814,7 +814,7 @@ class _ImportSignatureManager(ManagerModule):
         if not mirror:
             mirror = "http://archive.ubuntu.com/ubuntu"
 
-        repo = item_repo.Repo(self.collection_mgr)
+        repo = item_repo.Repo(self.api)
         repo.breed = enums.RepoBreeds.APT
         repo.arch = distribution.arch
         repo.keep_updated = True
@@ -830,8 +830,7 @@ class _ImportSignatureManager(ManagerModule):
             repo.mirror = "http://ftp.%s.debian.org/debian/dists/%s" % ('us', distribution.os_version)
 
         self.logger.info("Added repos for %s" % distribution.name)
-        repos = self.collection_mgr.repos()
-        repos.add(repo, save=True)
+        self.api.add_repo(repo)
         # FIXME: Add the found/generated repos to the profiles that were created during the import process
 
     def get_repo_mirror_from_apt(self):
@@ -878,16 +877,16 @@ class _ImportSignatureManager(ManagerModule):
 # ==========================================================================
 
 
-def get_import_manager(collection_mgr):
+def get_import_manager(api):
     """
     Get an instance of the import manager which enables you to import various things.
 
-    :param collection_mgr: The collection Manager instance of Cobbler
+    :param api: The API instance of Cobbler
     :return: The object to import data with.
     """
     # Singleton used, therefore ignoring 'global'
     global MANAGER  # pylint: disable=global-statement
 
     if not MANAGER:
-        MANAGER = _ImportSignatureManager(collection_mgr)
+        MANAGER = _ImportSignatureManager(api)
     return MANAGER

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -50,8 +50,8 @@ class _IscManager(ManagerModule):
         """
         return "isc"
 
-    def __init__(self, collection_mgr):
-        super().__init__(collection_mgr)
+    def __init__(self, api):
+        super().__init__(api)
 
         self.settings_file_v4 = utils.dhcpconf_location(utils.DHCP.V4)
         self.settings_file_v6 = utils.dhcpconf_location(utils.DHCP.V6)
@@ -420,16 +420,16 @@ class _IscManager(ManagerModule):
         return ret
 
 
-def get_manager(collection_mgr):
+def get_manager(api):
     """
     Creates a manager object to manage an isc dhcp server.
 
-    :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
+    :param api: The API which holds all information in the current Cobbler instance.
     :return: The object to manage the server with.
     """
     # Singleton used, therefore ignoring 'global'
     global MANAGER  # pylint: disable=global-statement
 
     if not MANAGER:
-        MANAGER = _IscManager(collection_mgr)
+        MANAGER = _IscManager(api)
     return MANAGER

--- a/cobbler/modules/managers/ndjbdns.py
+++ b/cobbler/modules/managers/ndjbdns.py
@@ -47,8 +47,8 @@ class _NDjbDnsManager(ManagerModule):
         """
         return "ndjbdns"
 
-    def __init__(self, collection_mgr):
-        super().__init__(collection_mgr)
+    def __init__(self, api):
+        super().__init__(api)
 
     def write_configs(self):
         """
@@ -86,16 +86,16 @@ class _NDjbDnsManager(ManagerModule):
             raise Exception('Could not regenerate tinydns data file.')
 
 
-def get_manager(collection_mgr):
+def get_manager(api):
     """
     Creates a manager object to manage an isc dhcp server.
 
-    :param collection_mgr: The collection manager which holds all information in the current Cobbler instance.
+    :param api: The API which holds all information in the current Cobbler instance.
     :return: The object to manage the server with.
     """
     # Singleton used, therefore ignoring 'global'
     global MANAGER  # pylint: disable=global-statement
 
     if not MANAGER:
-        MANAGER = _NDjbDnsManager(collection_mgr)
+        MANAGER = _NDjbDnsManager(api)
     return MANAGER

--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -141,8 +141,8 @@ def run(api, args):
 
     profiles = api.profiles()
     systems = api.systems()
-    templ = templar.Templar(api._collection_mgr)
-    tgen = tftpgen.TFTPGen(api._collection_mgr)
+    templ = templar.Templar(api)
+    tgen = tftpgen.TFTPGen(api)
 
     with open(os.path.join(settings.windows_template_dir, post_inst_cmd_template_name)) as template_win:
         post_tmpl_data = template_win.read()

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -94,19 +94,14 @@ class PowerManager:
     Handles power management in systems
     """
 
-    def __init__(self, api, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
         :param api: Cobbler API
-        :type api: CobblerAPI
-        :param collection_mgr: collection manager
-        :type collection_mgr: CollectionManager
         """
-
-        self.collection_mgr = collection_mgr
-        self.settings = collection_mgr.settings()
         self.api = api
+        self.settings = api.settings()
         self.logger = logging.getLogger()
 
     def _check_power_conf(self, system, user, password):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -135,8 +135,8 @@ class CobblerXMLRPCInterface:
         self.events = {}
         self.shared_secret = utils.get_shared_secret()
         random.seed(time.time())
-        self.tftpgen = tftpgen.TFTPGen(api._collection_mgr)
-        self.autoinstall_mgr = autoinstall_manager.AutoInstallationManager(api._collection_mgr)
+        self.tftpgen = tftpgen.TFTPGen(api)
+        self.autoinstall_mgr = autoinstall_manager.AutoInstallationManager(api)
 
     def check(self, token: str) -> Union[None, list]:
         """

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -27,7 +27,7 @@ import xmlrpc.client
 import yaml
 
 from cobbler import download_manager
-from cobbler.cobbler_collections import manager
+from cobbler.api import CobblerAPI
 from cobbler.settings import Settings
 
 
@@ -36,6 +36,7 @@ class CobblerSvc:
     Interesting mod python functions are all keyed off the parameter mode, which defaults to index. All options are
     passed as parameters into the function.
     """
+
     def __init__(self, server=None, req=None):
         """
         Default constructor which sets up everything to be ready.
@@ -47,8 +48,8 @@ class CobblerSvc:
         self.server = server
         self.remote = None
         self.req = req
-        self.collection_mgr = manager.CollectionManager(self)
-        self.dlmgr = download_manager.DownloadManager(self.collection_mgr)
+        self.api = CobblerAPI()
+        self.dlmgr = download_manager.DownloadManager(self.api)
 
     def __xmlrpc_setup(self):
         """
@@ -356,7 +357,7 @@ class CobblerSvc:
         """
         self.__xmlrpc_setup()
 
-        serverseg = "http://%s" % self.collection_mgr._settings.server
+        serverseg = "http://%s" % self.api.settings().server
 
         name = "?"
         if system is not None:
@@ -386,7 +387,7 @@ class CobblerSvc:
         """
         self.__xmlrpc_setup()
 
-        serverseg = "http://%s" % self.collection_mgr._settings.server
+        serverseg = "http://%s" % self.api.settings().server
 
         name = "?"
         if system is not None:

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -48,21 +48,14 @@ class Templar:
     via our self-defined API in this class.
     """
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The main collection manager instance which is used by the current running server.
+        :param api: The main API instance which is used by the current running server.
         """
-
-        self.collection_mgr = None
-        self.settings = None
-        if collection_mgr:
-            self.collection_mgr = collection_mgr
-            self.settings = collection_mgr.settings()
-
+        self.settings = api.settings()
         self.last_errors = []
-
         self.logger = logging.getLogger()
 
     def check_for_invalid_imports(self, data: str):

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -38,21 +38,20 @@ class TFTPGen:
     Generate files provided by TFTP server
     """
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
         """
-        self.collection_mgr = collection_mgr
         self.logger = logging.getLogger()
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.images = collection_mgr.images()
-        self.menus = collection_mgr.menus()
-        self.templar = templar.Templar(collection_mgr)
+        self.api = api
+        self.distros = api.distros()
+        self.profiles = api.profiles()
+        self.systems = api.systems()
+        self.settings = api.settings()
+        self.repos = api.repos()
+        self.images = api.images()
+        self.menus = api.menus()
+        self.templar = templar.Templar(self.api)
         self.bootloc = self.settings.tftpboot_location
 
     def copy_bootloaders(self, dest):

--- a/cobbler/yumgen.py
+++ b/cobbler/yumgen.py
@@ -21,9 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-
-import os
-import os.path
+import pathlib
 
 from cobbler import templar
 from cobbler import utils
@@ -31,20 +29,15 @@ from cobbler import utils
 
 class YumGen:
 
-    def __init__(self, collection_mgr):
+    def __init__(self, api):
         """
         Constructor
 
-        :param collection_mgr: The main collection manager instance which is used by the current running server.
+        :param api: The main API instance which is used by the current running server.
         """
-        self.collection_mgr = collection_mgr
-        self.api = collection_mgr.api
-        self.distros = collection_mgr.distros()
-        self.profiles = collection_mgr.profiles()
-        self.systems = collection_mgr.systems()
-        self.settings = collection_mgr.settings()
-        self.repos = collection_mgr.repos()
-        self.templar = templar.Templar(collection_mgr)
+        self.api = api
+        self.settings = api.settings()
+        self.templar = templar.Templar(self.api)
 
     def get_yum_config(self, obj, is_profile: bool) -> str:
         """
@@ -66,13 +59,13 @@ class YumGen:
 
         included = {}
         for r in blended["source_repos"]:
-            filename = self.settings.webdir + "/" + "/".join(r[0].split("/")[4:])
+            filename = pathlib.Path(self.settings.webdir).joinpath("/", "/".join(r[0].split("/")[4:]))
             if filename not in included:
                 input_files.append(filename)
             included[filename] = 1
 
         for repo in blended["repos"]:
-            path = os.path.join(self.settings.webdir, "repo_mirror", repo, "config.repo")
+            path = pathlib.Path(self.settings.webdir).joinpath("repo_mirror", repo, "config.repo")
             if path not in included:
                 input_files.append(path)
             included[path] = 1

--- a/tests/templar_test.py
+++ b/tests/templar_test.py
@@ -2,7 +2,6 @@ import pytest
 
 from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
-from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.templar import Templar
 
 
@@ -24,8 +23,7 @@ def setup_cheetah_macros_file():
 def test_check_for_invalid_imports():
     # Arrange
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    test_templar = Templar(test_collection_mgr)
+    test_templar = Templar(test_api)
     testdata = "#import json"
 
     # Act & Assert
@@ -36,8 +34,7 @@ def test_check_for_invalid_imports():
 def test_render():
     # Arrange
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    test_templar = Templar(test_collection_mgr)
+    test_templar = Templar(test_api)
 
     # Act
     result = test_templar.render("", {}, None, template_type="cheetah")
@@ -49,8 +46,7 @@ def test_render():
 def test_render_cheetah():
     # Arrange
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    test_templar = Templar(test_collection_mgr)
+    test_templar = Templar(test_api)
 
     # Act
     result = test_templar.render_cheetah("$test", {"test": 5})
@@ -64,8 +60,7 @@ def test_render_cheetah():
 def test_cheetah_macros():
     # Arrange
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    templar = Templar(test_collection_mgr)
+    templar = Templar(test_api)
 
     # Act
     result = templar.render_cheetah("$myMethodInMacros(5)", {})
@@ -77,8 +72,7 @@ def test_cheetah_macros():
 def test_render_jinja2():
     # Arrange
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    test_templar = Templar(test_collection_mgr)
+    test_templar = Templar(test_api)
 
     # Act
     result = test_templar.render_jinja2("{{ foo }}", {"foo": "Test successful"})

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -1,29 +1,29 @@
 import glob
 import os
-import pytest
 import shutil
 
 from cobbler.api import CobblerAPI
-from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler import tftpgen
 from cobbler.items.distro import Distro
-from tests.conftest import does_not_raise
 
-# Tests copying the bootloaders from the bootloaders_dir (setting specified in /etc/cobbler/settings.yaml) to the tftpboot directory.
+
 def test_copy_bootloaders(tmpdir):
+    """
+    Tests copying the bootloaders from the bootloaders_dir (setting specified in /etc/cobbler/settings.yaml) to the
+    tftpboot directory.
+    """
     # Instantiate TFTPGen class with collection_mgr parameter
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    generator = tftpgen.TFTPGen(test_collection_mgr)
+    generator = tftpgen.TFTPGen(test_api)
 
     # Arrange
-    ## Create temporary bootloader files using tmpdir fixture
+    # Create temporary bootloader files using tmpdir fixture
     file_contents = "I am a bootloader"
     sub_path = tmpdir.mkdir("loaders")
     sub_path.join("bootloader1").write(file_contents)
     sub_path.join("bootloader2").write(file_contents)
 
-    ## Copy temporary bootloader files from tmpdir to expected source directory
+    # Copy temporary bootloader files from tmpdir to expected source directory
     for file in glob.glob(str(sub_path + "/*")):
         bootloader_src = "/var/lib/cobbler/loaders/"
         shutil.copy(file, bootloader_src + file.split("/")[-1])
@@ -35,12 +35,14 @@ def test_copy_bootloaders(tmpdir):
     assert os.path.isfile("/srv/tftpboot/bootloader1")
     assert os.path.isfile("/srv/tftpboot/bootloader2")
 
-# Tests copy_single_distro_file() method using a sample initrd file pulled from Centos 8
+
 def test_copy_single_distro_file():
+    """
+    Tests copy_single_distro_file() method using a sample initrd file pulled from CentOS 8
+    """
     # Instantiate TFTPGen class with collection_mgr parameter
     test_api = CobblerAPI()
-    test_collection_mgr = CollectionManager(test_api)
-    generator = tftpgen.TFTPGen(test_collection_mgr)
+    generator = tftpgen.TFTPGen(test_api)
 
     # Arrange
     distro_file = "/code/tests/test_data/dummy_initramfs"
@@ -61,8 +63,6 @@ def test_copy_single_distro_files(create_kernel_initrd, fk_initrd, fk_kernel):
     directory = create_kernel_initrd(fk_kernel, fk_initrd)
     # Create test API        
     test_api = CobblerAPI()
-    # Get Collection Manager used by the API
-    test_collection_mgr = test_api._collection_mgr
     # Create a test Distro
     test_distro = Distro(test_api)
     test_distro.name = "test_copy_single_distro_files"
@@ -71,7 +71,7 @@ def test_copy_single_distro_files(create_kernel_initrd, fk_initrd, fk_kernel):
     # Add test distro to the API
     test_api.add_distro(test_distro)
     # Create class under test
-    test_gen = tftpgen.TFTPGen(test_collection_mgr)
+    test_gen = tftpgen.TFTPGen(test_api)
 
     # Act
     test_gen.copy_single_distro_files(test_distro, directory, False)


### PR DESCRIPTION
Currently we use in some places the collection manager. This is an internal component I don't want to access outside of the API module. Thus we need to remove the usage of the collection manager in more places around Cobbler.