### PR TITLE
Fix reposync wget

### DIFF
--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -328,7 +328,7 @@ class RepoSync:
             pipes.quote(dest_path),
             pipes.quote(repo.mirror),
         ]
-        rc = utils.subprocess_call(cmd)
+        rc = utils.subprocess_call(cmd, shell=False)
 
         if rc != 0:
             raise CX("cobbler reposync failed")


### PR DESCRIPTION
cobbler reposync with wget fails:
```
run, reposync, run!
running: ['wget', '-N', '-np', '-r', '-l', 'inf', '-nd', '-P', '/var/www/cobbler/repo_mirror/test0', 'http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/2']
received on stdout: 
received on stderr: wget: missing URL
Exception occurred: <class 'cobbler.cexceptions.CX'>
Exception value: 'cobbler reposync failed'
```