### PR TITLE
Fix `get_event_log` XML-RPC endpoint

### DIFF
--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -43,6 +43,31 @@ class ConvertableEnum(enum.Enum):
             raise ValueError(f"{value} must be one of {list(cls)}")
 
 
+class EventStatus(ConvertableEnum):
+    """
+    This enums describes the status an event can have. The cycle is the following:
+
+        "Running" --> "Complete" or "Failed"
+    """
+
+    RUNNING = "running"
+    """
+    Shows that an event is currently being processed by the server
+    """
+    COMPLETE = "complete"
+    """
+    Shows that an event did complete as desired
+    """
+    FAILED = "failed"
+    """
+    Shows that an event did not complete as expected
+    """
+    INFO = "notification"
+    """
+    Default Event status
+    """
+
+
 class ItemTypes(ConvertableEnum):
     """
     This enum represents all valid item types in Cobbler. If a new item type is created it must be added into this enum.

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -459,10 +459,9 @@ class CobblerXMLRPCInterface:
         """
         if not isinstance(event_id, str):
             raise TypeError('"event_id" must be of type str!')
-        if event_id in self.events:
-            return list(self.events[event_id])
-        else:
+        if event_id not in self.events:
             raise CX("no event with that id")
+        return list(self.events[event_id])
 
     def last_modified_time(self, token=None) -> float:
         """

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -17,6 +17,7 @@ import random
 import stat
 import time
 import re
+import uuid
 import xmlrpc.server
 from socketserver import ThreadingMixIn
 from threading import Thread
@@ -516,15 +517,8 @@ class CobblerXMLRPCInterface:
             julian,
             dst,
         ) = time.localtime()
-        return "%04d-%02d-%02d_%02d%02d%02d_%s" % (
-            year,
-            month,
-            day,
-            hour,
-            minute,
-            second,
-            optype,
-        )
+        task_uuid = uuid.uuid4().hex
+        return f"{year:04d}-{month:02d}-{day:02d}_{hour:02d}{minute:02d}{second:02d}_{optype}_{task_uuid}"
 
     def _new_event(self, name: str):
         """
@@ -533,7 +527,6 @@ class CobblerXMLRPCInterface:
         :param name: The name of the event.
         """
         event_id = self.__generate_event_id("event")
-        event_id = str(event_id)
         self.events[event_id] = [float(time.time()), str(name), EVENT_INFO, []]
 
     def __start_task(

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -12,6 +12,7 @@ import fcntl
 import keyword
 import logging
 import os
+import pathlib
 import random
 import stat
 import time
@@ -70,11 +71,25 @@ class CobblerThread(Thread):
         self.event_id = event_id
         self.remote = remote
         self.logger = logging.getLogger()
+        self.__setup_logger()
         if options is None:
             options = {}
         self.options = options
         self.task_name = task_name
         self.api = api
+
+    def __setup_logger(self):
+        """
+        Utility function that will setup the Python logger for the tasks in a special directory.
+        """
+        filename = pathlib.Path("/var/log/cobbler/tasks") / f"{self.event_id}.log"
+        task_log_handler = logging.FileHandler(str(filename), encoding="utf-8")
+        task_log_formatter = logging.Formatter(
+            "[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s"
+        )
+        task_log_handler.setFormatter(task_log_formatter)
+        self.logger.setLevel(logging.INFO)
+        self.logger.addHandler(task_log_handler)
 
     def on_done(self):
         """
@@ -87,6 +102,7 @@ class CobblerThread(Thread):
 
         :return: The return code of the action. This may possibly a boolean or a Linux return code.
         """
+        self.logger.info("start_task(%s); event_id(%s)", self.task_name, self.event_id)
         time.sleep(1)
         try:
             if utils.run_triggers(
@@ -548,7 +564,7 @@ class CobblerXMLRPCInterface:
         event_id = str(event_id)
         self.events[event_id] = [float(time.time()), str(name), EVENT_RUNNING, []]
 
-        self._log("start_task(%s); event_id(%s)" % (name, event_id))
+        self._log("create_task(%s); event_id(%s)" % (name, event_id))
 
         thr_obj = CobblerThread(event_id, self, args, role_name, self.api)
         thr_obj._run = thr_obj_fn
@@ -1006,7 +1022,7 @@ class CobblerXMLRPCInterface:
         flatten: bool = False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Get a menu.
@@ -1191,7 +1207,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a distro matching certain criteria.
@@ -1212,7 +1228,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a profile matching certain criteria.
@@ -1233,7 +1249,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a system matching certain criteria.
@@ -1254,7 +1270,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a repository matching certain criteria.
@@ -1275,7 +1291,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find an image matching certain criteria.
@@ -1296,7 +1312,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a management class matching certain criteria.
@@ -1317,7 +1333,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a package matching certain criteria.
@@ -1338,7 +1354,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a file matching certain criteria.
@@ -1359,7 +1375,7 @@ class CobblerXMLRPCInterface:
         expand=False,
         resolved: bool = False,
         token=None,
-        **rest
+        **rest,
     ):
         """
         Find a menu matching certain criteria.

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -765,7 +765,7 @@ def run_this(cmd: str, args: Union[str, tuple]):
         die("Command failed")
 
 
