### PR TITLE
Logging: Decrease grab_tree level to debug

### DIFF
--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -1010,7 +1010,7 @@ class Item:
             parent = parent.parent
             # FIXME: Now get the object and check its existence
         results.append(self.api.settings())
-        self.logger.info(
+        self.logger.debug(
             "grab_tree found %s children (including settings) of this object",
             len(results),
         )

--- a/config/cobbler/logging_config.conf
+++ b/config/cobbler/logging_config.conf
@@ -19,7 +19,7 @@ qualname=compiler.parser
 
 [handler_stdout]
 class=StreamHandler
-level=WARNING
+level=INFO
 formatter=stdout
 args=(sys.stdout,)
 
@@ -34,7 +34,7 @@ args=(sys.stdout,)
 
 [handler_FileLogger]
 class=FileHandler
-level=DEBUG
+level=INFO
 formatter=Logfile
 args=('/var/log/cobbler/cobbler.log', 'a')
 


### PR DESCRIPTION
In large environments the message for "grab_tree" is spamming the log and
making it barely readable. Thus, the message is decreased to debug and the
default level is raised to INFO.

The loglevel cannot be changed to something above INFO since the old (but
current) CLI is parsing the logfile and expecting to find
"### TASK COMPLETE ###" which is missing if the log is configured for level
WARNING.

Fixes #3174