### PR TITLE
Avoid possible override of existing values during migration of collections to 3.3.0

### DIFF
--- a/cobbler/settings/migrations/V3_0_0.py
+++ b/cobbler/settings/migrations/V3_0_0.py
@@ -246,9 +246,7 @@ def migrate(settings: dict) -> dict:
 
         filename += ".json"
         with open(filename, "w", encoding="UTF-8") as item_fd:
-            data = json.dumps(
-                item, encoding="utf-8", sort_keys=sort_keys, indent=indent
-            )
+            data = json.dumps(item, sort_keys=sort_keys, indent=indent)
             item_fd.write(data)
 
     def deserialize_raw_old(collection_types):
@@ -258,7 +256,7 @@ def migrate(settings: dict) -> dict:
         for file in all_files:
             with open(file, encoding="UTF-8") as item_fd:
                 json_data = item_fd.read()
-                _dict = json.loads(json_data, encoding="utf-8")
+                _dict = json.loads(json_data)
                 results.append(_dict)
         return results
 

--- a/cobbler/settings/migrations/V3_0_0.py
+++ b/cobbler/settings/migrations/V3_0_0.py
@@ -343,7 +343,10 @@ def migrate(settings: dict) -> dict:
                 new_item[key] = transform_key(key, old_item[key])
 
             if new_type in add:
-                new_item.update(add[new_type])
+                # We only add items if they don't exist
+                for item in add[new_type]:
+                    if item not in new_item:
+                        new_item[item] = add[new_type][item]
 
             serialize_item(new_type, new_item)
 

--- a/cobbler/settings/migrations/V3_3_0.py
+++ b/cobbler/settings/migrations/V3_3_0.py
@@ -406,9 +406,11 @@ def migrate_cobbler_collections(collections_dir: str):
             if data[key] is None:
                 data[key] = ""
 
-        # boot_loader -> boot_loaders
-        if "boot_loader" in data:
+        # boot_loader -> boot_loaders (preserving possible existing value)
+        if "boot_loader" in data and "boot_loaders" not in data:
             data["boot_loaders"] = data.pop("boot_loader")
+        elif "boot_loader" in data:
+            data.pop("boot_loader")
 
         # next_server -> next_server_v4, next_server_v6
         if "next_server" in data:

