### PR TITLE
Fixing boot menu issues

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -467,6 +467,7 @@ IMAGE_FIELDS = [
         "list",
     ],
     ["menu", "", "", "Parent boot menu", True, "", [], "str"],
+    ["display_name", "", "", "Display Name", True, "Ex: My Image", [], "str"],
     [
         "boot_loaders",
         "<<inherit>>",
@@ -881,7 +882,8 @@ PROFILE_FIELDS = [
         0,
         "dict",
     ],
-    ["menu", None, None, "Parent boot menu", True, "", 0, "str"],
+    ["menu", "", "", "Parent boot menu", True, "", 0, "str"],
+    ["display_name", "", "", "Display Name", True, "Ex: My Profile", [], "str"],
     [
         "virt_auto_boot",
         "SETTINGS:virt_auto_boot",
@@ -1479,6 +1481,7 @@ SYSTEM_FIELDS = [
         ["", "2400", "4800", "9600", "19200", "38400", "57600", "115200"],
         "int",
     ],
+    ["display_name", "", "", "Display Name", True, "Ex: My System", [], "str"],
 ]
 
 # network interface fields are in a separate list because a system may contain

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -40,8 +40,9 @@ class Image(item.Item):
         self._image_type = enums.ImageTypes.DIRECT
         self._network_count = 0
         self._os_version = ""
-        self._boot_loaders = []
+        self._boot_loaders: Union[list, str] = enums.VALUE_INHERITED
         self._menu = ""
+        self._display_name = ""
         self._virt_auto_boot = False
         self._virt_bridge = ""
         self._virt_cpus = 0
@@ -50,7 +51,6 @@ class Image(item.Item):
         self._virt_path = ""
         self._virt_ram = 0
         self._virt_type = enums.VirtType.AUTO
-        self._supported_boot_loaders = []
 
     def __getattr__(self, name):
         if name == "kickstart":
@@ -500,6 +500,25 @@ class Image(item.Item):
             if not menu_list.find(name=menu):
                 raise CX("menu %s not found" % menu)
         self._menu = menu
+
+    @property
+    def display_name(self) -> str:
+        """
+        Returns the display name.
+
+        :getter: Returns the display name for the boot menu.
+        :setter: Sets the display name for the boot menu.
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name: str):
+        """
+        Setter for the display_name of the item.
+
+        :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
+        """
+        self._display_name = display_name
 
     @property
     def supported_boot_loaders(self):

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -72,7 +72,7 @@ class Menu(item.Item):
         :raises CX: Raised in case of self parenting or if the menu with value ``value`` is not found.
         """
         old_parent = self._parent
-        if isinstance(old_parent, item.Item):
+        if isinstance(old_parent, Menu):
             old_parent.children.remove(self.name)
         if not value:
             self._parent = ""
@@ -86,11 +86,11 @@ class Menu(item.Item):
         self._parent = value
         self.depth = found.depth + 1
         new_parent = self._parent
-        if isinstance(new_parent, item.Item) and self.name not in new_parent.children:
+        if isinstance(new_parent, Menu) and self.name not in new_parent.children:
             new_parent.children.append(self.name)
 
     @property
-    def children(self) -> list:
+    def children(self) -> List[str]:
         """
         Child menu of a menu instance.
 
@@ -107,24 +107,7 @@ class Menu(item.Item):
         :param value: The value to set the children to.
         :raises TypeError: Raised in case the children of menu have the wrong type.
         """
-        if not isinstance(value, list):
-            raise TypeError("Field children of object menu must be of type list.")
-        if isinstance(value, list):
-            if not all(isinstance(x, str) for x in value):
-                raise TypeError(
-                    "Field children of object menu must be of type list and all items need to be menu "
-                    "names (str)."
-                )
-            self._children = []
-            for name in value:
-                menu = self.api.find_menu(name=name)
-                if menu is not None:
-                    self._children.append(name)
-                else:
-                    self.logger.warning(
-                        'Menu with the name "%s" did not exist. Skipping setting as a child!',
-                        name,
-                    )
+        self._children = value
 
     #
     # specific methods for item.Menu
@@ -135,8 +118,8 @@ class Menu(item.Item):
         """
         Returns the display name.
 
-        :getter: Returns the display name.
-        :setter: Sets the display name.
+        :getter: Returns the display name for the boot menu.
+        :setter: Sets the display name for the boot menu.
         """
         return self._display_name
 
@@ -145,6 +128,6 @@ class Menu(item.Item):
         """
         Setter for the display_name of the item.
 
-        :param display_name: The new display_name. If ``None`` the comment will be set to an emtpy string.
+        :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
         """
         self._display_name = display_name

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -111,15 +111,20 @@ class Menu(item.Item):
             raise TypeError("Field children of object menu must be of type list.")
         if isinstance(value, list):
             if not all(isinstance(x, str) for x in value):
-                raise TypeError("Field children of object menu must be of type list and all items need to be menu "
-                                "names (str).")
+                raise TypeError(
+                    "Field children of object menu must be of type list and all items need to be menu "
+                    "names (str)."
+                )
             self._children = []
             for name in value:
                 menu = self.api.find_menu(name=name)
                 if menu is not None:
                     self._children.append(name)
                 else:
-                    self.logger.warning("Menu with the name \"%s\" did not exist. Skipping setting as a child!", name)
+                    self.logger.warning(
+                        'Menu with the name "%s" did not exist. Skipping setting as a child!',
+                        name,
+                    )
 
     #
     # specific methods for item.Menu

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -107,7 +107,19 @@ class Menu(item.Item):
         :param value: The value to set the children to.
         :raises TypeError: Raised in case the children of menu have the wrong type.
         """
-        self._children = value
+        if not isinstance(value, list):
+            raise TypeError("Field children of object menu must be of type list.")
+        if isinstance(value, list):
+            if not all(isinstance(x, str) for x in value):
+                raise TypeError("Field children of object menu must be of type list and all items need to be menu "
+                                "names (str).")
+            self._children = []
+            for name in value:
+                menu = self.api.find_menu(name=name)
+                if menu is not None:
+                    self._children.append(name)
+                else:
+                    self.logger.warning("Menu with the name \"%s\" did not exist. Skipping setting as a child!", name)
 
     #
     # specific methods for item.Menu

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -51,6 +51,7 @@ class Profile(item.Item):
         self._repos = []
         self._server = enums.VALUE_INHERITED
         self._menu = ""
+        self._display_name = ""
         self._virt_auto_boot = api.settings().virt_auto_boot
         self._virt_bridge = enums.VALUE_INHERITED
         self._virt_cpus: Union[int, str] = 1
@@ -781,6 +782,25 @@ class Profile(item.Item):
             if not menu_list.find(name=menu):
                 raise CX("menu %s not found" % menu)
         self._menu = menu
+
+    @property
+    def display_name(self) -> str:
+        """
+        Returns the display name.
+
+        :getter: Returns the display name for the boot menu.
+        :setter: Sets the display name for the boot menu.
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name: str):
+        """
+        Setter for the display_name of the item.
+
+        :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
+        """
+        self._display_name = display_name
 
     @property
     def children(self) -> list:

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -55,7 +55,6 @@ class NetworkInterface:
         self._static = False
         self._static_routes = []
         self._virt_bridge = ""
