### PR TITLE
CI: Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Linked Items
+
+Fixes #<!-- insert issue here -->
+
+<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 
+
+## Description
+
+<!-- What does this PR do? -->
+
+## Behaviour changes
+
+Old: <!-- This is the old way Cobbler behaved -->
+
+New: <!-- This is the new way Cobbler behaves -->
+
+## Category
+
+This is related to a:
+
+- [ ] Bugfix
+- [ ] Feature
+- [ ] Packaging
+- [ ] Docs
+- [ ] Code Quality
+- [ ] Refactoring
+- [ ] Miscellaneous
+
+## Tests
+
+- [ ] Unit-Tests were created
+- [ ] System-Tests were created
+- [ ] Code is already covered by Unit-Tests
+- [ ] Code is already covered by System-Tests
+- [ ] No tests required 
+
+<!--
+If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
+the maintainer team has added tests for said functionality.
+-->


### PR DESCRIPTION
## Linked Items

Fixes #3206

## Description

Adds Pull Request templates to the repository.

## Behaviour changes

Old: PRs were opened and people had all kind of different formatting

New: PRs now have a unified UI for all contributors

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required
