### PR TITLE
[backport][3.3] fix: Use correct interface attributes

### DIFF
--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -86,7 +86,7 @@ class NetworkInterface:
                 new_key = key[1:].lower()
                 key_value = self.__dict__[key]
                 if isinstance(key_value, enum.Enum):
-                    result[new_key] = self.__dict__[key].name
+                    result[new_key] = self.__dict__[key].name.lower()
                 elif (
                     isinstance(key_value, str)
                     and key_value == enums.VALUE_INHERITED

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -113,10 +113,10 @@ class _IscManager(ManagerModule):
                     else:
                         ignore_macs.append(mac)
 
-                    ip = system.interfaces[interface["interface_master"]]["ip_address"]
-                    netmask = system.interfaces[interface["interface_master"]]["netmask"]
-                    dhcp_tag = system.interfaces[interface["interface_master"]]["dhcp_tag"]
-                    host = system.interfaces[interface["interface_master"]]["dns_name"]
+                    ip = system.interfaces[interface["interface_master"]].ip_address
+                    netmask = system.interfaces[interface["interface_master"]].netmask
+                    dhcp_tag = system.interfaces[interface["interface_master"]].dhcp_tag
+                    host = system.interfaces[interface["interface_master"]].dns_name
 
                     if ip is None or ip == "":
                         for (interface_name, interface_object) in list(system.interfaces.items()):
@@ -268,9 +268,9 @@ class _IscManager(ManagerModule):
                     else:
                         ignore_macs.append(mac)
 
-                    ip_v6 = system.interfaces[interface["interface_master"]]["ipv6_address"]
-                    dhcp_tag = system.interfaces[interface["interface_master"]]["dhcp_tag"]
-                    host = system.interfaces[interface["interface_master"]]["dns_name"]
+                    ip_v6 = system.interfaces[interface["interface_master"]].ipv6_address
+                    dhcp_tag = system.interfaces[interface["interface_master"]].dhcp_tag
+                    host = system.interfaces[interface["interface_master"]].dns_name
 
                     if not ip_v6:
                         for (interface_name, interface_object) in list(system.interfaces.items()):

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -795,10 +795,10 @@ class TFTPGen:
             # find the first management interface
             try:
                 for intf in list(system.interfaces.keys()):
-                    if system.interfaces[intf]["management"]:
+                    if system.interfaces[intf].management:
                         management_interface = intf
-                        if system.interfaces[intf]["mac_address"]:
-                            management_mac = system.interfaces[intf]["mac_address"]
+                        if system.interfaces[intf].mac_address:
+                            management_mac = system.interfaces[intf].mac_address
                         break
             except:
                 # just skip this then

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -208,7 +208,7 @@ def test_get_random_mac(remote, token):
                     "dns_name": "",
                     "if_gateway": "",
                     "interface_master": "",
-                    "interface_type": "NA",
+                    "interface_type": "na",
                     "ip_address": "",
                     "ipv6_address": "",
                     "ipv6_default_gateway": "",


### PR DESCRIPTION
system.interfaces is an instance of NetworkInterface. management and mac_address are attributes.

## Linked Items

Backport of #3256 