-def run_triggers(api, ref, globber, additional: list = None):
+def run_triggers(api, ref=None, globber: str = "", additional: list = None):
     """Runs all the trigger scripts in a given directory.
     Example: ``/var/lib/cobbler/triggers/blah/*``
 

--- a/cobbler/utils/event.py
+++ b/cobbler/utils/event.py
@@ -1,0 +1,78 @@
+"""
+This module contains logic to support the events Cobbler generates in its XML-RPC API.
+"""
+
+import time
+import uuid
+
+from cobbler import enums
+
+
+class CobblerEvent:
+    """
+    This is a small helper class that represents an event in Cobbler.
+    """
+
+    def __init__(self, name="", statetime=0.0):
+        """
+        Default Constructor that initializes the event id.
+
+        :param name: The human-readable name of the event
+        :statetime: The time the event was created.
+        """
+        self.__event_id = ""
+        self.statetime = statetime
+        self.__name = name
+        self.state = enums.EventStatus.INFO
+        self.read_by_who = []
+        # Initialize the even_id
+        self.__generate_event_id()
+
+    def __len__(self):
+        return len(self.__members())
+
+    def __getitem__(self, idx):
+        return self.__members()[idx]
+
+    def __members(self) -> list:
+        """
+        Lists the members with their current values.
+
+        :returns: This converts all members to scalar types that can be passed via XML-RPC.
+        """
+        return [self.statetime, self.name, self.state.value, self.read_by_who]
+
+    @property
+    def event_id(self):
+        """
+        Read only property to retrieve the internal ID of the event.
+        """
+        return self.__event_id
+
+    @property
+    def name(self):
+        """
+        Read only property to retrieve the human-readable name of the event.
+        """
+        return self.__name
+
+    def __generate_event_id(self):
+        """
+        Generate an event id based on the current timestamp
+
+        :return: An id in the format: "<4 digit year>-<2 digit month>-<two digit day>_<2 digit hour><2 digit minute>
+                 <2 digit second>_<optional string>"
+        """
+        (
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second,
+            _,
+            _,
+            _,
+        ) = time.localtime()
+        task_uuid = uuid.uuid4().hex
+        self.__event_id = f"{year:04d}-{month:02d}-{day:02d}_{hour:02d}{minute:02d}{second:02d}_{self.name}_{task_uuid}"

--- a/cobbler/utils/thread.py
+++ b/cobbler/utils/thread.py
@@ -37,7 +37,7 @@ class CobblerThread(Thread):
         :param run: The callable that is going to be executed with this thread.
         :param on_done: An optional callable that is going to be executed after ``run`` but before the triggers.
         """
-        Thread.__init__(self, name=event_id)
+        super().__init__(name=event_id)
         self.event_id = event_id
         self.remote = remote
         self.logger = logging.getLogger()
