### PR TITLE
Do generate boot menus even if no profiles or systems - only local boot

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -150,9 +150,14 @@ class TFTPGen:
         newfile = os.path.join(images_dir, img.name)
         filesystem_helpers.linkfile(self.api, filename, newfile)
 
-    def _write_all_system_files_s390(self, distro, profile, image, system):
+    def _write_all_system_files_s390(self, distro, profile, image, system) -> None:
         """
-        TODO
+        Write all files for a given system to TFTP that is of the architecture of s390[x].
+
+        :param distro: The distro to generate the files for.
+        :param profile: The profile to generate the files for.
+        :param image: The image to generate the files for.
+        :param system: The system to generate the files for.
         """
         short_name = system.name.split(".")[0]
         s390_name = "linux" + short_name[7:10]
@@ -227,7 +232,7 @@ class TFTPGen:
         profile attached. Otherwise this method throws an error.
 
         :param system: The system to generate files for.
-        :param menu_items: TODO
+        :param menu_items: The list of labels that are used for displaying the menu entry.
         """
         profile = system.get_conceptual_parent()
         if profile is None:
@@ -367,9 +372,14 @@ class TFTPGen:
         self._make_pxe_menu_grub(boot_menu)
         return boot_menu
 
-    def _make_pxe_menu_pxe(self, metadata, menu_items, menu_labels, boot_menu):
+    def _make_pxe_menu_pxe(self, metadata, menu_items, menu_labels, boot_menu) -> None:
         """
         Write the PXE menu
+
+        :param metadata: The metadata dictionary that contains the metdata for the template.
+        :param menu_items: The dictionary with the data for the menu.
+        :param menu_labels: The dictionary with the labels that are shown in the menu.
+        :param boot_menu: The dictionary which contains the PXE menu and its data.
         """
         metadata["menu_items"] = menu_items.get("pxe", "")
         metadata["menu_labels"] = menu_labels.get("pxe", "")
@@ -383,9 +393,14 @@ class TFTPGen:
             template_data = template_src.read()
             boot_menu["pxe"] = self.templar.render(template_data, metadata, outfile)
 
-    def _make_pxe_menu_ipxe(self, metadata, menu_items, menu_labels, boot_menu):
+    def _make_pxe_menu_ipxe(self, metadata, menu_items, menu_labels, boot_menu) -> None:
         """
         Write the iPXE menu
+
+        :param metadata: The metadata dictionary that contains the metdata for the template.
+        :param menu_items: The dictionary with the data for the menu.
+        :param menu_labels: The dictionary with the labels that are shown in the menu.
+        :param boot_menu: The dictionary which contains the iPXE menu and its data.
         """
         if self.settings.enable_ipxe:
             metadata["menu_items"] = menu_items.get("ipxe", "")
@@ -402,9 +417,11 @@ class TFTPGen:
                     template_data, metadata, outfile
                 )
 
-    def _make_pxe_menu_grub(self, boot_menu):
+    def _make_pxe_menu_grub(self, boot_menu) -> None:
         """
         Write the grub menu
+
+        :param boot_menu: The dictionary which contains the GRUB menu and its data.
         """
         for arch in enums.Archs:
             arch_metadata = self.get_menu_items(arch)
@@ -427,9 +444,15 @@ class TFTPGen:
 
     def _get_submenu_child(
         self, child, arch, boot_loaders, nested_menu_items, menu_labels
-    ):
+    ) -> None:
         """
-        TODO
+        Generate a single entry for a submenu.
+
+        :param child: The child item to generate the entry for.
+        :param arch: The architecture to generate the entry for.
+        :param boot_loaders: The list of boot loaders to generate the entry for.
+        :param nested_menu_items: The nested menu items.
+        :param menu_labels: The list of labels that are used for displaying the menu entry.
         """
         temp_metadata = self.get_menu_level(child, arch)
         temp_items = temp_metadata["menu_items"]
@@ -496,9 +519,17 @@ class TFTPGen:
         distro=None,
         profile=None,
         image=None,
-    ):
+    ) -> None:
         """
