### PR TITLE
[sync] Fix 'find: missing argument to `-exec''

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -276,6 +276,8 @@ class CobblerSync:
                     "-exec",
                     "rm",
                     "-f",
+                    "{}",
+                    ";",
                 ]
                 utils.subprocess_call(cmd, shell=False)
 


### PR DESCRIPTION
Signed-off-by: weiyang <weiyang.ones@gmail.com>

Hi, all.
First of all, thank you for your excellent work.

#### Version
v3.3.2

#### Issue
When I execute `cobbler sync`, I get the following error:
```
cleaning link caches
running: ['find', '/var/lib/tftpboot/images/.link_cache', '-maxdepth', '1', '-type', 'f', '-links', '1', '-exec', "rm", "-f"]
received on stdout:
received on stderr: find: missing argument to `-exec'
```
This error is caused by commit https://github.com/cobbler/cobbler/commit/470abbc4c925f68c6781373dcdd4fcf9be9679a8.

#### Fix
```
cleaning link caches
running: ['find', '/var/lib/tftpboot/images/.link_cache', '-maxdepth', '1', '-type', 'f', '-links', '1', '-exec', 'rm', '-f', '{}', ';']
received on stdout:
received on stderr:
```