### PR TITLE
Rename occurences of grubx86 to grubx64

### DIFF
--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -7,7 +7,45 @@ on:
     branches: [ main, release* ]
 
 jobs:
-  run_system_test:
+  basic:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Pull Docker Test Container
+        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Run previously built Docker Container
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Setup Cobbler in the Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "./docker/develop/scripts/setup-supervisor.sh"
+      - name: Run the Tests inside the Docker Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "make SYSTESTS='basic-*' system-test"
+      - name: Stop and remove the container
+        run: docker stop cobbler && docker rm cobbler
+  import:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Pull Docker Test Container
+        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Run previously built Docker Container
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Setup Cobbler in the Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "./docker/develop/scripts/setup-supervisor.sh"
+      - name: Run the Tests inside the Docker Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "make SYSTESTS='import-*' system-test"
+      - name: Stop and remove the container
+        run: docker stop cobbler && docker rm cobbler
+  settings-cli:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repository
@@ -23,6 +61,25 @@ jobs:
       - name: Run the Tests inside the Docker Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          docker exec -u 0 -it cobbler bash -c "make system-test"
+          docker exec -u 0 -it cobbler bash -c "make SYSTESTS='settings-cli-*' system-test"
+      - name: Stop and remove the container
+        run: docker stop cobbler && docker rm cobbler
+  svc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Pull Docker Test Container
+        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Run previously built Docker Container
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+      - name: Setup Cobbler in the Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "./docker/develop/scripts/setup-supervisor.sh"
+      - name: Run the Tests inside the Docker Container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "make SYSTESTS='svc-*' system-test"
       - name: Stop and remove the container
         run: docker stop cobbler && docker rm cobbler

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -87,7 +87,7 @@ class Settings:
                 "extra_modules": ["net", "ofnet"],
             },
             "x86_64-efi": {
-                "binary_name": "grubx86.efi",
+                "binary_name": "grubx64.efi",
                 "extra_modules": ["chain", "efinet"],
             },
         }

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -74,7 +74,7 @@ bootloaders_formats:
       - net
       - ofnet
   x86_64-efi:
-    binary_name: grubx86.efi
+    binary_name: grubx64.efi
     extra_modules:
       - chain
       - efinet

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -21,6 +21,8 @@ RUN zypper install --no-recommends -y \
     gzip                       \
     ipmitool                   \
     make                       \
+    curl                       \
+    wget2                      \
     python3                    \
     python3-Sphinx             \
     python3-coverage           \

--- a/docker/rpms/Fedora_34/Fedora34.dockerfile
+++ b/docker/rpms/Fedora_34/Fedora34.dockerfile
@@ -9,6 +9,8 @@ RUN dnf install -y          \
     git                     \
     rsync                   \
     make                    \
+    curl                    \
+    wget2                   \
     openssl                 \
     mod_ssl                 \
     initscripts             \

