### PR TITLE
Items: Fix creation of "default" NetworkInterface

### DIFF
--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -772,9 +772,7 @@ class System(Item):
         :param api: The Cobbler API
         """
         super().__init__(api, *args, **kwargs)
-        self._interfaces: Dict[str, NetworkInterface] = {
-            "default": NetworkInterface(api)
-        }
+        self._interfaces: Dict[str, NetworkInterface] = {}
         self._ipv6_autoconfiguration = False
         self._repos_enabled = False
         self._autoinstall = enums.VALUE_INHERITED

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2281,8 +2281,22 @@ class CobblerXMLRPCInterface:
                     'No system found with the specified name (name given: "%s")!'
                     % object_name
                 )
-            # If we don't have an explicit interface name use the default interface
-            interface_name = attributes.get("interface", "default")
+
+            # If we don't have an explicit interface name use the default interface or require an explicit
+            # interface if default cannot be found.
+            if (
+                len(system_to_edit.interfaces) > 1
+                and attributes.get("interface") is None
+            ):
+                if "default" not in system_to_edit.interfaces.keys():
+                    raise ValueError("Interface is required.")
+                interface_name = "default"
+            if len(system_to_edit.interfaces) == 1:
+                interface_name = attributes.get(
+                    "interface", next(iter(system_to_edit.interfaces))
+                )
+            else:
+                interface_name = attributes.get("interface", "default")
             self.logger.debug('Interface "%s" is being edited.', interface_name)
             interface = system_to_edit.interfaces.get(interface_name)
             if interface is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
-from cobbler.items.system import System
+from cobbler.items.system import NetworkInterface, System
 
 
 @contextmanager
@@ -124,6 +124,7 @@ def create_system(request, cobbler_api):
             test_system.profile = profile_name
         if image_name != "":
             test_system.image = image_name
+        test_system.interfaces = {"default": NetworkInterface(cobbler_api)}
         cobbler_api.add_system(test_system)
         return test_system
 

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -658,6 +658,7 @@ def test_serial_baud_rate(cobbler_api, value, expected_exception):
 def test_from_dict_with_network_interface(cobbler_api):
     # Arrange
     system = System(cobbler_api)
+    system.interfaces = {"default": NetworkInterface(cobbler_api)}
     sys_dict = system.to_dict()
 
     # Act
@@ -682,6 +683,7 @@ def test_is_management_supported(
 ):
     # Arrange
     system = System(cobbler_api)
+    system.interfaces = {"default": NetworkInterface(cobbler_api)}
     system.interfaces["default"].mac_address = input_mac
     system.interfaces["default"].ip_address = input_ipv4
     system.interfaces["default"].ipv6_address = input_ipv6

--- a/tests/modules/managers/dnsmasq_test.py
+++ b/tests/modules/managers/dnsmasq_test.py
@@ -2,7 +2,7 @@ import time
 from unittest.mock import MagicMock
 
 from cobbler.modules.managers import dnsmasq
-from cobbler.items.system import System
+from cobbler.items.system import NetworkInterface, System
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.templar import Templar
@@ -41,6 +41,7 @@ def test_manager_write_configs(mocker, cobbler_api):
     mock_profile = Profile(cobbler_api)
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_hosts_system"
+    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"
@@ -74,6 +75,7 @@ def test_manager_regen_ethers(mocker, cobbler_api):
     mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_ethers_system"
+    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"
@@ -96,6 +98,7 @@ def test_manager_regen_hosts(mocker, cobbler_api):
     mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_hosts_system"
+    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "AA:BB:CC:DD:EE:FF"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"

--- a/tests/modules/managers/ndjbdns_test.py
+++ b/tests/modules/managers/ndjbdns_test.py
@@ -2,7 +2,7 @@ import subprocess
 from unittest.mock import MagicMock
 
 from cobbler.modules.managers import ndjbdns
-from cobbler.items.system import System
+from cobbler.items.system import NetworkInterface, System
 from cobbler.templar import Templar
 
 
@@ -36,6 +36,7 @@ def test_manager_write_configs(mocker, cobbler_api):
     mock_subproc_popen.return_value.returncode = 0
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_hosts_system"
+    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -726,6 +726,305 @@ class TestMiscellaneous:
         # Assert
         assert result
 
+    def test_xapi_system_edit(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+        remove_system,
+    ):
+        # Arrange
+        name_distro = "testsystem_xapi_edit"
+        name_profile = "testsystem_xapi_edit"
+        name_system = "testsystem_xapi_edit"
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+        create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+
+        # Act
+        result = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "add",
+            {
+                "name": name_system,
+                "profile": name_profile,
+            },
+            token,
+        )
+
+        # Assert
+        assert result
+        assert len(remote.get_system("testsystem_xapi_edit").get("interfaces", {})) == 1
+        assert "default" in remote.get_system("testsystem_xapi_edit").get(
+            "interfaces", {}
+        )
+
+        # Cleanup
+        remove_system(name_system)
+
+    def test_xapi_system_edit_interface_name(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+        remove_system,
+    ):
+        # Arrange
+        name_distro = "testsystem_xapi_edit"
+        name_profile = "testsystem_xapi_edit"
+        name_system = "testsystem_xapi_edit"
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+        create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+
+        # Act
+        result = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "add",
+            {
+                "name": name_system,
+                "profile": name_profile,
+                "interface": "eth1",
+            },
+            token,
+        )
+
+        # Assert
+        assert result
+        assert len(remote.get_system("testsystem_xapi_edit").get("interfaces", {})) == 1
+        assert "eth1" in remote.get_system("testsystem_xapi_edit").get("interfaces", {})
+
+    def test_xapi_system_edit_two_interfaces(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+    ):
+        # Arrange
+        name_distro = "testsystem_xapi_edit"
+        name_profile = "testsystem_xapi_edit"
+        name_system = "testsystem_xapi_edit"
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+        create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+
+        # Act
+        result_add = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "add",
+            {
+                "name": name_system,
+                "profile": name_profile,
+            },
+            token,
+        )
+        result_edit = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "edit",
+            {
+                "name": name_system,
+                "interface": "eth1",
+            },
+            token,
+        )
+
+        # Assert
+        assert result_add
+        assert result_edit
+        assert len(remote.get_system("testsystem_xapi_edit").get("interfaces", {})) == 2
+        assert "default" in remote.get_system("testsystem_xapi_edit").get(
+            "interfaces", {}
+        )
+        assert "eth1" in remote.get_system("testsystem_xapi_edit").get("interfaces", {})
+
+    def test_xapi_system_edit_two_interfaces_no_default(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+    ):
+        # Arrange
+        name_distro = "testsystem_xapi_edit"
+        name_profile = "testsystem_xapi_edit"
+        name_system = "testsystem_xapi_edit"
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+        create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+
+        # Act
+        result_add = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "add",
+            {
+                "name": name_system,
+                "profile": name_profile,
+                "interface": "eth1",
+            },
+            token,
+        )
+        result_edit = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "edit",
+            {
+                "name": name_system,
+                "interface": "eth2",
+            },
+            token,
+        )
+
+        # Assert
+        assert result_add
+        assert result_edit
+        assert len(remote.get_system("testsystem_xapi_edit").get("interfaces", {})) == 2
+        assert "eth1" in remote.get_system("testsystem_xapi_edit").get("interfaces", {})
+        assert "eth2" in remote.get_system("testsystem_xapi_edit").get("interfaces", {})
+
+    def test_xapi_system_edit_two_interfaces_default(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+    ):
+        # Arrange
+        name_distro = "testsystem_xapi_edit"
+        name_profile = "testsystem_xapi_edit"
+        name_system = "testsystem_xapi_edit"
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+        create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+        remote.xapi_object_edit(
+            "system",
+            name_system,
+            "add",
+            {
+                "name": name_system,
+                "profile": name_profile,
+            },
+            token,
+        )
+        remote.xapi_object_edit(
+            "system",
+            name_system,
+            "edit",
+            {
+                "name": name_system,
+                "interface": "eth2",
+            },
+            token,
+        )
+
+        # Act
+        result = remote.xapi_object_edit(
+            "system",
+            name_system,
+            "edit",
+            {
+                "name": name_system,
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+            },
+            token,
+        )
+
+        # Assert
+        assert result
+        assert (
+            remote.get_system(name_system)
+            .get("interfaces", {})
+            .get("default", {})
+            .get("mac_address")
+            == "aa:bb:cc:dd:ee:ff"
+        )
+
+    def test_xapi_system_edit_two_interfaces_no_default_negative(
+        self,
+        remote,
+        token,
+        create_kernel_initrd,
+        create_distro,
+        create_profile,
+    ):
+        # Arrange
+        name_distro = "testsystem_xapi_edit"
+        name_profile = "testsystem_xapi_edit"
+        name_system = "testsystem_xapi_edit"
+        fk_kernel = "vmlinuz1"
+        fk_initrd = "initrd1.img"
+        basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+        path_kernel = os.path.join(basepath, fk_kernel)
+        path_initrd = os.path.join(basepath, fk_initrd)
+        create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
+        create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
+        remote.xapi_object_edit(
+            "system",
+            name_system,
+            "add",
+            {
+                "name": name_system,
+                "profile": name_profile,
+                "interface": "eth1",
+            },
+            token,
+        )
+        remote.xapi_object_edit(
+            "system",
+            name_system,
+            "edit",
+            {
+                "name": name_system,
+                "interface": "eth2",
+            },
+            token,
+        )
+
+        # Act & Assert
+        with pytest.raises(ValueError):
+            remote.xapi_object_edit(
+                "system",
+                name_system,
+                "edit",
+                {
+                    "name": name_system,
+                    "mac_address": "aa:bb:cc:dd:ee:ff",
+                },
+                token,
+            )
+
     @pytest.mark.usefixtures(
         "create_testdistro",
         "create_testmenu",


### PR DESCRIPTION
Do not force creation of a network interface named `default`.

Closes: #2838