### PR TITLE
utils: Thread - Fix that thread logs don't end after it completed

### DIFF
--- a/cobbler/utils/thread.py
+++ b/cobbler/utils/thread.py
@@ -41,6 +41,7 @@ class CobblerThread(Thread):
         self.event_id = event_id
         self.remote = remote
         self.logger = logging.getLogger()
+        self.__task_log_handler = None
         self.__setup_logger()
         self._run = run
         self.on_done = on_done
@@ -55,13 +56,13 @@ class CobblerThread(Thread):
         Utility function that will set up the Python logger for the tasks in a special directory.
         """
         filename = pathlib.Path("/var/log/cobbler/tasks") / f"{self.event_id}.log"
-        task_log_handler = logging.FileHandler(str(filename), encoding="utf-8")
+        self.__task_log_handler = logging.FileHandler(str(filename), encoding="utf-8")
         task_log_formatter = logging.Formatter(
             "[%(threadName)s] %(asctime)s - %(levelname)s | %(message)s"
         )
-        task_log_handler.setFormatter(task_log_formatter)
+        self.__task_log_handler.setFormatter(task_log_formatter)
         self.logger.setLevel(logging.INFO)
-        self.logger.addHandler(task_log_handler)
+        self.logger.addHandler(self.__task_log_handler)
 
     def _set_task_state(self, new_state: enums.EventStatus):
         """
@@ -113,3 +114,5 @@ class CobblerThread(Thread):
             utils.log_exc()
             self._set_task_state(enums.EventStatus.FAILED)
             return False
+        finally:
+            self.logger.removeHandler(self.__task_log_handler)


### PR DESCRIPTION
## Linked Items

Fixes #3263

## Description

This was due to the fact that the handler wasn't removed from the root logger.

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
