### PR TITLE
API: Add set attribute resolved

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -403,19 +403,16 @@ class CobblerAPI:
 
     # =======================================================================
 
-    def get_item_resolved_value(self, item_uuid: str, attribute: str):
+    def __item_resolved_helper(self, item_uuid: str, attribute: str):
         """
-        This method helps non Python API consumers to retrieve the final data of a field with inheritance.
+        This helper validates the common data for ``*_item_resolved_value``.
 
-        This does not help with network interfaces because they don't have a UUID at the moment and thus can't be
-        queried via their UUID.
-
-        :param item_uuid: The UUID of the item that should be retrieved.
-        :param attribute: The attribute that should be retrieved.
-        :raises ValueError: In case a value given was either malformed or the desired item did not exist.
-        :raises TypeError: In case the type of the method arguments do have the wrong type.
-        :raises AttributeError: In case the attribute specified is not available on the given item (type).
-        :returns: The attribute value. Since this might be of type NetworkInterface we cannot yet set this explicitly.
+        :param item_uuid: The uuid for the item.
+        :param attribute: The attribute name that is requested.
+        :returns: The desired item to further process.
+        :raises TypeError: If ``item_uuid`` or ``attribute`` are not a str.
+        :raises ValueError: In case the uuid was invalid or the requested item did not exist.
+        :raises AttributeError: In case the attribute did not exist on the item that was requested.
         """
         if not isinstance(item_uuid, str):
             raise TypeError("item_uuid must be of type str!")
@@ -438,7 +435,48 @@ class CobblerAPI:
                 % (attribute, desired_item.TYPE_NAME)
             )
 
+        return desired_item
+
+    def get_item_resolved_value(self, item_uuid: str, attribute: str):
+        """
+        This method helps non Python API consumers to retrieve the final data of a field with inheritance.
+
+        This does not help with network interfaces because they don't have a UUID at the moment and thus can't be
+        queried via their UUID.
+
+        :param item_uuid: The UUID of the item that should be retrieved.
+        :param attribute: The attribute that should be retrieved.
+        :raises ValueError: In case a value given was either malformed or the desired item did not exist.
+        :raises TypeError: In case the type of the method arguments do have the wrong type.
+        :raises AttributeError: In case the attribute specified is not available on the given item (type).
+        :returns: The attribute value. Since this might be of type NetworkInterface we cannot yet set this explicitly.
+        """
+        desired_item = self.__item_resolved_helper(item_uuid, attribute)
+
         return getattr(desired_item, attribute)
+
+    def set_item_resolved_value(self, item_uuid: str, attribute: str, value):
+        """
+        TODO
+        """
+        desired_item = self.__item_resolved_helper(item_uuid, attribute)
+        resolved_past_value = getattr(desired_item, attribute)
+        # Check if value can be inherited or not
+        # TODO: Checking if it can be inherited can be done via calling _resolve for the requested attribute, the
+        #  challenge is to not duplicate the name list we have in the getter of the various items.
+        if not True:
+            # If value cannot be inherited use setter and bail out
+            return
+        # Check type - Respect <<inherit>> value
+        if not isinstance(value, type(resolved_past_value)):
+            raise TypeError("value passed is not of the type that is expected")
+        # Deduplicate - only for dict
+        if isinstance(resolved_past_value, dict):
+            # Deduplicate through checking if the key-value pairs are present in parents, if yes skip them, otherwise
+            # keep them.
+            pass
+        # Use property setter
+        pass
 
     # =======================================================================
 

--- a/cobbler/decorator.py
+++ b/cobbler/decorator.py
@@ -1,0 +1,18 @@
+"""
+This module provides decorators that are required for Cobbler to work as expected.
+"""
+# The idea for the subclassed property decorators is from: https://stackoverflow.com/a/59313599/4730773
+
+
+class InheritableProperty(property):
+    """
+    This property is supposed to provide a way to identify properties in code that can be set to inherit.
+    """
+
+    inheritable = True
+
+
+class InheritableDictProperty(InheritableProperty):
+    """
+    This property is supposed to provide a way to identify properties in code that can be set to inherit.
+    """

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -26,6 +26,7 @@ from cobbler.items import item
 from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler import grub
