### PR TITLE
Bump version to 3.4.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,10 +13,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ master, release* ]
+    branches: [ main, release* ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ main ]
   schedule:
     - cron: '36 22 * * 3'
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,12 +3,12 @@ name: Linting
 on:
   push:
     branches:
-      - master
+      - main
       - release30
       - release32
   pull_request:
     branches:
-      - master
+      - main
       - release30
       - release32
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,12 +3,12 @@ name: Building Cobbler packages
 on:
   push:
     branches:
-      - master
+      - main
       - release30
       - release32
   pull_request:
     branches:
-      - master
+      - main
       - release30
       - release32
 

--- a/.github/workflows/release_master.yml
+++ b/.github/workflows/release_master.yml
@@ -3,7 +3,7 @@ name: Publish Python distributions to TestPyPI
 on:
   push:
     branches:
-      - master
+      - main
 
 env:
   DATAPATH: "/usr/share/cobbler"

--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -3,7 +3,7 @@ name: System testing
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   run_system_test:

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -3,12 +3,12 @@ name: Testing Cobbler
 on:
   push:
     branches:
-      - master
+      - main
       - release30
       - release32
   pull_request:
     branches:
-      - master
+      - main
       - release30
       - release32
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,19 @@
 
 ## Supported Versions
 
-| Version   | Supported                |
-| --------- | ------------------------ |
+| Version   | Supported                 |
+| --------- |---------------------------|
 | 4.0.X     | Next API breaking Release |
-| 3.3.x     | Current Version: 3.3.2   |
-| 3.2.x     | Security only            |
-| 3.1.x     | EOL                      |
-| 3.0.x     | EOL                      |
-| 2.8.x     | EOL                      |
-| 2.6.x     | EOL                      |
-| 2.4.x     | EOL                      |
-| 2.2.x     | EOL                      |
-| < 2.x.x   | EOL                      |
+| 3.4.x     | Current Version: 3.4.0    |
+| 3.3.x     | Security only             |
+| 3.2.x     | EOL                       |
+| 3.1.x     | EOL                       |
+| 3.0.x     | EOL                       |
+| 2.8.x     | EOL                       |
+| 2.6.x     | EOL                       |
+| 2.4.x     | EOL                       |
+| 2.2.x     | EOL                       |
+| < 2.x.x   | EOL                       |
 
 Due to the amount of maintainers we have, we can only support the most current version. Old versions won't be actively
 maintained.

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -151,7 +151,7 @@
 %endif
 
 Name:           cobbler
-Version:        3.3.2
+Version:        3.4.0
 Release:        1%{?dist}
 Summary:        Boot server configurator
 URL:            https://cobbler.github.io/

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -1,0 +1,53 @@
+"""
+Migration from V3.3.1 to V3.3.2
+"""
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2022 Dominik Gedon <dgedon@suse.de>
+# SPDX-FileCopyrightText: Copyright SUSE LLC
+
+
+from schema import SchemaError
+from cobbler.settings.migrations import V3_3_2
+
+schema = V3_3_2.schema
+
+
+def validate(settings: dict) -> bool:
+    """
+    Checks that a given settings dict is valid according to the reference V3.4.0 schema ``schema``.
+
+    :param settings: The settings dict to validate.
+    :return: True if valid settings dict otherwise False.
+    """
+    try:
+        schema.validate(settings)
+    except SchemaError:
+        return False
+    return True
+
+
+def normalize(settings: dict) -> dict:
+    """
+    If data in ``settings`` is valid the validated data is returned.
+
+    :param settings: The settings dict to validate.
+    :return: The validated dict.
+    """
+    return schema.validate(settings)
+
+
+def migrate(settings: dict) -> dict:
+    """
+    Migration of the settings ``settings`` to version V3.4.0 settings
+
+    :param settings: The settings dict to migrate
+    :return: The migrated dict
+    """
+
+    # rename keys and update their value
+    # add missing keys
+    # name - value pairs
+
+    if not validate(settings):
+        raise SchemaError("V3.4.0: Schema error while validating")
+    return normalize(settings)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,9 +24,9 @@ copyright = '2022, Enno Gotthold'
 author = 'Enno Gotthold'
 
 # The short X.Y version
