### PR TITLE
XML-RPC API: get_item_resolved_value for networks

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -731,6 +731,20 @@ class CobblerXMLRPCInterface:
         ):
             return return_value.name
         elif isinstance(return_value, dict):
+            if (
+                attribute == "interfaces"
+                and len(return_value) > 0
+                and all(
+                    isinstance(value, system.NetworkInterface)
+                    for value in return_value.values()
+                )
+            ):
+                interface_return_value = {}
+                for interface_name in return_value:
+                    interface_return_value[interface_name] = return_value[
+                        interface_name
+                    ].to_dict(resolved=True)
+                return interface_return_value
             return self.xmlrpc_hacks(return_value)
 
         if not isinstance(

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -195,6 +195,40 @@ def test_get_random_mac(remote, token):
         ("arch", "distro", "x86_64", does_not_raise()),
         ("distro", "profile", "testdistro_item_resolved_value", does_not_raise()),
         ("profile", "system", "testprofile_item_resolved_value", does_not_raise()),
+        (
+            "interfaces",
+            "system",
+            {
+                "eth0": {
+                    "bonding_opts": "",
+                    "bridge_opts": "",
+                    "cnames": [],
+                    "connected_mode": False,
+                    "dhcp_tag": "",
+                    "dns_name": "",
+                    "if_gateway": "",
+                    "interface_master": "",
+                    "interface_type": "NA",
+                    "ip_address": "",
+                    "ipv6_address": "",
+                    "ipv6_default_gateway": "",
+                    "ipv6_mtu": "",
+                    "ipv6_prefix": "",
+                    "ipv6_secondaries": [],
+                    "ipv6_static_routes": [],
+                    "mac_address": "aa:bb:cc:dd:ee:ff",
+                    "management": False,
+                    "mtu": "",
+                    "netmask": "",
+                    "static": False,
+                    "static_routes": [],
+                    "virt_bridge": "",
+                }
+            },
+            does_not_raise(),
+        ),
+        ("modify_interface", "system", {}, pytest.raises(ValueError)),
+        ("doesnt_exist", "system", {}, pytest.raises(AttributeError)),
     ],
 )
 def test_get_item_resolved_value(
@@ -223,6 +257,12 @@ def test_get_item_resolved_value(
     create_profile(name_profile, name_distro, "a=1 b=2 c=3 c=4 c=5 d e")
     test_system_handle = create_system(name_system, name_profile)
     remote.modify_system(test_system_handle, "kernel_options", "!c !e", token=token)
+    remote.modify_system(
+        test_system_handle,
+        "modify_interface",
+        {"macaddress-eth0": "aa:bb:cc:dd:ee:ff"},
+        token=token,
+    )
     if checked_object == "distro":
         test_item = remote.get_distro(name_distro, token=token)
     elif checked_object == "profile":


### PR DESCRIPTION
This is a follow-up for "e72a03db09397a5dde1b16d0d831a549e0a86bd2". It fixes
the same problem for NetworkInterface dictionaries. Attached in this commit are
also the tests for this functionality.