### PR TITLE
Fix ENOSPC on automigration

### DIFF
--- a/bin/cobblerd
+++ b/bin/cobblerd
@@ -58,7 +58,7 @@ def daemonize_self():
         os.dup2(dev_null.fileno(), sys.stderr.fileno())
 
 
-def main():
+def main() -> int:
     op = argparse.ArgumentParser()
     op.set_defaults(daemonize=True, log_level=None)
     op.add_argument("-B", "--daemonize", dest="daemonize", action="store_true",
@@ -109,4 +109,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -58,7 +58,7 @@ class CobblerAPI:
     __has_loaded = False
 
     def __init__(self, is_cobblerd: bool = False, settingsfile_location: str = "/etc/cobbler/settings.yaml",
-                 execute_settings_automigration: bool = True):
+                 execute_settings_automigration: bool = False):
         """
         Constructor
 

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -5,7 +5,7 @@
 
 # if "true" Cobbler will auto migrate the settings file after upgrading from older versions. The current settings
 # are backed up in the same folder before the upgrade.
-auto_migrate_settings: true
+auto_migrate_settings: false
 
 # If "true", Cobbler will allow insertions of system records that duplicate the "--dns-name" information of other system
 # records. In general, this is undesirable and should be left "false".

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -11,8 +11,8 @@ There are two main settings files which are located per default at ``/etc/cobble
 .. note:: Since we are cleaning a lot of tech-debt this may change over time. We are trying to find the balance which
           format is the best for us to handle in the code and the best for admins to handle in the config files.
 
-.. warning:: If you are using ``allow_dynamic_settings``, then the comments in the YAML file will vanish after the first
-             change due to the fact that PyYAML doesn't support comments
+.. warning:: If you are using ``allow_dynamic_settings`` or ``auto_migrate_settings``, then the comments in the YAML
+             file will vanish after the first change due to the fact that PyYAML doesn't support comments
              (`Source <https://github.com/yaml/pyyaml/issues/90>`_)
 
 There are additional configuration file locations which need to follow the YAML Syntax. These are loaded from the
@@ -25,6 +25,13 @@ main file.
 
 Updates to the yaml-settings-file
 #################################
+
+Starting with 3.3.2
+===================
+
+- After community feedback we changed the default of the auto-migration to be disabled. It can be re-enabled via the
+  already known methods ``cobbler-settings``-Tool, the settings file key ``auto_migrate_settings`` and the Daemon flag.
+  We have decided to not change the flag for existing installations.
 
 Starting with 3.3.1
 ===================

--- a/docs/scripts.rst
+++ b/docs/scripts.rst
@@ -48,3 +48,28 @@ Author
 ======
 
 `Enno Gotthold <https://github.com/SchoolGuy>`_
+
+cobbler-settings
+################
+
+Description
+===========
+
+This script will enable you to manage the settings of Cobbler.
+
+Execution examples
+==================
+
+.. code-block:: shell
+
+   cobbler-settings -c /etc/cobbler/settings migrate # Prints updated settings file to stdout
+   cobbler-settings -c /etc/cobbler/settings.yaml migrate -t /etc/cobbler/settings.new.yaml # Writes migrated result to file
+   cobbler-settings validate # Validates the file at /etc/cobbler/settings.yaml
+   cobbler-settings automigrate --enable # Enables settings auto-migration
+   cobbler-settings automigrate # Disables settings auto-migration
+   cobbler-settings modify --key="next_server_v4" --value="127.0.0.1" # Changes the key to the new value
+
+Author
+======
+
+`Enno Gotthold <https://github.com/SchoolGuy>`_ & `Dominik Gedon <https://github.com/nodeg>`_

--- a/tests/api/miscellaneous_test.py
+++ b/tests/api/miscellaneous_test.py
@@ -10,7 +10,7 @@ from cobbler.actions.buildiso.standalone import StandaloneBuildiso
 
 
 @pytest.mark.parametrize("input_automigration,result_migrate_count,result_validate_count", [
-    (None, 1, 2),
+    (None, 0, 3),
     (True, 1, 2),
     (False, 0, 3),
 ])


### PR DESCRIPTION
Fixes https://github.com/cobbler/cobbler/issues/2881

This PR disables the auto-migration for new installations and documents the `cobbler-settings` tool.