### PR TITLE
Add missing tests when building Cobbler package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -660,13 +660,103 @@ if __name__ == "__main__":
             ("%s/man1" % docpath, glob("build/sphinx/man/*.1")),
             ("%s/man5" % docpath, glob("build/sphinx/man/*.5")),
             ("%s/man8" % docpath, glob("build/sphinx/man/*.8")),
+            # tests
             ("%s/tests" % datadir, glob("tests/*.py")),
+            ("%s/tests/actions" % datadir, glob("tests/actions/*.py")),
+            (
+                "%s/tests/actions/buildiso" % datadir,
+                glob("tests/actions/buildiso/*.py"),
+            ),
+            ("%s/tests/api" % datadir, glob("tests/api/*.py")),
             ("%s/tests/cli" % datadir, glob("tests/cli/*.py")),
+            ("%s/tests/collections" % datadir, glob("tests/collections/*.py")),
+            ("%s/tests/items" % datadir, glob("tests/items/*.py")),
             ("%s/tests/modules" % datadir, glob("tests/modules/*.py")),
             (
                 "%s/tests/modules/authentication" % datadir,
                 glob("tests/modules/authentication/*.py"),
             ),
+            (
+                "%s/tests/modules/authorization" % datadir,
+                glob("tests/modules/authorization/*.py"),
+            ),
+            (
+                "%s/tests/modules/installation" % datadir,
+                glob("tests/modules/installation/*.py"),
+            ),
+            (
+                "%s/tests/modules/managers" % datadir,
+                glob("tests/modules/managers/*.py"),
+            ),
+            (
+                "%s/tests/modules/serializer" % datadir,
+                glob("tests/modules/serializer/*.py"),
+            ),
+            ("%s/tests/settings" % datadir, glob("tests/settings/*.py")),
+            (
+                "%s/tests/settings/migrations" % datadir,
+                glob("tests/settings/migrations/*.py"),
+            ),
+            ("%s/tests/special_cases" % datadir, glob("tests/special_cases/*.py")),
+            ("%s/tests/test_data" % datadir, glob("tests/test_data/*")),
+            ("%s/tests/test_data/V2_8_5" % datadir, glob("tests/test_data/V2_8_5/*")),
+            ("%s/tests/test_data/V3_0_0" % datadir, glob("tests/test_data/V3_0_0/*")),
+            (
+                "%s/tests/test_data/V3_0_0/settings.d" % datadir,
+                glob("tests/test_data/V3_0_0/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_0_1" % datadir, glob("tests/test_data/V3_0_1/*")),
+            (
+                "%s/tests/test_data/V3_0_1/settings.d" % datadir,
+                glob("tests/test_data/V3_0_1/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_1_0" % datadir, glob("tests/test_data/V3_1_0/*")),
+            (
+                "%s/tests/test_data/V3_1_0/settings.d" % datadir,
+                glob("tests/test_data/V3_1_0/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_1_1" % datadir, glob("tests/test_data/V3_1_1/*")),
+            (
+                "%s/tests/test_data/V3_1_1/settings.d" % datadir,
+                glob("tests/test_data/V3_1_1/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_1_2" % datadir, glob("tests/test_data/V3_1_2/*")),
+            (
+                "%s/tests/test_data/V3_1_2/settings.d" % datadir,
+                glob("tests/test_data/V3_1_2/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_2_0" % datadir, glob("tests/test_data/V3_2_0/*")),
+            (
+                "%s/tests/test_data/V3_2_0/settings.d" % datadir,
+                glob("tests/test_data/V3_2_0/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_2_1" % datadir, glob("tests/test_data/V3_2_1/*")),
+            (
+                "%s/tests/test_data/V3_2_1/settings.d" % datadir,
+                glob("tests/test_data/V3_2_1/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_3_0" % datadir, glob("tests/test_data/V3_3_0/*")),
+            (
+                "%s/tests/test_data/V3_3_0/settings.d" % datadir,
+                glob("tests/test_data/V3_3_0/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_3_1" % datadir, glob("tests/test_data/V3_3_1/*")),
+            (
+                "%s/tests/test_data/V3_3_1/settings.d" % datadir,
+                glob("tests/test_data/V3_3_1/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_3_2" % datadir, glob("tests/test_data/V3_3_2/*")),
+            (
+                "%s/tests/test_data/V3_3_2/settings.d" % datadir,
+                glob("tests/test_data/V3_3_2/settings.d/*"),
+            ),
+            ("%s/tests/test_data/V3_3_3" % datadir, glob("tests/test_data/V3_3_3/*")),
+            (
+                "%s/tests/test_data/V3_3_3/settings.d" % datadir,
+                glob("tests/test_data/V3_3_3/settings.d/*"),
+            ),
             ("%s/tests/xmlrpcapi" % datadir, glob("tests/xmlrpcapi/*.py")),
+            ("%s/tests/test_data/V3_4_0" % datadir, glob("tests/test_data/V3_4_0/*")),
+            ("%s/tests/utils" % datadir, glob("tests/utils/*.py")),
         ],
     )


### PR DESCRIPTION
## Description

This PR simply adds missing paths to `setup.py` script in order to include all implemented tests when building the Cobbler package.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