+from cobbler.decorator import InheritableProperty
 
 
 class Distro(item.Item):
@@ -419,7 +420,7 @@ class Distro(item.Item):
             self._supported_boot_loaders = utils.get_supported_distro_boot_loaders(self)
         return self._supported_boot_loaders
 
-    @property
+    @InheritableProperty
     def boot_loaders(self) -> list:
         """
         All boot loaders for which Cobbler generates entries for.
@@ -461,7 +462,7 @@ class Distro(item.Item):
             )
         self._boot_loaders = boot_loaders
 
-    @property
+    @InheritableProperty
     def redhat_management_key(self) -> str:
         """
         Get the redhat management key. This is probably only needed if you have spacewalk, uyuni or SUSE Manager

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -23,6 +23,7 @@ from typing import Union
 from cobbler import autoinstall_manager, enums, utils, validate
 from cobbler.cexceptions import CX
 from cobbler.items import item
+from cobbler.decorator import InheritableProperty
 
 
 class Image(item.Item):
@@ -525,7 +526,7 @@ class Image(item.Item):
             self._supported_boot_loaders = utils.get_supported_distro_boot_loaders(self)
             return self._supported_boot_loaders
 
-    @property
+    @InheritableProperty
     def boot_loaders(self) -> list:
         """
         Represents the boot loaders which are able to boot this image.

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -952,8 +952,13 @@ class Item:
                             interface_key
                         ].to_dict()
                     value[new_key] = serialized_interfaces
-                elif isinstance(key_value, (list, dict)):
+                elif isinstance(key_value, list):
                     value[new_key] = copy.deepcopy(key_value)
+                elif isinstance(key_value, dict):
+                    if resolved:
+                        value[new_key] = getattr(self, new_key)
+                    else:
+                        value[new_key] = copy.deepcopy(key_value)
                 elif (
                     isinstance(key_value, str)
                     and key_value == enums.VALUE_INHERITED

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -23,7 +23,7 @@ import yaml
 
 from cobbler import utils, enums
 from cobbler.cexceptions import CX
-
+from cobbler.decorator import InheritableProperty, InheritableDictProperty
 
 RE_OBJECT_NAME = re.compile(r"[a-zA-Z0-9_\-.:]*$")
 
@@ -358,7 +358,7 @@ class Item:
         """
         self._comment = comment
 
-    @property
+    @InheritableProperty
     def owners(self) -> list:
         """
         This is a feature which is related to the ownership module of Cobbler which gives only specific people access
@@ -386,7 +386,7 @@ class Item:
             raise TypeError("owners must be str or list!")
         self._owners = utils.input_string_or_list(owners)
 
-    @property
+    @InheritableDictProperty
     def kernel_options(self) -> dict:
         """
         Kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict.
@@ -413,7 +413,7 @@ class Item:
         except TypeError as e:
             raise TypeError("invalid kernel options") from e
 
-    @property
+    @InheritableDictProperty
     def kernel_options_post(self) -> dict:
         """
         Post kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict.
@@ -440,7 +440,7 @@ class Item:
         except TypeError as e:
             raise TypeError("invalid post kernel options") from e
 
-    @property
+    @InheritableDictProperty
     def autoinstall_meta(self) -> dict:
         """
         A comma delimited list of key value pairs, like 'a=b,c=d,e=f' or a dict.
@@ -464,7 +464,7 @@ class Item:
         value = utils.input_string_or_dict(options, allow_multiples=True)
         self._autoinstall_meta = value
 
-    @property
+    @InheritableProperty
     def mgmt_classes(self) -> list:
         """
         Assigns a list of configuration management classes that can be assigned to any object, such as those used by
@@ -488,7 +488,7 @@ class Item:
             raise TypeError("mgmt_classes has to be either str or list")
         self._mgmt_classes = utils.input_string_or_list(mgmt_classes)
 
-    @property
+    @InheritableDictProperty
     def mgmt_parameters(self) -> dict:
         """
         Parameters which will be handed to your management application (Must be a valid YAML dictionary)
