### PR TITLE
Actions: Buildiso - Fix isolinux.cfg generation

### DIFF
--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -348,7 +348,7 @@ class AppendLineBuilder:
         """
         self.dist = dist
 
-        self.append_line = " append initrd=%s.img" % self.distro_name
+        self.append_line = "  APPEND initrd=%s.img" % self.distro_name
         if self.dist.breed == "suse":
             self._generate_append_suse()
         elif self.dist.breed == "redhat":
@@ -463,7 +463,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         cfglines.append("")
         cfglines.append("LABEL %s" % system.name)
         cfglines.append("  MENU LABEL %s" % system.name)
-        cfglines.append("  kernel %s.krn" % distname)
+        cfglines.append("  KERNEL %s.krn" % distname)
 
         data = utils.blender(self.api, False, system)
         if not re.match(r"[a-z]+://.*", data["autoinstall"]):
@@ -536,7 +536,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         cfglines.append("MENU END")
 
         with open(isolinuxcfg, "w+") as cfg:
-            cfg.writelines(cfglines)
+            cfg.writelines("%s\n" % l for l in cfglines)
 
     def run(
         self,

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -23,7 +23,7 @@ def _generate_append_line_standalone(data: dict, distro, descendant) -> str:
     :param descendant: The profile or system which is underneath the distro.
     :return: The base append_line which we need for booting the built ISO. Contains initrd and autoinstall parameter.
     """
-    append_line = "  append initrd=%s" % os.path.basename(distro.initrd)
+    append_line = "  APPEND initrd=%s" % os.path.basename(distro.initrd)
     if distro.breed == "redhat":
         append_line += " inst.ks=cdrom:/isolinux/%s.cfg" % descendant.name
     elif distro.breed == "suse":
@@ -236,7 +236,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         if menu_indent:
             cfglines.append("  MENU INDENT %d" % menu_indent)
         cfglines.append("  MENU LABEL %s" % descendant.name)
-        cfglines.append("  kernel %s" % os.path.basename(distro.kernel))
+        cfglines.append("  KERNEL %s" % os.path.basename(distro.kernel))
 
         cfglines.append(_generate_append_line_standalone(data, distro, descendant))
 
@@ -291,11 +291,11 @@ class StandaloneBuildiso(buildiso.BuildIso):
                 descendant, cfglines, distro, airgapped, repo_names_to_copy
             )
 
-        self.logger.info("done writing config")
         cfglines.append("")
         cfglines.append("MENU END")
         with open(os.path.join(self.isolinuxdir, "isolinux.cfg"), "w+") as cfg:
-            cfg.writelines(cfglines)
+            cfg.writelines("%s\n" % l for l in cfglines)
+        self.logger.info("done writing config")
 
         self._sync_airgapped_repos(airgapped, repo_names_to_copy)
 


### PR DESCRIPTION
Before we didn't have proper linebreaks, and we didn't uppercase all commands.
This commit fixes this as well as printing the log-message after the file was
written to disk and not before.

Fixes #2993 