-version = '3.3'
+version = '3.4'
 # The full version, including alpha/beta/rc tags
-release = '3.3.2'
+release = '3.4.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import shutil
 import subprocess
 
 
-VERSION = "3.3.2"
+VERSION = "3.4.0"
 OUTPUT_DIR = "config"
 
 log = logging.getLogger("setup.py")

--- a/tests/settings/migrations/migrations_test.py
+++ b/tests/settings/migrations/migrations_test.py
@@ -6,15 +6,11 @@ Tests for the Cobbler settings migrations
 # SPDX-FileCopyrightText: 2021 Enno Gotthold <egotthold@suse.de>
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
-import os
-import pathlib
-import shutil
-import pytest
 import yaml
 
 from cobbler import settings
 from cobbler.settings import migrations
-from cobbler.settings.migrations import V3_3_0, V3_2_1, V3_2_0, V3_1_2, V3_1_1, V3_1_0, V3_0_1, V3_0_0, V3_3_1
+from cobbler.settings.migrations import V3_3_0, V3_2_1, V3_2_0, V3_1_2, V3_1_1, V3_1_0, V3_0_1, V3_0_0, V3_3_1, V3_3_2
 
 
 def test_cobbler_version_logic():
@@ -305,3 +301,15 @@ def test_normalize_v3_3_1():
 
     # Assert
     assert len(V3_3_1.normalize(new_settings)) == 129
+
+
+def test_normalize_v3_3_2():
+    # Arrange
+    with open("/code/tests/test_data/V3_3_2/settings.yaml") as old_settings:
+        old_settings_dict = yaml.safe_load(old_settings.read())
+
+    # Act
+    new_settings = V3_3_2.normalize(old_settings_dict)
+
+    # Assert
+    assert len(V3_3_2.normalize(new_settings)) == 129

--- a/tests/test_data/V3_3_2/settings.d/bind_manage_ipmi.settings
+++ b/tests/test_data/V3_3_2/settings.d/bind_manage_ipmi.settings
@@ -1,0 +1,3 @@
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind
+# is set.
+bind_manage_ipmi: true

--- a/tests/test_data/V3_3_2/settings.d/manage_genders.settings
+++ b/tests/test_data/V3_3_2/settings.d/manage_genders.settings
@@ -1,0 +1,2 @@
+# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
+manage_genders: false

--- a/tests/test_data/V3_3_2/settings.d/nsupdate.settings
+++ b/tests/test_data/V3_3_2/settings.d/nsupdate.settings
@@ -1,0 +1,12 @@
+# Set to "true" to enable Cobbler's dynamic DNS updates.
+nsupdate_enabled: false
+
+# define tsig key
+# please don't use this one, instead generate your own:
+#   dnssec-keygen -a HMAC-SHA512 -b 512 -n USER cobbler_update_key
+nsupdate_tsig_algorithm: "hmac-sha512"
+nsupdate_tsig_key: [ "cobbler_update_key.", "hvnK54HFJXFasHjzjEn09ASIkCOGYSnofRq4ejsiBHz3udVyGiuebFGAswSjKUxNuhmllPrkI0HRSSmM2qvZug==" ]
+
+# if set, enables logging to that file
+nsupdate_log: "/var/log/cobbler/nsupdate.log"
+

--- a/tests/test_data/V3_3_2/settings.d/windows.settings
+++ b/tests/test_data/V3_3_2/settings.d/windows.settings
@@ -1,0 +1,8 @@
+# Set to true to enable the generation of Windows boot files in Cobbler.
+windows_enabled: false
+
+# Location of templates used for Windows
+windows_template_dir: "/etc/cobbler/windows"
+
+# Samba share name for distros
+samba_distro_share: "DISTRO"

