### PR TITLE
Tests: Fix tests broken in 5f5a304

### DIFF
--- a/tests/actions/buildiso_test.py
+++ b/tests/actions/buildiso_test.py
@@ -279,7 +279,7 @@ class TestAppendLineBuilder:
         # TODO: Make tests more sophisticated
         assert (
             result
-            == " append initrd=testdistro.img install=http://192.168.1.1:80/cblr/links/testdistro autoyast=default.ks"
+            == "  APPEND initrd=testdistro.img install=http://192.168.1.1:80/cblr/links/testdistro autoyast=default.ks"
         )
 
     def test_generate_profile(


### PR DESCRIPTION
We adjusted the casing of the text and the whitespace. The adjustments in the
test were forgotten to be done.