### PR TITLE
API: Reduce sync logger level for skipping it

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1681,7 +1681,7 @@ class CobblerAPI:
         Only build out the DNS configuration.
         """
         if not self.settings().manage_dns:
-            self.logger.error("manage_dns not set")
+            self.logger.info('"manage_dns" not set. Skipping DNS sync.')
             return
         self.logger.info("sync_dns")
         dns_module = self.get_module_from_file("dns", "module", "managers.bind")
@@ -1695,7 +1695,7 @@ class CobblerAPI:
         Only build out the DHCP configuration.
         """
         if not self.settings().manage_dhcp:
-            self.logger.error("manage_dhcp not set")
+            self.logger.info('"manage_dhcp" not set. Skipping DHCP sync.')
             return
         self.logger.info("sync_dhcp")
         dhcp_module = self.get_module_from_file("dhcp", "module", "managers.isc")


### PR DESCRIPTION
Before this commit a skipped sync due to a disabled sync was an error. This is
not needed as it is totally valid. We now log info and say explicitly that
we skip the execution of the sync.

Fixes #2902