### PR TITLE
Migrate "proxy_url_ext" properly when it was set as None during 3.2.1 migration

### DIFF
--- a/cobbler/settings/migrations/V3_2_1.py
+++ b/cobbler/settings/migrations/V3_2_1.py
@@ -227,6 +227,10 @@ def migrate(settings: dict) -> dict:
             settings[mgmt_parameters]["from_cobbler"]
         )
 
+    # proxy_url_ext -> None to ''
+    if settings["proxy_url_ext"] is None:
+        settings["proxy_url_ext"] = ""
+
     # delete removed keys
     deleted_keys = ["manage_tftp"]
     for key in deleted_keys:

--- a/tests/test_data/V3_2_0/settings.yaml
+++ b/tests/test_data/V3_2_0/settings.yaml
@@ -449,7 +449,7 @@ always_write_dhcp_entries: 0
 # external proxy - used by: get-loaders, reposync, signature update
 # eg: proxy_url_ext: "http://192.168.1.1:8080" (HTTP)
 # or: proxy_url_ext: "https://192.168.1.1:8443" (HTTPS)
-proxy_url_ext: ""
+proxy_url_ext:
 
 # internal proxy - used by systems to reach cobbler for templates
 # eg: proxy_url_int: "http://10.0.0.1:8080"


### PR DESCRIPTION
## Description

Before Cobbler 3.2.1, the `proxy_url_ext` setting was accepted as `None` or as empty string.

Since the migration to version 3.2.1, this setting is now only accepted as empty string, but there was no migration happening for those cases where this setting was set to `None`.

This was breaking migrations in case you had `proxy_url_ext` set to `None`:
```
Traceback (most recent call last):
  File "/usr/lib/python3.6/site-packages/schema.py", line 276, in validate
    ignore_extra_keys=i).validate(value)
  File "/usr/lib/python3.6/site-packages/schema.py", line 313, in validate
    e.format(data) if e else None)
schema.SchemaUnexpectedTypeError: None should be instance of 'str'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/usr/bin/cobbler-settings", line 194, in <module>
    sys.exit(main(sys.argv))
  File "/usr/bin/cobbler-settings", line 188, in main
    return parsed_args.func(parsed_args)
  File "/usr/bin/cobbler-settings", line 87, in migrate
    result_settings = migrations.migrate(settings_dict, args.config, old, new)
  File "/usr/lib/python3.6/site-packages/cobbler/settings/migrations/__init__.py", line 267, in migrate
    yaml_dict = VERSION_LIST[key].migrate(yaml_dict)
  File "/usr/lib/python3.6/site-packages/cobbler/settings/migrations/V3_2_1.py", line 198, in migrate
    return normalize(settings)
  File "/usr/lib/python3.6/site-packages/cobbler/settings/migrations/V3_2_1.py", line 157, in normalize
    return schema.validate(settings)
  File "/usr/lib/python3.6/site-packages/schema.py", line 279, in validate
    raise SchemaError([k] + x.autos, [e] + x.errors)
schema.SchemaError: Key 'proxy_url_ext' error:
None should be instance of 'str'
```

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
