### PR TITLE
enable ldap-negative test again

### DIFF
--- a/tests/modules/authentication/ldap_test.py
+++ b/tests/modules/authentication/ldap_test.py
@@ -220,7 +220,6 @@ class TestLdap:
         # Assert
         assert result
 
-    @pytest.mark.skip(reason="causes a segfault in openldap 2.6.1")
     @pytest.mark.parametrize(
         "tls_cafile, tls_cert, tls_key",
         [("/etc/ssl/ca-slapd.crt", "/etc/ssl/bad.crt", "/etc/ssl/bad.key")],


### PR DESCRIPTION
Since the openldap bug is now fixed we can enable the ldap-negative test again

Bug: https://bugzilla.suse.com/show_bug.cgi?id=1199277

follow-up of this: https://github.com/cobbler/cobbler/pull/3091

fixes: https://github.com/cobbler/cobbler/issues/3090