### PR TITLE
Add support for CentOS Stream 9 and RHEL9 - fix issue #3068

### DIFF
--- a/autoinstall_templates/sample.ks
+++ b/autoinstall_templates/sample.ks
@@ -34,8 +34,6 @@ selinux --disabled
 skipx
 # System timezone
 timezone  America/New_York
-# Install OS instead of upgrade
-install
 # Clear the Master Boot Record
 zerombr
 # Allow anaconda to partition the system as needed

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1022,7 +1022,7 @@ class TFTPGen:
 
             if distro.breed is None or distro.breed == "redhat":
 
-                append_line += " kssendmac"
+                append_line += " inst.kssendmac"
                 append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
                 ipxe = blended["enable_ipxe"]
                 if ipxe:


### PR DESCRIPTION
- remove the 'install' directive from ks template (rhel9 removed it)
  as this is an optional directive the should maintain backward compat
- kssendmac must be now inst.kssendmac on the boot command Line

similar to PR #3196 targeting the `main` branch where the signature file was already updated with rhel9 info