### PR TITLE
skip ldap-negative test

### DIFF
--- a/tests/modules/authentication/ldap_test.py
+++ b/tests/modules/authentication/ldap_test.py
@@ -220,6 +220,7 @@ class TestLdap:
         # Assert
         assert result
 
+    @pytest.mark.skip(reason="causes a segfault in openldap 2.6.1")
     @pytest.mark.parametrize(
         "tls_cafile, tls_cert, tls_key",
         [("/etc/ssl/ca-slapd.crt", "/etc/ssl/bad.crt", "/etc/ssl/bad.key")],


### PR DESCRIPTION
This PR will skip a ldap_negative test that currently doesn't work because of a bug in openldap 2.6.1

openldap bug: https://bugzilla.suse.com/show_bug.cgi?id=1199277

Workaround until this bug is fixed: https://github.com/cobbler/cobbler/issues/3090