### PR TITLE
Retrieve resolved properties

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -30,6 +30,7 @@ from typing import Dict, List, Optional, Union
 
 from schema import SchemaError
 
+from cobbler import validate
 from cobbler.actions import (
     status,
     hardlink,
@@ -393,6 +394,45 @@ class CobblerAPI:
         Return the current list of menus
         """
         return self.get_items("menu")
+
+    # =======================================================================
+
+    def get_item_resolved_value(self, item_uuid: str, attribute: str):
+        """
+        This method helps non Python API consumers to retrieve the final data of a field with inheritance.
+
+        This does not help with network interfaces because they don't have a UUID at the moment and thus can't be
+        queried via their UUID.
+
+        :param item_uuid: The UUID of the item that should be retrieved.
+        :param attribute: The attribute that should be retrieved.
+        :raises ValueError: In case a value given was either malformed or the desired item did not exist.
+        :raises TypeError: In case the type of the method arguments do have the wrong type.
+        :raises AttributeError: In case the attribute specified is not available on the given item (type).
+        :returns: The attribute value. Since this might be of type NetworkInterface we cannot yet set this explicitly.
+        """
+        if not isinstance(item_uuid, str):
+            raise TypeError("item_uuid must be of type str!")
+
+        if not validate.validate_uuid(item_uuid):
+            raise ValueError("The given uuid did not have the correct format!")
+
+        if not isinstance(attribute, str):
+            raise TypeError("attribute must be of type str!")
+
+        desired_item = self.find_items(
+            "", {"uid": item_uuid}, return_list=False, no_errors=True
+        )
+        if desired_item is None:
+            raise ValueError('Item with item_uuid "%s" did not exist!' % item_uuid)
+
+        if not hasattr(desired_item, attribute):
+            raise AttributeError(
+                'Attribute "%s" did not exist on item type "%s".'
+                % (attribute, desired_item.TYPE_NAME)
+            )
+
+        return getattr(desired_item, attribute)
 
     # =======================================================================
 

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -52,7 +52,7 @@ class Distro(item.Item):
         self._kernel = ""
         self._mgmt_classes = []
         self._os_version = ""
-        self._redhat_management_key = ""
+        self._redhat_management_key = enums.VALUE_INHERITED
         self._source_repos = []
         self._fetchable_files = {}
         self._remote_boot_kernel = ""
@@ -427,6 +427,8 @@ class Distro(item.Item):
         """
         All boot loaders for which Cobbler generates entries for.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The bootloaders.
         :setter: Validates this against the list of well-known bootloaders and raises a ``TypeError`` or ``ValueError``
                  in case the validation goes south.
@@ -468,9 +470,11 @@ class Distro(item.Item):
         Get the redhat management key. This is probably only needed if you have spacewalk, uyuni or SUSE Manager
         running.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :return: The key as a string.
         """
-        return self._redhat_management_key
+        return self._resolve("redhat_management_key")
 
     @redhat_management_key.setter
     def redhat_management_key(self, management_key: str):

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -55,7 +55,7 @@ class Image(item.Item):
         self._virt_bridge = ""
         self._virt_cpus = 0
         self._virt_disk_driver = enums.VirtDiskDrivers.RAW
-        self._virt_file_size = 0.0
+        self._virt_file_size = enums.VALUE_INHERITED
         self._virt_path = ""
         self._virt_ram = 0
         self._virt_type = enums.VirtType.AUTO

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -325,6 +325,8 @@ class Item:
         .. warning:: This is never validated against a list of existing users. Thus you can lock yourself out of a
                      record.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Return the list of users which are currently assigned to the record.
         :setter: The list of people which should be new owners. May lock you out if you are using the ownership
                  authorization module.
@@ -344,6 +346,8 @@ class Item:
     def kernel_options(self) -> dict:
         """
         Kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: The parsed kernel options.
         :setter: The new kernel options as a space delimited list. May raise ``ValueError`` in case of parsing problems.
@@ -368,6 +372,8 @@ class Item:
     def kernel_options_post(self) -> dict:
         """
         Post kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: The dictionary with the parsed values.
         :setter: Accepts str in above mentioned format or directly a dict.
@@ -394,6 +400,8 @@ class Item:
         A comma delimited list of key value pairs, like 'a=b,c=d,e=f' or a dict.
         The meta tags are used as input to the templating system to preprocess automatic installation template files.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The metadata or an empty dict.
         :setter: Accepts anything which can be split by :meth:`~cobbler.utils.input_string_or_dict`.
         """
@@ -419,6 +427,8 @@ class Item:
         Assigns a list of configuration management classes that can be assigned to any object, such as those used by
         Puppet's external_nodes feature.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: An empty list or the list of mgmt_classes.
         :setter: Will split this according to :meth:`~cobbler.utils.input_string_or_list`.
         """
@@ -437,6 +447,8 @@ class Item:
     def mgmt_parameters(self) -> dict:
         """
         Parameters which will be handed to your management application (Must be a valid YAML dictionary)
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: The mgmt_parameters or an empty dict.
         :setter: A YAML string which can be assigned to any object, this is used by Puppet's external_nodes feature.
@@ -507,6 +519,8 @@ class Item:
         """
         A comma separated list of req_name=source_file_path that should be fetchable via tftp.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :param boot_files: The new value for the boot files used by the item.
         """
         (success, value) = utils.input_string_or_dict(boot_files, allow_multiples=False)
@@ -519,6 +533,8 @@ class Item:
     def fetchable_files(self) -> dict:
         """
         A comma seperated list of ``virt_name=path_to_template`` that should be fetchable via tftp or a webserver
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: The dictionary with name-path key-value pairs.
         :setter: A dict. If not a dict must be a str which is split by :meth:`~cobbler.utils.input_string_or_dict`.

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -78,7 +78,6 @@ class Profile(item.Item):
         self._kernel_options_post = enums.VALUE_INHERITED
         self._mgmt_classes = enums.VALUE_INHERITED
         self._mgmt_parameters = enums.VALUE_INHERITED
-        self._mgmt_classes = enums.VALUE_INHERITED
 
         # Use setters to validate settings
         self.virt_disk_driver = api.settings().default_virt_disk_driver
@@ -379,6 +378,8 @@ class Profile(item.Item):
         """
         Represents the hostname the Cobbler server is reachable by a client.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The hostname of the Cobbler server.
         :setter: May raise a ``TypeError`` in case the new value is not a ``str``.
         """
@@ -515,6 +516,8 @@ class Profile(item.Item):
         """
         Whether the VM should be booted when booting the host or not.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: ``True`` means autoboot is enabled, otherwise VM is not booted automatically.
         :setter: The new state for the property.
         """
@@ -556,6 +559,8 @@ class Profile(item.Item):
         .. warning:: There is a regression which makes the usage of multiple disks not possible right now. This will be
                      fixed in a future release.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The size of the image(s) in GB.
         :setter: The float with the new size in GB.
         """
@@ -574,6 +579,8 @@ class Profile(item.Item):
     def virt_disk_driver(self) -> enums.VirtDiskDrivers:
         """
         The type of disk driver used for storing the image.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: The enum type representation of the disk driver.
         :setter: May be a ``str`` with the name of the disk driver or from the enum type directly.
@@ -594,6 +601,8 @@ class Profile(item.Item):
         """
         The amount of RAM given to the guest in MB.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The amount of RAM currently assigned to the image.
         :setter: The new amount of ram. Must be an integer.
         """
@@ -613,6 +622,8 @@ class Profile(item.Item):
         """
         The type of image used.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The value of the virtual machine.
         :setter: May be of the enum type or a str which is then converted to the enum type.
         """
@@ -631,6 +642,8 @@ class Profile(item.Item):
     def virt_bridge(self) -> str:
         """
         Represents the name of the virtual bridge to use.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: Either the default name for the bridge or the specific one for this profile.
         :setter: The new name. Does not overwrite the default one.
@@ -691,6 +704,8 @@ class Profile(item.Item):
         """
         Getter of the redhat management key of the profile or it's parent.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the redhat_management_key of the profile.
         :setter: May raise a ``TypeError`` in case of a validation error.
         """
@@ -713,6 +728,8 @@ class Profile(item.Item):
     def boot_loaders(self) -> list:
         """
         This represents all boot loaders for which Cobbler will try to generate bootloader configuration for.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: The bootloaders.
         :setter: The new bootloaders. Will be validates against a list of well known ones.

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -60,14 +60,13 @@ class Profile(item.Item):
         self._repos = []
         self._server = enums.VALUE_INHERITED
         self._menu = ""
-        # FIXME: The virt_* attributes don't support inheritance so far
         self._virt_auto_boot = api.settings().virt_auto_boot
-        self._virt_bridge = api.settings().default_virt_bridge
+        self._virt_bridge = enums.VALUE_INHERITED
         self._virt_cpus: Union[int, str] = 1
-        self._virt_disk_driver = enums.VirtDiskDrivers.RAW
-        self._virt_file_size = 0.0
+        self._virt_disk_driver = enums.VirtDiskDrivers.INHERITED
+        self._virt_file_size = enums.VALUE_INHERITED
         self._virt_path = ""
-        self._virt_ram = api.settings().default_virt_ram
+        self._virt_ram = enums.VALUE_INHERITED
         self._virt_type = enums.VirtType.AUTO
 
         # Overwrite defaults from item.py
@@ -383,20 +382,18 @@ class Profile(item.Item):
         :getter: The hostname of the Cobbler server.
         :setter: May raise a ``TypeError`` in case the new value is not a ``str``.
         """
-        return self._server
+        return self._resolve("server")
 
     @server.setter
     def server(self, server: str):
         """
         Setter for the server property.
 
-        :param server: If this is None or an emtpy string this will be reset to be inherited from the parent object.
+        :param server: The str with the new value for the server property.
         :raises TypeError: In case the new value was not of type ``str``.
         """
         if not isinstance(server, str):
             raise TypeError("Field server of object profile needs to be of type str!")
-        if server == "":
-            server = enums.VALUE_INHERITED
         self._server = server
 
     @property
@@ -521,7 +518,7 @@ class Profile(item.Item):
         :getter: ``True`` means autoboot is enabled, otherwise VM is not booted automatically.
         :setter: The new state for the property.
         """
-        return self._virt_auto_boot
+        return self._resolve("virt_auto_boot")
 
     @virt_auto_boot.setter
     def virt_auto_boot(self, num: bool):
@@ -530,6 +527,9 @@ class Profile(item.Item):
 
         :param num: The new value for whether to enable it or not.
         """
+        if num == enums.VALUE_INHERITED:
+            self._virt_auto_boot = enums.VALUE_INHERITED
+            return
         self._virt_auto_boot = validate.validate_virt_auto_boot(num)
 
     @property
@@ -564,7 +564,7 @@ class Profile(item.Item):
         :getter: The size of the image(s) in GB.
         :setter: The float with the new size in GB.
         """
-        return self._virt_file_size
+        return self._resolve("virt_file_size")
 
     @virt_file_size.setter
     def virt_file_size(self, num: Union[str, int, float]):
@@ -585,7 +585,7 @@ class Profile(item.Item):
         :getter: The enum type representation of the disk driver.
         :setter: May be a ``str`` with the name of the disk driver or from the enum type directly.
         """
-        return self._virt_disk_driver
+        return self._resolve_enum("virt_disk_driver", enums.VirtDiskDrivers)
 
     @virt_disk_driver.setter
     def virt_disk_driver(self, driver: str):
@@ -606,7 +606,7 @@ class Profile(item.Item):
         :getter: The amount of RAM currently assigned to the image.
         :setter: The new amount of ram. Must be an integer.
         """
-        return self._virt_ram
+        return self._resolve("virt_ram")
 
     @virt_ram.setter
     def virt_ram(self, num: Union[str, int]):
@@ -627,7 +627,7 @@ class Profile(item.Item):
         :getter: The value of the virtual machine.
         :setter: May be of the enum type or a str which is then converted to the enum type.
         """
-        return self._virt_type
+        return self._resolve_enum("virt_type", enums.VirtType)
 
     @virt_type.setter
     def virt_type(self, vtype: str):
@@ -648,9 +648,7 @@ class Profile(item.Item):
         :getter: Either the default name for the bridge or the specific one for this profile.
         :setter: The new name. Does not overwrite the default one.
         """
-        if not self._virt_bridge:
-            return self.api.settings().default_virt_bridge
-        return self._virt_bridge
+        return self._resolve("virt_bridge")
 
     @virt_bridge.setter
     def virt_bridge(self, vbridge: str):

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -329,6 +329,8 @@ class Repo(item.Item):
         Flags passed to createrepo when it is called. Common flags to use would be ``-c cache`` or ``-g comps.xml`` to
         generate group information.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: The createrepo_flags to apply to the repo.
         :setter: The new flags. May raise a ``TypeError`` in case the options are not a ``str``.
         """
@@ -495,6 +497,8 @@ class Repo(item.Item):
     def proxy(self) -> str:
         """
         Override the default external proxy which is used for accessing the internet.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: Returns the default one or the specific one for this repository.
         :setter: May raise a ``TypeError`` in case the wrong value is given.

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -1085,6 +1085,8 @@ class System(Item):
         """
         boot_loaders property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``boot_loaders``.
         :setter: Sets the value for the property ``boot_loaders``.
         :return:
@@ -1130,9 +1132,10 @@ class System(Item):
         """
         server property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``server``.
         :setter: Sets the value for the property ``server``.
-        :return:
         """
         return self._server
 
@@ -1155,6 +1158,8 @@ class System(Item):
     def next_server_v4(self) -> str:
         """
         next_server_v4 property.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: Returns the value for ``next_server_v4``.
         :setter: Sets the value for the property ``next_server_v4``.
@@ -1181,6 +1186,8 @@ class System(Item):
     def next_server_v6(self) -> str:
         """
         next_server_v6 property.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: Returns the value for ``next_server_v6``.
         :setter: Sets the value for the property ``next_server_v6``.
@@ -1234,11 +1241,12 @@ class System(Item):
     @property
     def proxy(self) -> str:
         """
-        proxy property.
+        proxy property. This corresponds per default to the setting``proxy_url_int``.
+
+        .. note:: This property can be set to ``<<inherit>>``.
 
         :getter: Returns the value for ``proxy``.
         :setter: Sets the value for the property ``proxy``.
-        :return:
         """
         return self._resolve("proxy_url_int")
 
@@ -1247,10 +1255,8 @@ class System(Item):
         """
         Setter for the proxy of the System class.
 
-
-        :param proxy:
+        :param proxy: The new value for the proxy.
         :raises TypeError: In case proxy is no string.
-        :return:
         """
         if not isinstance(proxy, str):
             raise TypeError("Field proxy of object system needs to be of type str!")
@@ -1261,9 +1267,10 @@ class System(Item):
         """
         redhat_management_key property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``redhat_management_key``.
         :setter: Sets the value for the property ``redhat_management_key``.
-        :return:
         """
         return self._resolve("redhat_management_key")
 
@@ -1272,8 +1279,7 @@ class System(Item):
         """
         Setter for the redhat_management_key of the System class.
 
-
-        :param management_key:
+        :param management_key: The new value for the redhat management key
         :raises TypeError: In case management_key is no string.
         """
         if not isinstance(management_key, str):
@@ -1475,6 +1481,8 @@ class System(Item):
         """
         enable_ipxe property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``enable_ipxe``.
         :setter: Sets the value for the property ``enable_ipxe``.
         :return:
@@ -1613,19 +1621,19 @@ class System(Item):
         """
         virt_cpus property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``virt_cpus``.
         :setter: Sets the value for the property ``virt_cpus``.
-        :return:
         """
-        return self._virt_cpus
+        return self._resolve("virt_cpus")
 
     @virt_cpus.setter
     def virt_cpus(self, num: int):
         """
         Setter for the virt_cpus of the System class.
 
-
-        :param num:
+        :param num: The new value for the number of CPU cores.
         """
         self._virt_cpus = validate.validate_virt_cpus(num)
 
@@ -1636,7 +1644,6 @@ class System(Item):
 
         :getter: Returns the value for ``virt_file_size``.
         :setter: Sets the value for the property ``virt_file_size``.
-        :return:
         """
         return self._virt_file_size
 
@@ -1655,9 +1662,10 @@ class System(Item):
         """
         virt_disk_driver property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``virt_disk_driver``.
         :setter: Sets the value for the property ``virt_disk_driver``.
-        :return:
         """
         return self._virt_disk_driver
 
@@ -1666,8 +1674,7 @@ class System(Item):
         """
         Setter for the virt_disk_driver of the System class.
 
-
-        :param driver:
+        :param driver: The new disk driver for the virtual disk.
         """
         self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
@@ -1676,21 +1683,23 @@ class System(Item):
         """
         virt_auto_boot property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``virt_auto_boot``.
         :setter: Sets the value for the property ``virt_auto_boot``.
-        :return:
         """
-        return self._virt_auto_boot
+        return self._resolve("virt_auto_boot")
 
     @virt_auto_boot.setter
-    def virt_auto_boot(self, num: bool):
+    def virt_auto_boot(self, value: bool):
         """
         Setter for the virt_auto_boot of the System class.
 
-
-        :param num:
+        :param value: Weather the VM should automatically boot or not.
         """
-        self._virt_auto_boot = validate.validate_virt_auto_boot(num)
+        if value == enums.VALUE_INHERITED:
+            self._virt_auto_boot = enums.VALUE_INHERITED
+        self._virt_auto_boot = validate.validate_virt_auto_boot(value)
 
     @property
     def virt_pxe_boot(self) -> bool:
@@ -1699,7 +1708,6 @@ class System(Item):
 
         :getter: Returns the value for ``virt_pxe_boot``.
         :setter: Sets the value for the property ``virt_pxe_boot``.
-        :return:
         """
         return self._virt_pxe_boot
 
@@ -1707,7 +1715,6 @@ class System(Item):
     def virt_pxe_boot(self, num: bool):
         """
         Setter for the virt_pxe_boot of the System class.
-
 
         :param num:
         """
@@ -1718,11 +1725,12 @@ class System(Item):
         """
         virt_ram property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``virt_ram``.
         :setter: Sets the value for the property ``virt_ram``.
-        :return:
         """
-        return self._virt_ram
+        return self._resolve("virt_ram")
 
     @virt_ram.setter
     def virt_ram(self, num: Union[int, str]):
@@ -1739,9 +1747,10 @@ class System(Item):
         """
         virt_type property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``virt_type``.
         :setter: Sets the value for the property ``virt_type``.
-        :return:
         """
         return self._virt_type
 
@@ -1750,8 +1759,7 @@ class System(Item):
         """
         Setter for the virt_type of the System class.
 
-
-        :param vtype:
+        :param vtype: The new virtual type.
         """
         self._virt_type = enums.VirtType.to_enum(vtype)
 
@@ -1760,19 +1768,19 @@ class System(Item):
         """
         virt_path property.
 
+        .. note:: This property can be set to ``<<inherit>>``.
+
         :getter: Returns the value for ``virt_path``.
         :setter: Sets the value for the property ``virt_path``.
-        :return:
         """
-        return self._virt_path
+        return self._resolve("virt_path")
 
     @virt_path.setter
     def virt_path(self, path: str):
         """
         Setter for the virt_path of the System class.
 
-
-        :param path:
+        :param path: The new path.
         """
         self._virt_path = validate.validate_virt_path(path, for_system=True)
 
@@ -1783,7 +1791,6 @@ class System(Item):
 
         :getter: Returns the value for ``netboot_enabled``.
         :setter: Sets the value for the property ``netboot_enabled``.
-        :return:
         """
         return self._netboot_enabled
 

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -795,6 +795,13 @@ class CobblerXMLRPCInterface:
         (otype, oname) = object_id.split("::", 1)
         return self.api.get_item(otype, oname)
 
+    def get_item_resolved_value(self, item_uuid: str, attribute: str):
+        """
+        .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.get_item_resolved_value`
+        """
+        self._log("get_item_resolved_value(%s)" % item_uuid, attribute=attribute)
+        return self.api.get_item_resolved_value(item_uuid, attribute)
+
     def get_item(self, what: str, name: str, flatten=False):
         """
         Returns a dict describing a given object.

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -39,7 +39,7 @@ import urllib.request
 import xmlrpc.client
 from functools import reduce
 from pathlib import Path
-from typing import List, Optional, Pattern, Union
+from typing import Any, Dict, List, Optional, Pattern, Tuple, Union
 from xmlrpc.client import ServerProxy
 
 import distro
@@ -568,7 +568,20 @@ def input_string_or_list(options: Optional[Union[str, list]]) -> Union[list, str
     return input_string_or_list_no_inherit(options)
 
 
-def input_string_or_dict(options: Union[str, list, dict], allow_multiples=True):
+def input_string_or_dict_no_inherit(
+    options: Union[str, list, dict], allow_multiples=True
+) -> Union[str, Tuple[bool, dict]]:
+    """
+    See :meth:`~cobbler.utils.input_string_or_dict`
+    """
+    if options == enums.VALUE_INHERITED:
+        return enums.VALUE_INHERITED
+    return input_string_or_dict(options, allow_multiples)
+
+
+def input_string_or_dict(
+    options: Union[str, list, dict], allow_multiples=True
+) -> Tuple[bool, dict]:
     """
     Older Cobbler files stored configurations in a flat way, such that all values for strings. Newer versions of Cobbler
     allow dictionaries. This function is used to allow loading of older value formats so new users of Cobbler aren't
@@ -579,16 +592,12 @@ def input_string_or_dict(options: Union[str, list, dict], allow_multiples=True):
     :return: A tuple of True and a dict.
     :raises TypeError: Raised in case the input type is wrong.
     """
-
-    if options == "<<inherit>>":
-        options = {}
-
     if options is None or options == "delete":
         return True, {}
     elif isinstance(options, list):
         raise TypeError("No idea what to do with list: %s" % options)
     elif isinstance(options, str):
-        new_dict = {}
+        new_dict: Dict[str, Any] = {}
         tokens = shlex.split(options)
         for t in tokens:
             tokens2 = t.split("=", 1)
@@ -603,7 +612,7 @@ def input_string_or_dict(options: Union[str, list, dict], allow_multiples=True):
             # If we're allowing multiple values for the same key, check to see if this token has already been inserted
             # into the dictionary of values already.
 
-            if key in list(new_dict.keys()) and allow_multiples:
+            if key in new_dict.keys() and allow_multiples:
                 # If so, check to see if there is already a list of values otherwise convert the dictionary value to an
                 # array, and add the new value to the end of the list.
                 if isinstance(new_dict[key], list):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -412,13 +412,12 @@ def find_kernel(path: str) -> str:
     return ""
 
 
-def remove_yum_olddata(path):
+def remove_yum_olddata(path: os.PathLike):
     """
     Delete .olddata folders that might be present from a failed run of createrepo.
 
     :param path: The path to check for .olddata files.
     """
-    # FIXME: If the folder is actually a file this method fails wonderfully.
     directories_to_try = [
         ".olddata",
         ".repodata/.olddata",
@@ -426,9 +425,9 @@ def remove_yum_olddata(path):
         "repodata/repodata",
     ]
     for pathseg in directories_to_try:
-        olddata = os.path.join(path, pathseg)
-        if os.path.exists(olddata):
-            logger.info("removing: %s", olddata)
+        olddata = Path(path, pathseg)
+        if olddata.is_dir() and olddata.exists():
+            logger.info('Removing: "%s"', olddata)
             shutil.rmtree(olddata, ignore_errors=False, onerror=None)
 
 

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -400,7 +400,6 @@ def validate_virt_ram(value: Union[int, str]) -> Union[str, int]:
 
     if isinstance(value, str):
         if value == enums.VALUE_INHERITED:
-            # FIXME: The default value is 0 instead of enums.VALUE_INHERITED.
             return enums.VALUE_INHERITED
         if value == "":
             return 0
@@ -427,9 +426,8 @@ def validate_virt_bridge(vbridge: str) -> str:
     """
     if not isinstance(vbridge, str):
         raise TypeError("vbridge must be of type str.")
-    # FIXME: Settings are not available here
     if not vbridge:
-        return ""
+        return enums.VALUE_INHERITED
     return vbridge
 
 

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -607,9 +607,10 @@ def validate_uuid(possible_uuid: str) -> bool:
 
 def validate_obj_type(object_type: str) -> bool:
     """
+    This validates the given object type against the available object types in Cobbler.
 
-    :param object_type:
-    :return:
+    :param object_type: The str with the object type to validate.
+    :return: True in case it is one, False in all other cases.
     """
     if not isinstance(object_type, str):
         return False
@@ -628,9 +629,10 @@ def validate_obj_type(object_type: str) -> bool:
 
 def validate_obj_name(object_name: str) -> bool:
     """
+    This validates the name of an object against the Cobbler specific object name schema.
 
-    :param object_name:
-    :return:
+    :param object_name: The object name candidate.
+    :return: True in case it matches the RE_OBJECT_NAME regex, False in all other cases.
     """
     if not isinstance(object_name, str):
         return False
@@ -639,8 +641,9 @@ def validate_obj_name(object_name: str) -> bool:
 
 def validate_obj_id(object_id: str) -> bool:
     """
+    This validates a possible object ID against its Cobbler specific object id schema.
 
-    :param object_id:
+    :param object_id: The possible object id candidate.
     :return: True in case it is one, False otherwise.
     """
     if not isinstance(object_id, str):

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -590,7 +590,7 @@ def validate_autoinstall_script_name(name: str) -> bool:
 
 def validate_uuid(possible_uuid: str) -> bool:
     """
-    Validate if the handed string is a valid UUIDv4.
+    Validate if the handed string is a valid UUIDv4 hex representation.
 
     :param possible_uuid: The str with the UUID.
     :return: True in case it is one, False otherwise.
@@ -602,7 +602,7 @@ def validate_uuid(possible_uuid: str) -> bool:
         uuid_obj = UUID(possible_uuid, version=4)
     except ValueError:
         return False
-    return str(uuid_obj) == possible_uuid
+    return uuid_obj.hex == possible_uuid
 
 
 def validate_obj_type(object_type: str) -> bool:

--- a/tests/api/miscellaneous_test.py
+++ b/tests/api/miscellaneous_test.py
@@ -84,10 +84,10 @@ def test_buildiso(mocker, cobbler_api):
         ),  # Attribute not existing
         ("", "redhat_management_key", does_not_raise(), ""),  # str attribute test
         ("", "enable_ipxe", does_not_raise(), False),  # bool attribute
-        ("", "virt_ram", does_not_raise(), 0),  # int attribute
-        ("", "virt_file_size", does_not_raise(), 0.0),  # double attribute
+        ("", "virt_ram", does_not_raise(), 512),  # int attribute
+        ("", "virt_file_size", does_not_raise(), 5.0),  # double attribute
         ("", "kernel_options", does_not_raise(), {}),  # dict attribute
-        ("", "owners", does_not_raise(), []),  # list attribute
+        ("", "owners", does_not_raise(), ["admin"]),  # list attribute
     ],
 )
 def test_get_item_resolved_value(

--- a/tests/api/miscellaneous_test.py
+++ b/tests/api/miscellaneous_test.py
@@ -7,6 +7,7 @@ from cobbler import settings
 from cobbler.api import CobblerAPI
 from cobbler.actions.buildiso.netboot import NetbootBuildiso
 from cobbler.actions.buildiso.standalone import StandaloneBuildiso
+from tests.conftest import does_not_raise
 
 
 @pytest.mark.parametrize(
@@ -56,3 +57,60 @@ def test_buildiso(mocker, cobbler_api):
     # Assert
     assert netboot_stub.run.call_count == 1
     assert standalone_stub.run.call_count == 0
+
+
+@pytest.mark.parametrize(
+    "input_uuid,input_attribute_name,expected_exception,expected_result",
+    [
+        (0, "", pytest.raises(TypeError), ""),  # Wrong argument type uuid
+        ("", 0, pytest.raises(TypeError), ""),  # Wrong argument type attribute name
+        (
+            "yxvyxcvyxcvyxcvyxcvyxcvyxcv",
+            "kernel_options",
+            pytest.raises(ValueError),
+            "",
+        ),  # Wrong uuid format
+        (
+            "4c1d2e0050344a9ba96e2fd36908a53e",
+            "kernel_options",
+            pytest.raises(ValueError),
+            "",
+        ),  # Item not existing
+        (
+            "",
+            "test_not_existing",
+            pytest.raises(AttributeError),
+            "",
+        ),  # Attribute not existing
+        ("", "redhat_management_key", does_not_raise(), ""),  # str attribute test
+        ("", "enable_ipxe", does_not_raise(), False),  # bool attribute
+        ("", "virt_ram", does_not_raise(), 0),  # int attribute
+        ("", "virt_file_size", does_not_raise(), 0.0),  # double attribute
+        ("", "kernel_options", does_not_raise(), {}),  # dict attribute
+        ("", "owners", does_not_raise(), []),  # list attribute
+    ],
+)
+def test_get_item_resolved_value(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    create_system,
+    input_uuid,
+    input_attribute_name,
+    expected_exception,
+    expected_result,
+):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(test_profile.name)
+
+    if input_uuid == "":
+        input_uuid = test_system.uid
+
+    # Act
+    with expected_exception:
+        result = cobbler_api.get_item_resolved_value(input_uuid, input_attribute_name)
+
+        # Assert
+        assert expected_result == result

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def does_not_raise():
 
 
 @pytest.fixture(scope="function")
-def cobbler_api():
+def cobbler_api() -> CobblerAPI:
     CobblerAPI.__shared_state = {}
     CobblerAPI.__has_loaded = False
     return CobblerAPI()
@@ -30,6 +30,28 @@ def reset_settings_yaml(tmp_path):
     shutil.copy(filepath, tmp_path.joinpath(filename))
     yield
     shutil.copy(tmp_path.joinpath(filename), filepath)
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_items(cobbler_api):
+    for system in cobbler_api.systems():
+        cobbler_api.remove_system(system.name)
+    for image in cobbler_api.images():
+        cobbler_api.remove_distro(image.name)
+    for profile in cobbler_api.profiles():
+        cobbler_api.remove_profile(profile.name)
+    for distro in cobbler_api.distros():
+        cobbler_api.remove_distro(distro.name)
+    for package in cobbler_api.packages():
+        cobbler_api.remove_package(package.name)
+    for repo in cobbler_api.repos():
+        cobbler_api.remove_repo(repo.name)
+    for mgmtclass in cobbler_api.mgmtclasses():
+        cobbler_api.remove_mgmtclass(mgmtclass.name)
+    for file in cobbler_api.files():
+        cobbler_api.remove_file(file.name)
+    for menu in cobbler_api.menus():
+        cobbler_api.remove_menu(menu.name)
 
 
 @pytest.fixture(scope="function")

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -42,8 +42,8 @@ def test_make_clone(cobbler_api, create_kernel_initrd, fk_kernel, fk_initrd):
     distro = Distro(cobbler_api)
     distro.breed = "suse"
     distro.os_version = "sles15generic"
-    distro.kernel = os.path.join(folder, "vmlinuz1")
-    distro.initrd = os.path.join(folder, "initrd1.img")
+    distro.kernel = os.path.join(folder, fk_kernel)
+    distro.initrd = os.path.join(folder, fk_initrd)
 
     # Act
     result = distro.make_clone()
@@ -144,15 +144,16 @@ def test_arch(cobbler_api, value, expected):
 
 
 @pytest.mark.parametrize(
-    "value,expected_exception",
+    "value,expected_exception,expected_result",
     [
-        ("", does_not_raise()),
-        ("Test", pytest.raises(ValueError)),
-        (0, pytest.raises(TypeError)),
-        (["grub"], does_not_raise()),
+        ("", does_not_raise(), ""),
+        ("<<inherit>>", does_not_raise(), ["grub", "pxe", "ipxe"]),
+        ("Test", pytest.raises(ValueError), ""),
+        (0, pytest.raises(TypeError), ""),
+        (["grub"], does_not_raise(), ["grub"]),
     ],
 )
-def test_boot_loaders(cobbler_api, value, expected_exception):
+def test_boot_loaders(cobbler_api, value, expected_exception, expected_result):
     # Arrange
     distro = Distro(cobbler_api)
 
@@ -164,7 +165,7 @@ def test_boot_loaders(cobbler_api, value, expected_exception):
         if value == "":
             assert distro.boot_loaders == []
         else:
-            assert distro.boot_loaders == value
+            assert distro.boot_loaders == expected_result
 
 
 @pytest.mark.parametrize(
@@ -267,10 +268,14 @@ def test_owners(cobbler_api, value):
 
 
 @pytest.mark.parametrize(
-    "value,expected_exception",
-    [("", does_not_raise()), (["Test"], pytest.raises(TypeError))],
+    "value,expected_exception,expected_result",
+    [
+        ("", does_not_raise(), ""),
+        (["Test"], pytest.raises(TypeError), ""),
+        ("<<inherit>>", does_not_raise(), ""),
+    ],
 )
-def test_redhat_management_key(cobbler_api, value, expected_exception):
+def test_redhat_management_key(cobbler_api, value, expected_exception, expected_result):
     # Arrange
     distro = Distro(cobbler_api)
 
@@ -279,7 +284,7 @@ def test_redhat_management_key(cobbler_api, value, expected_exception):
         distro.redhat_management_key = value
 
         # Assert
-        assert distro.redhat_management_key == value
+        assert distro.redhat_management_key == expected_result
 
 
 @pytest.mark.parametrize("value", [[""], ["Test"]])

--- a/tests/items/repo_test.py
+++ b/tests/items/repo_test.py
@@ -117,15 +117,30 @@ def test_rpm_list(cobbler_api):
     assert testrepo.rpm_list == []
 
 
-def test_createrepo_flags(cobbler_api):
+@pytest.mark.parametrize(
+    "input_flags,expected_exception,expected_result",
+    [
+        ("", does_not_raise(), ""),
+        (
+            "<<inherit>>",
+            does_not_raise(),
+            "-c cache -s sha",
+        ),  # Result is coming from settings.yaml
+        (0, pytest.raises(TypeError), ""),
+    ],
+)
+def test_createrepo_flags(
+    cobbler_api, input_flags, expected_exception, expected_result
+):
     # Arrange
     testrepo = Repo(cobbler_api)
 
     # Act
-    testrepo.createrepo_flags = ""
+    with expected_exception:
+        testrepo.createrepo_flags = input_flags
 
-    # Assert
-    assert testrepo.createrepo_flags == ""
+        # Assert
+        assert testrepo.createrepo_flags == expected_result
 
 
 def test_breed(cobbler_api):
@@ -210,12 +225,21 @@ def test_apt_dists(cobbler_api):
     assert testrepo.apt_dists == []
 
 
-def test_proxy(cobbler_api):
+@pytest.mark.parametrize(
+    "input_proxy,expected_exception,expected_result",
+    [
+        ("", does_not_raise(), ""),
+        ("<<inherit>>", does_not_raise(), ""),
+        (0, pytest.raises(TypeError), ""),
+    ],
+)
+def test_proxy(cobbler_api, input_proxy, expected_exception, expected_result):
     # Arrange
     testrepo = Repo(cobbler_api)
 
     # Act
-    testrepo.proxy = ""
+    with expected_exception:
+        testrepo.proxy = input_proxy
 
-    # Assert
-    assert testrepo.proxy == ""
+        # Assert
+        assert testrepo.proxy == expected_result

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -225,7 +225,7 @@ def test_input_string_or_list(test_input, expected_result):
 @pytest.mark.parametrize(
     "testinput,expected_result,possible_exception",
     [
-        ("<<inherit>>", (True, {}), does_not_raise()),
+        ("<<inherit>>", (True, {"<<inherit>>": None}), does_not_raise()),
         ([""], None, pytest.raises(TypeError)),
         ("a b=10 c=abc", (True, {"a": None, "b": "10", "c": "abc"}), does_not_raise()),
         ({"ab": 0}, (True, {"ab": 0}), does_not_raise()),

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -1,3 +1,5 @@
+import uuid
+
 import pytest
 
 from cobbler import enums, utils, validate
@@ -224,3 +226,15 @@ def test_validate_grub_remote_file(test_value, expected_result):
 
     # Assert
     assert expected_result == result
+
+
+def test_validate_uuid():
+    # Arrange
+    test_uuid = uuid.uuid4().hex
+    expected_result = True
+
+    # Act
+    result = validate.validate_uuid(test_uuid)
+
+    # Arrange
+    assert result is expected_result

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 import time
 import re
@@ -6,13 +8,13 @@ TEST_POWER_MANAGEMENT = True
 TEST_SYSTEM = ""
 
 
-class TestNonObjectCalls:
+@pytest.fixture(scope="function")
+def wait_task_end():
+    """
+    Wait until a task is finished
+    """
 
-    # TODO: Obsolete this method via a unittest method
-    def _wait_task_end(self, tid, remote):
-        """
-        Wait until a task is finished
-        """
+    def _wait_task_end(tid, remote):
         timeout = 0
         # "complete" is the constant: EVENT_COMPLETE from cobbler.remote
         while remote.get_task_status(tid)[2] != "complete":
@@ -24,146 +26,192 @@ class TestNonObjectCalls:
             if timeout == 60:
                 raise Exception
 
-    def test_token(self, token):
-        """
-        Test: authentication token validation
-        """
+    return _wait_task_end
 
-        assert token not in ("", None)
 
-    def test_get_user_from_token(self, remote, token):
-        """
-        Test: get user data from authentication token
-        """
+def test_token(token):
+    """
+    Test: authentication token validation
+    """
 
-        assert remote.get_user_from_token(token)
+    assert token not in ("", None)
 
-    def test_check(self, remote, token):
-        """
-        Test: check Cobbler status
-        """
 
-        assert remote.check(token)
+def test_get_user_from_token(remote, token):
+    """
+    Test: get user data from authentication token
+    """
 
-    def test_last_modified_time(self, remote, token):
-        """
-        Test: get last modification time
-        """
+    assert remote.get_user_from_token(token)
 
-        assert remote.last_modified_time(token) != 0
 
-    def test_power_system(self, remote, token):
-        """
-        Test: reboot a system
-        """
+def test_check(remote, token):
+    """
+    Test: check Cobbler status
+    """
 
-        if TEST_SYSTEM and TEST_POWER_MANAGEMENT:
-            tid = remote.background_power_system(
-                {"systems": [TEST_SYSTEM], "power": "reboot"}, token
-            )
-            self._wait_task_end(tid, remote)
+    assert remote.check(token)
 
-    def test_sync(self, remote, token):
-        """
-        Test: synchronize Cobbler internal data with managed services
-        (dhcp, tftp, dns)
-        """
 
-        tid = remote.background_sync({}, token)
-        events = remote.get_events(token)
+def test_last_modified_time(remote, token):
+    """
+    Test: get last modification time
+    """
 
-        assert len(events) > 0
+    assert remote.last_modified_time(token) != 0
 
-        self._wait_task_end(tid, remote)
 
-        event_log = remote.get_event_log(tid)
+def test_power_system(remote, token, wait_task_end):
+    """
+    Test: reboot a system
+    """
 
-    def test_get_autoinstall_templates(self, remote, token):
-        """
-        Test: get autoinstall templates
-        """
-
-        result = remote.get_autoinstall_templates(token)
-        assert len(result) > 0
-
-    def test_get_autoinstall_snippets(self, remote, token):
-        """
-        Test: get autoinstall snippets
-        """
-
-        result = remote.get_autoinstall_snippets(token)
-        assert len(result) > 0
-
-    def test_generate_autoinstall(self, remote):
-        """
-        Test: generate autoinstall content
-        """
-
-        if TEST_SYSTEM:
-            remote.generate_autoinstall(None, TEST_SYSTEM)
-
-    def test_generate_ipxe(self, remote):
-        """
-        Test: generate iPXE file content
-        """
-
-        if TEST_SYSTEM:
-            remote.generate_ipxe(None, TEST_SYSTEM)
-
-    def test_generate_bootcfg(self, remote):
-        """
-        Test: generate boot loader configuration file content
-        """
-
-        if TEST_SYSTEM:
-            remote.generate_bootcfg(None, TEST_SYSTEM)
-
-    def test_get_settings(self, remote, token):
-        """
-        Test: get settings
-        """
-
-        remote.get_settings(token)
-
-    def test_get_signatures(self, remote, token):
-        """
-        Test: get distro signatures
-        """
-
-        remote.get_signatures(token)
-
-    def test_get_valid_breeds(self, remote, token):
-        """
-        Test: get valid OS breeds
-        """
-
-        breeds = remote.get_valid_breeds(token)
-        assert len(breeds) > 0
-
-    def test_get_valid_os_versions_for_breed(self, remote, token):
-        """
-        Test: get valid OS versions for a OS breed
-        """
-
-        versions = remote.get_valid_os_versions_for_breed("generic", token)
-        assert len(versions) > 0
-
-    def test_get_valid_os_versions(self, remote, token):
-        """
-        Test: get valid OS versions
-        """
-
-        versions = remote.get_valid_os_versions(token)
-        assert len(versions) > 0
-
-    def test_get_random_mac(self, remote, token):
-        """
-        Test: get a random mac for a virtual network interface
-        """
-
-        mac = remote.get_random_mac("xen", token)
-        hexa = "[0-9A-Fa-f]{2}"
-        match_obj = re.match(
-            "%s:%s:%s:%s:%s:%s" % (hexa, hexa, hexa, hexa, hexa, hexa), mac
+    if TEST_SYSTEM and TEST_POWER_MANAGEMENT:
+        tid = remote.background_power_system(
+            {"systems": [TEST_SYSTEM], "power": "reboot"}, token
         )
-        assert match_obj
+        wait_task_end(tid, remote)
+
+
+def test_sync(remote, token, wait_task_end):
+    """
+    Test: synchronize Cobbler internal data with managed services
+    (dhcp, tftp, dns)
+    """
+
+    tid = remote.background_sync({}, token)
+    events = remote.get_events(token)
+
+    assert len(events) > 0
+
+    wait_task_end(tid, remote)
+
+    event_log = remote.get_event_log(tid)
+
+
+def test_get_autoinstall_templates(remote, token):
+    """
+    Test: get autoinstall templates
+    """
+
+    result = remote.get_autoinstall_templates(token)
+    assert len(result) > 0
+
+
+def test_get_autoinstall_snippets(remote, token):
+    """
+    Test: get autoinstall snippets
+    """
+
+    result = remote.get_autoinstall_snippets(token)
+    assert len(result) > 0
+
+
+def test_generate_autoinstall(remote):
+    """
+    Test: generate autoinstall content
+    """
+
+    if TEST_SYSTEM:
+        remote.generate_autoinstall(None, TEST_SYSTEM)
+
+
+def test_generate_ipxe(remote):
+    """
+    Test: generate iPXE file content
+    """
+
+    if TEST_SYSTEM:
+        remote.generate_ipxe(None, TEST_SYSTEM)
+
+
+def test_generate_bootcfg(remote):
+    """
+    Test: generate boot loader configuration file content
+    """
+
+    if TEST_SYSTEM:
+        remote.generate_bootcfg(None, TEST_SYSTEM)
+
+
+def test_get_settings(remote, token):
+    """
+    Test: get settings
+    """
+
+    remote.get_settings(token)
+
+
+def test_get_signatures(remote, token):
+    """
+    Test: get distro signatures
+    """
+
+    remote.get_signatures(token)
+
+
+def test_get_valid_breeds(remote, token):
+    """
+    Test: get valid OS breeds
+    """
+
+    breeds = remote.get_valid_breeds(token)
+    assert len(breeds) > 0
+
+
+def test_get_valid_os_versions_for_breed(remote, token):
+    """
+    Test: get valid OS versions for a OS breed
+    """
+
+    versions = remote.get_valid_os_versions_for_breed("generic", token)
+    assert len(versions) > 0
+
+
+def test_get_valid_os_versions(remote, token):
+    """
+    Test: get valid OS versions
+    """
+
+    versions = remote.get_valid_os_versions(token)
+    assert len(versions) > 0
+
+
+def test_get_random_mac(remote, token):
+    """
+    Test: get a random mac for a virtual network interface
+    """
+
+    mac = remote.get_random_mac("xen", token)
+    hexa = "[0-9A-Fa-f]{2}"
+    match_obj = re.match(
+        "%s:%s:%s:%s:%s:%s" % (hexa, hexa, hexa, hexa, hexa, hexa), mac
+    )
+    assert match_obj
+
+
+def test_get_item_resolved_value(
+    remote, token, create_distro, create_profile, create_system, create_kernel_initrd
+):
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    name_distro = "testdistro_item_resolved_value"
+    name_profile = "testprofile_item_resolved_value"
+    name_system = "testsystem_item_resolved_value"
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+
+    create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+    create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+    test_system_handle = create_system(name_system, name_profile)
+    remote.modify_system(test_system_handle, "kernel_options", "!c !e", token=token)
+    test_system = remote.get_system(name_system, token=token)
+    expected_result = {"a": "1", "b": "2", "d": None}
+
+    # Act
+    result = remote.get_item_resolved_value(test_system.get("uid"), "kernel_options")
+
+    # Assert
+    assert expected_result == result


### PR DESCRIPTION
Before this PR it was not possible to retrieve inherited attributes without being able to use the Cobbler Python API Client on the Cobbler machine. This PR adds a new endpoint to be able to resolve those attributes.

TODO:

- [x] Add tests for the new endpoint
- [x] Add the endpoint itself
- [x] Fix the uuid comparison bug
- [x] Adjust API so we don't need a collection to search for an item
- [x] Fix utils inherit bug
- [x] Add docstrings so we know what is inheritable
- [x] Add/Adjust tests for inherited properties

Fixes https://github.com/SUSE/spacewalk/issues/17443
Fixes #3025
Fixes #3026
Fixes #3027