-        self._display_name = ""
 
     def from_dict(self, dictionary: dict):
         """
@@ -814,6 +813,7 @@ class System(Item):
         self._virt_type = enums.VirtType.INHERITED
         self._serial_device = -1
         self._serial_baud_rate = enums.BaudRates.DISABLED
+        self._display_name = ""
 
         # Overwrite defaults from item.py
         self._owners = enums.VALUE_INHERITED

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -55,6 +55,7 @@ class NetworkInterface:
         self._static = False
         self._static_routes = []
         self._virt_bridge = ""
+        self._display_name = ""
 
     def from_dict(self, dictionary: dict):
         """
@@ -2143,3 +2144,22 @@ class System(Item):
             return utils.get_host_ip(ip)
         else:
             return self.name
+
+    @property
+    def display_name(self) -> str:
+        """
+        Returns the display name.
+
+        :getter: Returns the display name for the boot menu.
+        :setter: Sets the display name for the boot menu.
+        """
+        return self._display_name
+
+    @display_name.setter
+    def display_name(self, display_name: str):
+        """
+        Setter for the display_name of the item.
+
+        :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
+        """
+        self._display_name = display_name

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -20,6 +20,7 @@ from cobbler.enums import Archs
 from cobbler.utils import input_converters
 from cobbler.validate import validate_autoinstall_script_name
 from cobbler.utils import filesystem_helpers
