### PR TITLE
XML-RPC API: Add `resolved` parameter to `find_*` methods

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -18,7 +18,6 @@ from typing import Dict, List, Optional, Union
 
 from schema import SchemaError
 
-from cexceptions import CX
 from cobbler import validate
 from cobbler.actions import (
     status,
@@ -935,32 +934,16 @@ class CobblerAPI:
         """
         Creates a new (unconfigured) object. The object is not persisted.
 
-        :param what: specifies the type of object: ``distro``, ``profile``, ``system``, ``repo``, ``image``
-                                                   ``mgmtclass``, ``package``, ``file`` or ``menu``
+        :param what: Specifies the type of object. Valid item types can be seen at
+                     :func:`~cobbler.enums.ItemTypes`.
         :param is_subobject: If the object is a subobject of an already existing object or not.
         :return: The newly created object.
         """
-        if what == "distro":
-            new_item = self.new_distro(is_subobject=is_subobject)
-        elif what == "profile":
-            new_item = self.new_profile(is_subobject=is_subobject)
-        elif what == "system":
-            new_item = self.new_system(is_subobject=is_subobject)
-        elif what == "repo":
-            new_item = self.new_repo(is_subobject=is_subobject)
-        elif what == "image":
-            new_item = self.new_image(is_subobject=is_subobject)
-        elif what == "mgmtclass":
-            new_item = self.new_mgmtclass(is_subobject=is_subobject)
-        elif what == "package":
-            new_item = self.new_package(is_subobject=is_subobject)
-        elif what == "file":
-            new_item = self.new_file(is_subobject=is_subobject)
-        elif what == "menu":
-            new_item = self.new_menu(is_subobject=is_subobject)
-        else:
-            raise CX('internal error, collection name is "%s"' % what)
-        return new_item
+        try:
+            enums.ItemTypes(what)  # verify that <what> is an ItemTypes member
+            return getattr(self, f"new_{what}")(is_subobject=is_subobject)
+        except (ValueError, AttributeError):
+            raise Exception(f"internal error, collection name is {what}")
 
     def new_distro(self, is_subobject: bool = False):
         """

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -18,6 +18,7 @@ from typing import Dict, List, Optional, Union
 
 from schema import SchemaError
 
+from cexceptions import CX
 from cobbler import validate
 from cobbler.actions import (
     status,
@@ -930,7 +931,36 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    # FIXME: add a new_item method
+    def new_item(self, what: str = "", is_subobject: bool = False):
+        """
+        Creates a new (unconfigured) object. The object is not persisted.
+
+        :param what: specifies the type of object: ``distro``, ``profile``, ``system``, ``repo``, ``image``
+                                                   ``mgmtclass``, ``package``, ``file`` or ``menu``
+        :param is_subobject: If the object is a subobject of an already existing object or not.
+        :return: The newly created object.
+        """
+        if what == "distro":
+            new_item = self.new_distro(is_subobject=is_subobject)
+        elif what == "profile":
+            new_item = self.new_profile(is_subobject=is_subobject)
+        elif what == "system":
+            new_item = self.new_system(is_subobject=is_subobject)
+        elif what == "repo":
+            new_item = self.new_repo(is_subobject=is_subobject)
+        elif what == "image":
+            new_item = self.new_image(is_subobject=is_subobject)
+        elif what == "mgmtclass":
+            new_item = self.new_mgmtclass(is_subobject=is_subobject)
+        elif what == "package":
+            new_item = self.new_package(is_subobject=is_subobject)
+        elif what == "file":
+            new_item = self.new_file(is_subobject=is_subobject)
+        elif what == "menu":
+            new_item = self.new_menu(is_subobject=is_subobject)
+        else:
+            raise CX('internal error, collection name is "%s"' % what)
+        return new_item
 
     def new_distro(self, is_subobject: bool = False):
         """

--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -43,6 +43,50 @@ class ConvertableEnum(enum.Enum):
             raise ValueError(f"{value} must be one of {list(cls)}")
 
 
+class ItemTypes(ConvertableEnum):
+    """
+    This enum represents all valid item types in Cobbler. If a new item type is created it must be added into this enum.
+    Abstract base item types don't have to be added here.
+    """
+
+    DISTRO = "distro"
+    """
+    See :func:`~cobbler.items.distro.Distro`
+    """
+    PROFILE = "profile"
+    """
+    See :func:`~cobbler.items.profile.Profile`
+    """
+    SYSTEM = "system"
+    """
+    See :func:`~cobbler.items.system.System`
+    """
+    REPO = "repo"
+    """
+    See :func:`~cobbler.items.repo.Repo`
+    """
+    IMAGE = "image"
+    """
+    See :func:`~cobbler.items.image.Image`
+    """
+    MGMTCLASS = "mgmtclass"
+    """
+    See :func:`~cobbler.items.mgmtclass.Mgmtclass`
+    """
+    PACKAGE = "package"
+    """
+    See :func:`~cobbler.items.package.Package`
+    """
+    FILE = "file"
+    """
+    See :func:`~cobbler.items.file.File`
+    """
+    MENU = "menu"
+    """
+    See :func:`~cobbler.items.menu.Menu`
+    """
+
+
 class DHCP(enum.Enum):
     V4 = 4
     V6 = 6

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1154,6 +1154,7 @@ class CobblerXMLRPCInterface:
         criteria: Optional[dict] = None,
         sort_field=None,
         expand: bool = True,
+        resolved: bool = False,
     ) -> list:
         """Works like get_items but also accepts criteria as a dict to search on.
 
@@ -1165,6 +1166,8 @@ class CobblerXMLRPCInterface:
         :param criteria: The criteria an item needs to match.
         :param sort_field: The field to sort the results after.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :returns: A list of dicts.
         """
         if criteria is None:
