### PR TITLE
import: autoinstall_meta.setter should not be used as dict

### DIFF
--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -747,7 +747,7 @@ class _ImportSignatureManager(ManagerModule):
         :param distribution: The distribution object for which the install tree should be set.
         :param url: The url for the tree.
         """
-        distribution.autoinstall_meta["tree"] = url
+        distribution.autoinstall_meta = {"tree": url}
 
     # ==========================================================================
     # Repo Functions


### PR DESCRIPTION
autoinstall_meta is empty after distro imported because
autoinstall_meta["tree"] is calling property rather than
setter