@@ -88,13 +88,11 @@ class CobblerThread(Thread):
         :return: The return code of the action. This may a boolean or a Linux return code.
         """
         self.logger.info("start_task(%s); event_id(%s)", self.task_name, self.event_id)
-        time.sleep(1)
         try:
             if utils.run_triggers(
-                self.api,
-                None,
-                f"/var/lib/cobbler/triggers/task/{self.task_name}/pre/*",
-                self.options,
+                api=self.api,
+                globber=f"/var/lib/cobbler/triggers/task/{self.task_name}/pre/*",
+                additional=self.options,
             ):
                 self._set_task_state(enums.EventStatus.FAILED)
                 return False
@@ -106,13 +104,12 @@ class CobblerThread(Thread):
                 if self.on_done is not None:
                     self.on_done()
                 utils.run_triggers(
-                    self.api,
-                    None,
-                    f"/var/lib/cobbler/triggers/task/{self.task_name}/post/*",
-                    self.options,
+                    api=self.api,
+                    globber=f"/var/lib/cobbler/triggers/task/{self.task_name}/post/*",
+                    additional=self.options,
                 )
             return rc
-        except:
+        except Exception:
             utils.log_exc()
             self._set_task_state(enums.EventStatus.FAILED)
             return False

--- a/cobbler/utils/thread.py
+++ b/cobbler/utils/thread.py
@@ -1,0 +1,118 @@
+"""
+This module is responsible for managing the custom common threading logic Cobbler has.
+"""
+
+import logging
+import pathlib
+from threading import Thread
+from typing import Callable
+
+from cobbler import enums
+from cobbler import utils
+
+
+class CobblerThread(Thread):
+    """
+    This is a custom thread that has a custom logger as well as logic to execute Cobbler triggers.
+    """
+
+    def __init__(
+        self,
+        event_id: str,
+        remote,
+        options: dict,
+        task_name: str,
+        api,
+        run: Callable,
+        on_done: Callable = None,
+    ):
+        """
+        This constructor creates a Cobbler thread which then may be run by calling ``run()``.
+
+        :param event_id: The event-id which is associated with this thread. Also used as thread name
+        :param remote: The Cobbler remote object to execute actions with.
+        :param options: Additional options which can be passed into the Thread.
+        :param task_name: The high level task name which is used to trigger pre- and post-task triggers
+        :param api: The Cobbler api object to resolve information with.
+        :param run: The callable that is going to be executed with this thread.
+        :param on_done: An optional callable that is going to be executed after ``run`` but before the triggers.
+        """
+        Thread.__init__(self, name=event_id)
+        self.event_id = event_id
+        self.remote = remote
+        self.logger = logging.getLogger()
+        self.__setup_logger()
+        self._run = run
+        self.on_done = on_done
+        if options is None:
+            options = {}
+        self.options = options
+        self.task_name = task_name
+        self.api = api
+
+    def __setup_logger(self):
+        """
+        Utility function that will set up the Python logger for the tasks in a special directory.
+        """
+        filename = pathlib.Path("/var/log/cobbler/tasks") / f"{self.event_id}.log"
+        task_log_handler = logging.FileHandler(str(filename), encoding="utf-8")
+        task_log_formatter = logging.Formatter(
+            "[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s"
+        )
+        task_log_handler.setFormatter(task_log_formatter)
+        self.logger.setLevel(logging.INFO)
+        self.logger.addHandler(task_log_handler)
+
+    def _set_task_state(self, new_state: enums.EventStatus):
+        """
+        Set the state of the task. (For internal use only)
+
+        :param new_state: The new state of the task.
+        """
+        if not isinstance(new_state, enums.EventStatus):
+            raise TypeError('"new_state" needs to be of type enums.EventStatus!')
+        if self.event_id not in self.remote.events:
+            raise ValueError('"event_id" not existing!')
+        self.remote.events[self.event_id].state = new_state
+        # clear the list of who has read it
+        self.remote.events[self.event_id].read_by_who = []
+        if new_state == enums.EventStatus.COMPLETE:
+            self.logger.info("### TASK COMPLETE ###")
+        elif new_state == enums.EventStatus.FAILED:
+            self.logger.error("### TASK FAILED ###")
+
+    def run(self):
+        """
+        Run the thread.
+
+        :return: The return code of the action. This may a boolean or a Linux return code.
+        """
+        self.logger.info("start_task(%s); event_id(%s)", self.task_name, self.event_id)
+        time.sleep(1)
+        try:
+            if utils.run_triggers(
+                self.api,
+                None,
+                f"/var/lib/cobbler/triggers/task/{self.task_name}/pre/*",
+                self.options,
+            ):
+                self._set_task_state(enums.EventStatus.FAILED)
+                return False
+            rc = self._run(self)
+            if rc is not None and not rc:
+                self._set_task_state(enums.EventStatus.FAILED)
+            else:
+                self._set_task_state(enums.EventStatus.COMPLETE)
+                if self.on_done is not None:
+                    self.on_done()
+                utils.run_triggers(
+                    self.api,
+                    None,
+                    f"/var/lib/cobbler/triggers/task/{self.task_name}/post/*",
+                    self.options,
+                )
+            return rc
+        except:
+            utils.log_exc()
+            self._set_task_state(enums.EventStatus.FAILED)
+            return False


### PR DESCRIPTION
## Linked Items

Fixes #3164
Fixes #1646

## Description

This PR does the following:

- [x] Create logfiles with level INFO in the tasks again. This does not affect the root logger which logs to the main logfile with a level of choice.
- [x] The task ID that is generated will be now unique via a UUID V4
- [x] The `CobblerThread` logic was moved away from XML-RPC and is moved into a more suitable place
- [x] ~~The `CobblerAPI` can make use of the Threads as well for actions~~ - I consider this part of #3148

## Behaviour changes

Old: The folder `/var/log/cobbler/tasks/` was empty due to a logger misconfiguration

New: The folder is filled with logfiles for tasks again.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 