@@ -1179,134 +1182,197 @@ class CobblerXMLRPCInterface:
         if not expand:
             items = [x.name for x in items]
         else:
-            items = [x.to_dict() for x in items]
+            items = [x.to_dict(resolved=resolved) for x in items]
         return self.xmlrpc_hacks(items)
 
     def find_distro(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a distro matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All distributions which have matched the criteria.
         """
-        return self.find_items("distro", criteria, expand=expand)
+        return self.find_items("distro", criteria, expand=expand, resolved=resolved)
 
     def find_profile(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a profile matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All profiles which have matched the criteria.
         """
-        return self.find_items("profile", criteria, expand=expand)
+        return self.find_items("profile", criteria, expand=expand, resolved=resolved)
 
     def find_system(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a system matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All systems which have matched the criteria.
         """
-        return self.find_items("system", criteria, expand=expand)
+        return self.find_items("system", criteria, expand=expand, resolved=resolved)
 
     def find_repo(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a repository matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All repositories which have matched the criteria.
         """
-        return self.find_items("repo", criteria, expand=expand)
+        return self.find_items("repo", criteria, expand=expand, resolved=resolved)
 
     def find_image(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find an image matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All images which have matched the criteria.
         """
-        return self.find_items("image", criteria, expand=expand)
+        return self.find_items("image", criteria, expand=expand, resolved=resolved)
 
     def find_mgmtclass(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a management class matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All management classes which have matched the criteria.
         """
-        return self.find_items("mgmtclass", criteria, expand=expand)
+        return self.find_items("mgmtclass", criteria, expand=expand, resolved=resolved)
 
     def find_package(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a package matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All packages which have matched the criteria.
         """
-        return self.find_items("package", criteria, expand=expand)
+        return self.find_items("package", criteria, expand=expand, resolved=resolved)
 
     def find_file(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a file matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All files which have matched the criteria.
         """
-        return self.find_items("file", criteria, expand=expand)
+        return self.find_items("file", criteria, expand=expand, resolved=resolved)
 
     def find_menu(
-        self, criteria: Optional[dict] = None, expand=False, token=None, **rest
+        self,
+        criteria: Optional[dict] = None,
+        expand=False,
+        resolved: bool = False,
+        token=None,
+        **rest
     ):
         """
         Find a menu matching certain criteria.
 
         :param criteria: The criteria a distribution needs to match.
         :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is not used currently.
         :return: All files which have matched the criteria.
         """
-        return self.find_items("menu", criteria, expand=expand)
+        return self.find_items("menu", criteria, expand=expand, resolved=resolved)
 
     def find_items_paged(
         self,
@@ -1315,6 +1381,7 @@ class CobblerXMLRPCInterface:
         sort_field: Optional[str] = None,
         page=1,
         items_per_page=25,
+        resolved: bool = False,
         token: Optional[str] = None,
     ):
         """
@@ -1326,6 +1393,8 @@ class CobblerXMLRPCInterface:
         :param sort_field: The field to sort the results after.
         :param page: The page to return
         :param items_per_page: The number of items per page.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
         :param token: The API-token obtained via the login() method.
         :return: The found items.
         """
@@ -1340,7 +1409,7 @@ class CobblerXMLRPCInterface:
             items = self.api.find_items(what, criteria=criteria)
         items = self.__sort(items, sort_field)
         (items, pageinfo) = self.__paginate(items, page, items_per_page)
-        items = [x.to_dict() for x in items]
+        items = [x.to_dict(resolved=resolved) for x in items]
         return self.xmlrpc_hacks({"items": items, "pageinfo": pageinfo})
 
     def has_item(self, what: str, name: str, token: Optional[str] = None):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1828,26 +1828,7 @@ class CobblerXMLRPCInterface:
         """
         self._log("new_item(%s)" % what, token=token)
         self.check_access(token, "new_%s" % what)
-        if what == "distro":
-            new_item = self.api.new_distro(is_subobject=is_subobject)
-        elif what == "profile":
-            new_item = self.api.new_profile(is_subobject=is_subobject)
-        elif what == "system":
-            new_item = self.api.new_system(is_subobject=is_subobject)
-        elif what == "repo":
-            new_item = self.api.new_repo(is_subobject=is_subobject)
-        elif what == "image":
-            new_item = self.api.new_image(is_subobject=is_subobject)
-        elif what == "mgmtclass":
-            new_item = self.api.new_mgmtclass(is_subobject=is_subobject)
-        elif what == "package":
-            new_item = self.api.new_package(is_subobject=is_subobject)
-        elif what == "file":
-            new_item = self.api.new_file(is_subobject=is_subobject)
-        elif what == "menu":
-            new_item = self.api.new_menu(is_subobject=is_subobject)
-        else:
-            raise CX('internal error, collection name is "%s"' % what)
+        new_item = self.api.new_item(what, is_subobject)
         self.unsaved_items[new_item.uid] = (time.time(), new_item)
         return new_item.uid
 

--- a/tests/utils/process_management_test.py
+++ b/tests/utils/process_management_test.py
@@ -56,6 +56,9 @@ def test_service_restart_systemctl(mocker):
     mocker.patch(
         "cobbler.utils.process_management.is_systemd", autospec=True, return_value=True
     )
+    mocker.patch(
+        "cobbler.utils.process_management.is_service", autospec=True, return_value=False
+    )
     subprocess_mock = mocker.patch(
         "cobbler.utils.subprocess_call", autospec=True, return_value=0
     )


### PR DESCRIPTION
## Linked Items

Fixes #3160
Fixes #1685

## Description

Add `resolved` param to the `find_*` methods

## Behaviour changes

Old: `find_*` methods were not able to utilize the new `resolved` mechanism.

New: Users can now directly retrieve resolved objects via the `find_*` methods.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 