@@ -578,7 +578,7 @@ class Item:
         except TypeError as e:
             raise TypeError("invalid boot files specified") from e
 
-    @property
+    @InheritableDictProperty
     def fetchable_files(self) -> dict:
         """
         A comma seperated list of ``virt_name=path_to_template`` that should be fetchable via tftp or a webserver

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -921,10 +921,12 @@ class Item:
                 "The following keys supplied could not be set: %s" % result.keys()
             )
 
-    def to_dict(self) -> dict:
+    def to_dict(self, resolved: bool = False) -> dict:
         """
         This converts everything in this object to a dictionary.
 
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                     objects raw value.
         :return: A dictionary with all values present in this object.
         """
         value = {}
@@ -938,19 +940,26 @@ class Item:
                 ):
                     continue
                 new_key = key[1:].lower()
-                if isinstance(self.__dict__[key], enum.Enum):
-                    value[new_key] = self.__dict__[key].value
+                key_value = self.__dict__[key]
+                if isinstance(key_value, enum.Enum):
+                    value[new_key] = key_value.value
                 elif new_key == "interfaces":
                     # This is the special interfaces dict. Lets fix it before it gets to the normal process.
                     serialized_interfaces = {}
-                    interfaces = self.__dict__[key]
+                    interfaces = key_value
                     for interface_key in interfaces:
                         serialized_interfaces[interface_key] = interfaces[
                             interface_key
                         ].to_dict()
                     value[new_key] = serialized_interfaces
-                elif isinstance(self.__dict__[key], (list, dict)):
-                    value[new_key] = copy.deepcopy(self.__dict__[key])
+                elif isinstance(key_value, (list, dict)):
+                    value[new_key] = copy.deepcopy(key_value)
+                elif (
+                    isinstance(key_value, str)
+                    and key_value == enums.VALUE_INHERITED
+                    and resolved
+                ):
+                    value[new_key] = getattr(self, key[1:])
                 else:
                     value[new_key] = self.__dict__[key]
         if "autoinstall" in value:

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -25,6 +25,7 @@ from cobbler.items import item
 from cobbler import utils, validate, enums
 from cobbler.cexceptions import CX
 from cobbler.items.distro import Distro
+from cobbler.decorator import InheritableProperty
 
 
 class Profile(item.Item):
@@ -242,7 +243,7 @@ class Profile(item.Item):
         if self.name not in distro.children:
             distro.children.append(self.name)
 
-    @property
+    @InheritableProperty
     def name_servers(self) -> list:
         """
         Represents the list of nameservers to set for the profile.
@@ -261,7 +262,7 @@ class Profile(item.Item):
         """
         self._name_servers = validate.name_servers(data)
 
-    @property
+    @InheritableProperty
     def name_servers_search(self) -> list:
         """
         Represents the list of DNS search paths.
@@ -280,7 +281,7 @@ class Profile(item.Item):
         """
         self._name_servers_search = validate.name_servers_search(data)
 
-    @property
+    @InheritableProperty
     def proxy(self) -> str:
         """
         Override the default external proxy which is used for accessing the internet.
@@ -302,7 +303,7 @@ class Profile(item.Item):
             raise TypeError("Field proxy of object profile needs to be of type str!")
         self._proxy = proxy
 
-    @property
+    @InheritableProperty
     def enable_ipxe(self) -> bool:
         r"""
         Sets whether or not the profile will use iPXE for booting.
@@ -325,7 +326,7 @@ class Profile(item.Item):
             raise TypeError("enable_ipxe needs to be of type bool")
         self._enable_ipxe = enable_ipxe
 
-    @property
+    @InheritableProperty
     def enable_menu(self) -> bool:
         """
         Sets whether or not the profile will be listed in the default PXE boot menu. This is pretty forgiving for