--- a/tests/test_data/V3_3_2/settings.yaml
+++ b/tests/test_data/V3_3_2/settings.yaml
@@ -1,0 +1,575 @@
+# Cobbler settings file
+
+# Restart cobblerd and run "cobbler sync" after making changes.
+# This config file is in YAML 1.2 format; see "http://yaml.org".
+
+# if "true" Cobbler will auto migrate the settings file after upgrading from older versions. The current settings
+# are backed up in the same folder before the upgrade.
+auto_migrate_settings: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the "--dns-name" information of other system
+# records. In general, this is undesirable and should be left "false".
+allow_duplicate_hostnames: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the ip address information of other system
+# records. In general, this is undesirable and should be left "false".
+allow_duplicate_ips: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the MAC address information of other system
+# records. In general, this is undesirable.
+allow_duplicate_macs: false
+
+# If "true", Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can
+# only change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
+allow_dynamic_settings: false
+
+# By default, installs are *not* set to send installation logs to the Cobbler server. With "anamon_enabled", automatic
+# installation templates may use the "pre_anamon" snippet to allow remote live monitoring of their installations from
+# the Cobbler server. Installation logs will be stored under "/var/log/cobbler/anamon/".
+# NOTE: This does allow an xmlrpc call to send logs to this directory, without authentication, so enable only if you are
+# ok with this limitation.
+anamon_enabled: false
+
+# If using "authn_pam" in the "modules.conf", this can be configured to change the PAM service authentication will be
+# tested against.
+# The default value is "login".
+authn_pam_service: "login"
+
+# How long the authentication token is valid for, in seconds.
+auth_token_expiration: 3600
+
+# This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information.  Changing
+# this directory should not be required.
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+
+# location of templates used for boot loader config generation
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+grub2_mod_dir: '@@grub_mod_folder@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+
+# Email out a report when Cobbler finishes installing a system.
+# enabled: set to true to turn this feature on
+# sender: optional
+# email: which addresses to email
+# smtp_server: used to specify another server for an MTA
+# subject: use the default subject unless overridden
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+
+# Cheetah-language autoinstall templates can import Python modules. While this is a useful feature, it is not safe to
+# allow them to import anything they want. This whitelists which modules can be imported through Cheetah. Users can
+# expand this as needed but should never allow modules such as subprocess or those that allow access to the filesystem
+# as Cheetah templates are evaluated by cobblerd as code.
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+
+# Default "createrepo_flags" to use for new repositories. If you have createrepo >= 0.4.10, consider
+# "-c cache --update -C", which can dramatically improve your "cobbler reposync" time. "-s sha" enables working with
+# Fedora repos from F11/F12 from EL-4 or EL-5 without python-hashlib installed (which is not available on EL-4)
+createrepo_flags: "-c cache -s sha"
+
+# if no autoinstall template is specified to profile add, use this template (path is relative to template root)
+autoinstall: "default.ks"
+
+# configure all installed systems to use these nameservers by default
+# unless defined differently in the profile.  For DHCP configurations
+# you probably do /not/ want to supply this.
+default_name_servers: []
+default_name_servers_search: []
+
+# if using the authz_ownership module (see the Wiki), objects
+# created without specifying an owner are assigned to this
+# owner and/or group.  Can be a comma seperated list.
+default_ownership:
+ - "admin"
+
+# Cobbler has various sample automatic installation templates stored
+# in /var/lib/cobbler/templates/.  This controls
+# what install (root) password is set up for those
+# systems that reference this variable.  The factory
+# default is "cobbler" and Cobbler check will warn if
+# this is not changed.
+# The simplest way to change the password is to run
+# openssl passwd -1
+# and put the output between the "" below.
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+
+# the default template type to use in the absence of any
+# other detected template. If you do not specify the template
+# with '#template=<template_type>' on the first line of your
+# templates/snippets, Cobbler will assume try to use the
+# following template engine to parse the templates.
+#
+# Current valid values are: cheetah, jinja2
+default_template_type: "cheetah"
+
+# for libvirt based installs in koan, if no virt bridge
+# is specified, which bridge do we try?  For EL 4/5 hosts
+# this should be xenbr0, for all versions of Fedora, try
+# "virbr0".  This can be overriden on a per-profile
+# basis or at the koan command line though this saves
+# typing to just set it here to the most common option.
+default_virt_bridge: xenbr0
+
+# use this as the default disk size for virt guests (GB)
+default_virt_file_size: 5
+
+# use this as the default memory size for virt guests (MB)
+default_virt_ram: 512
+
+# if koan is invoked without --virt-type and no virt-type
+# is set on the profile/system, what virtualization type
+# should be assumed?  Values: xenpv, xenfv, qemu, vmware
+# (NOTE: this does not change what virt_type is chosen by import)
+default_virt_type: xenpv
+
+# enable iPXE booting? Enabling this option will cause Cobbler
+# to copy the undionly.kpxe file to the tftp root directory,
+# and if a profile/system is configured to boot via iPXE it will
+# chain load off pxelinux.0.
+# Default: false
+enable_ipxe: false
+
+# controls whether Cobbler will add each new profile entry to the default
+# PXE boot menu.  This can be over-ridden on a per-profile
+# basis when adding/editing profiles with --enable-menu=false/true.  Users
+# should ordinarily leave this setting enabled unless they are concerned
+# with accidental reinstalls from users who select an entry at the PXE
+# boot menu.  Adding a password to the boot menus templates
+# may also be a good solution to prevent unwanted reinstallations
+enable_menu: true
+
+# change this port if Apache is not running plaintext on port
+# 80.  Most people can leave this alone.
+http_port: 80
+
+# kernel options that should be present in every Cobbler installation.
+# kernel options can also be applied at the distro/profile/system
+# level.
+kernel_options: {}
+
+# configuration options if using the authn_ldap module. See the
+# the Wiki for details.  This can be ignored if you are not using
+# LDAP for WebUI/XMLRPC authentication.
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+
+# Cobbler has a feature that allows for integration with config management
+# systems such as Puppet.  The following parameters work in conjunction with
+# --mgmt-classes  and are described in further detail at:
+# https://github.com/cobbler/cobbler/wiki/Using-cobbler-with-a-configuration-management-system
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+
+# if enabled, this setting ensures that puppet is installed during
+# machine provision, a client certificate is generated and a
+# certificate signing request is made with the puppet master server
+puppet_auto_setup: false
+
+# when puppet starts on a system after installation it needs to have
+# its certificate signed by the puppet master server. Enabling the
+# following feature will ensure that the puppet server signs the
+# certificate after installation if the puppet master server is
+# running on the same machine as Cobbler. This requires
+# puppet_auto_setup above to be enabled
+sign_puppet_certs_automatically: false
+
+# location of the puppet executable, used for revoking certificates
+puppetca_path: "/usr/bin/puppet"
+
+# when a puppet managed machine is reinstalled it is necessary to
+# remove the puppet certificate from the puppet master server before a
+# new certificate is signed (see above). Enabling the following
+# feature will ensure that the certificate for the machine to be
+# installed is removed from the puppet master server if the puppet
+# master server is running on the same machine as Cobbler. This
+# requires puppet_auto_setup above to be enabled
+remove_old_puppet_certs_automatically: false
+
+# choose a --server argument when running puppetd/puppet agent during autoinstall
+#puppet_server: 'puppet'
+
+# let Cobbler know that you're using a newer version of puppet
+# choose version 3 to use: 'puppet agent'; version 2 uses status quo: 'puppetd'
+#puppet_version: 2
+
+# choose whether to enable puppet parameterized classes or not.
+# puppet versions prior to 2.6.5 do not support parameters
+puppet_parameterized_classes: true
+
+# set to true to enable Cobbler's DHCP management features.
+# the choice of DHCP management engine is in /etc/cobbler/modules.conf
+# See the docs (https://cobbler.readthedocs.io/en/latest/user-guide.html#dhcp-management) for more info
+manage_dhcp: false
+
+# set to true to enable DHCP IPv6 address configuration generation.
+# This currently only works with manager.isc DHCP module (isc dhcpd6 daemon)
+# See /etc/cobbler/modules.conf whether this isc module is chosen for dhcp
+# generation.
+manage_dhcp_v6: false
+
+# set to true to enable DHCP IPv4 address configuration generation.
+# This currently only works with manager.isc DHCP module
+# Other dhcp modules ignore this and above settings
+manage_dhcp_v4: false
+
+# if using Cobbler with manage_dhcp, put the IP address
+# of the Cobbler server here so that PXE booting guests can find it
+# if you do not set this correctly, this will be manifested in TFTP open timeouts.
+next_server_v4: 127.0.0.1
+
+# And the same if you set manage_dhcp_v6 to true.
+# Set the cobbler IPv6 address here so that PXE booting guests can find it
+next_server_v6: "::1"
+
+# set to true to enable Cobbler's DNS management features.
+# the choice of DNS management engine is in /etc/cobbler/modules.conf
+# needs manage_forward_zones and manage_reverse_zones to be set, too.
+manage_dns: false
+
+# set to path of bind chroot to create bind-chroot compatible bind
+# configuration files.
+bind_chroot_path: ""
+
+# set to path where zonefiles of bind/named server are located.
+bind_zonefile_path: "@@bind_zonefiles@@"
+
+# set to the ip address of the master bind DNS server for creating secondary
+# bind configuration files
+bind_master: 127.0.0.1
+
+# if using BIND (named) for DNS management in /etc/cobbler/modules.conf
+# and manage_dns is enabled (above), this lists which zones are managed
+# See the docs (https://cobbler.readthedocs.io/en/latest/user-guide.html#dns-configuration-management) for more info
+manage_forward_zones: []
+manage_reverse_zones: []
+
+# set to true to enable Cobbler's TFTP management features.
+# the choice of TFTP management engine is in /etc/cobbler/modules.conf
+manage_tftpd: true
+
+# This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not
+# start.
+# Default: @@tftproot@@
+tftpboot_location: "@@tftproot@@"
+
+# set to true to enable Cobbler's RSYNC management features.
+manage_rsync: false
+
+# settings for power management features.  optional.
+# see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
+# choices (refer to codes.py):
+#    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
+#    ipmilan ipmilanplus lpar rsa virsh wti
+power_management_default_type: 'ipmilanplus'
+
+# if this setting is set to true, Cobbler systems that pxe boot
+# will request at the end of their installation to toggle the
+# --netboot-enabled record in the Cobbler system record.  This eliminates
+# the potential for a PXE boot loop if the system is set to PXE
+# first in it's BIOS order.  Enable this if PXE is first in your BIOS
+# boot order, otherwise leave this disabled.   See the manpage
+# for --netboot-enabled.
+pxe_just_once: true
+
+# if this setting is set to one, triggers will be executed when systems
+# will request to toggle the --netboot-enabled record at the end of their installation.
+nopxe_with_triggers: true
+
+# This setting is only used by the code that supports using Spacewalk/Satellite
+# authentication within Cobbler Web and Cobbler XMLRPC.
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+
+# if using authn_spacewalk in modules.conf to let Cobbler authenticate
+# against Satellite/Spacewalk's auth system, by default it will not allow per user
+# access into Cobbler Web and Cobbler XMLRPC.
+# in order to permit this, the following setting must be enabled HOWEVER
+# doing so will permit all Spacewalk/Satellite users of certain types to edit all
+# of Cobbler's configuration.
+# these roles are:  config_admin and org_admin
+# users should turn this on only if they want this behavior and
+# do not have a cross-multi-org seperation concern.  If you have
+# a single org in your satellite, it's probably safe to turn this
+# on and then you can use CobblerWeb alongside a Satellite install.
+redhat_management_permissive: false
+
+# specify the default Red Hat authorization key to use to register
+# system.  If left blank, no registration will be attempted.  Similarly
+# you can set the --redhat-management-key to blank on any system to
+# keep it from trying to register.
+redhat_management_key: ""
+
+# if set to true, allows /usr/bin/cobbler-register (part of the koan package)
+# to be used to remotely add new Cobbler system records to Cobbler.
+# this effectively allows for registration of new hardware from system
+# records.
+register_new_installs: false
+
+# Flags to use for dnf's reposync. You can exclude some packages by adding --exclude.
+# For example exclude source packages: --exclude=\\*.src
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+
+# Flags to use for rysync's reposync. If flag 'a' is used then createrepo
+# is not ran after the rsync
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+
+# when DHCP and DNS management are enabled, Cobbler sync can automatically
+# restart those services to apply changes.  The exception for this is
+# if using ISC for DHCP, then omapi eliminates the need for a restart.
+# omapi, however, is experimental and not recommended for most configurations.
+# If DHCP and DNS are going to be managed, but hosted on a box that
+# is not on this server, disable restarts here and write some other
+# script to ensure that the config files get copied/rsynced to the destination
+# box.  This can be done by modifying the restart services trigger.
+# Note that if manage_dhcp and manage_dns are disabled, the respective
+# parameter will have no effect.  Most users should not need to change
+# this.
+restart_dns: true
+restart_dhcp: true
+
+# install triggers are scripts in /var/lib/cobbler/triggers/install
+# that are triggered in autoinstall pre and post sections.  Any
+# executable script in those directories is run.  They can be used
+# to send email or perform other actions.  They are currently
+# run as root so if you do not need this functionality you can
+# disable it, though this will also disable "cobbler status" which
+# uses a logging trigger to audit install progress.
+run_install_triggers: true
+
+# enables a trigger which version controls all changes to /var/lib/cobbler
+# when add, edit, or sync events are performed.  This can be used
+# to revert to previous database versions, generate RSS feeds, or for
+# other auditing or backup purposes. "git" and "hg" are currently suported,
+# but git is the recommend SCM for use with this feature.
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+
+# this is the address of the Cobbler server -- as it is used
+# by systems during the install process, it must be the address
+# or hostname of the system as those systems can see the server.
+# if you have a server that appears differently to different subnets
+# (dual homed, etc), you need to read the --server-override section
+# of the manpage for how that works.
+server: 127.0.0.1
+
+# If set to true, all commands will be forced to use the localhost address
+# instead of using the above value which can force commands like
+# cobbler sync to open a connection to a remote address if one is in the
+# configuration and would traceback.
+client_use_localhost: false
+
+# If set to "true", all commands to the API (not directly to the XMLRPC server) will go over HTTPS instead of plaintext.
+# Be sure to change the "http_port" setting to the correct value for the web server.
+client_use_https: false
+
+# Should new profiles for virtual machines default to auto booting with the physical host when the physical host
+# reboots? This can be overridden on each profile or system object.
+virt_auto_boot: true
+
+# Cobbler's web directory. Don't change this setting -- see the Wiki on "Relocating your Cobbler install" if your "/var"
+# partition is not large enough.
+webdir: "@@webroot@@/cobbler"
+
+# Directories that will not get wiped and recreated on a "cobbler sync".
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+
+# Cobbler's public XMLRPC listens on this port.  Change this only
+# if absolutely needed, as you'll have to start supplying a new
+# port option to koan if it is not the default.
+xmlrpc_port: 25151
+
+# "cobbler repo add" commands set Cobbler up with repository
+# information that can be used during autoinstall and is automatically
+# set up in the Cobbler autoinstall templates.  By default, these
+# are only available at install time.  To make these repositories
+# usable on installed systems (since Cobbler makes a very convenient
+# mirror) set this to true.  Most users can safely set this to true.  Users
+# who have a dual homed Cobbler server, or are installing laptops that
+# will not always have access to the Cobbler server may wish to leave
+# this as false.  In that case, the Cobbler mirrored yum repos are still
+# accessable at http://cobbler.example.org/cblr/repo_mirror and yum
+# configuration can still be done manually.  This is just a shortcut.
+yum_post_install_mirror: true
+
+# the default yum priority for all the distros. This is only used if yum-priorities plugin is used.
+# 1=maximum
+# Tweak with caution!
+yum_distro_priority: 1
+
+# Flags to use for yumdownloader.  Not all versions may support
+# --resolve.
+yumdownloader_flags: "--resolve"
+
+# sort and indent JSON output to make it more human-readable
+serializer_pretty_json: false
+
+# replication rsync options for distros, autoinstalls, snippets set to override default value of "-avzH"
+replicate_rsync_options: "-avzH"
+
+# replication rsync options for repos set to override default value of "-avzH"
+replicate_repo_rsync_options: "-avzH"
+
+# always write DHCP entries, regardless if netboot is enabled
+always_write_dhcp_entries: false
+
+# External proxy - used by: reposync", "signature update"
+# Eg: "http://192.168.1.1:8080" (HTTP), "https://192.168.1.1:8443" (HTTPS)
+proxy_url_ext: ""
+
+# Internal proxy - used by systems to reach Cobbler for templates
+# Eg: proxy_url_int: "http://10.0.0.1:8080"
+proxy_url_int: ""
+
+# This is a directory of files that Cobbler uses to include
+# files into Jinja2 templates
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+
+# Up to now, cobblerd used $server's IP address instead of the DNS name in autoinstallation
+# file settings (pxelinux.cfg files) to save bytes, which seemed required for S/390 systems.
+# This behavior can have negative impact on installs with multi-homed Cobbler servers, because
+# not all of the IP addresses may be reachable during system install.
+# This behavior was now made conditional, with default being "off".
+convert_server_to_ip: false
+
+# Leftover settings
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+
+# Puppet
+puppet_server: ""
+puppet_version: 2
+
+# Signatures
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+
+# Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
+# this file.
+include: [ "/etc/cobbler/settings.d/*.settings" ]

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -131,10 +131,10 @@ class TestMiscellaneous:
         result = remote.extended_version()
 
         # Assert Example Dict: {'builddate': 'Mon Feb 10 15:38:48 2020', 'gitdate': '?', 'gitstamp': '?', 'version':
-        #                       '3.3.2', 'version_tuple': [3, 3, 2]}
+        #                       '3.4.0', 'version_tuple': [3, 4, 0]}
         assert type(result) == dict
         assert type(result.get("version_tuple")) == list
-        assert [3, 3, 2] == result.get("version_tuple")
+        assert [3, 4, 0] == result.get("version_tuple")
 
     def test_find_items_paged(
         self, remote, token, create_distro, remove_distro, create_kernel_initrd, cleanup_find_items_paged
@@ -688,7 +688,7 @@ class TestMiscellaneous:
 
         # Assert
         # Will fail if the version is adjusted in the setup.py
-        assert result == 3.302
+        assert result == 3.4
 
     def test_xapi_object_edit(self, remote, token, remove_distro, create_kernel_initrd):
         # Arrange


### PR DESCRIPTION
This PR adds a new schema migration from 3.3.2 to 3.4.0 and bumps the version in all other places as well.