### PR TITLE
Managers: Fix non-existent method call

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -104,7 +104,7 @@ class CobblerSync:
         if self.settings.manage_dns:
             self.logger.info("rendering DNS files")
             self.dns.regen_hosts()
-            self.dns.write_dns_files()
+            self.dns.write_configs()
 
         self.logger.info("cleaning link caches")
         self.clean_link_cache()


### PR DESCRIPTION
All DNS managers are subclassed from Manager Modules. Thus they don't have a
custom function "write_dns_files" anymore. The correct replacement is
"write_configs" from the "Managers" parent class.

Fixes #2984