--- a/system-tests/tests/settings-cli-migrate-from-2.8.5
+++ b/system-tests/tests/settings-cli-migrate-from-2.8.5
@@ -1,0 +1,514 @@
+#!/bin/bash
+# Check that cobbler-settings can migrate the YAML file from one version to the next one
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+OLD_CONFIG="${tmp}/settings-old.yaml"
+NEW_CONFIG="${tmp}/settings-new.yaml"
+NEW_VERSION="3.3.0"
+
+# Test migration from old 2.8.5 to 3.3.0
+cat <<-END >$OLD_CONFIG
+---
+# cobbler settings file
+# restart cobblerd and run "cobbler sync" after making changes
+# This config file is in YAML 1.0 format
+# see http://yaml.org
+# ==========================================================
+# if 1, cobbler will allow insertions of system records that duplicate
+# the --dns-name information of other system records.  In general,
+# this is undesirable and should be left 0.
+allow_duplicate_hostnames: 0
+
+# if 1, cobbler will allow insertions of system records that duplicate
+# the ip address information of other system records.  In general,
+# this is undesirable and should be left 0.
+allow_duplicate_ips: 0
+
+# if 1, cobbler will allow insertions of system records that duplicate
+# the mac address information of other system records.  In general,
+# this is undesirable.
+allow_duplicate_macs: 0
+
+# if 1, cobbler will allow settings to be changed dynamically without
+# a restart of the cobblerd daemon. You can only change this variable
+# by manually editing the settings file, and you MUST restart cobblerd
+# after changing it.
+allow_dynamic_settings: 0
+
+# by default, installs are *not* set to send installation logs to the cobbler
+# # # server.  With 'anamon_enabled', kickstart templates may use the pre_anamon
+# # # snippet to allow remote live monitoring of their installations from the
+# # # cobbler server.  Installation logs will be stored under
+# # # /var/log/cobbler/anamon/.  NOTE: This does allow an xmlrpc call to send logs
+# # # to this directory, without authentication, so enable only if you are
+# # # ok with this limitation.
+anamon_enabled: 0
+
+# If using authn_pam in the modules.conf, this can be configured
+# to change the PAM service authentication will be tested against.
+# The default value is "login".
+authn_pam_service: "login"
+
+# How long the authentication token is valid for, in seconds
+auth_token_expiration: 3600
+
+# Email out a report when cobbler finishes installing a system.
+# enabled: set to 1 to turn this feature on
+# sender: optional
+# email: which addresses to email
+# smtp_server: used to specify another server for an MTA
+# subject: use the default subject unless overridden
+build_reporting_enabled: 0
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: [ "" ]
+
+# Cheetah-language kickstart templates can import Python modules.
+# while this is a useful feature, it is not safe to allow them to
+# import anything they want. This whitelists which modules can be
+# imported through Cheetah.  Users can expand this as needed but
+# should never allow modules such as subprocess or those that
+# allow access to the filesystem as Cheetah templates are evaluated
+# by cobblerd as code.
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+
+# Default createrepo_flags to use for new repositories. If you have
+# createrepo >= 0.4.10, consider "-c cache --update -C", which can
+# dramatically improve your "cobbler reposync" time.  "-s sha"
+# enables working with Fedora repos from F11/F12 from EL-4 or
+# EL-5 without python-hashlib installed (which is not available
+# on EL-4)
+createrepo_flags: "-c cache -s sha"
+
+# if no kickstart is specified to profile add, use this template
+default_kickstart: /var/lib/cobbler/kickstarts/default.ks
+
+# configure all installed systems to use these nameservers by default
+# unless defined differently in the profile.  For DHCP configurations
+# you probably do /not/ want to supply this.
+default_name_servers: []
+
+# if using the authz_ownership module (see the Wiki), objects
+# created without specifying an owner are assigned to this
+# owner and/or group.  Can be a comma seperated list.
+default_ownership:
+ - "admin"
+
+# cobbler has various sample kickstart templates stored
+# in /var/lib/cobbler/kickstarts/.  This controls
+# what install (root) password is set up for those
+# systems that reference this variable.  The factory
+# default is "cobbler" and cobbler check will warn if
+# this is not changed.
+# The simplest way to change the password is to run
+# openssl passwd -1
+# and put the output between the "" below.
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+
+# the default template type to use in the absence of any
+# other detected template. If you do not specify the template
+# with '#template=<template_type>' on the first line of your
+# templates/snippets, cobbler will assume try to use the
+# following template engine to parse the templates.
+#
+# Current valid values are: cheetah, jinja2
+default_template_type: "cheetah"
+
+# for libvirt based installs in koan, if no virt bridge
+# is specified, which bridge do we try?  For EL 4/5 hosts
+# this should be xenbr0, for all versions of Fedora, try
+# "virbr0".  This can be overriden on a per-profile
+# basis or at the koan command line though this saves
+# typing to just set it here to the most common option.
+default_virt_bridge: xenbr0
+
+# use this as the default disk size for virt guests (GB)
+default_virt_file_size: 5
+
+# use this as the default memory size for virt guests (MB)
+default_virt_ram: 512
+
+# if koan is invoked without --virt-type and no virt-type
+# is set on the profile/system, what virtualization type
+# should be assumed?  Values: xenpv, xenfv, qemu, vmware
+# (NOTE: this does not change what virt_type is chosen by import)
+default_virt_type: xenpv
+
+# enable gPXE booting? Enabling this option will cause cobbler
+# to copy the undionly.kpxe file to the tftp root directory,
+# and if a profile/system is configured to boot via gpxe it will
+# chain load off pxelinux.0.
+# Default: 0
+enable_gpxe: 0
+
+# controls whether cobbler will add each new profile entry to the default
+# PXE boot menu.  This can be over-ridden on a per-profile
+# basis when adding/editing profiles with --enable-menu=0/1.  Users
+# should ordinarily leave this setting enabled unless they are concerned
+# with accidental reinstalls from users who select an entry at the PXE
+# boot menu.  Adding a password to the boot menus templates
+# may also be a good solution to prevent unwanted reinstallations
+enable_menu: 1
+
+# enable Func-integration?  This makes sure each installed machine is set up
+# to use func out of the box, which is a powerful way to script and control
+# remote machines.
+# Func lives at http://fedorahosted.org/func
+# read more at https://github.com/cobbler/cobbler/wiki/Func-integration
+# you will need to mirror Fedora/EPEL packages for this feature, so see
+# https://github.com/cobbler/cobbler/wiki/Manage-yum-repos if you want cobbler
+# to help you with this
+func_auto_setup: 0
+func_master: overlord.example.org
+
+# change this port if Apache is not running plaintext on port
+# 80.  Most people can leave this alone.
+http_port: 80
+
+# kernel options that should be present in every cobbler installation.
+# kernel options can also be applied at the distro/profile/system
+# level.
+kernel_options:
+ ksdevice: bootif
+ lang: ' '
+ text: ~
+
+# s390 systems require additional kernel options in addition to the
+# above defaults
+kernel_options_s390x:
+ RUNKS: 1
+ ramdisk_size: 40000
+ root: /dev/ram0
+ ro: ~
+ ip: off
+ vnc: ~
+
+# configuration options if using the authn_ldap module. See the
+# the Wiki for details.  This can be ignored if you are not using
+# LDAP for WebUI/XMLRPC authentication.
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: 1
+ldap_anonymous_bind: 1
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+
+# cobbler has a feature that allows for integration with config management
+# systems such as Puppet.  The following parameters work in conjunction with
+# --mgmt-classes  and are described in furhter detail at:
+# https://github.com/cobbler/cobbler/wiki/Using-cobbler-with-a-configuration-management-system
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: 1
+
+# if enabled, this setting ensures that puppet is installed during
+# machine provision, a client certificate is generated and a
+# certificate signing request is made with the puppet master server
+puppet_auto_setup: 0
+
+# when puppet starts on a system after installation it needs to have
+# its certificate signed by the puppet master server. Enabling the
+# following feature will ensure that the puppet server signs the
+# certificate after installation if the puppet master server is
+# running on the same machine as cobbler. This requires
+# puppet_auto_setup above to be enabled
+sign_puppet_certs_automatically: 0
+
+# location of the puppet executable, used for revoking certificates
+puppetca_path: "/usr/bin/puppet"
+
+# when a puppet managed machine is reinstalled it is necessary to
+# remove the puppet certificate from the puppet master server before a
+# new certificate is signed (see above). Enabling the following
+# feature will ensure that the certificate for the machine to be
+# installed is removed from the puppet master server if the puppet
+# master server is running on the same machine as cobbler. This
+# requires puppet_auto_setup above to be enabled
+remove_old_puppet_certs_automatically: 0
+
+# choose a --server argument when running puppetd/puppet agent during kickstart
+#puppet_server: 'puppet'
+
+# let cobbler know that you're using a newer version of puppet
+# choose version 3 to use: 'puppet agent'; version 2 uses status quo: 'puppetd'
+#puppet_version: 2
+
+# choose whether to enable puppet parameterized classes or not.
+# puppet versions prior to 2.6.5 do not support parameters
+#puppet_parameterized_classes: 1
+
+# set to 1 to enable Cobbler's DHCP management features.
+# the choice of DHCP management engine is in /etc/cobbler/modules.conf
+manage_dhcp: 0
+
+# set to 1 to enable Cobbler's DNS management features.
+# the choice of DNS mangement engine is in /etc/cobbler/modules.conf
+manage_dns: 0
+
+# set to path of bind chroot to create bind-chroot compatible bind
+# configuration files.  This should be automatically detected.
+bind_chroot_path: ""
+
+# set to the ip address of the master bind DNS server for creating secondary
+# bind configuration files
+bind_master: 127.0.0.1
+
+# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
+manage_genders: 0
+
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind is set.
+bind_manage_ipmi: 0
+
+# set to 1 to enable Cobbler's TFTP management features.
+# the choice of TFTP mangement engine is in /etc/cobbler/modules.conf
+manage_tftpd: 1
+
+# set to 1 to enable Cobbler's RSYNC management features.
+manage_rsync: 0
+
+# if using BIND (named) for DNS management in /etc/cobbler/modules.conf
+# and manage_dns is enabled (above), this lists which zones are managed
+# See the Wiki (https://github.com/cobbler/cobbler/wiki/Dns-management) for more info
+manage_forward_zones: []
+manage_reverse_zones: []
+
+# if using cobbler with manage_dhcp, put the IP address
+# of the cobbler server here so that PXE booting guests can find it
+# if you do not set this correctly, this will be manifested in TFTP open timeouts.
+next_server: 127.0.0.1
+
+# settings for power management features.  optional.
+# see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
+# choices (refer to codes.py):
+#    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
+#    ipmilan ipmitool lpar rsa virsh wti
+power_management_default_type: 'ipmitool'
+
+# the commands used by the power management module are sourced
+# from what directory?
+power_template_dir: "/etc/cobbler/power"
+
+# if this setting is set to 1, cobbler systems that pxe boot
+# will request at the end of their installation to toggle the
+# --netboot-enabled record in the cobbler system record.  This eliminates
+# the potential for a PXE boot loop if the system is set to PXE
+# first in it's BIOS order.  Enable this if PXE is first in your BIOS
+# boot order, otherwise leave this disabled.   See the manpage
+# for --netboot-enabled.
+pxe_just_once: 0
+
+# the templates used for PXE config generation are sourced
+# from what directory?
+pxe_template_dir: "/etc/cobbler/pxe"
+
+# Path to where system consoles are
+consoles: "/var/consoles"
+
+# Are you using a Red Hat management platform in addition to Cobbler?
+# Cobbler can help you register to it.  Choose one of the following:
+#   "off"    : I'm not using Red Hat Network, Satellite, or Spacewalk
+#   "hosted" : I'm using Red Hat Network
+#   "site"   : I'm using Red Hat Satellite Server or Spacewalk
+# You will also want to read: https://github.com/cobbler/cobbler/wiki/Tips-for-RHN
+redhat_management_type: "off"
+
+# if redhat_management_type is enabled, choose your server
+#   "management.example.org" : For Satellite or Spacewalk
+#   "xmlrpc.rhn.redhat.com"  : For Red Hat Network
+# This setting is also used by the code that supports using Spacewalk/Satellite users/passwords
+# within Cobbler Web and Cobbler XMLRPC.  Using RHN Hosted for this is not supported.
+# This feature can be used even if redhat_management_type is off, you just have
+# to have authn_spacewalk selected in modules.conf
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+
+# specify the default Red Hat authorization key to use to register
+# system.  If left blank, no registration will be attempted.  Similarly
+# you can set the --redhat-management-key to blank on any system to
+# keep it from trying to register.
+redhat_management_key: ""
+
+# if using authn_spacewalk in modules.conf to let cobbler authenticate
+# against Satellite/Spacewalk's auth system, by default it will not allow per user
+# access into Cobbler Web and Cobbler XMLRPC.
+# in order to permit this, the following setting must be enabled HOWEVER
+# doing so will permit all Spacewalk/Satellite users of certain types to edit all
+# of cobbler's configuration.
+# these roles are:  config_admin and org_admin
+# users should turn this on only if they want this behavior and
+# do not have a cross-multi-org seperation concern.  If you have
+# a single org in your satellite, it's probably safe to turn this
+# on and then you can use CobblerWeb alongside a Satellite install.
+redhat_management_permissive: 0
+
+# if set to 1, allows /usr/bin/cobbler-register (part of the koan package)
+# to be used to remotely add new cobbler system records to cobbler.
+# this effectively allows for registration of new hardware from system
+# records.
+register_new_installs: 0
+
+# Flags to use for yum's reposync.  If your version of yum reposync
+# does not support -l, you may need to remove that option.
+reposync_flags: "-l -n -d"
+
+# when DHCP and DNS management are enabled, cobbler sync can automatically
+# restart those services to apply changes.  The exception for this is
+# if using ISC for DHCP, then omapi eliminates the need for a restart.
+# omapi, however, is experimental and not recommended for most configurations.
+# If DHCP and DNS are going to be managed, but hosted on a box that
+# is not on this server, disable restarts here and write some other
+# script to ensure that the config files get copied/rsynced to the destination
+# box.  This can be done by modifying the restart services trigger.
+# Note that if manage_dhcp and manage_dns are disabled, the respective
+# parameter will have no effect.  Most users should not need to change
+# this.
+restart_dns: 1
+restart_dhcp: 1
+
+# install triggers are scripts in /var/lib/cobbler/triggers/install
+# that are triggered in kickstart pre and post sections.  Any
+# executable script in those directories is run.  They can be used
+# to send email or perform other actions.  They are currently
+# run as root so if you do not need this functionality you can
+# disable it, though this will also disable "cobbler status" which
+# uses a logging trigger to audit install progress.
+run_install_triggers: 1
+
+# enables a trigger which version controls all changes to /var/lib/cobbler
+# when add, edit, or sync events are performed.  This can be used
+# to revert to previous database versions, generate RSS feeds, or for
+# other auditing or backup purposes. "git" and "hg" are currently suported,
+# but git is the recommend SCM for use with this feature.
+scm_track_enabled: 0
+scm_track_mode: "git"
+
+# this is the address of the cobbler server -- as it is used
+# by systems during the install process, it must be the address
+# or hostname of the system as those systems can see the server.
+# if you have a server that appears differently to different subnets
+# (dual homed, etc), you need to read the --server-override section
+# of the manpage for how that works.
+server: 127.0.0.1
+
+# If set to 1, all commands will be forced to use the localhost address
+# instead of using the above value which can force commands like
+# cobbler sync to open a connection to a remote address if one is in the
+# configuration and would traceback.
+client_use_localhost: 0
+
+# If set to 1, all commands to the API (not directly to the XMLRPC
+# server) will go over HTTPS instead of plaintext. Be sure to change
+# the http_port setting to the correct value for the web server
+client_use_https: 0
+
+# this is a directory of files that cobbler uses to make
+# templating easier.  See the Wiki for more information.  Changing
+# this directory should not be required.
+snippetsdir: /var/lib/cobbler/snippets
+
+# Normally if a kickstart is specified at a remote location, this
+# URL will be passed directly to the kickstarting system, thus bypassing
+# the usual snippet templating Cobbler does for local kickstart files. If
+# this option is enabled, Cobbler will fetch the file contents internally
+# and serve a templated version of the file to the client.
+template_remote_kickstarts: 0
+
+# should new profiles for virtual machines default to auto booting with the physical host when the physical host reboots?
+# this can be overridden on each profile or system object.
+virt_auto_boot: 1
+
+# cobbler's web directory.  Don't change this setting -- see the
+# Wiki on "relocating your cobbler install" if your /var partition
+# is not large enough.
+webdir: "@@webroot@@/cobbler"
+
+# cobbler's public XMLRPC listens on this port.  Change this only
+# if absolutely needed, as you'll have to start supplying a new
+# port option to koan if it is not the default.
+xmlrpc_port: 25151
+
+# "cobbler repo add" commands set cobbler up with repository
+# information that can be used during kickstart and is automatically
+# set up in the cobbler kickstart templates.  By default, these
+# are only available at install time.  To make these repositories
+# usable on installed systems (since cobbler makes a very convient)
+# mirror, set this to 1.  Most users can safely set this to 1.  Users
+# who have a dual homed cobbler server, or are installing laptops that
+# will not always have access to the cobbler server may wish to leave
+# this as 0.  In that case, the cobbler mirrored yum repos are still
+# accessable at http://cobbler.example.org/cblr/repo_mirror and yum
+# configuration can still be done manually.  This is just a shortcut.
+yum_post_install_mirror: 1
+
+# the default yum priority for all the distros.  This is only used
+# if yum-priorities plugin is used.  1=maximum.  Tweak with caution.
+yum_distro_priority: 1
+
+# Flags to use for yumdownloader.  Not all versions may support
+# --resolve.
+yumdownloader_flags: "--resolve"
+
+# sort and indent JSON output to make it more human-readable
+serializer_pretty_json: 0
+
+# replication rsync options for distros, kickstarts, snippets set to override default value of "-avzH"
+replicate_rsync_options: "-avzH"
+
+# replication rsync options for repos set to override default value of "-avzH"
+replicate_repo_rsync_options: "-avzH"
+
+# always write DHCP entries, regardless if netboot is enabled
+always_write_dhcp_entries: 0
+
+# external proxy - used by: get-loaders, reposync, signature update
+# eg: proxy_url_ext: "http://192.168.1.1:8080"
+proxy_url_ext: ""
+
+# internal proxy - used by systems to reach cobbler for kickstarts
+# eg: proxy_url_int: "http://10.0.0.1:8080"
+proxy_url_int: ""
+END
+
+##### Act
+# Create new distro
+cobbler distro add --name fake --arch x86_64 --kernel ${fake_kernel} \
+        --initrd ${fake_initramfs} --boot-loaders "<<inherit>>"
+
+# Move collections to old "config" place to be processed during migration
+rm -rf /var/lib/cobbler/config/
+cp -r /var/lib/cobbler/collections/ /var/lib/cobbler/config/
+mv /var/lib/cobbler/config/distros /var/lib/cobbler/config/distros.d
+
+# Fake the current installed version
+cp /etc/cobbler/version /etc/cobbler/version.bak
+sed -i s'/version = .*/version = 3.3.0/g' /etc/cobbler/version
+touch /etc/cobbler/modules.conf
+
+# Perform the migration of collections
+cobbler-settings -c "$OLD_CONFIG" migrate -t "$NEW_CONFIG" --new "$NEW_VERSION"
+
+# Remove faked Cobbler version
+cp /etc/cobbler/version.bak /etc/cobbler/version
+
+# Restart cobblerd after migration to reload migrated collections
+srvctl restart cobblerd
+
+# Assert - Boot loaders should be preserved after migration.
+cobbler distro report --name fake | grep "Boot loaders" | grep "<<inherit>>"
+
+# Cleanup
+cobbler distro remove --name fake
+rm -rf /var/lib/cobbler/config/


### PR DESCRIPTION
## Description

This PR fixes an issue found when running the migration of collections from 2.8.5 to 3.3.0. This can lead into profiles not being available in PXE menu after the migration.

The mechanism for adding predefined new items to collections (or renaming them) is not taking into consideration that those items may be existing already and may have different values than the default ones to add.

We have detected this happening in distros where `boot_loaders` attribute was already existing because of any reason (i.a. retriggering the migration), where `boot_loaders` is set to `<<inherit>>`, then after the migration runs the `boot_loaders` will end up wrongly with default value "grub", instead of preserving the existing value. This makes then profiles for this distro to not being available in the generated PXE menus.

## Behaviour changes

Old:

Given a collection with `boot_loaders: <<inherit>>`, after the migration is done for this collection, value would be `boot_loaders: ['grub']` -> profiles are not shown in the PXE menu

New:

Given a collection with `boot_loaders: <<inherit>>`, after the migration is done for this collection, the value will be preserved -> profiles are still shown in the PXE menu.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
