### PR TITLE
Fix connected_mode not working in modify_interface

### DIFF
--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -737,7 +737,7 @@ class NetworkInterface:
                 self.bonding_opts = value
             if field == "bridgeopts":
                 self.bridge_opts = value
-            if field == "connected_mode":
+            if field == "connectedmode":
                 self.connected_mode = value
             if field == "cnames":
                 self.cnames = value


### PR DESCRIPTION
As we do `field = field.replace("_", "").replace("-", "")` the `connected_mode` will never work.
This should be `connectedmode`