### PR TITLE
Fix `cobbler status` for gzipped logfiles

### DIFF
--- a/cobbler/actions/status.py
+++ b/cobbler/actions/status.py
@@ -11,6 +11,7 @@ import glob
 import gzip
 import re
 import time
+from typing import List, Union
 
 # ARRAY INDEXES
 MOST_RECENT_START = 0
@@ -34,32 +35,40 @@ class CobblerStatusReport:
         self.ip_data = {}
         self.mode = mode
 
-    # -------------------------------------------------------
-
-    def scan_logfiles(self):
+    @staticmethod
+    def collect_logfiles() -> List[str]:
         """
-        Scan the install log-files - starting with the oldest file.
+        Collects all installation logfiles from ``/var/log/cobbler/``. This will also collect gzipped logfiles.
+
+        :returns: List of absolute paths that are matching the filepattern ``install.log`` or ``install.log.x``, where
+                  x is a number equal or greater than zero.
         """
         unsorted_files = glob.glob("/var/log/cobbler/install.log*")
-        files_dict = dict()
+        files_dict = {}
         log_id_re = re.compile(r"install.log.(\d+)")
         for fname in unsorted_files:
             id_match = log_id_re.search(fname)
             if id_match:
                 files_dict[int(id_match.group(1))] = fname
 
-        files = list()
+        files = []
         sorted_ids = sorted(files_dict, key=files_dict.get, reverse=True)
         for file_id in sorted_ids:
             files.append(files_dict[file_id])
         if "/var/log/cobbler/install.log" in unsorted_files:
             files.append("/var/log/cobbler/install.log")
 
-        for fname in files:
+        return files
+
+    def scan_logfiles(self):
+        """
+        Scan the installation log-files - starting with the oldest file.
+        """
+        for fname in self.collect_logfiles():
             if fname.endswith(".gz"):
-                fd = gzip.open(fname)
+                fd = gzip.open(fname, "rt")
             else:
-                fd = open(fname)
+                fd = open(fname, "rt")
             data = fd.read()
             for line in data.split("\n"):
                 tokens = line.split()
@@ -68,8 +77,6 @@ class CobblerStatusReport:
                 (profile_or_system, name, ip, start_or_stop, ts) = tokens
                 self.catalog(profile_or_system, name, ip, start_or_stop, ts)
             fd.close()