@@ -371,7 +372,7 @@ class Profile(item.Item):
             raise TypeError("Field dhcp_tag of object profile needs to be of type str!")
         self._dhcp_tag = dhcp_tag
 
-    @property
+    @InheritableProperty
     def server(self) -> str:
         """
         Represents the hostname the Cobbler server is reachable by a client.
@@ -445,7 +446,7 @@ class Profile(item.Item):
         else:
             self._next_server_v6 = validate.ipv6_address(server)
 
-    @property
+    @InheritableProperty
     def filename(self) -> str:
         """
         The filename which is fetched by the client from TFTP.
@@ -505,7 +506,7 @@ class Profile(item.Item):
             autoinstall
         )
 
-    @property
+    @InheritableProperty
     def virt_auto_boot(self) -> bool:
         """
         Whether the VM should be booted when booting the host or not.
@@ -548,7 +549,7 @@ class Profile(item.Item):
         """
         self._virt_cpus = validate.validate_virt_cpus(num)
 
-    @property
+    @InheritableProperty
     def virt_file_size(self) -> float:
         r"""
         The size of the image and thus the usable size for the guest.
@@ -572,7 +573,7 @@ class Profile(item.Item):
         """
         self._virt_file_size = validate.validate_virt_file_size(num)
 
-    @property
+    @InheritableProperty
     def virt_disk_driver(self) -> enums.VirtDiskDrivers:
         """
         The type of disk driver used for storing the image.
@@ -593,7 +594,7 @@ class Profile(item.Item):
         """
         self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
-    @property
+    @InheritableProperty
     def virt_ram(self) -> int:
         """
         The amount of RAM given to the guest in MB.
@@ -614,7 +615,7 @@ class Profile(item.Item):
         """
         self._virt_ram = validate.validate_virt_ram(num)
 
-    @property
+    @InheritableProperty
     def virt_type(self) -> enums.VirtType:
         """
         The type of image used.
@@ -635,7 +636,7 @@ class Profile(item.Item):
         """
         self._virt_type = enums.VirtType.to_enum(vtype)
 
-    @property
+    @InheritableProperty
     def virt_bridge(self) -> str:
         """
         Represents the name of the virtual bridge to use.
@@ -694,7 +695,7 @@ class Profile(item.Item):
         """
         self._repos = validate.validate_repos(repos, self.api, bypass_check=False)
 
-    @property
+    @InheritableProperty
     def redhat_management_key(self) -> str:
         """
         Getter of the redhat management key of the profile or it's parent.
@@ -719,7 +720,7 @@ class Profile(item.Item):
             self._redhat_management_key = enums.VALUE_INHERITED
         self._redhat_management_key = management_key
 
-    @property
+    @InheritableProperty
     def boot_loaders(self) -> list:
         """
         This represents all boot loaders for which Cobbler will try to generate bootloader configuration for.

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -24,6 +24,7 @@ from cobbler import enums
 from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler.items import item
+from cobbler.decorator import InheritableProperty
 
 
 class Repo(item.Item):
@@ -321,7 +322,7 @@ class Repo(item.Item):
         """
         self._rpm_list = utils.input_string_or_list(rpms)
 
-    @property
+    @InheritableProperty
     def createrepo_flags(self) -> str:
         r"""
         Flags passed to createrepo when it is called. Common flags to use would be ``-c cache`` or ``-g comps.xml`` to
@@ -491,7 +492,7 @@ class Repo(item.Item):
         """
         self._apt_dists = utils.input_string_or_list(value)
 
-    @property
+    @InheritableProperty
     def proxy(self) -> str:
         """
         Override the default external proxy which is used for accessing the internet.

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -72,10 +72,12 @@ class NetworkInterface:
                 str(dictionary_keys),
             )
 
-    def to_dict(self) -> dict:
+    def to_dict(self, resolved: bool = False) -> dict:
         """
         This converts everything in this object to a dictionary.
 
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :return: A dictionary with all values present in this object.
         """
         result = {}
