### PR TITLE
[mkloaders] Add the missing 'syslinux/libutil.c32'

### DIFF
--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -122,13 +122,23 @@ class MkLoaders:
                 "syslinux command not available. Bailing out of syslinux setup!"
             )
             return
+        syslinux_version = get_syslinux_version()
         # Make modules
         symlink(
             self.syslinux_folder.joinpath("menu.c32"),
             self.bootloaders_dir.joinpath("menu.c32"),
             skip_existing=True,
         )
-        if get_syslinux_version() < 5:
+        # According to https://wiki.syslinux.org/wiki/index.php?title=Library_modules,
+        # 'menu.c32' depends on 'libutil.c32'.
+        libutil_c32_path = self.syslinux_folder.joinpath("libutil.c32")
+        if syslinux_version > 4 and libutil_c32_path.exists():
+            symlink(
+                libutil_c32_path,
+                self.bootloaders_dir.joinpath("libutil.c32"),
+                skip_existing=True,
+            )
+        if syslinux_version < 5:
             # This file is only required for Syslinux 5 and newer.
             # Source: https://wiki.syslinux.org/wiki/index.php?title=Library_modules
             self.logger.info(


### PR DESCRIPTION
Signed-off-by: weiyang <weiyang.ones@gmail.com>

According to https://wiki.syslinux.org/wiki/index.php?title=Library_modules, 'menu.c32' depends on 'libutil.c32'.
So 'libutil.c32' needs to be copied to '/var/lib/cobbler/loaders' as well.

<img width="525" alt="image" src="https://user-images.githubusercontent.com/4213483/162410829-e69e0aa1-cd90-47d1-9fbd-1b3a2eb0f619.png">

### Issue screenshot

![Ro2Xz3LRV3](https://user-images.githubusercontent.com/4213483/162411178-c94111c1-29a3-4ddb-aa4f-fcaa48ebfe8d.png)
