### PR TITLE
filesystem_helpers mkdir create parent directories

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -193,13 +193,16 @@ class CobblerSync:
                 ]:
                     # clean out directory contents
                     filesystem_helpers.rmtree_contents(path)
+        for directory in [
+            self.pxelinux_dir,
+            self.grub_dir,
+            self.images_dir,
+            self.ipxe_dir,
+            self.esxi_dir,
+            self.rendered_dir,
+        ]:
+            filesystem_helpers.rmtree(directory)
         filesystem_helpers.create_tftpboot_dirs(self.api)
-        filesystem_helpers.rmtree_contents(self.pxelinux_dir)
-        filesystem_helpers.rmtree_contents(self.grub_dir)
-        filesystem_helpers.rmtree_contents(self.images_dir)
-        filesystem_helpers.rmtree_contents(self.ipxe_dir)
-        filesystem_helpers.rmtree_contents(self.esxi_dir)
-        filesystem_helpers.rmtree_contents(self.rendered_dir)
 
     def write_dhcp(self):
         """

--- a/cobbler/utils/filesystem_helpers.py
+++ b/cobbler/utils/filesystem_helpers.py
@@ -437,6 +437,7 @@ def create_tftpboot_dirs(api):
         bootloc / "images",
         bootloc / "ipxe",
         esxi_dir,
+        esxi_dir / "system",
     ]
     for directory_path in tftpboot_directory_paths:
         __create_if_not_exists(directory_path)

--- a/tests/utils/filesystem_helpers_test.py
+++ b/tests/utils/filesystem_helpers_test.py
@@ -244,7 +244,7 @@ def test_create_tftpboot_dirs(mocker, cobbler_api):
     filesystem_helpers.create_tftpboot_dirs(cobbler_api)
 
     # Assert
-    assert mock_mkdir.call_count == 12
+    assert mock_mkdir.call_count == 13
     assert mock_path_symlink_to.call_count == 3
 
 


### PR DESCRIPTION
## Linked Items

Fixes #3242

## Description

Restore previous `utils.filesystem_helpers.mkdir()` behavior, where any missing parent of given path was created.   

## Behaviour changes

Old: 
`utils.filesystem_helpers.mkdir('/var/lib/tftpboot/esxi/system/01-52-54-00-54-de-11')` fails if directory `/var/lib/tftpboot/esxi/system` does not exist. 
On `cobbler sync`, `clean_trees` is called and any content inside `/var/lib/tftpboot/esxi` is deleted; thus `cobbler sync` fails for esxi as it needs to create 2 levels of directories.

New: 
`utils.filesystem_helpers.mkdir('/var/lib/tftpboot/esxi/system/01-52-54-00-54-de-11')` create any missing directory. 

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
