### PR TITLE
Added backport fix for reposync

### DIFF
--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -443,6 +443,9 @@ class RepoSync:
         if repo.arch != "":
             cmd = "%s -a %s" % (cmd, repo.arch)
 
+        if repo.arch == "":
+            cmd = "%s" % (cmd)
+
         # Now regardless of whether we're doing yumdownloader or reposync or whether the repo was http://, ftp://, or
         # rhn://, execute all queued commands here. Any failure at any point stops the operation.
 
@@ -537,7 +540,7 @@ class RepoSync:
                     # Counter-intuitive, but we want the newish kernels too
                     cmd = "%s -a i686" % (cmd)
                 else:
-                    cmd = "%s -a %s" % (cmd, repo.arch)
+                    cmd = "%s -a %s -a noarch" % (cmd, repo.arch)
 
         else:
             # Create the output directory if it doesn't exist
@@ -570,10 +573,14 @@ class RepoSync:
             proxy = repo.proxy
         (cert, verify) = self.gen_urlgrab_ssl_opts(repo.yumopts)
 
-        # FIXME: These two variables were deleted
-        repodata_path = ""
-        repomd_path = ""
+        repodata_path = os.path.join(temp_path, "repodata")
+        repomd_path = os.path.join(repodata_path, "repomd.xml")
         if os.path.exists(repodata_path) and not os.path.isfile(repomd_path):
+            shutil.rmtree(repodata_path, ignore_errors=False, onerror=None)
+
+        repodata_path = os.path.join(temp_path, "repodata")
+        if os.path.exists(repodata_path):
+            self.logger.info("Deleted old repo metadata for %s" % repodata_path)
             shutil.rmtree(repodata_path, ignore_errors=False, onerror=None)
 
         h = librepo.Handle()


### PR DESCRIPTION
## Linked Items

Fixes #2865 for v3.2.2 which is the current supported stable branch in epel8.

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This PR backports some of the changes presented in #2942. Namely, the librepo "Cannot create output directory" error and the missing noarch package downloads referenced [in this comment](https://github.com/cobbler/cobbler/pull/2942#issuecomment-1046951371)

## Behaviour changes

Old: Reposyncs fail on consecutive runs and noarch packages are ignored in repos.

New: Reposyncs pass on consecutive runs and noarch packages are downloaded.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
