### PR TITLE
Fix: allow empty string as value for "interface_type" 

### DIFF
--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -416,8 +416,6 @@ class NetworkInterface:
                     f'intf_type with number "{intf_type}" was not a valid interface type!'
                 ) from value_error
         elif isinstance(intf_type, str):
-            if not intf_type:
-                intf_type = "na"
             try:
                 intf_type = enums.NetworkInterfaceType[intf_type.upper()]
             except KeyError as key_error:

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -416,6 +416,8 @@ class NetworkInterface:
                     f'intf_type with number "{intf_type}" was not a valid interface type!'
                 ) from value_error
         elif isinstance(intf_type, str):
+            if not intf_type:
+                intf_type = "na"
             try:
                 intf_type = enums.NetworkInterfaceType[intf_type.upper()]
             except KeyError as key_error:

--- a/cobbler/settings/migrations/V3_3_0.py
+++ b/cobbler/settings/migrations/V3_3_0.py
@@ -6,14 +6,11 @@ Migration from V3.2.1 to V3.3.0
 # SPDX-FileCopyrightText: 2021 Enno Gotthold <egotthold@suse.de>
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
-import datetime
 import glob
 import ipaddress
 import json
 import os
 import socket
-
-from shutil import copytree
 
 from schema import Optional, Schema, SchemaError
 
@@ -389,18 +386,6 @@ def migrate(settings: dict) -> dict:
     return normalize(settings)
 
 
-def backup_dir(dir_path: str):
-    """
-    Copies the directory tree and adds a suffix ".backup.XXXXXXXXX" to it.
-
-    :param dir_path: The full path to the directory which should be backed up.
-    :raises FileNotFoundError: In case the path specified was not existing.
-    """
-    src = os.path.normpath(dir_path)
-    now_iso = datetime.datetime.now().isoformat()
-    copytree(dir_path, f"{src}.backup.{now_iso}")
-
-
 def migrate_cobbler_collections(collections_dir: str):
     """
     Manipulate the main Cobbler stored collections and migrate deprecated settings
@@ -408,7 +393,7 @@ def migrate_cobbler_collections(collections_dir: str):
 
     :param collections_dir: The directory of Cobbler where the collections files are.
     """
-    backup_dir(collections_dir)
+    helper.backup_dir(collections_dir)
     for collection_file in glob.glob(
         os.path.join(collections_dir, "**/*.json"), recursive=True
     ):

--- a/cobbler/settings/migrations/helper.py
+++ b/cobbler/settings/migrations/helper.py
@@ -6,6 +6,9 @@ Helper module which contains shared logic for adjusting the settings.
 # SPDX-FileCopyrightText: 2021 Enno Gotthold <egotthold@suse.de>
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
+import datetime
+import os
+from shutil import copytree
 from typing import List, Union
 
 
@@ -161,3 +164,15 @@ def key_drop_if_default(settings: dict, defaults: dict) -> dict:
             if settings[key] == defaults[key]:
                 settings.pop(key)
     return settings
+
+
+def backup_dir(dir_path: str):
+    """
+    Copies the directory tree and adds a suffix ".backup.XXXXXXXXX" to it.
+
+    :param dir_path: The full path to the directory which should be backed up.
+    :raises FileNotFoundError: In case the path specified was not existing.
+    """
+    src = os.path.normpath(dir_path)
+    now_iso = datetime.datetime.now().isoformat()
+    copytree(dir_path, f"{src}.backup.{now_iso}")

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -672,7 +672,7 @@ def test_from_dict_with_network_interface(cobbler_api):
     "value,expected_exception,expected_result",
     [
         ("foobar_not_existing", pytest.raises(ValueError), None),
-        ("", does_not_raise(), enums.NetworkInterfaceType.NA),
+        ("", pytest.raises(ValueError), None),
         ("na", does_not_raise(), enums.NetworkInterfaceType.NA),
         ("bond", does_not_raise(), enums.NetworkInterfaceType.BOND),
         ("bond_slave", does_not_raise(), enums.NetworkInterfaceType.BOND_SLAVE),

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -669,6 +669,47 @@ def test_from_dict_with_network_interface(cobbler_api):
 
 
 @pytest.mark.parametrize(
+    "value,expected_exception,expected_result",
+    [
+        ("foobar_not_existing", pytest.raises(ValueError), None),
+        ("", does_not_raise(), enums.NetworkInterfaceType.NA),
+        ("na", does_not_raise(), enums.NetworkInterfaceType.NA),
+        ("bond", does_not_raise(), enums.NetworkInterfaceType.BOND),
+        ("bond_slave", does_not_raise(), enums.NetworkInterfaceType.BOND_SLAVE),
+        ("bridge", does_not_raise(), enums.NetworkInterfaceType.BRIDGE),
+        ("bridge_slave", does_not_raise(), enums.NetworkInterfaceType.BRIDGE_SLAVE),
+        (
+            "bonded_bridge_slave",
+            does_not_raise(),
+            enums.NetworkInterfaceType.BONDED_BRIDGE_SLAVE,
+        ),
+        ("bmc", does_not_raise(), enums.NetworkInterfaceType.BMC),
+        ("infiniband", does_not_raise(), enums.NetworkInterfaceType.INFINIBAND),
+        (0, does_not_raise(), enums.NetworkInterfaceType.NA),
+        (1, does_not_raise(), enums.NetworkInterfaceType.BOND),
+        (2, does_not_raise(), enums.NetworkInterfaceType.BOND_SLAVE),
+        (3, does_not_raise(), enums.NetworkInterfaceType.BRIDGE),
+        (4, does_not_raise(), enums.NetworkInterfaceType.BRIDGE_SLAVE),
+        (5, does_not_raise(), enums.NetworkInterfaceType.BONDED_BRIDGE_SLAVE),
+        (6, does_not_raise(), enums.NetworkInterfaceType.BMC),
+        (7, does_not_raise(), enums.NetworkInterfaceType.INFINIBAND),
+    ],
+)
+def test_network_interface_type(
+    cobbler_api, value, expected_exception, expected_result
+):
+    # Arrange
+    interface = NetworkInterface(cobbler_api)
+
+    # Act
+    with expected_exception:
+        interface.interface_type = value
+
+        # Assert
+        assert interface.interface_type == expected_result
+
+
+@pytest.mark.parametrize(
     "input_mac,input_ipv4,input_ipv6,expected_result",
     [
         ("AA:BB:CC:DD:EE:FF", "192.168.1.2", "::1", True),


### PR DESCRIPTION
## Description

This PR fixes a small regression apparentely introduced during the refactor of `NetworkInterface` class, which made it to not longer accept empty string as input value for `interface_type` property.

In previous versions, an empty string value was explicitely accepted and considered as `na` internally. Now it raises an exception:

```console
cobbler.cexceptions.CX: "serializer: error loading collection system: intf_type choices include: ['NetworkInterfaceType.NA', 'NetworkInterfaceType.BOND', 'NetworkInterfaceType.BOND_SLAVE', 'NetworkInterfaceType.BRIDGE', 'NetworkInterfaceType.BRIDGE_SLAVE', 'NetworkInterfaceType.BONDED_BRIDGE_SLAVE', 'NetworkInterfaceType.BMC', 'NetworkInterfaceType.INFINIBAND']. Check /etc/cobbler/modules.conf"
```

There was no migration implemeted for `interface_type` value of collections, so I simply keep allowing empty string as input for `NetworkInterfaceType`.

## Behaviour changes

Old: Cobbler was not able to start as there was stored collections with `interface_type` being empty string.

New: Cobbler is able to process the empty string for `interface_type`, making it to successfully start.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

