### PR TITLE
Modules: DNS - Fix Bind9 CNAME record generation

### DIFF
--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -486,7 +486,7 @@ zone "%(arpa)s." {
                 cnames = interface.cnames
 
                 try:
-                    if interface.get("dns_name", "") != "":
+                    if interface.dns_name != "":
                         dnsname = interface.dns_name.split(".")[0]
                         for cname in cnames:
                             s += "%s  %s  %s;\n" % (
@@ -495,14 +495,17 @@ zone "%(arpa)s." {
                                 dnsname,
                             )
                     else:
-                        self.logger.info(
-                            "Warning: dns_name unspecified in the system: %s, Skipped!, while writing "
-                            "cname records",
+                        self.logger.warning(
+                            'CNAME generation for system "%s" was skipped due to a missing dns_name entry while writing'
+                            "records!",
                             system.name,
                         )
                         continue
-                except:
-                    pass
+                except Exception as exception:
+                    self.logger.exception(
+                        "Unspecified error during creation of CNAME for bind9 records!",
+                        exc_info=exception,
+                    )
 
         return s
 


### PR DESCRIPTION
## Linked Items

Fixes #3228

## Description

This commit fixes the fact that the bind9 module did not account for the change
from a dict to a real object.

Additionally, this commit adds better formatted error messages since this error
was silently dropped.

## Behaviour changes

Old: CNAME generation for bind9 was broken

New: CNAME generation is working again

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 