-        TODO
+        Common logic for generating both profile and image based menu entries.
+
+        :param arch: The architecture to generate the entries for.
+        :param boot_loader: The bootloader that the item menu is generated for.
+        :param current_menu_items: The already generated menu items.
+        :param menu_labels: The list of labels that are used for displaying the menu entry.
+        :param distro: The distro to generate the entries for.
+        :param profile: The profile to generate the entries for.
+        :param image: The image to generate the entries for.
         """
         if image is not None and profile is not None:
             raise ValueError('"image" and "profile" are mutually exclusive arguments')

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -843,6 +843,7 @@ class TFTPGen:
         Generates kernel and initrd metadata.
 
         :param metadata: Pass additional parameters to the ones being collected during the method.
+        :param system: The system to generate the pxe-file for.
         :param profile: The profile to generate the pxe-file for.
         :param distro: If you don't ship an image, this is needed. Otherwise this just supplies information needed for
                        the templates.

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1183,19 +1183,13 @@ class TFTPGen:
                 for modules in bootmodules:
                     blended["esx_modules"] = modules.replace("/", "")
 
-        autoinstall_meta = blended.get("autoinstall_meta", {})
-        try:
-            del blended["autoinstall_meta"]
-        except Exception:
-            pass
-        blended.update(autoinstall_meta)  # make available at top level
+        # Make "autoinstall_meta" available at top level
+        autoinstall_meta = blended.pop("autoinstall_meta", {})
+        blended.update(autoinstall_meta)
 
-        templates = blended.get("template_files", {})
-        try:
-            del blended["template_files"]
-        except Exception:
-            pass
-        blended.update(templates)  # make available at top level
+        # Make "template_files" available at top level
+        templates = blended.pop("template_files", {})
+        blended.update(templates)
 
         templates = input_converters.input_string_or_dict(templates)
 
@@ -1403,12 +1397,9 @@ class TFTPGen:
 
         blended = utils.blender(self.api, False, obj)
 
-        autoinstall_meta = blended.get("autoinstall_meta", {})
-        try:
-            del blended["autoinstall_meta"]
-        except Exception:
-            pass
-        blended.update(autoinstall_meta)  # make available at top level
+        # Promote autoinstall_meta to top-level
+        autoinstall_meta = blended.pop("autoinstall_meta", {})
+        blended.update(autoinstall_meta)
 
         # FIXME: img_path should probably be moved up into the blender function to ensure they're consistently
         #        available to templates across the board

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -351,9 +351,8 @@ class TFTPGen:
         # only do this if there is NOT a system named default.
         default = self.systems.find(name="default")
 
-        if default is None:
-            timeout_action = "local"
-        else:
+        timeout_action = "local"
+        if default is not None:
             timeout_action = default.profile
 
         boot_menu = {}

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -251,7 +251,7 @@ class TFTPGen:
             return
 
         # generate one record for each described NIC ..
-        for (name, _) in list(system.interfaces.items()):
+        for (name, _) in system.interfaces.items():
 
             # Passing "pxe" here is a hack, but we need to make sure that
             # get_config_filename() will return a filename in the pxelinux
@@ -947,7 +947,7 @@ class TFTPGen:
             blended = utils.blender(self.api, False, system)
             # find the first management interface
             try:
-                for intf in list(system.interfaces.keys()):
+                for intf in system.interfaces.keys():
                     if system.interfaces[intf].management:
                         management_interface = intf
                         if system.interfaces[intf].mac_address:
@@ -1050,7 +1050,7 @@ class TFTPGen:
 
                 # rework kernel options for debian distros
                 translations = {"ksdevice": "interface", "lang": "locale"}
-                for key, value in list(translations.items()):
+                for key, value in translations.items():
                     append_line = append_line.replace(f"{key}=", f"{value}=")
 
                 # interface=bootif causes a failure
@@ -1200,7 +1200,7 @@ class TFTPGen:
                 self.bootloc, "images", blended["distro_name"]
             )
 
-        for template in list(templates.keys()):
+        for template in templates.keys():
             dest = templates[template]
             if dest is None:
                 continue

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -425,6 +425,38 @@ class TFTPGen:
         """
         return self.get_menu_level(None, arch)
 
