### PR TITLE
Add support for CentOS Stream 9 and RHEL9

### DIFF
--- a/autoinstall_templates/sample.ks
+++ b/autoinstall_templates/sample.ks
@@ -34,8 +34,6 @@ selinux --disabled
 skipx
 # System timezone
 timezone  America/New_York
-# Install OS instead of upgrade
-install
 # Clear the Master Boot Record
 zerombr
 # Allow anaconda to partition the system as needed

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -730,7 +730,7 @@ class TFTPGen:
 
             if distro.breed is None or distro.breed == "redhat":
 
-                append_line += " kssendmac"
+                append_line += " inst.kssendmac"
                 append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
                 gpxe = blended["enable_gpxe"]
                 if gpxe:

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -148,6 +148,34 @@
         "kernel_options_post": "",
         "boot_files": []
       },
+      "rhel9": {
+        "signatures": [
+          "BaseOS"
+        ],
+        "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*9[\\.-]+(.*)\\.rpm",
+        "version_file_regex": null,
+        "kernel_arch": "kernel-(.*).rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "x86_64",
+          "ppc",
+          "ppc64",
+          "ppc64le"
+        ],
+        "supported_repo_breeds": [
+          "rsync",
+          "rhn",
+          "yum"
+        ],
+        "kernel_file": "vmlinuz(.*)",
+        "initrd_file": "initrd(.*)\\.img",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
       "ovz7": {
         "signatures": [
           "Packages"


### PR DESCRIPTION
- added signatures for rhel9 and clones
- remove the 'install' directive from ks template (rhel9 removed it)
  as this is an optional directive the should maintain backward compat
- kssendmac must be now inst.kssendmac on the boot command Line