+from cobbler.items.menu import Menu
 
 
 class TFTPGen:
@@ -370,7 +371,7 @@ class TFTPGen:
         # Write the PXE menu:
         if "pxe" in menu_items:
             loader_metadata["menu_items"] = menu_items["pxe"]
-            loader_metadata["menu_labels"] = {}
+            loader_metadata["menu_labels"] = menu_labels["pxe"]
             outfile = os.path.join(self.bootloc, "pxelinux.cfg", "default")
             template_src = open(
                 os.path.join(
@@ -423,7 +424,7 @@ class TFTPGen:
         """
         return self.get_menu_level(None, arch)
 
-    def get_submenus(self, menu, metadata: dict, arch: enums.Archs):
+    def get_submenus(self, menu: Menu, metadata: dict, arch: enums.Archs):
         """
         Generates submenus metatdata for pxe, ipxe and grub.
 
@@ -456,29 +457,30 @@ class TFTPGen:
                     else:
                         nested_menu_items[boot_loader] = temp_items[boot_loader]
 
-            if "ipxe" in temp_items:
-                if "ipxe" not in menu_labels:
-                    menu_labels["ipxe"] = []
-                display_name = (
-                    child.display_name
-                    if child.display_name and child.display_name != ""
-                    else child.name
-                )
-                menu_labels["ipxe"].append(
-                    {"name": child.name, "display_name": display_name}
-                )
+                if boot_loader not in menu_labels:
+                    menu_labels[boot_loader] = []
+
+                if "ipxe" in temp_items:
+                    display_name = (
+                        child.display_name
+                        if child.display_name and child.display_name != ""
+                        else child.name
+                    )
+                    menu_labels[boot_loader].append(
+                        {"name": child.name, "display_name": display_name}
+                    )
 
         for boot_loader in boot_loaders:
             if (
                 boot_loader in nested_menu_items
-                and nested_menu_items[boot_loader] != ""
+                and nested_menu_items[boot_loader][-2:] == "\n\n"
             ):
                 nested_menu_items[boot_loader] = nested_menu_items[boot_loader][:-1]
 
         metadata["menu_items"] = nested_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_profiles_menu(self, menu, metadata, arch: enums.Archs):
+    def get_profiles_menu(self, menu: Menu, metadata: dict, arch: enums.Archs):
         """
         Generates profiles metadata for pxe, ipxe and grub.
 
@@ -533,7 +535,6 @@ class TFTPGen:
 
                     # iPXE Level menu
                     if boot_loader == "ipxe":
-                        current_menu_items[boot_loader] += "\n"
                         if "ipxe" not in menu_labels:
                             menu_labels["ipxe"] = []
                         menu_labels["ipxe"].append(
@@ -543,7 +544,7 @@ class TFTPGen:
         metadata["menu_items"] = current_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_images_menu(self, menu, metadata, arch: enums.Archs):
+    def get_images_menu(self, menu: Menu, metadata: dict, arch: enums.Archs):
         """
         Generates profiles metadata for pxe, ipxe and grub.
 
@@ -587,7 +588,6 @@ class TFTPGen:
 
                         # iPXE Level menu
                         if boot_loader == "ipxe":
-                            current_menu_items[boot_loader] += "\n"
                             if "ipxe" not in menu_labels:
                                 menu_labels["ipxe"] = []
                             menu_labels["ipxe"].append(
@@ -598,14 +598,14 @@ class TFTPGen:
         for boot_loader in boot_loaders:
             if (
                 boot_loader in current_menu_items
-                and current_menu_items[boot_loader] != ""
+                and current_menu_items[boot_loader][-2:] == "\n\n"
             ):
                 current_menu_items[boot_loader] = current_menu_items[boot_loader][:-1]
 
         metadata["menu_items"] = current_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_menu_level(self, menu=None, arch: enums.Archs = None) -> dict:
+    def get_menu_level(self, menu: Menu = None, arch: enums.Archs = None) -> dict:
         """
         Generates menu items for submenus, pxe, ipxe and grub.
 
@@ -615,8 +615,21 @@ class TFTPGen:
                   utils.get_supported_system_boot_loaders().
         """
         metadata = {}
+        metadata["parent_menu_name"] = "Cobbler"
+        metadata["parent_menu_label"] = "Cobbler"
         template_data = {}
         boot_loaders = utils.get_supported_system_boot_loaders()
+
+        if menu:
+            parent_menu = menu.parent
+            metadata["menu_name"] = menu.name
+            metadata["menu_label"] = \
+                menu.display_name if menu.display_name and menu.display_name != "" else menu.name
+            if parent_menu and parent_menu != "":
+                metadata["parent_menu_name"] = parent_menu.name
+                metadata["parent_menu_label"] = parent_menu.name
+                if parent_menu.display_name and parent_menu.display_name != "":
+                    metadata["parent_menu_label"] = parent_menu.display_name
 
         for boot_loader in boot_loaders:
             template = os.path.join(
@@ -626,23 +639,6 @@ class TFTPGen:
             if os.path.exists(template):
                 with open(template) as template_fh:
                     template_data[boot_loader] = template_fh.read()
-                if menu:
-                    parent_menu = menu.parent
-                    metadata["menu_name"] = menu.name
-                    metadata["menu_label"] = (
-                        menu.display_name
-                        if menu.display_name and menu.display_name != ""
-                        else menu.name
-                    )
-                    if parent_menu:
-                        metadata["parent_menu_name"] = parent_menu.name
-                        if parent_menu.display_name and parent_menu.display_name != "":
-                            metadata["parent_menu_label"] = parent_menu.display_name
-                        else:
-                            metadata["parent_menu_label"] = parent_menu.name
-                    else:
-                        metadata["parent_menu_name"] = "Cobbler"
-                        metadata["parent menu_label"] = "Cobbler"
             else:
                 self.logger.warning(
                     'Template for building a submenu not found for bootloader "%s"! Submenu '
@@ -754,14 +750,20 @@ class TFTPGen:
             boot_loaders = system.boot_loaders
             metadata["menu_label"] = system.name
             metadata["menu_name"] = system.name
+            if system.display_name and system.display_name != "":
+                metadata["menu_label"] = system.display_name
         elif profile:
             boot_loaders = profile.boot_loaders
             metadata["menu_label"] = profile.name
             metadata["menu_name"] = profile.name
+            if profile.display_name and profile.display_name != "":
+                metadata["menu_label"] = profile.display_name
         elif image:
             boot_loaders = image.boot_loaders
             metadata["menu_label"] = image.name
             metadata["menu_name"] = image.name
+            if image.display_name and image.display_name != "":
+                metadata["menu_label"] = image.display_name
         if boot_loaders is None or format not in boot_loaders:
             return None
 

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -466,7 +466,10 @@ class TFTPGen:
                         else child.name
                     )
                     menu_labels[boot_loader].append(
-                        {"name": child.name, "display_name": display_name + " -> [submenu]"}
+                        {
+                            "name": child.name,
+                            "display_name": display_name + " -> [submenu]",
+                        }
                     )
 
         metadata["menu_items"] = nested_menu_items
@@ -597,7 +600,7 @@ class TFTPGen:
         metadata["menu_items"] = current_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_menu_level(self, menu = None, arch: enums.Archs = None) -> dict:
+    def get_menu_level(self, menu=None, arch: enums.Archs = None) -> dict:
         """
         Generates menu items for submenus, pxe, ipxe and grub.
 
@@ -615,8 +618,11 @@ class TFTPGen:
         if menu:
             parent_menu = menu.parent
             metadata["menu_name"] = menu.name
-            metadata["menu_label"] = \
-                menu.display_name if menu.display_name and menu.display_name != "" else menu.name
+            metadata["menu_label"] = (
+                menu.display_name
+                if menu.display_name and menu.display_name != ""
+                else menu.name
+            )
             if parent_menu and parent_menu != "":
                 metadata["parent_menu_name"] = parent_menu.name
                 metadata["parent_menu_label"] = parent_menu.name

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -538,8 +538,11 @@ class TFTPGen:
 
                     # iPXE Level menu
                     if boot_loader == "ipxe":
+                        display_name = profile.name
+                        if profile.display_name and profile.display_name != "":
+                            display_name = profile.display_name
                         menu_labels["ipxe"].append(
-                            {"name": profile.name, "display_name": profile.name}
+                            {"name": profile.name, "display_name": display_name}
                         )
 
         metadata["menu_items"] = current_menu_items
@@ -592,8 +595,11 @@ class TFTPGen:
 
                         # iPXE Level menu
                         if boot_loader == "ipxe":
+                            display_name = image.name
+                            if image.display_name and image.display_name != "":
+                                display_name = image.display_name
                             menu_labels["ipxe"].append(
-                                {"name": image.name, "display_name": image.name}
+                                {"name": image.name, "display_name": display_name}
                             )
 
         boot_loaders = utils.get_supported_system_boot_loaders()

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -533,10 +533,11 @@ class TFTPGen:
                         current_menu_items[boot_loader] = ""
                     current_menu_items[boot_loader] += contents
 
+                    if boot_loader not in menu_labels:
+                        menu_labels[boot_loader] = []
+
                     # iPXE Level menu
                     if boot_loader == "ipxe":
-                        if "ipxe" not in menu_labels:
-                            menu_labels["ipxe"] = []
                         menu_labels["ipxe"].append(
                             {"name": profile.name, "display_name": profile.name}
                         )
@@ -586,10 +587,11 @@ class TFTPGen:
                             current_menu_items[boot_loader] = ""
                         current_menu_items[boot_loader] += contents
 
+                        if boot_loader not in menu_labels:
+                            menu_labels[boot_loader] = []
+
                         # iPXE Level menu
                         if boot_loader == "ipxe":
-                            if "ipxe" not in menu_labels:
-                                menu_labels["ipxe"] = []
                             menu_labels["ipxe"].append(
                                 {"name": image.name, "display_name": image.name}
                             )

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -20,7 +20,6 @@ from cobbler.enums import Archs, ImageTypes
 from cobbler.utils import input_converters
 from cobbler.validate import validate_autoinstall_script_name
 from cobbler.utils import filesystem_helpers
-from cobbler.items.menu import Menu
 
 
 class TFTPGen:
@@ -424,7 +423,7 @@ class TFTPGen:
         """
         return self.get_menu_level(None, arch)
 
-    def get_submenus(self, menu: Menu, metadata: dict, arch: enums.Archs):
+    def get_submenus(self, menu, metadata: dict, arch: enums.Archs):
         """
         Generates submenus metatdata for pxe, ipxe and grub.
 
@@ -467,20 +466,13 @@ class TFTPGen:
                         else child.name
                     )
                     menu_labels[boot_loader].append(
-                        {"name": child.name, "display_name": display_name}
+                        {"name": child.name, "display_name": display_name + " -> [submenu]"}
                     )
-
-        for boot_loader in boot_loaders:
-            if (
-                boot_loader in nested_menu_items
-                and nested_menu_items[boot_loader][-2:] == "\n\n"
-            ):
-                nested_menu_items[boot_loader] = nested_menu_items[boot_loader][:-1]
 
         metadata["menu_items"] = nested_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_profiles_menu(self, menu: Menu, metadata: dict, arch: enums.Archs):
+    def get_profiles_menu(self, menu, metadata: dict, arch: enums.Archs):
         """
         Generates profiles metadata for pxe, ipxe and grub.
 
@@ -548,7 +540,7 @@ class TFTPGen:
         metadata["menu_items"] = current_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_images_menu(self, menu: Menu, metadata: dict, arch: enums.Archs):
+    def get_images_menu(self, menu, metadata: dict, arch: enums.Archs):
         """
         Generates profiles metadata for pxe, ipxe and grub.
 
@@ -602,18 +594,10 @@ class TFTPGen:
                                 {"name": image.name, "display_name": display_name}
                             )
 
-        boot_loaders = utils.get_supported_system_boot_loaders()
-        for boot_loader in boot_loaders:
-            if (
-                boot_loader in current_menu_items
-                and current_menu_items[boot_loader][-2:] == "\n\n"
-            ):
-                current_menu_items[boot_loader] = current_menu_items[boot_loader][:-1]
-
         metadata["menu_items"] = current_menu_items
         metadata["menu_labels"] = menu_labels
 
-    def get_menu_level(self, menu: Menu = None, arch: enums.Archs = None) -> dict:
+    def get_menu_level(self, menu = None, arch: enums.Archs = None) -> dict:
         """
         Generates menu items for submenus, pxe, ipxe and grub.
 
@@ -691,8 +675,6 @@ class TFTPGen:
                 if boot_loader in nested_menu_items:
                     menu_items[boot_loader] = nested_menu_items[boot_loader]
                 if boot_loader in current_menu_items:
-                    if menu is None:
-                        menu_items[boot_loader] += "\n"
                     menu_items[boot_loader] += current_menu_items[boot_loader]
                 # Indentation for nested pxe and grub menu items.
                 if menu:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -16,7 +16,7 @@ from typing import Dict, List, Optional
 
 from cobbler import enums, templar, utils
 from cobbler.cexceptions import CX
-from cobbler.enums import Archs
+from cobbler.enums import Archs, ImageTypes
 from cobbler.utils import input_converters
 from cobbler.validate import validate_autoinstall_script_name
 from cobbler.utils import filesystem_helpers
@@ -902,9 +902,9 @@ class TFTPGen:
                 initrd_path = os.path.join(img_path, os.path.basename(distro.initrd))
         else:
             # this is an image we are making available, not kernel+initrd
-            if image.image_type == "direct":
+            if image.image_type == ImageTypes.DIRECT:
                 kernel_path = os.path.join("/images2", image.name)
-            elif image.image_type == "memdisk":
+            elif image.image_type == ImageTypes.MEMDISK:
                 kernel_path = "/memdisk"
                 initrd_path = os.path.join("/images2", image.name)
             else:

--- a/templates/boot_loader_conf/grub.template
+++ b/templates/boot_loader_conf/grub.template
@@ -2,12 +2,12 @@
 set system="$system_name"
 set timeout=1
 #if $netboot_enabled
-set default='$menu_name'
+set default='$menu_label'
 #else
 set default='local'
 #end if
 #end if
-menuentry '$menu_name' --class gnu-linux --class gnu --class os {
+menuentry '$menu_label' --class gnu-linux --class gnu --class os {
   echo 'Loading kernel ...'
   clinux $kernel_path $kernel_options
   echo 'Loading initial ramdisk ...'

--- a/templates/boot_loader_conf/grub_submenu.template
+++ b/templates/boot_loader_conf/grub_submenu.template
@@ -1,3 +1,3 @@
-submenu '$menu_name -> [submenu]' --class gnu-linux --class gnu --class os {
+submenu '$menu_label -> [submenu]' --class gnu-linux --class gnu --class os {
 $menu_items
 }

--- a/templates/boot_loader_conf/ipxe_submenu.template
+++ b/templates/boot_loader_conf/ipxe_submenu.template
@@ -3,7 +3,7 @@ menu $menu_name $menu_label
 #for $label in $menu_labels
 item $label["name"] $label["display_name"]
 #end for
-item return$menu_name Return to $menu_label menu.
+item return$menu_name Return to $parent_menu_name menu.
 choose --default \${menu-default} --timeout \${submenu-timeout} target && goto \${target}
 
 $menu_items

--- a/templates/boot_loader_conf/ipxe_submenu.template
+++ b/templates/boot_loader_conf/ipxe_submenu.template
@@ -1,9 +1,9 @@
 :$menu_name
-menu $menu_name $menu_label
+menu $menu_label
 #for $label in $menu_labels
 item $label["name"] $label["display_name"]
 #end for
-item return$menu_name Return to $parent_menu_name menu.
+item return$menu_name Return to $parent_menu_label menu.
 choose --default \${menu-default} --timeout \${submenu-timeout} target && goto \${target}
 
 $menu_items

--- a/templates/boot_loader_conf/pxe_submenu.template
+++ b/templates/boot_loader_conf/pxe_submenu.template
@@ -1,8 +1,8 @@
 MENU BEGIN $menu_name
 MENU TITLE $menu_label
-MENU LABEL $menu_name
+MENU LABEL $menu_label
 $menu_items
 LABEL return$menu_name
-	MENU LABEL Return to $menu_label menu.
+	MENU LABEL Return to $parent_menu_label menu.
 	MENU EXIT
 MENU END

--- a/templates/boot_loader_conf/pxe_submenu.template
+++ b/templates/boot_loader_conf/pxe_submenu.template
@@ -2,7 +2,7 @@ MENU BEGIN $menu_name
 MENU TITLE $menu_label
 MENU LABEL $menu_label
 $menu_items
-LABEL return$menu_name
-	MENU LABEL Return to $parent_menu_label menu.
-	MENU EXIT
+	LABEL return$menu_name
+		MENU LABEL Return to $parent_menu_label menu.
+		MENU EXIT
 MENU END

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -217,6 +217,17 @@ def test_menu(cobbler_api):
     assert image.menu == ""
 
 
+def test_display_name(cobbler_api):
+    # Arrange
+    image = Image(cobbler_api)
+
+    # Act
+    image.display_name = ""
+
+    # Assert
+    assert image.display_name == ""
+
+
 def test_supported_boot_loaders(cobbler_api):
     # Arrange
     image = Image(cobbler_api)

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -233,7 +233,7 @@ def test_supported_boot_loaders(cobbler_api):
     image = Image(cobbler_api)
 
     # Act & Assert
-    assert image.supported_boot_loaders == []
+    assert image.supported_boot_loaders == ['grub', 'pxe', 'ipxe']
 
 
 def test_boot_loaders(cobbler_api):

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -233,7 +233,7 @@ def test_supported_boot_loaders(cobbler_api):
     image = Image(cobbler_api)
 
     # Act & Assert
-    assert image.supported_boot_loaders == ['grub', 'pxe', 'ipxe']
+    assert image.supported_boot_loaders == ["grub", "pxe", "ipxe"]
 
 
 def test_boot_loaders(cobbler_api):

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -424,3 +424,14 @@ def test_menu(cobbler_api):
 
     # Assert
     assert profile.menu == ""
+
+
+def test_display_name(cobbler_api):
+    # Arrange
+    profile = Profile(cobbler_api)
+
+    # Act
+    profile.display_name = ""
+
+    # Assert
+    assert profile.display_name == ""

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -46,7 +46,7 @@ def test_to_dict(cobbler_api, cleanup_to_dict):
     result = profile.to_dict()
 
     # Assert
-    assert len(result) == 44
+    assert len(result) == 45
     assert result["distro"] == "test_to_dict_distro"
 
 

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -693,3 +693,14 @@ def test_is_management_supported(
 
     # Assert
     assert result is expected_result
+
+
+def test_display_name(cobbler_api):
+    # Arrange
+    system = System(cobbler_api)
+
+    # Act
+    system.display_name = ""
+
+    # Assert
+    assert system.display_name == ""


### PR DESCRIPTION
- fix menu item generation to return to parent menu (pxe/ipxe)
- the large boot menu took a very long time to generate due to the template being read from disk in a loop for each menu item at each menu level
- in a large boot menu it is difficult to navigate by the short names of profiles, images and systems, so I suggest adding a display_name property for them to be displayed in the boot menu