### PR TITLE
Cobbler-SVC: Lower permissions for modules.conf

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -353,12 +353,13 @@ fi
 # Fixup permission for world readable settings files
 chmod 640 %{_sysconfdir}/cobbler/settings.yaml
 chmod 600 %{_sysconfdir}/cobbler/mongodb.conf
-chmod 600 %{_sysconfdir}/cobbler/modules.conf
+chmod 640 %{_sysconfdir}/cobbler/modules.conf
 chmod 640 %{_sysconfdir}/cobbler/users.conf
 chmod 640 %{_sysconfdir}/cobbler/users.digest
 chmod 750 %{_sysconfdir}/cobbler/settings.d
 chmod 640 %{_sysconfdir}/cobbler/settings.d/*
 chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
+chgrp %{apache_group} %{_sysconfdir}/cobbler/modules.conf
 chgrp %{apache_group} %{_sysconfdir}/cobbler/users.conf
 chgrp %{apache_group} %{_sysconfdir}/cobbler/users.digest
 chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.d
@@ -377,12 +378,13 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.d/*
 # Fixup permission for world readable settings files
 chmod 640 %{_sysconfdir}/cobbler/settings.yaml
 chmod 600 %{_sysconfdir}/cobbler/mongodb.conf
-chmod 600 %{_sysconfdir}/cobbler/modules.conf
+chmod 640 %{_sysconfdir}/cobbler/modules.conf
 chmod 640 %{_sysconfdir}/cobbler/users.conf
 chmod 640 %{_sysconfdir}/cobbler/users.digest
 chmod 750 %{_sysconfdir}/cobbler/settings.d
 chmod 640 %{_sysconfdir}/cobbler/settings.d/*
 chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
+chgrp %{apache_group} %{_sysconfdir}/cobbler/modules.conf
 chgrp %{apache_group} %{_sysconfdir}/cobbler/users.conf
 chgrp %{apache_group} %{_sysconfdir}/cobbler/users.digest
 chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.d
@@ -422,7 +424,7 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.d/*
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf
-%attr(600, root, root) %config(noreplace) %{_sysconfdir}/cobbler/modules.conf
+%attr(640, root, %{apache_group}) %config(noreplace) %{_sysconfdir}/cobbler/modules.conf
 %attr(600, root, root) %config(noreplace) %{_sysconfdir}/cobbler/mongodb.conf
 %config(noreplace) %{_sysconfdir}/cobbler/named.template
 %config(noreplace) %{_sysconfdir}/cobbler/ndjbdns.template

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -148,10 +148,10 @@ class CobblerAPI:
             )
 
             self.authn = self.get_module_from_file(
-                "authentication", "module", "authn_configfile"
+                "authentication", "module", "authentication.configfile"
             )
             self.authz = self.get_module_from_file(
-                "authorization", "module", "authz_allowall"
+                "authorization", "module", "authorization.allowall"
             )
 
             # FIXME: pass more loggers around, and also see that those using things via tasks construct their own


### PR DESCRIPTION
This is a temporary workaround until we find a way to remove access to the
Cobbler Settings.

Currently the XMLRPC Client of Cobbler-SVC requires access to the Cobbler
Settings to gather the IP and Port.