### PR TITLE
XML-RPC API: Fix complex objects are return value

### DIFF
--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -24,6 +24,8 @@ class Distro(item.Item):
     A Cobbler distribution object
     """
 
+    # Constants
+    TYPE_NAME = "distro"
     COLLECTION_TYPE = "distro"
 
     def __init__(self, api, *args, **kwargs):

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -764,6 +764,8 @@ class System(Item):
     A Cobbler system object.
     """
 
+    # Constants
+    TYPE_NAME = "system"
     COLLECTION_TYPE = "system"
 
     def __init__(self, api, *args, **kwargs):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -22,6 +22,7 @@ from threading import Thread
 from typing import Dict, List, Optional, Union
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 
+from cobbler import enums
 from cobbler import autoinstall_manager
 from cobbler import configgen
 from cobbler.items import (
@@ -790,7 +791,39 @@ class CobblerXMLRPCInterface:
         .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.get_item_resolved_value`
         """
         self._log("get_item_resolved_value(%s)" % item_uuid, attribute=attribute)
-        return self.api.get_item_resolved_value(item_uuid, attribute)
+        return_value = self.api.get_item_resolved_value(item_uuid, attribute)
+        if return_value is None:
+            self._log(
+                "get_item_resolved_value(%s): returned None" % item_uuid,
+                attribute=attribute,
+            )
+            raise ValueError(
+                'None is not a valid value for the resolved attribute "%s". Please fix the item(s) '
+                'starting at uuid "%s"' % (attribute, item_uuid)
+            )
+        elif isinstance(return_value, item.Item):
+            return return_value.name
+        elif isinstance(return_value, enums.ConvertableEnum):
+            return return_value.value
+        elif isinstance(
+            return_value, (enums.DHCP, enums.NetworkInterfaceType, enums.BaudRates)
+        ):
+            return return_value.name
+        elif isinstance(return_value, dict):
+            return self.xmlrpc_hacks(return_value)
+
+        if not isinstance(
+            return_value, (str, int, float, bool, tuple, bytes, bytearray, dict, list)
+        ):
+            self._log(
+                "get_item_resolved_value(%s): Cannot return XML-RPC compliant type. Please add a case to convert"
+                ' type "%s" to an XML-RPC compliant type!'
+                % (item_uuid, type(return_value))
+            )
+            raise ValueError(
+                "Cannot return XML-RPC compliant type. See logs for more information!"
+            )
+        return return_value
 
     def set_item_resolved_value(
         self, item_uuid: str, attribute: str, value, token=None


### PR DESCRIPTION
This bug is appearing in "get_item_resolved_value" and could be triggered for
example when "arch" was asked with a distro. The fix is to catch all types in
"remote.py" and convert them on a per-type basis.

This commit also adds tests for the known cases that would cause trouble in the
past.