### PR TITLE
Logrotate: Fix size syntax

### DIFF
--- a/config/rotate/cobblerd_rotate
+++ b/config/rotate/cobblerd_rotate
@@ -2,12 +2,11 @@
    compress
    dateext
    maxage 14
-   rotate 99
-   size=+4096k
+   minsize 4M
    missingok
    notifempty
-   rotate 4
-   weekly
+   rotate 9
+   daily
    create 644 root root
    postrotate
       /usr/bin/systemctl try-reload-or-restart cobblerd


### PR DESCRIPTION
## Linked Items

Fixes #3298

## Description

This commit also removes the exclusive or between size and rotation time (before weekly). The new behaviour is that the log file will be rotated daily if it is more significant than 4 MB.

Lastly, this commit changes the default logs that are kept to 9 (to have a single-digit suffix).

## Behaviour changes

Old: The logfile is growing infinitely during the time of a week.

New: The logfile is rotated daily IF it exceeds 4 MB.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 