-
-    # ------------------------------------------------------
 
     def catalog(
         self, profile_or_system: str, name: str, ip, start_or_stop: str, ts: float
@@ -81,13 +88,11 @@ class CobblerStatusReport:
         :param name: The name of the object.
         :param ip: The ip of the system to watch.
         :param start_or_stop: This parameter may be ``start`` or ``stop``
-        :param ts: Don't know what this does.
+        :param ts: Timestamp as returned by ``time.time()``
         """
-        ip_data = self.ip_data
-
-        if ip not in ip_data:
-            ip_data[ip] = [-1, -1, "?", 0, 0, "?"]
-        elem = ip_data[ip]
+        if ip not in self.ip_data:
+            self.ip_data[ip] = [-1, -1, "?", 0, 0, "?"]
+        elem = self.ip_data[ip]
 
         ts = float(ts)
 
@@ -98,22 +103,20 @@ class CobblerStatusReport:
         if start_or_stop == "start":
             if mrstart < ts:
                 mrstart = ts
-                mrtarg = "%s:%s" % (profile_or_system, name)
+                mrtarg = f"{profile_or_system}:{name}"
                 elem[SEEN_START] += 1
 
         if start_or_stop == "stop":
             if mrstop < ts:
                 mrstop = ts
-                mrtarg = "%s:%s" % (profile_or_system, name)
+                mrtarg = f"{profile_or_system}:{name}"
                 elem[SEEN_STOP] += 1
 
         elem[MOST_RECENT_START] = mrstart
         elem[MOST_RECENT_STOP] = mrstop
         elem[MOST_RECENT_TARGET] = mrtarg
 
-    # -------------------------------------------------------
-
-    def process_results(self):
+    def process_results(self) -> dict:
         """
         Look through all systems which were collected and update the status.
 
@@ -121,7 +124,7 @@ class CobblerStatusReport:
         """
         # FIXME: this should update the times here
         tnow = int(time.time())
-        for ip in list(self.ip_data.keys()):
+        for ip in self.ip_data.keys():
             elem = self.ip_data[ip]
             start = int(elem[MOST_RECENT_START])
             stop = int(elem[MOST_RECENT_STOP])
@@ -129,24 +132,23 @@ class CobblerStatusReport:
                 elem[STATE] = "finished"
             else:
                 delta = tnow - start
-                min = delta // 60
-                sec = delta % 60
-                if min > 100:
+                minutes = delta // 60
+                seconds = delta % 60
+                if minutes > 100:
                     elem[STATE] = "unknown/stalled"
                 else:
-                    elem[STATE] = "installing (%sm %ss)" % (min, sec)
+                    elem[STATE] = f"installing ({minutes}m {seconds}s)"
 
         return self.ip_data
 
-    def get_printable_results(self):
+    def get_printable_results(self) -> str:
         """
-        Convert the status of Cobbler from a machine readable form to human readable.
+        Convert the status of Cobbler from a machine-readable form to human-readable.
 
         :return: A nice formatted representation of the results of ``cobbler status``.
         """
-        format = "%-15s|%-20s|%-17s|%-17s"
-        ip_data = self.ip_data
-        ips = list(ip_data.keys())
+        printable_status_format = "%-15s|%-20s|%-17s|%-17s"
+        ips = list(self.ip_data.keys())
         ips.sort()
         line = (
             "ip",
@@ -154,20 +156,18 @@ class CobblerStatusReport:
             "start",
             "state",
         )
-        buf = format % line
+        buf = printable_status_format % line
         for ip in ips:
-            elem = ip_data[ip]
+            elem = self.ip_data[ip]
             if elem[MOST_RECENT_START] > -1:
                 start = time.ctime(elem[MOST_RECENT_START])
             else:
                 start = "Unknown"
             line = (ip, elem[MOST_RECENT_TARGET], start, elem[STATE])
-            buf += "\n" + format % line
+            buf += "\n" + printable_status_format % line
         return buf
 
-    # -------------------------------------------------------
-
-    def run(self):
+    def run(self) -> Union[dict, str]:
         """
         Calculate and print a automatic installation status report.
         """

--- a/tests/actions/status_test.py
+++ b/tests/actions/status_test.py
@@ -1,0 +1,76 @@
+import pytest
+
+from cobbler.actions import status
+
+
+def test_collect_logfiles():
+    # Arrange
+    # Act
+    status.CobblerStatusReport.collect_logfiles()
+
+    # Assert
+    assert False
+
+
+def test_scan_logfiles(mocker, cobbler_api):
+    # Arrange
+    test_status = status.CobblerStatusReport(cobbler_api, "text")
+    mocker.patch.object(test_status, "collect_logfiles", return_value=[])
+
+    # Act
+    test_status.scan_logfiles()
+
+    # Assert
+    assert False
+
+
+def test_catalog(cobbler_api):
+    # Arrange
+    test_status = status.CobblerStatusReport(cobbler_api, "text")
+
+    # Act
+    test_status.catalog("system", "test", None, "", 0.0)
+
+    # Assert
+    assert False
+
+
+def test_process_results(cobbler_api):
+    # Arrange
+    test_status = status.CobblerStatusReport(cobbler_api, "text")
+
+    # Act
+    test_status.process_results()
+
+    # Assert
+    assert False
+
+
+def test_get_printable_results(cobbler_api):
+    # Arrange
+    test_status = status.CobblerStatusReport(cobbler_api, "text")
+
+    # Act
+    result = test_status.get_printable_results()
+
+    # Assert
+    assert False
+
+
+@pytest.mark.parametrize(
+    "input_mode,expected_result", [("text", str), ("non-text", dict)]
+)
+def test_run(mocker, cobbler_api, input_mode, expected_result):
+    # Arrange
+    test_status = status.CobblerStatusReport(cobbler_api, input_mode)
+    mocker.patch.object(test_status, "scan_logfiles")
+    if input_mode == "text":
+        mocker.patch.object(test_status, "process_results", return_value="")
+    else:
+        mocker.patch.object(test_status, "process_results", return_value={})
+
+    # Act
+    result = test_status.run()
+
+    # Assert
+    assert isinstance(result, expected_result)

--- a/tests/actions/status_test.py
+++ b/tests/actions/status_test.py
@@ -1,49 +1,95 @@
 import pytest
 
+from cobbler.actions.status import InstallStatus
 from cobbler.actions import status
 
 
-def test_collect_logfiles():
+def test_collect_logfiles(mocker):
     # Arrange
+    mocker.patch(
+        "glob.glob",
+        return_value=[
+            "/var/log/cobbler/install.log",
+            "/var/log/cobbler/install.log1",
+            "/var/log/cobbler/install.log.1",
+        ],
+    )
+    expected_result = [
+        "/var/log/cobbler/install.log.1",
+        "/var/log/cobbler/install.log",
+    ]
+
     # Act
-    status.CobblerStatusReport.collect_logfiles()
+    result = status.CobblerStatusReport.collect_logfiles()
 
     # Assert
-    assert False
+    assert result == expected_result
 
 
 def test_scan_logfiles(mocker, cobbler_api):
     # Arrange
+    mocker.patch("gzip.open", mocker.mock_open(read_data="test test test test test"))
+    mocker.patch(
+        "builtins.open", mocker.mock_open(read_data="test test test test test")
+    )
     test_status = status.CobblerStatusReport(cobbler_api, "text")
-    mocker.patch.object(test_status, "collect_logfiles", return_value=[])
+    mocker.patch.object(
+        test_status, "collect_logfiles", return_value=["/test/test", "/test/test.gz"]
+    )
+    mock_catalog = mocker.patch.object(test_status, "catalog")
 
     # Act
     test_status.scan_logfiles()
 
     # Assert
-    assert False
+    assert mock_catalog.call_count == 2
 
 
 def test_catalog(cobbler_api):
     # Arrange
     test_status = status.CobblerStatusReport(cobbler_api, "text")
+    expected_result = InstallStatus()
+    expected_result.most_recent_start = 0
+    expected_result.most_recent_stop = -1
+    expected_result.most_recent_target = "system:test"
+    expected_result.seen_start = 0
+    expected_result.seen_stop = -1
+    expected_result.state = "?"
 
     # Act
-    test_status.catalog("system", "test", None, "", 0.0)
+    test_status.catalog("system", "test", "192.168.0.1", "start", 0.0)
 
     # Assert
-    assert False
+    assert "192.168.0.1" in test_status.ip_data
+    assert test_status.ip_data["192.168.0.1"] == expected_result
 
 
-def test_process_results(cobbler_api):
+@pytest.mark.parametrize(
+    "input_start,input_stop,expected_status",
+    [
+        (0, 5, "finished"),
+        (50, 0, "unknown/stalled"),
+        (99900, 0, "installing (1m 40s)"),
+    ],
+)
+def test_process_results(mocker, cobbler_api, input_start, input_stop, expected_status):
     # Arrange
+    mocker.patch("time.time", return_value=100000)
     test_status = status.CobblerStatusReport(cobbler_api, "text")
+    new_status = InstallStatus()
+    new_status.most_recent_start = input_start
+    new_status.most_recent_stop = input_stop
+    new_status.most_recent_target = ""
+    new_status.seen_start = -1
+    new_status.seen_stop = -1
+    new_status.state = "?"
+    test_status.ip_data["192.168.0.1"] = new_status
 
     # Act
     test_status.process_results()
 
     # Assert
-    assert False
+    assert test_status.ip_data["192.168.0.1"].state == expected_status
 
 
 def test_get_printable_results(cobbler_api):
@@ -54,7 +100,8 @@ def test_get_printable_results(cobbler_api):
     result = test_status.get_printable_results()
 
     # Assert
-    assert False
+    result_list = result.split("\n")
+    assert len(result_list) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Linked Items

Fixes #3247

## Description

This PR adds tests for `cobbler status` and fixes a bug where gzipped logfiles cannot be correctly read.

## Behaviour changes

Old: `cobbler status` fails when gzipped logfiles are present in the log directory.

New: Command succeeds

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 