@@ -83,13 +85,21 @@ class NetworkInterface:
             if "__" in key:
                 continue
             if key.startswith("_"):
-                if isinstance(self.__dict__[key], enum.Enum):
-                    result[key[1:]] = self.__dict__[key].name
+                new_key = key[1:].lower()
+                key_value = self.__dict__[key]
+                if isinstance(key_value, enum.Enum):
+                    result[new_key] = self.__dict__[key].name
+                elif (
+                    isinstance(key_value, str)
+                    and key_value == enums.VALUE_INHERITED
+                    and resolved
+                ):
+                    result[new_key] = getattr(self, key[1:])
                 else:
-                    result[key[1:]] = self.__dict__[key]
+                    result[new_key] = self.__dict__[key]
         return result
 
-    # These two methods are currently not used but we do want to use them in the future, so let's define them.
+    # These two methods are currently not used, but we do want to use them in the future, so let's define them.
     def serialize(self):
         """
         This method is a proxy for :meth:`~cobbler.items.item.Item.to_dict` and contains additional logic for

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -15,6 +15,7 @@ from ipaddress import AddressValueError
 from cobbler import autoinstall_manager, enums, power_manager, utils, validate
 from cobbler.cexceptions import CX
 from cobbler.items.item import Item
+from cobbler.decorator import InheritableProperty
 
 
 class NetworkInterface:
@@ -1056,7 +1057,7 @@ class System(Item):
             raise TypeError("Field status of object system needs to be of type str!")
         self._status = status
 
-    @property
+    @InheritableProperty
     def boot_loaders(self) -> list:
         """
         boot_loaders property.
@@ -1109,7 +1110,7 @@ class System(Item):
             )
         self._boot_loaders = boot_loaders_split
 
-    @property
+    @InheritableProperty
     def server(self) -> str:
         """
         server property.
@@ -1136,7 +1137,7 @@ class System(Item):
             server = enums.VALUE_INHERITED
         self._server = server
 
-    @property
+    @InheritableProperty
     def next_server_v4(self) -> str:
         """
         next_server_v4 property.
@@ -1164,7 +1165,7 @@ class System(Item):
         else:
             self._next_server_v4 = validate.ipv4_address(server)
 
-    @property
+    @InheritableProperty
     def next_server_v6(self) -> str:
         """
         next_server_v6 property.
@@ -1192,7 +1193,7 @@ class System(Item):
         else:
             self._next_server_v6 = validate.ipv6_address(server)
 
-    @property
+    @InheritableProperty
     def filename(self) -> str:
         """
         filename property.
@@ -1220,7 +1221,7 @@ class System(Item):
         else:
             self._filename = filename.strip()
 
-    @property
+    @InheritableProperty
     def proxy(self) -> str:
         """
         proxy property. This corresponds per default to the setting``proxy_url_int``.
@@ -1244,7 +1245,7 @@ class System(Item):
             raise TypeError("Field proxy of object system needs to be of type str!")
         self._proxy = proxy
 
-    @property
+    @InheritableProperty
     def redhat_management_key(self) -> str:
         """
         redhat_management_key property.
@@ -1458,7 +1459,7 @@ class System(Item):
             interface_name = ""
         self._ipv6_default_device = interface_name
 
-    @property
+    @InheritableProperty
     def enable_ipxe(self) -> bool:
         """
         enable_ipxe property.
@@ -1598,7 +1599,7 @@ class System(Item):
         if isinstance(new_parent, Item) and self.name not in new_parent.children:
             new_parent.children.append(self.name)
 
-    @property
+    @InheritableProperty
     def virt_cpus(self) -> int:
         """
         virt_cpus property.
@@ -1619,7 +1620,7 @@ class System(Item):
         """
         self._virt_cpus = validate.validate_virt_cpus(num)
 
-    @property
+    @InheritableProperty
     def virt_file_size(self) -> float:
         """
         virt_file_size property.
