### PR TITLE
[managers] Fix 'signatures' key error

### DIFF
--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -330,7 +330,7 @@ class _ImportSignatureManager(ManagerModule):
             for version in list(sigdata["breeds"][breed].keys()):
                 if self.os_version and self.os_version != version:
                     continue
-                for sig in sigdata["breeds"][breed][version]["signatures"]:
+                for sig in sigdata["breeds"][breed][version].get("signatures", []):
                     pkgdir = os.path.join(self.path, sig)
                     if os.path.exists(pkgdir):
                         self.logger.debug(


### PR DESCRIPTION
Signed-off-by: weiyang <weiyang.ones@gmail.com>

Hi, all.
First of all, thank you for your excellent work.

#### Version
v3.3.2

#### Issue
When I try to import rocky-8.5, I get the following error:
```
[root@10-255-101-101 cobbler]# mount -t iso9660 -o loop,ro ./Rocky-8.5-x86_64-dvd1.iso /mnt
[root@10-255-101-101 cobbler]# cobbler import --name=rocky-8.5 --arch=x86_64 --path=/mnt
task started: 2022-03-16_061357_import
task started (id=Media import, time=Wed Mar 16 06:13:57 2022)
running python triggers from /var/lib/cobbler/triggers/task/import/pre/*
running shell triggers from /var/lib/cobbler/triggers/task/import/pre/*
shell triggers finished successfully
import_tree; ['/mnt', 'rocky-8.5', None, None, None]
importing from a network location, running rsync to fetch the files first
running: rsync -a  '/mnt/' /var/www/cobbler/distro_mirror/rocky-8.5-x86_64 --progress
received on stdout: sending incremental file list
received on stderr:
Found a candidate signature: breed=suse, version=opensuse15generic
Found a candidate signature: breed=suse, version=sles15generic
Exception occurred: <class 'KeyError'>
Exception value: 'signatures'
Exception Info:
!!! TASK FAILED !!!
```

This error is caused by code https://github.com/cobbler/cobbler/blob/v3.3.2/cobbler/modules/managers/import_signatures.py#L286.

#### Fix
```
[root@10-255-101-101 local]# systemctl restart cobblerd.service
[root@10-255-101-101 local]# cobbler import --name=rocky-8.5 --arch=x86_64 --path=/mnt
task started: 2022-03-16_061938_import
task started (id=Media import, time=Wed Mar 16 06:19:38 2022)
running python triggers from /var/lib/cobbler/triggers/task/import/pre/*
running shell triggers from /var/lib/cobbler/triggers/task/import/pre/*
shell triggers finished successfully
import_tree; ['/mnt', 'rocky-8.5', None, None, None]
importing from a network location, running rsync to fetch the files first
running: rsync -a  '/mnt/' /var/www/cobbler/distro_mirror/rocky-8.5-x86_64 --progress

received on stdout: sending incremental file list
received on stderr:
Found a candidate signature: breed=redhat, version=rhel8
Found a matching signature: breed=redhat, version=rhel8
Adding distros from path /var/www/cobbler/distro_mirror/rocky-8.5-x86_64:
creating new distro: rocky-8.5-x86_64
trying symlink: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64 -> /var/www/cobbler/links/rocky-8.5-x86_64
running python triggers from /var/lib/cobbler/triggers/add/distro/pre/*
running shell triggers from /var/lib/cobbler/triggers/add/distro/pre/*
shell triggers finished successfully
trying hardlink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/www/cobbler/images/rocky-8.5-x86_64/vmlinuz
trying hardlink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/www/cobbler/images/rocky-8.5-x86_64/initrd.img
running: /usr/bin/sha1sum /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz
received on stdout: ef10e4b55349910ff78846d07e5c2edc7379df76  /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz
received on stderr:
trying to create cache file /var/lib/tftpboot/images/.link_cache/ef10e4b55349910ff78846d07e5c2edc7379df76
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/.link_cache/ef10e4b55349910ff78846d07e5c2edc7379df76
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/.link_cache/ef10e4b55349910ff78846d07e5c2edc7379df76 -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
running: /usr/bin/sha1sum /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img
received on stdout: cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d  /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img
received on stderr:
trying to create cache file /var/lib/tftpboot/images/.link_cache/cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/.link_cache/cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/.link_cache/cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
processing boot_files for distro: rocky-8.5-x86_64
skipping symlink, destination (/var/www/cobbler/links/rocky-8.5-x86_64) exists
Writing template files for rocky-8.5-x86_64
running python triggers from /var/lib/cobbler/triggers/change/*
running python trigger cobbler.modules.scm_track
running python trigger cobbler.modules.managers.genders
running shell triggers from /var/lib/cobbler/triggers/change/*
shell triggers finished successfully
running python triggers from /var/lib/cobbler/triggers/add/distro/post/*
running shell triggers from /var/lib/cobbler/triggers/add/distro/post/*
shell triggers finished successfully
creating new profile: rocky-8.5-x86_64
running python triggers from /var/lib/cobbler/triggers/add/profile/pre/*
running shell triggers from /var/lib/cobbler/triggers/add/profile/pre/*
shell triggers finished successfully
Writing template files for rocky-8.5-x86_64
sync_systems
sync_systems needs at least one system to do something. Bailing out early.
running python triggers from /var/lib/cobbler/triggers/change/*
running python trigger cobbler.modules.scm_track
running python trigger cobbler.modules.managers.genders
running shell triggers from /var/lib/cobbler/triggers/change/*
shell triggers finished successfully
running python triggers from /var/lib/cobbler/triggers/add/profile/post/*
running shell triggers from /var/lib/cobbler/triggers/add/profile/post/*
shell triggers finished successfully
associating repos
checking for rsync repo(s)
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/.link_cache/ef10e4b55349910ff78846d07e5c2edc7379df76 -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/.link_cache/cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
processing boot_files for distro: rocky-8.5-x86_64
skipping symlink, destination (/var/www/cobbler/links/rocky-8.5-x86_64) exists
{"ctime": 1644772803.5454762, "depth": 0, "mtime": 1644772918.3767147, "source_repos": [["http://@@http_server@@/cobbler/distro_mirror/config/centos7.2-x86_64-0.repo", "http://@@http_server@@/cobbler/distro_mirror/centos7.2-x86_64"]], "trWriting template files for rocky-8.5-x86_64
Writing template files for rocky-8.5-x86_64
checking for rhn repo(s)
{"ctime": 1644774161.7699873, "depth": 0, "mtime": 1644774163.1596394, "source_repos": [["http://@@http_server@@/cobbler/distro_mirror/config/centos-7.8-x86_64-0.repo", "http://@@http_server@@/cobbler/distro_mirror/centos-7.8-x86_64"]], "trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/.link_cache/ef10e4b55349910ff78846d07e5c2edc7379df76 -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/.link_cache/cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
processing boot_files for distro: rocky-8.5-x86_64
skipping symlink, destination (/var/www/cobbler/links/rocky-8.5-x86_64) exists
Writing template files for rocky-8.5-x86_64
Writing template files for rocky-8.5-x86_64
checking for yum repo(s)
starting descent into /var/www/cobbler/distro_mirror/rocky-8.5-x86_64 for rocky-8.5-x86_64
processing repo at : /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/AppStream
need to process repo/comps: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/AppStream
looking for /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/AppStream/repodata/*comps*.xml
Keeping repodata as-is :/var/www/cobbler/distro_mirror/rocky-8.5-x86_64/AppStream/repodata
processing repo at : /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/BaseOS
need to process repo/comps: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/BaseOS
looking for /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/BaseOS/repodata/*comps*.xml
Keeping repodata as-is :/var/www/cobbler/distro_mirror/rocky-8.5-x86_64/BaseOS/repodata
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/.link_cache/ef10e4b55349910ff78846d07e5c2edc7379df76 -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/vmlinuz -> /var/lib/tftpboot/images/rocky-8.5-x86_64/vmlinuz
trying cachelink /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/.link_cache/cc7cbd18a28572fd0b5a07d30f4c43535ca6e27d -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
copying: /var/www/cobbler/distro_mirror/rocky-8.5-x86_64/images/pxeboot/initrd.img -> /var/lib/tftpboot/images/rocky-8.5-x86_64/initrd.img
processing boot_files for distro: rocky-8.5-x86_64
skipping symlink, destination (/var/www/cobbler/links/rocky-8.5-x86_64) exists
Writing template files for rocky-8.5-x86_64
Writing template files for rocky-8.5-x86_64
*** TASK COMPLETE ***
```