### PR TITLE
Packaging: Add classifiers and keywords

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -526,6 +526,17 @@ if __name__ == "__main__":
             "Tracker": "https://github.com/cobbler/cobbler/issues",
         },
         license="GPLv2+",
+        classifiers=[
+            "Development Status :: 5 - Production/Stable",
+            "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+            "Programming Language :: Python :: 3.6",
+            "Topic :: System :: Installation/Setup",
+            "Topic :: System :: Systems Administration",
+            "Intended Audience :: System Administrators",
+            "Natural Language :: English",
+            "Operating System :: POSIX :: Linux",
+        ],
+        keywords=["pxe", "autoinstallation", "dhcp", "tftp", "provisioning"],
         install_requires=[
             "mod_wsgi",
             "requests",


### PR DESCRIPTION
## Linked Items

This is a step on the way to consider #2624 as done.

## Description

This PR adds Python Packaging classifiers and keywords to satisfy the Prospector warnings in Pyroma. 

I do not want to enable running Prospector (the tool wrapping Pyroma for us) yet as locally we still have over 500 warnings that are not taken care of from other tools. (The configuration file maybe also needs fine-tuning)

## Behaviour changes

Old: Pyroma would ask us to fix missing classifiers and keywords

New: Tool passes successfully 

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [x] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