@@ -1641,7 +1642,7 @@ class System(Item):
         """
         self._virt_file_size = validate.validate_virt_file_size(num)
 
-    @property
+    @InheritableProperty
     def virt_disk_driver(self) -> enums.VirtDiskDrivers:
         """
         virt_disk_driver property.
@@ -1662,7 +1663,7 @@ class System(Item):
         """
         self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
-    @property
+    @InheritableProperty
     def virt_auto_boot(self) -> bool:
         """
         virt_auto_boot property.
@@ -1705,7 +1706,7 @@ class System(Item):
         """
         self._virt_pxe_boot = validate.validate_virt_pxe_boot(num)
 
-    @property
+    @InheritableProperty
     def virt_ram(self) -> int:
         """
         virt_ram property.
@@ -1727,7 +1728,7 @@ class System(Item):
         """
         self._virt_ram = validate.validate_virt_ram(num)
 
-    @property
+    @InheritableProperty
     def virt_type(self) -> enums.VirtType:
         """
         virt_type property.
@@ -1748,7 +1749,7 @@ class System(Item):
         """
         self._virt_type = enums.VirtType.to_enum(vtype)
 
-    @property
+    @InheritableProperty
     def virt_path(self) -> str:
         """
         virt_path property.
@@ -1801,7 +1802,7 @@ class System(Item):
             raise TypeError("netboot_enabled needs to be a bool")
         self._netboot_enabled = netboot_enabled
 
-    @property
+    @InheritableProperty
     def autoinstall(self) -> str:
         """
         autoinstall property.

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -802,130 +802,173 @@ class CobblerXMLRPCInterface:
         self._log("get_item_resolved_value(%s)" % item_uuid, attribute=attribute)
         return self.api.get_item_resolved_value(item_uuid, attribute)
 
-    def get_item(self, what: str, name: str, flatten=False):
+    def get_item(self, what: str, name: str, flatten=False, resolved: bool = False):
         """
         Returns a dict describing a given object.
 
         :param what: "distro", "profile", "system", "image", "repo", etc
         :param name: the object name to retrieve
         :param flatten: reduce dicts to string representations (True/False)
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :return: The item or None.
         """
         self._log("get_item(%s,%s)" % (what, name))
-        item = self.api.get_item(what, name)
-        if item is not None:
-            item = item.to_dict()
-        if flatten:
-            item = utils.flatten(item)
-        return self.xmlrpc_hacks(item)
+        requested_item = self.api.get_item(what, name)
+        if requested_item is not None:
+            requested_item = requested_item.to_dict(resolved=resolved)
+            if flatten:
+                requested_item = utils.flatten(requested_item)
+        return self.xmlrpc_hacks(requested_item)
 
-    def get_distro(self, name: str, flatten=False, token=None, **rest):
+    def get_distro(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a distribution.
 
         :param name: The name of the distribution to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("distro", name, flatten=flatten)
+        return self.get_item("distro", name, flatten=flatten, resolved=resolved)
 
-    def get_profile(self, name: str, flatten=False, token=None, **rest):
+    def get_profile(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a profile.
 
         :param name: The name of the profile to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("profile", name, flatten=flatten)
+        return self.get_item("profile", name, flatten=flatten, resolved=resolved)
 
-    def get_system(self, name: str, flatten=False, token=None, **rest):
+    def get_system(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a system.
 
         :param name: The name of the system to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("system", name, flatten=flatten)
+        return self.get_item("system", name, flatten=flatten, resolved=resolved)
 
-    def get_repo(self, name: str, flatten=False, token=None, **rest):
+    def get_repo(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a repository.
 
         :param name: The name of the repository to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("repo", name, flatten=flatten)
+        return self.get_item("repo", name, flatten=flatten, resolved=resolved)
 
-    def get_image(self, name: str, flatten=False, token=None, **rest):
+    def get_image(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get an image.
 
         :param name: The name of the image to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("image", name, flatten=flatten)
+        return self.get_item("image", name, flatten=flatten, resolved=resolved)
 
-    def get_mgmtclass(self, name: str, flatten=False, token=None, **rest):
+    def get_mgmtclass(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a management class.
 
         :param name: The name of the management class to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("mgmtclass", name, flatten=flatten)
+        return self.get_item("mgmtclass", name, flatten=flatten, resolved=resolved)
 
-    def get_package(self, name: str, flatten=False, token=None, **rest):
+    def get_package(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a package.
 
         :param name: The name of the package to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("package", name, flatten=flatten)
+        return self.get_item("package", name, flatten=flatten, resolved=resolved)
 
-    def get_file(self, name: str, flatten=False, token=None, **rest):
+    def get_file(
+        self, name: str, flatten=False, resolved: bool = False, token=None, **rest
+    ):
         """
         Get a file.
 
         :param name: The name of the file to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("file", name, flatten=flatten)
