### PR TITLE
Fix - Owners inheritance

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1498,15 +1498,18 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    def dump_vars(self, obj, formatted_output: bool = False):
+    def dump_vars(
+        self, obj, formatted_output: bool = False, remove_dicts: bool = False
+    ):
         """
         Dump all known variables related to that object.
 
         :param obj: The object for which the variables should be dumped.
         :param formatted_output: If True the values will align in one column and be pretty printed for cli example.
+        :param remove_dicts: If True the dictionaries will be put into str form.
         :return: A dictionary with all the information which could be collected.
         """
-        return obj.dump_vars(formatted_output)
+        return obj.dump_vars(formatted_output, remove_dicts)
 
     # ==========================================================================
 

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -851,14 +851,17 @@ class Item:
         else:
             return self.__find_compare(value, data[key])
 
-    def dump_vars(self, formatted_output: bool = True) -> Union[dict, str]:
+    def dump_vars(
+        self, formatted_output: bool = True, remove_dicts: bool = False
+    ) -> Union[dict, str]:
         """
         Dump all variables.
 
         :param formatted_output: Whether to format the output or not.
+        :param remove_dicts: If True the dictionaries will be put into str form.
         :return: The raw or formatted data.
         """
-        raw = utils.blender(self.api, False, self)
+        raw = utils.blender(self.api, remove_dicts, self)
         if formatted_output:
             return pprint.pformat(raw)
         else:

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -984,3 +984,23 @@ class Item:
         :param item_dict: The dictionary with the data to deserialize.
         """
         self.from_dict(item_dict)
+
+    def grab_tree(self) -> list:
+        """
+        Climb the tree and get every node.
+
+        :return: The list of items with all parents from that object upwards the tree. Contains at least the item
+                 itself and the settings of Cobbler.
+        """
+        results = [self]
+        parent = self.parent
+        while parent is not None:
+            results.append(parent)
+            parent = parent.parent
+            # FIXME: Now get the object and check its existence
+        results.append(self.api.settings())
+        self.logger.info(
+            "grab_tree found %s children (including settings) of this object",
+            len(results),
+        )
+        return results

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -136,7 +136,7 @@ class Item:
         self._boot_files: Union[dict, str] = {}
         self._template_files = {}
         self._last_cached_mtime = 0
-        self._owners: Union[list, str] = api.settings().default_ownership
+        self._owners: Union[list, str] = enums.VALUE_INHERITED
         self._cached_dict = ""
         self._mgmt_classes: Union[list, str] = []
         self._mgmt_parameters: Union[dict, str] = {}
@@ -171,8 +171,8 @@ class Item:
         settings_name = property_name
         if property_name.startswith("proxy_url_"):
             property_name = "proxy"
-        if property_name == "default_ownership":
-            property_name = "owners"
+        if property_name == "owners":
+            settings_name = "default_ownership"
         attribute = "_" + property_name
 
         if not hasattr(self, attribute):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2515,9 +2515,28 @@ class CobblerXMLRPCInterface:
         self._log('generate_script, name is "%s"' % name)
         return self.api.generate_script(profile, system, name)
 
+    def dump_vars(
+        self, item_uuid: str, formatted_output: bool = False, remove_dicts: bool = True
+    ):
+        """
+        This function dumps all variables related to an object. The difference to the above mentioned function is that
+        it accepts the item uid instead of the Python object itself.
+
+        .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.dump_vars`
+        """
+        obj = self.api.find_items(
+            "", {"uid": item_uuid}, return_list=False, no_errors=True
+        )
+        if obj is None:
+            raise ValueError('Item with uuid "%s" does not exist!' % item_uuid)
+        self.api.dump_vars(obj, formatted_output, remove_dicts)
+
     def get_blended_data(self, profile=None, system=None):
         """
         Combine all data which is available from a profile and system together and return it.
+
+        .. deprecated:: 3.4.0
+           Please make use of the dump_vars endpoint.
 
         :param profile: The profile of the system.
         :param system: The system for which the data should be rendered.

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -678,9 +678,10 @@ def blender(api_handle, remove_dicts: bool, root_obj):
             repo = api_handle.find_repo(name=r)
             if repo:
                 repo_data.append(repo.to_dict())
-        # FIXME: sort the repos in the array based on the repo priority field so that lower priority repos come first in
-        #  the array
-        results["repo_data"] = repo_data
+        # Sorting is courtesy of https://stackoverflow.com/a/73050/4730773
+        results["repo_data"] = sorted(
+            repo_data, key=lambda repo_dict: repo_dict["priority"], reverse=True
+        )
 
     http_port = results.get("http_port", 80)
     if http_port in (80, "80"):

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -655,8 +655,10 @@ def grab_tree(api_handle, item) -> list:
     :return: The list of items with all parents from that object upwards the tree. Contains at least the item itself.
     """
     # TODO: Move into item.py
+    # We check for the parent attribute to prevent that we have a non-item object here (like settings)
+    if item is None or not hasattr(item, "parent"):
+        return [api_handle.settings()]
     results = [item]
-    # FIXME: The following line will throw an AttributeError for None because there is not get_parent() for None
     parent = item.parent
     while parent is not None:
         results.append(parent)

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -808,19 +808,23 @@ def __consolidate(node, results: dict) -> dict:
     node_data_copy = {}
     for key in node_data:
         value = node_data[key]
-        if value != enums.VALUE_INHERITED:
+        if value == enums.VALUE_INHERITED:
+            if key not in results:
+                # We need to add at least one value per key, use the property getter to resolve to the
+                # settings or wherever we inherit from.
+                node_data_copy[key] = getattr(node, key)
+            # Old keys should have no inherit and thus are not a real property
+            if key == "kickstart":
+                node_data_copy[key] = getattr(type(node), "autoinstall").fget(node)
+            elif key == "ks_meta":
+                node_data_copy[key] = getattr(type(node), "autoinstall_meta").fget(node)
+        else:
             if isinstance(value, dict):
                 node_data_copy[key] = value.copy()
             elif isinstance(value, list):
                 node_data_copy[key] = value[:]
             else:
                 node_data_copy[key] = value
-        else:
-            # Old keys should have no inherit and thus are not a real property
-            if key == "kickstart":
-                node_data_copy[key] = getattr(type(node), "autoinstall").fget(node)
-            elif key == "ks_meta":
-                node_data_copy[key] = getattr(type(node), "autoinstall_meta").fget(node)
 
     for field in node_data_copy:
         data_item = node_data_copy[field]

--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -646,28 +646,6 @@ def input_boolean(value: Union[str, bool, int]) -> bool:
     return value in ["true", "1", "on", "yes", "y"]
 
 
-def grab_tree(api_handle, item) -> list:
-    """
-    Climb the tree and get every node.
-
-    :param api_handle: The api to use for checking the tree.
-    :param item: The item to check for parents
-    :return: The list of items with all parents from that object upwards the tree. Contains at least the item itself.
-    """
-    # TODO: Move into item.py
-    # We check for the parent attribute to prevent that we have a non-item object here (like settings)
-    if item is None or not hasattr(item, "parent"):
-        return [api_handle.settings()]
-    results = [item]
-    parent = item.parent
-    while parent is not None:
-        results.append(parent)
-        parent = parent.parent
-        # FIXME: Now get the object and check its existence
-    results.append(api_handle.settings())
-    return results
-
-
 def blender(api_handle, remove_dicts: bool, root_obj):
     """
     Combine all of the data in an object tree from the perspective of that point on the tree, and produce a merged
@@ -678,7 +656,7 @@ def blender(api_handle, remove_dicts: bool, root_obj):
     :param root_obj: The object which should act as the root-node object.
     :return: A dictionary with all the information from the root node downwards.
     """
-    tree = grab_tree(api_handle, root_obj)
+    tree = root_obj.grab_tree()
     tree.reverse()  # start with top of tree, override going down
     results = {}
     for node in tree:

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from cobbler import enums
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.item import Item

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -131,7 +131,9 @@ def test_comment(cobbler_api):
     "input_owners,expected_exception,expected_result",
     [
         ("", does_not_raise(), []),
+        (enums.VALUE_INHERITED, does_not_raise(), ["admin"]),
         ("Test1 Test2", does_not_raise(), ["Test1", "Test2"]),
+        (["Test1", "Test2"], does_not_raise(), ["Test1", "Test2"]),
         (False, pytest.raises(TypeError), None),
     ],
 )
@@ -336,6 +338,9 @@ def test_dump_vars(cobbler_api):
     result = titem.dump_vars(formatted_output=False)
 
     # Assert
+    print(result)
+    assert "default_ownership" in result
+    assert "owners" in result
     assert len(result) == 148
 
 

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -446,3 +446,16 @@ def test_serialize(cobbler_api):
     assert titem.remote_boot_kernel == kernel_url
     assert titem.remote_grub_kernel.startswith("(http,")
     assert "remote_grub_kernel" not in result
+
+
+def test_grab_tree(cobbler_api):
+    # Arrange
+    object_to_check = Distro(cobbler_api)
+    # TODO: Create some objects and give them some inheritance.
+
+    # Act
+    result = object_to_check.grab_tree()
+
+    # Assert
+    assert isinstance(result, list)
+    assert result[-1].server == "192.168.1.1"

--- a/tests/modules/managers/genders_test.py
+++ b/tests/modules/managers/genders_test.py
@@ -22,7 +22,7 @@ def api_genders_mock():
     settings_mock.http_port = 80
     settings_mock.next_server_v4 = ""
     settings_mock.next_server_v6 = "127.0.0.1"
-    settings_mock.default_ownership = ""
+    settings_mock.default_ownership = []
     settings_mock.default_virt_bridge = ""
     settings_mock.default_virt_type = "auto"
     settings_mock.default_virt_ram = 64

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -24,7 +24,7 @@ def api_mock_tftp():
     settings_mock.http_port = 80
     settings_mock.next_server_v4 = ""
     settings_mock.next_server_v6 = ""
-    settings_mock.default_ownership = ""
+    settings_mock.default_ownership = []
     settings_mock.default_virt_bridge = ""
     settings_mock.default_virt_type = "auto"
     settings_mock.default_virt_ram = 64

--- a/tests/modules/managers/isc_test.py
+++ b/tests/modules/managers/isc_test.py
@@ -21,7 +21,7 @@ def api_isc_mock():
     settings_mock.http_port = 80
     settings_mock.next_server_v4 = "127.0.0.1"
     settings_mock.next_server_v6 = "::1"
-    settings_mock.default_ownership = ""
+    settings_mock.default_ownership = []
     settings_mock.default_virt_bridge = ""
     settings_mock.default_virt_type = "auto"
     settings_mock.default_virt_ram = 64

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -267,19 +267,6 @@ def test_input_boolean(testinput, expected_exception, expected_result):
         assert expected_result == result
 
 
-def test_grab_tree(cobbler_api):
-    # Arrange
-    object_to_check = Distro(cobbler_api)
-    # TODO: Create some objects and give them some inheritance.
-
-    # Act
-    result = utils.grab_tree(cobbler_api, object_to_check)
-
-    # Assert
-    assert isinstance(result, list)
-    assert result[-1].server == "192.168.1.1"
-
-
 def test_blender(cobbler_api):
     # Arrange
     root_item = Distro(cobbler_api)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -275,9 +275,13 @@ def test_blender(cobbler_api):
     result = utils.blender(cobbler_api, False, root_item)
 
     # Assert
-    assert len(result) == 160
+    assert len(result) == 161
+    # Must be present because the settings have it
     assert "server" in result
+    # Must be present because it is a field of distro
     assert "os_version" in result
+    # Must be present because it inherits but is a field of distro
+    assert "boot_loaders" in result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes #3118 

The branch in this PR was initially mainly thought for adding the `dump_vars` endpoint to the XML-RPC API but the bug which was found during testing caused a shift in this.

Nevertheless the new endpoint is in this branch along with:

- the bugfix mentioned in the issue and PR title
- the fact that the `owners` field no inherits per default from the settings instead of copying the settings into its object