### PR TITLE
System Remove: Fix system "default" GRUB case

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -500,7 +500,9 @@ class CobblerSync:
                 interface=name, loader="grub"
             )
             utils.rmfile(os.path.join(bootloc, "pxelinux.cfg", pxe_filename))
-            utils.rmfile(os.path.join(bootloc, "grub", "system", grub_filename))
+            if not (system_record.name == "default" and grub_filename is None):
+                # A default system can't have GRUB entries and thus we want to skip this.
+                utils.rmfile(os.path.join(bootloc, "grub", "system", grub_filename))
             utils.rmfile(
                 os.path.join(bootloc, "grub", "system_link", system_record.name)
             )

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -2115,6 +2115,11 @@ class System(Item):
                 loader = boot_loaders[0]
 
         if interface not in self.interfaces:
+            self.logger.warning(
+                'System "%s" did not have an interface with the name "%s" attached to it.',
+                self.name,
+                interface,
+            )
             return None
 
         if self.name == "default":


### PR DESCRIPTION
Before this commit we did not skip removing the GRUB bootloader for the system
named "default". This caused the removal of a system to fail. After skipping this
now a removal of a system named "default" should work again.