### PR TITLE
Fix issue when validating with kernel filenames

### DIFF
--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -158,7 +158,7 @@ class Distro(item.Item):
         if not isinstance(kernel, str):
             raise TypeError("kernel was not of type str")
         if not utils.find_kernel(kernel):
-            raise ValueError("kernel not found: %s" % kernel)
+            raise ValueError("kernel not found or it does not match with allowed kernel filename pattern [%s]: %s." % (utils.re_kernel.pattern, kernel))
         self._kernel = kernel
 
     @property

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -158,7 +158,10 @@ class Distro(item.Item):
         if not isinstance(kernel, str):
             raise TypeError("kernel was not of type str")
         if not utils.find_kernel(kernel):
-            raise ValueError("kernel not found or it does not match with allowed kernel filename pattern [%s]: %s." % (utils.re_kernel.pattern, kernel))
+            raise ValueError(
+                "kernel not found or it does not match with allowed kernel filename pattern [%s]: %s."
+                % (utils.re_kernel.pattern, kernel)
+            )
         self._kernel = kernel
 
     @property

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -48,7 +48,7 @@ CHEETAH_ERROR_DISCLAIMER = """
 """
 
 re_kernel = re.compile(
-    r"(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|mboot\.c32)"
+    r"(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|mboot\.c32|.+\.kernel)"
 )
 re_initrd = re.compile(r"(initrd(.*)\.img|ramdisk\.image\.gz|boot\.sdi|imgpayld\.tgz)")
 


### PR DESCRIPTION
This PR does the following:
- Enhance find_kernel regex to match generic `*.kernel` names
- Enhance error message when kernel is not valid.

The old error message was:
```console
# cobbler distro add --name=test  --kernel=/tmp/my_kernel.foobar --initrd=/tmp/fooo
exception on server: kernel not found: /tmp/my_kernel.foobar
```

The new one:
```console
# cobbler distro add --name=test  --kernel=/tmp/my_kernel.foobar --initrd=/tmp/fooo
exception on server: kernel not found or it does not match with allowed kernel filename pattern [(vmlinu[xz]|(kernel|linux(\.img)?)|pxeboot\.n12|wimboot|.+\.kernel)]: /tmp/my_kernel.foobar.
```

Fixes #3193 