+        return self.get_item("file", name, flatten=flatten, resolved=resolved)
 
-    def get_menu(self, name: str, flatten: bool = False, token=None, **rest):
+    def get_menu(
+        self,
+        name: str,
+        flatten: bool = False,
+        resolved: bool = False,
+        token=None,
+        **rest
+    ):
         """
         Get a menu.
 
         :param name: The name of the file to get.
         :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :param rest: Not used with this method currently.
         :return: The item or None.
         """
-        return self.get_item("menu", name, flatten=flatten)
+        return self.get_item("menu", name, flatten=flatten, resolved=resolved)
 
     def get_items(self, what: str):
         """

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -278,13 +278,14 @@ class Settings:
         buf += "kernel options  : %s\n" % self.__dict__["kernel_options"]
         return buf
 
-    def to_dict(self) -> dict:
+    def to_dict(self, resolved: bool = False) -> dict:
         """
         Return an easily serializable representation of the config.
 
         .. deprecated:: 3.2.1
            Use ``obj.__dict__`` directly please. Will be removed with 3.3.0
 
+        :param resolved: Present for the compatibility with the Cobbler collections.
         :return: The dict with all user settings combined with settings which are left to the default.
         """
         # TODO: Deprecate and remove. Tailcall is not needed.

--- a/tests/api/miscellaneous_test.py
+++ b/tests/api/miscellaneous_test.py
@@ -3,6 +3,7 @@ from unittest.mock import create_autospec
 
 import pytest
 
+from cobbler import enums
 from cobbler import settings
 from cobbler.api import CobblerAPI
 from cobbler.actions.buildiso.netboot import NetbootBuildiso
@@ -114,3 +115,91 @@ def test_get_item_resolved_value(
 
         # Assert
         assert expected_result == result
+
+
+@pytest.mark.parametrize(
+    "input_uuid,input_attribute_name,input_value,expected_exception,expected_result",
+    [
+        (0, "", "", pytest.raises(TypeError), ""),  # Wrong argument type uuid
+        ("", 0, "", pytest.raises(TypeError), ""),  # Wrong argument type attribute name
+        (
+            "yxvyxcvyxcvyxcvyxcvyxcvyxcv",
+            "kernel_options",
+            "",
+            pytest.raises(ValueError),
+            "",
+        ),  # Wrong uuid format
+        (
+            "4c1d2e0050344a9ba96e2fd36908a53e",
+            "kernel_options",
+            "",
+            pytest.raises(ValueError),
+            "",
+        ),  # Item not existing
+        (
+            "",
+            "test_not_existing",
+            "",
+            pytest.raises(AttributeError),
+            "",
+        ),  # Attribute not existing
+        ("", "redhat_management_key", "", does_not_raise(), ""),  # str attribute test
+        ("", "enable_ipxe", "", does_not_raise(), False),  # bool attribute
+        ("", "virt_ram", "", does_not_raise(), 0),  # int attribute
+        (
+            "",
+            "virt_ram",
+            enums.VALUE_INHERITED,
+            does_not_raise(),
+            enums.VALUE_INHERITED,
+        ),  # int attribute inherit
+        ("", "virt_file_size", "", does_not_raise(), 0.0),  # double attribute
+        ("", "kernel_options", "", does_not_raise(), {}),  # dict attribute
+        ("", "kernel_options", "a=5", does_not_raise(), {}),  # dict attribute
+        ("", "kernel_options", "a=6", does_not_raise(), {"a": "6"}),  # dict attribute
+        (
+            "",
+            "kernel_options",
+            enums.VALUE_INHERITED,
+            does_not_raise(),
+            enums.VALUE_INHERITED,
+        ),  # dict attribute
+        ("", "owners", "", does_not_raise(), []),  # list attribute
+        (
+            "",
+            "owners",
+            enums.VALUE_INHERITED,
+            does_not_raise(),
+            enums.VALUE_INHERITED,
+        ),  # list attribute inherit
+    ],
+)
+def test_set_item_resolved_value(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    create_system,
+    input_uuid,
+    input_attribute_name,
+    input_value,
+    expected_exception,
+    expected_result,
+):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = "a=5"
+    cobbler_api.add_profile(test_profile)
+    test_system = create_system(test_profile.name)
+
+    if input_uuid == "":
+        input_uuid = test_system.uid
+
+    # Act
+    with expected_exception:
+        cobbler_api.set_item_resolved_value(
+            input_uuid, input_attribute_name, input_value
+        )
+
+        # Assert
+        assert test_system.to_dict().get(input_attribute_name) == expected_result

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -431,6 +431,19 @@ def test_to_dict(cobbler_api):
 
     # Assert
     assert isinstance(result, dict)
+    assert result.get("owners") == enums.VALUE_INHERITED
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = Item(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("owners") == ["admin"]
 
 
 def test_serialize(cobbler_api):

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -446,6 +446,25 @@ def test_to_dict_resolved(cobbler_api):
     assert result.get("owners") == ["admin"]
 
 
+def test_to_dict_resolved_dict(cobbler_api, create_distro):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    cobbler_api.add_distro(test_distro)
+    titem = Profile(cobbler_api)
+    titem.name = "to_dict_resolved_profile"
+    titem.distro = test_distro.name
+    titem.kernel_options = {"my_value": 5}
+    cobbler_api.add_profile(titem)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("kernel_options") == {"test": True, "my_value": 5}
+
+
 def test_serialize(cobbler_api):
     # Arrange
     kernel_url = "http://10.0.0.1/custom-kernels-are-awesome"

--- a/tests/xmlrpcapi/distro_test.py
+++ b/tests/xmlrpcapi/distro_test.py
@@ -2,6 +2,7 @@ import os
 
 import pytest
 
+from cobbler import enums
 from cobbler.cexceptions import CX
 
 
@@ -120,6 +121,7 @@ class TestDistro:
 
         # Assert
         assert distro.get("name") == "testdistro0"
+        assert distro.get("redhat_management_key") == enums.VALUE_INHERITED
         assert fk_initrd in distro.get("initrd")
         assert fk_kernel in distro.get("kernel")
 

--- a/tests/xmlrpcapi/item_test.py
+++ b/tests/xmlrpcapi/item_test.py
@@ -1,0 +1,18 @@
+import pytest
+
+
+@pytest.mark.usefixtures("create_testdistro", "remove_testdistro")
+def test_get_item_resolved(remote, fk_initrd, fk_kernel):
+    """
+    Test: get an item object (in this case distro) which is resolved
+    """
+    # Arrange --> Done in fixture
+
+    # Act
+    distro = remote.get_item("distro", "testdistro0", resolved=True)
+
+    # Assert
+    assert distro.get("name") == "testdistro0"
+    assert distro.get("redhat_management_key") == ""
+    assert fk_initrd in distro.get("initrd")
+    assert fk_kernel in distro.get("kernel")


### PR DESCRIPTION
This PR will add a new endpoint which adds the possibility to use the setter of an object with a resolved value. This is not the preferred way as it can't be guaranteed to work in all scenarios but it is an option for those who only have access to resolved values.