### PR TITLE
Module-Loader: Fix bug from pylint refactoring

### DIFF
--- a/cobbler/module_loader.py
+++ b/cobbler/module_loader.py
@@ -63,7 +63,7 @@ class ModuleLoader:
             basename = filename.replace(self.mod_path, "")
             modname = ""
 
-            if basename in ("__pycache__", "__init__.py"):
+            if "__pycache__" in basename or "__init__.py" in basename:
                 continue
 
             if basename[0] == "/":


### PR DESCRIPTION
## Linked Items

Fixes #3291

## Description

Invert the if condition that was inverted in https://github.com/cobbler/cobbler/commit/2477c78094af7ba44ecbe350294c775296d96560

## Behaviour changes

Old: Modules don't load properly

New: Modules load properly

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
