### PR TITLE
Avoid creating duplicated settings files when automigration is disabled

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -165,7 +165,7 @@ class CobblerAPI:
             self.perms_ok = True
 
     def __generate_settings(
-        self, settings_path: Path, execute_settings_automigration: bool = True
+        self, settings_path: Path, execute_settings_automigration: bool = False
     ) -> settings.Settings:
         yaml_dict = settings.read_yaml_file(settings_path)
 
@@ -175,7 +175,7 @@ class CobblerAPI:
             )
             yaml_dict["auto_migrate_settings"] = execute_settings_automigration
 
-        if yaml_dict.get("auto_migrate_settings", True):
+        if yaml_dict.get("auto_migrate_settings", False):
             self.logger.info("Automigration executed")
             normalized_settings = settings.migrate(yaml_dict, settings_path)
         else:
@@ -192,7 +192,7 @@ class CobblerAPI:
         new_settings = settings.Settings()
         new_settings.from_dict(normalized_settings)
 
-        if yaml_dict.get("auto_migrate_settings", True):
+        if yaml_dict.get("auto_migrate_settings", False):
             # save to disk only when automigration was performed
             # to avoid creating duplicated files
             new_settings.save(settings_path)

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -187,12 +187,15 @@ class CobblerAPI:
                 raise ValueError(
                     "Settings are invalid and auto-migration is disabled. Please correct this manually!"
                 ) from error
+
         # Use normalized or migrated dict and create settings object
         new_settings = settings.Settings()
         new_settings.from_dict(normalized_settings)
 
-        # save to disk
-        new_settings.save(settings_path)
+        if yaml_dict.get("auto_migrate_settings", True):
+            # save to disk only when automigration was performed
+            # to avoid creating duplicated files
+            new_settings.save(settings_path)
 
         # Return object
         return new_settings

--- a/tests/api/miscellaneous_test.py
+++ b/tests/api/miscellaneous_test.py
@@ -12,9 +12,9 @@ from cobbler.actions.buildiso.standalone import StandaloneBuildiso
 @pytest.mark.parametrize(
     "input_automigration,result_migrate_count,result_validate_count",
     [
-        (None, 0, 3),
+        (None, 0, 2),
         (True, 1, 2),
-        (False, 0, 3),
+        (False, 0, 2),
     ],
 )
 def test_settings_migration(


### PR DESCRIPTION
We introduced a PR https://github.com/cobbler/cobbler/pull/2966 to disable setting automigration to be executed by default, this works fine but we just noticed there are still duplicated settings files being created on each restart of cobbler or during instantiation of `CobblerAPI` object:

```console
suma-test-srv:~ # ls -ld /etc/cobbler/settings*
-rw-r--r-- 1 root   root    40 mar 15 06:55 /etc/cobbler/settings
-rw-r----- 1 root   root  4892 mar 15 01:44 /etc/cobbler/settings_20220315_01-44-38.yaml
-rw-r----- 1 root   root  5389 mar 15 01:45 /etc/cobbler/settings_20220315_01-45-13.yaml
-rw-r----- 1 root   root  5388 mar 15 01:46 /etc/cobbler/settings_20220315_01-46-12.yaml
-rw-r----- 1 root   root  5388 mar 15 03:47 /etc/cobbler/settings_20220315_03-47-21.yaml
-rw-r----- 1 root   root  5388 mar 15 03:48 /etc/cobbler/settings_20220315_03-48-21.yaml
-rw-r----- 1 root   root  5388 mar 15 06:55 /etc/cobbler/settings_20220315_06-55-46.yaml
-rw-r----- 1 root   root  5388 mar 15 06:58 /etc/cobbler/settings_20220315_06-58-10.yaml
-rw-r----- 1 root   root  5388 mar 15 09:03 /etc/cobbler/settings_20220315_09-03-42.yaml
-rw-r----- 1 root   root  5388 mar 15 11:38 /etc/cobbler/settings_20220315_11-38-08.yaml
-rw-r----- 1 root   root  5388 mar 15 11:38 /etc/cobbler/settings_20220315_11-38-45.yaml
-rw-r----- 1 root   root  5388 mar 15 11:40 /etc/cobbler/settings_20220315_11-40-07.yaml
-rw-r----- 1 root   root  5388 mar 15 11:40 /etc/cobbler/settings_20220315_11-40-25.yaml
-rw-r----- 1 root   root  5388 mar 15 11:42 /etc/cobbler/settings_20220315_11-42-10.yaml
-rw-r----- 1 root   root  5388 mar 15 12:09 /etc/cobbler/settings_20220315_12-09-19.yaml
-rw-r----- 1 wwwrun www   5388 mar 15 12:09 /etc/cobbler/settings_20220315_12-09-40.yaml
-rw-r----- 1 root   root  5388 mar 15 12:10 /etc/cobbler/settings_20220315_12-10-21.yaml
-rw-r----- 1 wwwrun www   5388 mar 15 12:10 /etc/cobbler/settings_20220315_12-10-27.yaml
-rw-r----- 1 wwwrun www   5388 mar 15 12:11 /etc/cobbler/settings_20220315_12-11-04.yaml
drwxr-x--- 2 root   www    119 mar 15 01:37 /etc/cobbler/settings.d
-rw-r----- 1 root   www   5388 mar 15 12:11 /etc/cobbler/settings.yaml
-rw-r--r-- 1 root   root 22573 mar 15 01:44 /etc/cobbler/settings.yaml.backup
-rw-r----- 1 root   root  5389 mar 15 01:45 /etc/cobbler/settings.yaml.bak


```

This PR simply fixed this issue by preventing we save a copy of the settings when automigration was not performed.