### PR TITLE
System-Tests: Add tests for cobbler-settings

### DIFF
--- a/system-tests/scripts/run-tests
+++ b/system-tests/scripts/run-tests
@@ -6,7 +6,7 @@ topdir=$(realpath $(dirname ${0})/..)
 if [ ${#} -ge 1 ]; then
 	patterns=${@}
 else
-	patterns=(basic-* import-*)
+	patterns=(basic-* import-* settings-cli-*)
 fi
 
 list_selected_tests() {

--- a/system-tests/tests/settings-cli-automigrate-disable
+++ b/system-tests/tests/settings-cli-automigrate-disable
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that cobbler-settings can enable/disable the auto-migration of the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" automigrate --disable
+
+# Assert
+exit 1

--- a/system-tests/tests/settings-cli-automigrate-enable
+++ b/system-tests/tests/settings-cli-automigrate-enable
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that cobbler-settings can enable/disable the auto-migration of the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" automigrate --enable
+
+# Assert
+exit 1

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that cobbler-settings can migrate the YAML file from one version to the next one
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+# Act
+cobbler-settings -c "$OLD_CONFIG" migrate -t "$NEW_CONFIG" --new "$NEW_VERSION"
+
+# Assert
+exit 1

--- a/system-tests/tests/settings-cli-modify
+++ b/system-tests/tests/settings-cli-modify
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+exit 1

--- a/system-tests/tests/settings-cli-verify
+++ b/system-tests/tests/settings-cli-verify
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that cobbler-settings can verify the YAML configuration
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" validate -v "$CONFIG_VERSION"
+
+# Assert
+exit 1


### PR DESCRIPTION
Sadly the "simple" script we wrote was not so simple after all. Since the errors
we found were inside the script and not inside the main code, we need tests that
actually test the script itself. Since coverage for this script is irrelevant,
this is going into the integration tests.

Fixes #2992 