### PR TITLE
Profiles: virt_file_size docstring had wrong type

### DIFF
--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -65,7 +65,7 @@ class Profile(item.Item):
         self._virt_bridge = api.settings().default_virt_bridge
         self._virt_cpus: Union[int, str] = 1
         self._virt_disk_driver = enums.VirtDiskDrivers.RAW
-        self._virt_file_size = 0
+        self._virt_file_size = 0.0
         self._virt_path = ""
         self._virt_ram = api.settings().default_virt_ram
         self._virt_type = enums.VirtType.AUTO
@@ -549,7 +549,7 @@ class Profile(item.Item):
         self._virt_cpus = validate.validate_virt_cpus(num)
 
     @property
-    def virt_file_size(self) -> int:
+    def virt_file_size(self) -> float:
         r"""
         The size of the image and thus the usable size for the guest.
 

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -325,7 +325,7 @@ def validate_repos(repos: list, api, bypass_check: bool = False):
     return repos
 
 
-def validate_virt_file_size(num: Union[str, int, float]):
+def validate_virt_file_size(num: Union[str, float]):
     """
     For Virt only: Specifies the size of the virt image in gigabytes. Older versions of koan (x<0.6.3) interpret 0 as
     "don't care". Newer versions (x>=0.6.4) interpret 0 as "no disks"
@@ -347,7 +347,7 @@ def validate_virt_file_size(num: Union[str, int, float]):
         if num == enums.VALUE_INHERITED:
             return enums.VALUE_INHERITED
         if num == "":
-            return 0
+            return 0.0
         if not utils.is_str_float(num):
             raise TypeError("virt_file_size needs to be a float")
         num = float(num)


### PR DESCRIPTION
This was discovered while manually investigating other problems. Now the type of the `virt_file_size` property matches the return value of the validation function in the setter.