### PR TITLE
cobbler sync: fix problem passing exec command to find

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -276,6 +276,8 @@ class CobblerSync:
                     "-exec",
                     "rm",
                     "-f",
+                    "{}",
+                    ";",
                 ]
                 utils.subprocess_call(cmd, shell=False)
 


### PR DESCRIPTION
This PR fixes a small issue when running `cobbler sync` at the time of cleaning old cache links.

After adapting to `shell=False`, there is a problem with the `exec` argument we pass to the `find` command:

```console
[2022-03-15_070806_sync] 2022-03-15T07:08:08 - INFO | running: ['find', '/srv/tftpboot/images/.link_cache', '-maxdepth', '1', '-type', 'f', '-links', '1', '-exec', 'rm', '-f']
[2022-03-15_070806_sync] 2022-03-15T07:08:08 - INFO | received on stdout:
[2022-03-15_070806_sync] 2022-03-15T07:08:08 - DEBUG | received on stderr: find: missing argument to `-exec'
```