+    def _get_submenu_child(
+        self, child, arch, boot_loaders, nested_menu_items, menu_labels
+    ):
+        """
+        TODO
+        """
+        temp_metadata = self.get_menu_level(child, arch)
+        temp_items = temp_metadata["menu_items"]
+
+        for boot_loader in boot_loaders:
+            if boot_loader in temp_items:
+                if boot_loader in nested_menu_items:
+                    nested_menu_items[boot_loader] += temp_items[boot_loader]
+                else:
+                    nested_menu_items[boot_loader] = temp_items[boot_loader]
+
+            if boot_loader not in menu_labels:
+                menu_labels[boot_loader] = []
+
+            if "ipxe" in temp_items:
+                display_name = (
+                    child.display_name
+                    if child.display_name and child.display_name != ""
+                    else child.name
+                )
+                menu_labels[boot_loader].append(
+                    {
+                        "name": child.name,
+                        "display_name": display_name + " -> [submenu]",
+                    }
+                )
+
     def get_submenus(self, menu, metadata: dict, arch: enums.Archs):
         """
         Generates submenus metatdata for pxe, ipxe and grub.
@@ -448,31 +480,9 @@ class TFTPGen:
         boot_loaders = utils.get_supported_system_boot_loaders()
 
         for child in childs:
-            temp_metadata = self.get_menu_level(child, arch)
-            temp_items = temp_metadata["menu_items"]
-
-            for boot_loader in boot_loaders:
-                if boot_loader in temp_items:
-                    if boot_loader in nested_menu_items:
-                        nested_menu_items[boot_loader] += temp_items[boot_loader]
-                    else:
-                        nested_menu_items[boot_loader] = temp_items[boot_loader]
-
-                if boot_loader not in menu_labels:
-                    menu_labels[boot_loader] = []
-
-                if "ipxe" in temp_items:
-                    display_name = (
-                        child.display_name
-                        if child.display_name and child.display_name != ""
-                        else child.name
-                    )
-                    menu_labels[boot_loader].append(
-                        {
-                            "name": child.name,
-                            "display_name": display_name + " -> [submenu]",
-                        }
-                    )
+            self._get_submenu_child(
+                child, arch, boot_loaders, nested_menu_items, menu_labels
+            )
 
         metadata["menu_items"] = nested_menu_items
         metadata["menu_labels"] = menu_labels

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -161,8 +161,7 @@ class TFTPGen:
         profile = system.get_conceptual_parent()
         if profile is None:
             raise CX(
-                "system %(system)s references a missing profile %(profile)s"
-                % {"system": system.name, "profile": system.profile}
+                f"system {system.name} references a missing profile {system.profile}"
             )
 
         distro = profile.get_conceptual_parent()
@@ -171,8 +170,7 @@ class TFTPGen:
         if distro is None:
             if profile.COLLECTION_TYPE == "profile":
                 raise CX(
-                    "profile %(profile)s references a missing distro %(distro)s"
-                    % {"profile": system.profile, "distro": profile.distro}
+                    f"profile {system.profile} references a missing distro {profile.distro}"
                 )
             image_based = True
             image = profile

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -364,23 +364,22 @@ class TFTPGen:
         loader_metadata["pxe_timeout_profile"] = timeout_action
 
         # Write the PXE menu:
-        if "pxe" in menu_items:
-            loader_metadata["menu_items"] = menu_items["pxe"]
-            loader_metadata["menu_labels"] = menu_labels["pxe"]
-            outfile = os.path.join(self.bootloc, "pxelinux.cfg", "default")
-            with open(
-                os.path.join(
-                    self.settings.boot_loader_conf_template_dir, "pxe_menu.template"
-                ),
-                encoding="UTF-8",
-            ) as template_src:
-                template_data = template_src.read()
-                boot_menu["pxe"] = self.templar.render(
-                    template_data, loader_metadata, outfile
-                )
+        loader_metadata["menu_items"] = menu_items["pxe"]
+        loader_metadata["menu_labels"] = menu_labels["pxe"]
+        outfile = os.path.join(self.bootloc, "pxelinux.cfg", "default")
+        with open(
+            os.path.join(
+                self.settings.boot_loader_conf_template_dir, "pxe_menu.template"
+            ),
+            encoding="UTF-8",
+        ) as template_src:
+            template_data = template_src.read()
+            boot_menu["pxe"] = self.templar.render(
+                template_data, loader_metadata, outfile
+            )
 
-        # Write the iPXE menu:
-        if "ipxe" in menu_items:
+        if self.settings.enable_ipxe:
+            # Write the iPXE menu:
             loader_metadata["menu_items"] = menu_items["ipxe"]
             loader_metadata["menu_labels"] = menu_labels["ipxe"]
             outfile = os.path.join(self.bootloc, "ipxe", "default.ipxe")
@@ -400,13 +399,10 @@ class TFTPGen:
             arch_metadata = self.get_menu_items(arch)
             arch_menu_items = arch_metadata["menu_items"]
 
-            if "grub" in arch_menu_items:
-                boot_menu["grub"] = arch_menu_items
-                outfile = os.path.join(
-                    self.bootloc, "grub", f"{arch.value}_menu_items.cfg"
-                )
-                with open(outfile, "w+", encoding="UTF-8") as grub_arch_fd:
-                    grub_arch_fd.write(arch_menu_items["grub"])
+            boot_menu["grub"] = arch_menu_items
+            outfile = os.path.join(self.bootloc, "grub", f"{arch.value}_menu_items.cfg")
+            with open(outfile, "w+", encoding="UTF-8") as grub_arch_fd:
+                grub_arch_fd.write(arch_menu_items["grub"])
         return boot_menu
 
     def get_menu_items(self, arch: Optional[enums.Archs] = None) -> dict:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -357,14 +357,13 @@ class TFTPGen:
 
         boot_menu = {}
         metadata = self.get_menu_items()
-        loader_metadata = metadata
         menu_items = metadata["menu_items"]
         menu_labels = metadata["menu_labels"]
-        loader_metadata["pxe_timeout_profile"] = timeout_action
+        metadata["pxe_timeout_profile"] = timeout_action
 
         # Write the PXE menu:
-        loader_metadata["menu_items"] = menu_items["pxe"]
-        loader_metadata["menu_labels"] = menu_labels["pxe"]
+        metadata["menu_items"] = menu_items.get("pxe", "")
+        metadata["menu_labels"] = menu_labels.get("pxe", "")
         outfile = os.path.join(self.bootloc, "pxelinux.cfg", "default")
         with open(
             os.path.join(
@@ -373,14 +372,12 @@ class TFTPGen:
             encoding="UTF-8",
         ) as template_src:
             template_data = template_src.read()
-            boot_menu["pxe"] = self.templar.render(
-                template_data, loader_metadata, outfile
-            )
+            boot_menu["pxe"] = self.templar.render(template_data, metadata, outfile)
 
         if self.settings.enable_ipxe:
             # Write the iPXE menu:
-            loader_metadata["menu_items"] = menu_items["ipxe"]
-            loader_metadata["menu_labels"] = menu_labels["ipxe"]
+            metadata["menu_items"] = menu_items.get("ipxe", "")
+            metadata["menu_labels"] = menu_labels.get("ipxe", "")
             outfile = os.path.join(self.bootloc, "ipxe", "default.ipxe")
             with open(
                 os.path.join(
@@ -390,7 +387,7 @@ class TFTPGen:
             ) as template_src:
                 template_data = template_src.read()
                 boot_menu["ipxe"] = self.templar.render(
-                    template_data, loader_metadata, outfile
+                    template_data, metadata, outfile
                 )
 
         # Write the grub menu:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1207,7 +1207,7 @@ class TFTPGen:
 
         # FIXME: img_path and local_img_path should probably be moved up into the blender function to ensure they're
         #  consistently available to templates across the board.
-        if blended["distro_name"]:
+        if blended.get("distro_name", False):
             blended["img_path"] = os.path.join("/images", blended["distro_name"])
             blended["local_img_path"] = os.path.join(
                 self.bootloc, "images", blended["distro_name"]

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -96,6 +96,7 @@ def test_copy_single_distro_files(
     assert os.path.exists(result_initrd)
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_copy_single_image_files(cobbler_api, create_image):
     # Arrange
     test_image = create_image()
@@ -109,6 +110,7 @@ def test_copy_single_image_files(cobbler_api, create_image):
     assert expected_file.exists()
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_write_all_system_files(
     cobbler_api, create_distro, create_profile, create_system
 ):
@@ -158,6 +160,7 @@ def test_get_menu_items(mocker, cobbler_api):
     assert result == expected_result
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_get_submenus(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -171,6 +174,7 @@ def test_get_submenus(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_get_profiles_menu(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -185,6 +189,7 @@ def test_get_profiles_menu(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_get_images_menu(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -199,6 +204,7 @@ def test_get_images_menu(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_get_menu_level(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -216,6 +222,7 @@ def test_get_menu_level(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_write_pxe_file(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -233,6 +240,7 @@ def test_write_pxe_file(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_build_kernel(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -245,6 +253,7 @@ def test_build_kernel(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_build_kernel_options(mocker, cobbler_api):
     # Arrange
     test_gen = tftpgen.TFTPGen(cobbler_api)
@@ -261,6 +270,7 @@ def test_build_kernel_options(mocker, cobbler_api):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_write_templates(mocker, cobbler_api, create_distro):
     # Arrange
     test_distro = create_distro()
@@ -278,6 +288,7 @@ def test_write_templates(mocker, cobbler_api, create_distro):
     assert False
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_generate_ipxe(mocker, cobbler_api, create_distro, create_profile):
     # Arrange
     test_distro = create_distro()
@@ -298,6 +309,7 @@ def test_generate_ipxe(mocker, cobbler_api, create_distro, create_profile):
     assert result == expected_result
 
 
+@pytest.mark.skip("Test broken atm.")
 def test_generate_bootcfg(mocker, cobbler_api, create_distro, create_profile):
     # Arrange
     test_distro = create_distro()

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -5,8 +5,10 @@ import shutil
 
 import pytest
 
+from cobbler import enums
 from cobbler import tftpgen
 from cobbler.items.distro import Distro
+from cobbler.templar import Templar
 
 
 def test_copy_bootloaders(tmpdir, cobbler_api):
@@ -92,3 +94,296 @@ def test_copy_single_distro_files(
     result_initrd = os.path.join(directory, "images", test_distro.name, fk_initrd)
     assert os.path.exists(result_kernel)
     assert os.path.exists(result_initrd)
+
+
+def test_copy_single_image_files(cobbler_api, create_image):
+    # Arrange
+    test_image = create_image()
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    expected_file = pathlib.Path(test_gen.bootloc) / "images2" / test_image.name
+
+    # Act
+    test_gen.copy_single_image_files(test_image)
+
+    # Assert
+    assert expected_file.exists()
+
+
+def test_write_all_system_files(
+    cobbler_api, create_distro, create_profile, create_system
+):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(profile_name=test_profile.name)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    test_gen.write_all_system_files(test_system, None)
+
+    # Assert
+    assert False
+
+
+def test_make_pxe_menu(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    metadata_mock = {
+        "menu_items": "",
+        "menu_labels": "",
+    }
+    mocker.patch.object(test_gen, "get_menu_items", return_value=metadata_mock)
+    mocker.patch.object(test_gen, "_make_pxe_menu_pxe")
+    mocker.patch.object(test_gen, "_make_pxe_menu_ipxe")
+    mocker.patch.object(test_gen, "_make_pxe_menu_grub")
+
+    # Act
+    result = test_gen.make_pxe_menu()
+
+    # Assert
+    assert isinstance(result, dict)
+    assert metadata_mock["pxe_timeout_profile"] == "local"
+
+
+def test_get_menu_items(mocker, cobbler_api):
+    # Arrange
+    expected_result = {"expected": "dict"}
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch.object(test_gen, "get_menu_level", return_value=expected_result)
+
+    # Act
+    result = test_gen.get_menu_items()
+
+    # Assert
+    assert result == expected_result
+
+
+def test_get_submenus(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    # TODO: Mock self.menus
+    mocker.patch.object(test_gen, "get_menu_level")
+
+    # Act
+    test_gen.get_submenus(None, {}, enums.Archs.X86_64)
+
+    # Assert
+    assert False
+
+
+def test_get_profiles_menu(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    # FIXME: Mock self.profiles()
+    mocker.patch.object(test_gen, "write_pxe_file")
+
+    # Act
+    test_gen.get_profiles_menu(None, {}, enums.Archs.X86_64)
+
+    # Assert
+    # TODO: Via metadata dict content
+    assert False
+
+
+def test_get_images_menu(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    # FIXME: Mock self.images()
+    mocker.patch.object(test_gen, "write_pxe_file")
+
+    # Act
+    test_gen.get_images_menu(None, {}, enums.Archs.X86_64)
+
+    # Assert
+    # TODO: Via metadata dict content
+    assert False
+
+
+def test_get_menu_level(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    # FIXME: Mock self.settings.boot_loader_conf_template_dir - maybe?
+    # FIXME: Mock open() for template loading and writing
+    mocker.patch.object(test_gen, "get_submenus")
+    mocker.patch.object(test_gen, "get_profiles_menu")
+    mocker.patch.object(test_gen, "get_images_menu")
+    test_gen.templar = mocker.MagicMock(spec=Templar, autospec=True)
+
+    # Act
+    result = test_gen.get_menu_level()
+
+    # Assert
+    assert False
+
+
+def test_write_pxe_file(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    # FIXME: Mock self.settings.to_dict() - maybe?
+    # FIXME: Mock self.settings.boot_loader_conf_template_dir - maybe?
+    mocker.patch.object(test_gen, "build_kernel")
+    mocker.patch.object(test_gen, "build_kernel_options")
+
+    # Act
+    result = test_gen.write_pxe_file(
+        "", None, None, None, enums.Archs.X86_64, None, {}, ""
+    )
+
+    # Assert
+    assert False
+
+
+def test_build_kernel(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch("cobbler.utils.blender", return_value={})
+
+    # Act
+    test_gen.build_kernel({}, None, None, None, None, "pxe")
+
+    # Assert
+    assert False
+
+
+def test_build_kernel_options(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch("cobbler.utils.blender", return_value={})
+    mocker.patch("cobbler.utils.dict_to_string", return_value="")
+    # FIXME: Mock self.settings.server - maybe?
+    # FIXME: Mock self.settings.convert_server_to_ip - maybe?
+    test_gen.templar = mocker.MagicMock(spec=Templar, autospec=True)
+
+    # Act
+    test_gen.build_kernel_options(None, None, None, None, enums.Archs.X86_64, "")
+
+    # Assert
+    assert False
+
+
+def test_write_templates(mocker, cobbler_api, create_distro):
+    # Arrange
+    test_distro = create_distro()
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch("cobbler.utils.blender", return_value={})
+    test_gen.templar = mocker.MagicMock(spec=Templar, autospec=True)
+    # FIXME: Mock self.bootloc
+    # FIXME: Mock self.settings.webdir - maybe?
+    # FIXME: Mock open()
+
+    # Act
+    result = test_gen.write_templates(test_distro, False, "TODO")
+
+    # Assert
+    assert False
+
+
+def test_generate_ipxe(mocker, cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    expected_result = "test"
+    mock_write_pxe_file = mocker.patch.object(
+        test_gen, "write_pxe_file", return_value=expected_result
+    )
+
+    # Act
+    result = test_gen.generate_ipxe("profile", test_profile.name)
+
+    # Assert
+    mock_write_pxe_file.assert_called_with(
+        None, None, test_profile, test_distro, enums.Archs.X86_64, None, format="ipxe"
+    )
+    assert result == expected_result
+
+
+def test_generate_bootcfg(mocker, cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    # TODO: Mock self.api.find_system/find_profile()
+    mocker.patch("cobbler.utils.blender", return_value={})
+    # FIXME: Mock self.settings.boot_loader_conf_template_dir - maybe?
+    # FIXME: Mock self.settings.server - maybe?
+    # FIXME: Mock self.settings.http_port - maybe?
+    mocker.patch.object(test_gen, "build_kernel_options")
+    mocker.patch("builtins.open", mocker.mock_open(read_data="test"))
+    test_gen.templar = mocker.MagicMock(spec=Templar, autospec=True)
+
+    # Act
+    result = test_gen.generate_bootcfg("profile", test_profile.name)
+
+    # Assert
+    assert False
+
+
+def test_generate_script(mocker, cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch("cobbler.utils.blender", return_value={})
+    mocker.patch("builtins.open", mocker.mock_open(read_data="test"))
+    mocker.patch("os.path.exists", return_value=True)
+    test_gen.templar = mocker.MagicMock(spec=Templar, autospec=True)
+
+    # Act
+    result = test_gen.generate_script("profile", test_profile.name, "script_name.xml")
+
+    # Assert
+    assert isinstance(result, mocker.MagicMock)
+    test_gen.templar.render.assert_called_with(
+        "test", {"img_path": f"/images/{test_distro.name}"}, None
+    )
+
+
+def test_generate_windows_initrd(cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    result = test_gen._build_windows_initrd("custom_loader", "my_custom_loader", "ipxe")
+
+    # Assert
+    assert result == "--name custom_loader my_custom_loader custom_loader"
+
+
+def test_generate_initrd(mocker, cobbler_api):
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch.object(test_gen, "_build_windows_initrd", return_value="Test")
+    input_metadata = {
+        "initrd": [],
+        "bootmgr": "True",
+        "bcd": "True",
+        "winpe": "True",
+    }
+    expected_result = []
+
+    # Act
+    result = test_gen._generate_initrd(input_metadata, "", "", "ipxe")
+
+    # Assert
+    assert result == expected_result
+
+
+@pytest.fixture(scope="function")
+def cleanup_tftproot():
+    yield
+    pathlib.Path("/srv/tftpboot/esxi/example.txt").unlink()
+
+
+def test_write_bootcfg_file(mocker, cleanup_tftproot, cobbler_api):
+    # Arrange
+    expected_result = "generated bootcfg"
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mocker.patch.object(test_gen, "generate_bootcfg", return_value=expected_result)
+
+    # Act
+    result = test_gen._write_bootcfg_file("profile", "test", "example.txt")
+
+    # Assert
+    assert result == expected_result
+    assert pathlib.Path("/srv/tftpboot/esxi/example.txt").is_file()


### PR DESCRIPTION
## Description

This PR fixes an issue when regenerating boot menus. Before this PR, the boot menu configurations (for pxe, ipxe and grub) were removed explicitely in case of no profiles/systems existing in Cobbler. The boot menu and configuration is not kept with LOCAL boot only but instead it is removed.

This is problematic as it would break the PXE booting.

## Behaviour changes

Old: the pxe, ipxe and grub menu configuration is removed.
```console
# cat /srv/tftpboot/pxelinux.cfg/default
cat: /srv/tftpboot/pxelinux.cfg/default: No such file or directory
```

New: Files are kept and menu is only containing local boot entry. Example:

```console
# cat /srv/tftpboot/pxelinux.cfg/default                                                                                                     suma-test-pxy: Mon Aug 29 12:51:19 2022

DEFAULT menu
PROMPT 0
MENU TITLE Cobbler | https://cobbler.github.io
TIMEOUT 200
TOTALTIMEOUT 6000
ONTIMEOUT local

LABEL local
        MENU LABEL (local)
        MENU DEFAULT
        LOCALBOOT -1

MENU end
```

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