--- a/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
+++ b/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
@@ -20,6 +20,8 @@ RUN touch /var/lib/rpm/* &&   \
     iproute                   \
     git                       \
     rsync                     \
+    curl                      \
+    wget                      \
     make                      \
     openssl                   \
     mod_ssl                   \

--- a/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
@@ -13,6 +13,8 @@ RUN zypper install -y          \
     apache2-devel              \
     apache2-mod_wsgi-python3   \
     bash-completion            \
+    curl                       \
+    wget2                      \
     git                        \
     gzip                       \
     make                       \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -15,6 +15,8 @@ RUN zypper install -y          \
     bash-completion            \
     git                        \
     gzip                       \
+    curl                       \
+    wget2                      \
     make                       \
     util-linux                 \
     hardlink                   \

--- a/system-tests/prelude
+++ b/system-tests/prelude
@@ -1,44 +1,63 @@
+# If you adjust anything in this file please check also with the "scripts/bootstrap" script
+
+#
+# Variables
+#
+
+server=192.168.1.1
+
 #
 # Helpers
 #
 
 _dir() {
-	for dir in ${@}; do
-		test -e ${dir} && echo ${dir} && return
-	done
+    for dir in ${@}; do
+        test -e ${dir} && echo ${dir} && return
+    done
 }
 
 srvctl() {
-	$(command -v supervisorctl systemctl | head -1) ${@}
+    $(command -v supervisorctl systemctl | head -1) ${@}
 }
 
 stop_cobblerd() {
-	srvctl stop cobblerd
+    srvctl stop cobblerd
 }
 
 restart_cobblerd() {
-	srvctl restart cobblerd
-	sleep 1
+    srvctl restart cobblerd
+    sleep 1
 }
 
 _make_system_id() {
-	local id=$(cat ${tmp}/_next-system-id 2>/dev/null)
-	echo $((id + 1)) | tee ${tmp}/_next-system-id
+    local id=$(cat ${tmp}/_next-system-id 2>/dev/null)
+    echo $((id + 1)) | tee ${tmp}/_next-system-id
 }
 
 make_mac_address() {
-	printf "52:54:00"
-	printf "%06x\n" $(_make_system_id) | sed 's/\(..\)/:\1/g'
+    printf "52:54:00"
+    printf "%06x\n" $(_make_system_id) | sed 's/\(..\)/:\1/g'
 }
 
 prepare() {
-	mkdir -p ${tmp}
-	stop_cobblerd
-	rm -f ${path_templates}/${autoinstall_template}
-	rm -f ${path_collections}/*/*.json
-	rm -rf ${path_distro_mirrors}/*
-	restart_cobblerd
-	cobbler sync >/dev/null
+    mkdir -p ${tmp}
+    stop_cobblerd
+    rm -f ${path_templates}/${autoinstall_template}
+    rm -f ${path_collections}/*/*.json
+    rm -rf ${path_distro_mirrors}/*
+    rm /etc/cobbler/settings.yaml*
+    # This is specific for the openSUSE environment
+    cat >/etc/cobbler/settings.yaml <<-EOF
+server: ${server}
+next_server_v4: ${server}
+manage_dhcp: true
+manage_dhcp_v4: true
+manage_dhcp_v6: false
+power_management_default_type: 'ipmilan'
+tftpboot_location: '/srv/tftpboot'
+EOF
+    restart_cobblerd
+    cobbler sync >/dev/null
 }
 
 #

--- a/system-tests/scripts/bootstrap
+++ b/system-tests/scripts/bootstrap
@@ -1,5 +1,6 @@
 #!/bin/sh -e
 # Bootstrap the OS for system tests
+# If you adjust anything in this file please check also with the "../prelude" script
 
 server=192.168.1.1
 bridge=pxe

--- a/system-tests/scripts/run-tests
+++ b/system-tests/scripts/run-tests
@@ -6,7 +6,7 @@ topdir=$(realpath $(dirname ${0})/..)
 if [ ${#} -ge 1 ]; then
 	patterns=${@}
 else
-	patterns=(basic-* import-* settings-cli-*)
+	patterns=(basic-* import-* settings-cli-* svc-*)
 fi
 
 list_selected_tests() {

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -53,7 +53,7 @@ bootloaders_formats:
       - net
       - ofnet
   x86_64-efi:
-    binary_name: grubx86.efi
+    binary_name: grubx64.efi
     extra_modules:
       - chain
       - efinet

--- a/system-tests/tests/svc-puppet
+++ b/system-tests/tests/svc-puppet
@@ -17,7 +17,7 @@ TODO
 EOF
 
 # Act
-curl --output=${tmp}/b http://localhost/cblr/svc/op/puppet/
+curl --output ${tmp}/b http://localhost/cblr/svc/op/puppet/
 
 # Assert
 # FIXME endpoint not yet testable

--- a/system-tests/tests/svc-settings
+++ b/system-tests/tests/svc-settings
@@ -212,7 +212,7 @@ cat >${tmp}/a <<-EOF
             ]
         },
         "x86_64-efi": {
-            "binary_name": "grubx86.efi",
+            "binary_name": "grubx64.efi",
             "extra_modules": [
                 "chain",
                 "efinet"

--- a/templates/etc/dhcp6.template
+++ b/templates/etc/dhcp6.template
@@ -35,7 +35,7 @@ option dhcp6.bootfile-url code 59 = string ;
 class "pxeclients" {
     match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
     if substring (option vendor-class-identifier, 15, 5) = "00007" {
-        option dhcp6.bootfile-url "tftp://[$next_server_v6]/grub/grubx86.efi";
+        option dhcp6.bootfile-url "tftp://[$next_server_v6]/grub/grubx64.efi";
     }
     else if substring (option vendor-class-identifier, 15, 5) = "00000" {
         option dhcp6.bootfile-url "tftp://[$next_server_v6]/grub/grub.0";

--- a/tests/actions/buildiso_test.py
+++ b/tests/actions/buildiso_test.py
@@ -47,7 +47,7 @@ class TestBuildiso:
     @pytest.mark.parametrize(
         "input_arch,result_binary_name,expected_exception",
         [
-            (enums.Archs.X86_64, "grubx86.efi", does_not_raise()),
+            (enums.Archs.X86_64, "grubx64.efi", does_not_raise()),
             (enums.Archs.PPC, "grub.ppc64le", does_not_raise()),
             (enums.Archs.PPC64, "grub.ppc64le", does_not_raise()),
             (enums.Archs.PPC64EL, "grub.ppc64le", does_not_raise()),

--- a/tests/test_data/V3_4_0/settings.yaml
+++ b/tests/test_data/V3_4_0/settings.yaml
@@ -74,7 +74,7 @@ bootloaders_formats:
       - net
       - ofnet
   x86_64-efi:
-    binary_name: grubx86.efi
+    binary_name: grubx64.efi
     extra_modules:
       - chain
       - efinet


### PR DESCRIPTION
This is a bugfix that enables the DHCPv6 template to work as expected again.

Fixes #3092