### PR TITLE
Use inst.ks.sendmac instead of deprecated kssendmac

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -867,7 +867,10 @@ class TFTPGen:
 
             if distro.breed is None or distro.breed == "redhat":
 
-                append_line += " kssendmac"
+                if distro.os_version in ["rhel5", "rhel6"]:
+                    append_line += " kssendmac"
+                else:
+                    append_line += " inst.ks.sendmac"
                 append_line = "%s inst.ks=%s" % (append_line, autoinstall_path)
                 ipxe = blended["enable_ipxe"]
                 if ipxe:


### PR DESCRIPTION
## Linked Items

Fixe: https://github.com/uyuni-project/uyuni/issues/5513

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

RHEL 7 and later introduced inst.ks.sendmac as a replacement for kssendmac option. Only use the old one for RHEL 6.

## Behaviour changes

Old: the `kssendmac` option was added for RHEL kickstart kernel options

New: the `kssendmac` option is only added for RHEL 6, other (hopefully not older than 6) RHELs will have the `inst.ks.sendmac` option.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
