### PR TITLE
Item: to_dict cache

### DIFF
--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -1,4 +1,4 @@
-name: Testing Cobbler
+name: Performance testing
 
 on:
   push:
@@ -7,7 +7,7 @@ on:
     branches: [ main, release* ]
 
 jobs:
-  run_tests:
+  run_performance_tests:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -19,9 +19,9 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           docker exec -u 0 -it cobbler bash -c "./docker/develop/scripts/setup-supervisor.sh"
-      - name: Run the Tests inside the Docker Container
+      - name: Run the Performance Tests inside the Docker Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-skip && git config --global --add safe.directory /code && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"
+          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-only --benchmark-autosave tests/performance"
       - name: Stop and remove the container
         run: docker stop cobbler && docker rm cobbler

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -99,7 +99,7 @@ class Collection:
             "Please implement this in a child class of this class."
         )
 
-    def get(self, name: str):
+    def get(self, name: str) -> Optional[item_base.Item]:
         """
         Return object with name in the collection
 
@@ -282,23 +282,26 @@ class Collection:
             self.collection_mgr.serialize_one_item(ref)
             self.listing[newname] = ref
 
-        # for mgmt classes, update all objects that use it
-        if ref.COLLECTION_TYPE == "mgmtclass":
-            for what in ["distro", "profile", "system"]:
-                items = self.api.find_items(what, {"mgmt_classes": oldname})
-                for item in items:
-                    for i in range(0, len(item.mgmt_classes)):
-                        if item.mgmt_classes[i] == oldname:
-                            item.mgmt_classes[i] = newname
-                    self.api.add_item(what, item, save=True)
-
-        # for menus, update all objects that use it
-        if ref.COLLECTION_TYPE == "menu":
-            for what in ["profile", "image"]:
-                items = self.api.find_items(what, {"menu": oldname})
-                for item in items:
-                    item.menu = newname
-                    self.api.add_item(what, item, save=True)
+        for dep_type in item_base.Item.TYPE_DEPENDENCIES[ref.COLLECTION_TYPE]:
+            items = self.api.find_items(dep_type[0], {dep_type[1]: oldname})
+            for item in items:
+                attr = getattr(item, "_" + dep_type[1])
+                if isinstance(attr, (str, item_base.Item)):
+                    setattr(item, dep_type[1], newname)
+                elif isinstance(attr, list):
+                    for i, attr_val in enumerate(attr):
+                        if attr_val == oldname:
+                            attr[i] = newname
+                else:
+                    raise CX(
+                        f'Internal error, unknown attribute type {type(attr)} for "{item.name}"!'
+                    )
+                self.api.get_items(item.COLLECTION_TYPE).add(
+                    item,
+                    save=True,
+                    with_sync=with_sync,
+                    with_triggers=with_triggers,
+                )
 
         # for a repo, rename the mirror directory
         if ref.COLLECTION_TYPE == "repo":
@@ -332,40 +335,6 @@ class Collection:
                         distro_obj.kernel = distro_obj.kernel.replace(path, newpath)
                         distro_obj.initrd = distro_obj.initrd.replace(path, newpath)
                         self.collection_mgr.serialize_one_item(distro_obj)
-
-        if ref.COLLECTION_TYPE in ("profile", "system"):
-            if ref.parent is not None:
-                ref.parent.children.remove(oldname)
-
-        # Now descend to any direct ancestors and point them at the new object allowing the original object to be
-        # removed without orphanage. Direct ancestors will either be profiles or systems. Note that we do have to
-        # care as setting the parent is only really meaningful for subprofiles. We ideally want a more generic parent
-        # setter.
-        kids = ref.get_children()
-        for k in kids:
-            if self.api.find_profile(name=k) is not None:
-                k = self.api.find_profile(name=k)
-                if ref.COLLECTION_TYPE == "distro":
-                    k.distro = newname
-                else:
-                    k.parent = newname
-                self.api.profiles().add(
-                    k, save=True, with_sync=with_sync, with_triggers=with_triggers
-                )
-            elif self.api.find_menu(name=k) is not None:
-                k = self.api.find_menu(name=k)
-                k.parent = newname
-                self.api.menus().add(
-                    k, save=True, with_sync=with_sync, with_triggers=with_triggers
-                )
-            elif self.api.find_system(name=k) is not None:
-                k = self.api.find_system(name=k)
-                k.profile = newname
-                self.api.systems().add(
-                    k, save=True, with_sync=with_sync, with_triggers=with_triggers
-                )
-            else:
-                raise CX(f'Internal error, unknown child type for child "{k}"!')
 
     def add(
         self,
@@ -440,13 +409,6 @@ class Collection:
         with self.lock:
             self.listing[ref.name] = ref
 
-        # update children cache in parent object in case it is not in there already
-        if ref.parent and ref.name not in ref.parent.children:
-            ref.parent.children.append(ref.name)
-            self.logger.debug(
-                'Added child "%s" to parent "%s"', ref.name, ref.parent.name
-            )
-
         # perform filesystem operations
         if save:
             # Save just this item if possible, if not, save the whole collection
@@ -465,8 +427,15 @@ class Collection:
                     # we don't need openvz containers to be network bootable
                     if ref.virt_type == "openvz":
                         ref.enable_menu = False
-                    self.lite_sync.add_single_profile(ref.name)
-                    self.api.sync_systems(systems=ref.get_children())
+                    self.lite_sync.add_single_profile(ref)
+                    self.api.sync_systems(
+                        systems=self.find(
+                            "system",
+                            return_list=True,
+                            no_errors=False,
+                            **{"profile": ref.name},
+                        )
+                    )
                 elif isinstance(ref, distro.Distro):
                     self.lite_sync.add_single_distro(ref.name)
                 elif isinstance(ref, image.Image):

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -64,7 +64,7 @@ class Distros(collection.Collection):
 
         kernel = obj.kernel
         if recursive:
-            kids = obj.get_children()
+            kids = self.api.find_items("profile", {"distro": obj.name})
             for k in kids:
                 self.api.remove_profile(
                     k,

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -59,7 +59,7 @@ class Images(collection.Collection):
                     raise CX(f"removal would orphan system: {system.name}")
 
         if recursive:
-            kids = obj.get_children()
+            kids = self.api.find_items("system", {"image": obj.name})
             for k in kids:
                 self.api.remove_system(k, recursive=True)
 

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Union, Dict, Any
 from cobbler.cexceptions import CX
 from cobbler import serializer
 from cobbler import validate
+from cobbler.settings import Settings
 from cobbler.cobbler_collections.distros import Distros
 from cobbler.cobbler_collections.files import Files
 from cobbler.cobbler_collections.images import Images
@@ -184,6 +185,8 @@ class CollectionManager:
 
         :raises CX: if there is an error in deserialization
         """
+        old_cache_enabled = self.api.settings().cache_enabled
+        self.api.settings().cache_enabled = False
         for collection in (
             self._menus,
             self._distros,
@@ -202,11 +205,21 @@ class CollectionManager:
                     f"serializer: error loading collection {collection.collection_type()}: {error}."
                     f"Check your settings!"
                 ) from error
+        self.api.settings().cache_enabled = old_cache_enabled
 
     def get_items(
         self, collection_type: str
     ) -> Union[
-        Distros, Profiles, Systems, Repos, Images, Mgmtclasses, Packages, Files, Menus
+        Distros,
+        Profiles,
+        Systems,
+        Repos,
+        Images,
+        Mgmtclasses,
+        Packages,
+        Files,
+        Menus,
+        Settings,
     ]:
         """
         Get a full collection of a single type.
@@ -228,6 +241,7 @@ class CollectionManager:
             Packages,
             Files,
             Menus,
+            Settings,
         ]
         if validate.validate_obj_type(collection_type) and hasattr(
             self, f"_{collection_type}s"

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -65,12 +65,6 @@ class Systems(collection.Collection):
                 lite_sync = self.api.get_sync()
                 lite_sync.remove_single_system(name)
 
-        if obj.parent is not None and obj.name in obj.parent.children:
-            obj.parent.children.remove(obj.name)
-            # ToDo: Only serialize parent object, use:
-            #       Use self.collection_mgr.serialize_one_item(obj.parent)
-            self.api.serialize()
-
         with self.lock:
             del self.listing[name]
         self.collection_mgr.serialize_delete(self, obj)

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -37,6 +37,9 @@ class Distro(item.Item):
         :param kwargs: Place for extra parameters in this distro object.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._tree_build_time = 0.0
         self._arch = enums.Archs.X86_64
         self._boot_loaders: Union[list, str] = enums.VALUE_INHERITED
@@ -53,6 +56,8 @@ class Distro(item.Item):
         self._remote_boot_initrd = ""
         self._remote_grub_initrd = ""
         self._supported_boot_loaders: List[str] = []
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name):
         if name == "ks_meta":
@@ -481,25 +486,6 @@ class Distro(item.Item):
                 "Field redhat_management_key of object distro needs to be of type str!"
             )
         self._redhat_management_key = management_key
-
-    @property
-    def children(self) -> list:
-        """
-        This property represents all children of a distribution. It should not be set manually.
-
-        :getter: The children of the distro.
-        :setter: No validation is done because this is a Cobbler internal property.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: list):
-        """
-        Setter for the children property.
-
-        :param value: The new children of the distro.
-        """
-        self._children = value
 
     def find_distro_path(self):
         """

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -31,7 +31,12 @@ class File(resource.Resource):
         :param kwargs: The keyword arguments which should be passed additionally to a Resource.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._is_dir = False
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -36,6 +36,9 @@ class Image(item.Item):
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._arch = enums.Archs.X86_64
         self._autoinstall = enums.VALUE_INHERITED
         self._breed = ""
@@ -55,6 +58,9 @@ class Image(item.Item):
         self._virt_path = ""
         self._virt_ram: Union[str, int] = enums.VALUE_INHERITED
         self._virt_type: Union[str, enums.VirtType] = enums.VirtType.INHERITED
+        self._supported_boot_loaders = []
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name: str):
         if name == "kickstart":
@@ -573,22 +579,3 @@ class Image(item.Item):
             self._boot_loaders = boot_loaders_split
         else:
             self._boot_loaders = []
-
-    @property
-    def children(self) -> list:
-        """
-        This property represents all children of an image. It should not be set manually.
-
-        :getter: The children of the image.
-        :setter: No validation is done because this is a Cobbler internal property.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: list):
-        """
-        Setter for the children property.
-
-        :param value: The new children of the distro.
-        """
-        self._children = value

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -17,6 +17,7 @@ class Menu(item.Item):
     A Cobbler menu object.
     """
 
+    TYPE_NAME = "menu"
     COLLECTION_TYPE = "menu"
 
     def __init__(self, api, *args, **kwargs):
@@ -24,7 +25,12 @@ class Menu(item.Item):
         Constructor
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._display_name = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)
@@ -50,83 +56,6 @@ class Menu(item.Item):
         """
         self._remove_depreacted_dict_keys(dictionary)
         super().from_dict(dictionary)
-
-    @property
-    def parent(self) -> Optional["Menu"]:
-        """
-        Parent menu of a menu instance.
-
-        :getter: The menu object or None.
-        :setter: Sets the parent.
-        """
-        if not self._parent:
-            return None
-        return self.api.menus().find(name=self._parent)
-
-    @parent.setter
-    def parent(self, value: str):
-        """
-        Setter for the parent menu of a menu.
-
-        :param value: The name of the parent to set.
-        :raises CX: Raised in case of self parenting or if the menu with value ``value`` is not found.
-        """
-        if not isinstance(value, str):
-            raise TypeError('Property "parent" must be of type str!')
-        old_parent = self._parent
-        if isinstance(old_parent, Menu):
-            old_parent.children.remove(self.name)
-        if not value:
-            self._parent = ""
-            return
-        if value == self.name:
-            # check must be done in two places as the parent setter could be called before/after setting the name...
-            raise CX("self parentage is weird")
-        found = self.api.menus().find(name=value)
-        if found is None:
-            raise CX(f"menu {value} not found")
-        self._parent = value
-        self.depth = found.depth + 1
-        new_parent = self._parent
-        if isinstance(new_parent, Menu) and self.name not in new_parent.children:
-            new_parent.children.append(self.name)
-
-    @property
-    def children(self) -> List[str]:
-        """
-        Child menu of a menu instance.
-
-        :getter: Returns the children.
-        :setter: Sets the children. Raises a TypeError if children have the wrong type.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: List[str]):
-        """
-        Setter for the children.
-
-        :param value: The value to set the children to.
-        :raises TypeError: Raised in case the children of menu have the wrong type.
-        """
-        if not isinstance(value, list):
-            raise TypeError("Field children of object menu must be of type list.")
-        if isinstance(value, list):
-            if not all(isinstance(x, str) for x in value):
-                raise TypeError(
-                    "Field children of object menu must be of type list and all items need to be menu "
-                    "names (str)."
-                )
-            self._children = []
-            for name in value:
-                menu = self.api.find_menu(name=name)
-                if menu is not None:
-                    self._children.append(name)
-                else:
-                    self.logger.warning(
-                        'Menu with the name "%s" did not exist. Skipping setting as a child!',
-                        name,
-                    )
 
     #
     # specific methods for item.Menu

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -29,11 +29,16 @@ class Mgmtclass(item.Item):
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._is_definition = False
         self._params = {}
         self._class_name = ""
         self._files = []
         self._packages = []
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -28,8 +28,13 @@ class Package(resource.Resource):
         :param kwargs: The keyword arguments which should be passed additionally to a Resource.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._installer = ""
         self._version = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -36,6 +36,9 @@ class Profile(item.Item):
         :param kwargs:
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._template_files = {}
         self._autoinstall = enums.VALUE_INHERITED
         self._boot_loaders: Union[List[str], str] = enums.VALUE_INHERITED
@@ -78,6 +81,8 @@ class Profile(item.Item):
         # Use setters to validate settings
         self.virt_disk_driver = api.settings().default_virt_disk_driver
         self.virt_type = api.settings().default_virt_type
+        if not self._has_initialized:
+            self._has_initialized = True
 
     def __getattr__(self, name):
         if name == "kickstart":
@@ -138,57 +143,6 @@ class Profile(item.Item):
     #
 
     @property
-    def parent(self) -> Optional[item.Item]:
-        r"""
-        Instead of a ``--distro``, set the parent of this object to another profile and use the values from the parent
-        instead of this one where the values for this profile aren't filled in, and blend them together where they
-        are dictionaries. Basically this enables profile inheritance. To use this, the object MUST have been
-        constructed with ``is_subobject=True`` or the default values for everything will be screwed up and this will
-        likely NOT work. So, API users -- make sure you pass ``is_subobject=True`` into the constructor when using this.
-
-        Return object next highest up the tree. If this property is not set it falls back to the value of the
-        ``distro``. In case neither distro nor parent is set, it returns None (which would make the profile invalid).
-
-        :getter: The parent object which can be either another profile, a distro or None in case the object could not be
-                 resolved.
-        :setter: The name of the parent object. Might throw a ``CX`` in case the object could not be found.
-        """
-        if not self._parent:
-            parent = self.distro
-            if parent is None:
-                return None
-            return parent
-        return self.api.profiles().find(name=self._parent)
-
-    @parent.setter
-    def parent(self, parent: str):
-        r"""
-        Setter for the ``parent`` property.
-
-        :param parent: The name of the parent object.
-        :raises CX: In case self parentage is found or the profile given could not be found.
-        """
-        if not isinstance(parent, str):
-            raise TypeError('Property "parent" must be of type str!')
-        old_parent = self.parent
-        if isinstance(old_parent, item.Item) and self.name in old_parent.children:
-            old_parent.children.remove(self.name)
-        if not parent:
-            self._parent = ""
-            return
-        if parent == self.name:
-            # check must be done in two places as setting parent could be called before/after setting name...
-            raise CX("self parentage is weird")
-        found = self.api.profiles().find(name=parent)
-        if found is None:
-            raise CX(f'profile "{parent}" not found, inheritance not possible')
-        self._parent = parent
-        self.depth = found.depth + 1
-        new_parent = self.parent
-        if isinstance(new_parent, item.Item) and self.name not in new_parent.children:
-            new_parent.children.append(self.name)
-
-    @property
     def arch(self):
         """
         This represents the architecture of a profile. It is read only.
@@ -196,8 +150,8 @@ class Profile(item.Item):
         :getter: ``None`` or the parent architecture.
         """
         # FIXME: This looks so wrong. It cries: Please open a bug for me!
-        parent = self.parent
-        if parent:
+        parent = self.logical_parent
+        if parent is not None:
             return parent.arch
         return None
 
@@ -229,15 +183,10 @@ class Profile(item.Item):
         distro = self.api.distros().find(name=distro_name)
         if distro is None:
             raise ValueError(f'distribution "{distro_name}" not found')
-        old_parent = self.parent
-        if isinstance(old_parent, item.Item) and self.name in old_parent.children:
-            old_parent.children.remove(self.name)
         self._distro = distro_name
         self.depth = (
             distro.depth + 1
         )  # reset depth if previously a subprofile and now top-level
-        if self.name not in distro.children:
-            distro.children.append(self.name)
 
     @InheritableProperty
     def name_servers(self) -> list:
@@ -463,14 +412,10 @@ class Profile(item.Item):
         if not isinstance(filename, str):
             raise TypeError("Field filename of object profile needs to be of type str!")
         parent = self.parent
-        if (
-            filename == enums.VALUE_INHERITED
-            and parent
-            and parent.TYPE_NAME == "distro"
-        ):
+        if filename == enums.VALUE_INHERITED and parent is None:
             filename = ""
         if not filename:
-            if parent and parent.TYPE_NAME == "profile":
+            if parent:
                 filename = enums.VALUE_INHERITED
             else:
                 filename = ""
@@ -740,6 +685,8 @@ class Profile(item.Item):
             boot_loaders_split = input_converters.input_string_or_list(boot_loaders)
 
             parent = self.parent
+            if parent is None:
+                parent = self.distro
             if parent is not None:
                 parent_boot_loaders = parent.boot_loaders
             else:
@@ -801,22 +748,3 @@ class Profile(item.Item):
         :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
         """
         self._display_name = display_name
-
-    @property
-    def children(self) -> list:
-        """
-        This property represents all children of a distribution. It should not be set manually.
-
-        :getter: The children of the distro.
-        :setter: No validation is done because this is a Cobbler internal property.
-        """
-        return self._children
-
-    @children.setter
-    def children(self, value: list):
-        """
-        Setter for the children property.
-
-        :param value: The new children of the distro.
-        """
-        self._children = value

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -32,6 +32,9 @@ class Repo(item.Item):
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._breed = enums.RepoBreeds.NONE
         self._arch = enums.RepoArchs.NONE
         self._environment = {}
@@ -48,6 +51,8 @@ class Repo(item.Item):
         self._proxy = enums.VALUE_INHERITED
         self._rpm_list = []
         self._os_version = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -26,12 +26,17 @@ class Resource(item.Item):
         Constructor.
         """
         super().__init__(api, *args, **kwargs)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
         self._action = enums.ResourceAction.CREATE
         self._mode = ""
         self._owner = ""
         self._group = ""
         self._path = ""
         self._template = ""
+        if not self._has_initialized:
+            self._has_initialized = True
 
     #
     # override some base class methods first (item.Item)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2067,6 +2067,7 @@ class CobblerXMLRPCInterface:
             return 1
 
         setattr(self.api.settings(), setting_name, value)
+        self.api.clean_items_cache(self.api.settings())
         self.api.settings().save()
         return 0
 

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -282,6 +282,7 @@ class Settings:
         self.windows_enabled = False
         self.windows_template_dir = "/etc/cobbler/windows"
         self.samba_distro_share = "DISTRO"
+        self.cache_enabled = False
 
     def to_string(self) -> str:
         """

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -166,6 +166,7 @@ schema = Schema(
             Optional("host"): str,
             Optional("port"): int,
         },
+        Optional("cache_enabled"): bool,
         Optional("autoinstall_scheme"): str,
     },
     ignore_extra_keys=False,

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -541,14 +541,10 @@ class TFTPGen:
         :param arch: The processor architecture to generate the menu items for. (Optional)
         """
         if menu:
-            child_names = menu.get_children(sort_list=True)
-            childs = []
-            for child in child_names:
-                child = self.api.find_menu(name=child)
-                if child is not None:
-                    childs.append(child)
+            childs = menu.children
         else:
-            childs = [child for child in self.menus if child.parent is None]
+            childs = self.api.find_items("menu", {"parent": ""})
+        childs.sort(key=lambda child: child.name)
 
         nested_menu_items = {}
         menu_labels = {}
@@ -625,19 +621,14 @@ class TFTPGen:
         :param metadata: Pass additional parameters to the ones being collected during the method.
         :param arch: The processor architecture to generate the menu items for. (Optional)
         """
-        if menu:
-            profile_list = [
-                profile for profile in self.profiles if profile.menu == menu.name
-            ]
-        else:
-            profile_list = [
-                profile
-                for profile in self.profiles
-                if profile.menu is None or profile.menu == ""
-            ]
-        profile_list = sorted(profile_list, key=lambda profile: profile.name)
+        menu_name = ""
+        if menu is not None:
+            menu_name = menu.name
+        profile_filter = {"menu": menu_name}
         if arch:
-            profile_list = [profile for profile in profile_list if profile.arch == arch]
+            profile_filter["arch"] = arch.value
+        profile_list = self.api.find_items("profile", profile_filter)
+        profile_list.sort(key=lambda profile: profile.name)
 
         current_menu_items = {}
         menu_labels = metadata["menu_labels"]
@@ -677,12 +668,13 @@ class TFTPGen:
         :param metadata: Pass additional parameters to the ones being collected during the method.
         :param arch: The processor architecture to generate the menu items for. (Optional)
         """
-        if menu:
-            image_list = [image for image in self.images if image.menu == menu.name]
-        else:
-            image_list = [
-                image for image in self.images if image.menu is None or image.menu == ""
-            ]
+        menu_name = ""
+        if menu is not None:
+            menu_name = menu.name
+        image_filter = {"menu": menu_name}
+        if arch:
+            image_filter["arch"] = arch.value
+        image_list = self.api.find_items("image", image_filter)
         image_list = sorted(image_list, key=lambda image: image.name)
 
         current_menu_items = metadata["menu_items"]

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -618,6 +618,10 @@ mongodb:
   host: "localhost"
   port: 27017
 
+# Set to true to cache of some internal operations can speed up their execution, but can slow down
+# editing objects.
+cache_enabled: false
+
 # This should contain the protocol over which the autointall-file is available.
 # Valid values are: http, https
 # This is setting does not setup your api for https it just changes the way the url for your profiles and systems are

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -44,6 +44,7 @@ RUN zypper install --no-recommends -y \
     python3-pytest-cov         \
     python3-pytest-mock        \
     python3-pytest-pythonpath  \
+    python3-pytest-benchmark   \
     python3-netaddr            \
     python3-pymongo            \
     python3-gunicorn           \

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -1128,3 +1128,10 @@ port
 The port where MongoDB is running.
 
 default: ``27017``
+
+cache_enabled
+#############
+
+If set to ``True``, allows the results of some internal operations to be cached, but may slow down editing of objects.
+
+default: ``False``

--- a/setup.py
+++ b/setup.py
@@ -552,7 +552,13 @@ if __name__ == "__main__":
         ],
         extras_require={
             "lint": ["pyflakes", "pycodestyle", "pylint", "black", "mypy"],
-            "test": ["pytest>6", "pytest-cov", "codecov", "pytest-mock"],
+            "test": [
+                "pytest>6",
+                "pytest-cov",
+                "codecov",
+                "pytest-mock",
+                "pytest-benchmark",
+            ],
             "docs": ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-apidoc"],
         },
         packages=find_packages(exclude=["*tests*"]),
@@ -761,6 +767,7 @@ if __name__ == "__main__":
             ("%s/tests/xmlrpcapi" % datadir, glob("tests/xmlrpcapi/*.py")),
             ("%s/tests/test_data/V3_4_0" % datadir, glob("tests/test_data/V3_4_0/*")),
             ("%s/tests/utils" % datadir, glob("tests/utils/*.py")),
+            (f"{datadir}/tests/performance", glob("tests/performance/*.py")),
             # tests containers subpackage
             ("%s/docker" % datadir, glob("docker/*")),
             ("%s/docker/debs" % datadir, glob("docker/debs/*")),

--- a/tests/autoinstallation_manager_test.py
+++ b/tests/autoinstallation_manager_test.py
@@ -30,6 +30,7 @@ def api_mock():
     settings_mock.default_name_servers = []
     settings_mock.default_name_servers_search = []
     settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
     api_mock.settings.return_value = settings_mock
     test_distro = Distro(api_mock)
     test_distro.name = "test"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,11 +98,11 @@ def create_distro(
     fk_initrd: str,
 ):
     """
-    Returns a function which has no arguments. The function returns a distro object. The distro is already added to
+    Returns a function which has the distro name as an argument. The function returns a distro object. The distro is already added to
     the CobblerAPI.
     """
 
-    def _create_distro() -> Distro:
+    def _create_distro(name="") -> Distro:
         test_folder = create_kernel_initrd(fk_kernel, fk_initrd)
         test_distro = cobbler_api.new_distro()
         test_distro.name = (
@@ -110,6 +110,8 @@ def create_distro(
             if request.node.originalname
             else request.node.name
         )
+        if name != "":
+            test_distro.name = name
         test_distro.kernel = os.path.join(test_folder, fk_kernel)
         test_distro.initrd = os.path.join(test_folder, fk_initrd)
         cobbler_api.add_distro(test_distro)
@@ -121,18 +123,23 @@ def create_distro(
 @pytest.fixture(scope="function")
 def create_profile(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
-    Returns a function which has the distro name as an argument. The function returns a profile object. The profile is
+    Returns a function which has the distro or profile name as an argument. The function returns a profile object. The profile is
     already added to the CobblerAPI.
     """
 
-    def _create_profile(distro_name: str) -> Profile:
+    def _create_profile(distro_name="", profile_name="", name="") -> Profile:
         test_profile = cobbler_api.new_profile()
         test_profile.name = (
             request.node.originalname
             if request.node.originalname
             else request.node.name
         )
-        test_profile.distro = distro_name
+        if name != "":
+            test_profile.name = name
+        if profile_name == "":
+            test_profile.distro = distro_name
+        else:
+            test_profile.parent = profile_name
         cobbler_api.add_profile(test_profile)
         return test_profile
 
@@ -142,17 +149,19 @@ def create_profile(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
 @pytest.fixture(scope="function")
 def create_image(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
-    Returns a function which has no arguments. The function returns an image object. The image is already added to the
+    Returns a function which has the image name as an argument. The function returns an image object. The image is already added to the
     CobblerAPI.
     """
 
-    def _create_image() -> Image:
+    def _create_image(name: str = "") -> Image:
         test_image = cobbler_api.new_image()
         test_image.name = (
             request.node.originalname
             if request.node.originalname
             else request.node.name
         )
+        if name != "":
+            test_image.name = name
         cobbler_api.add_image(test_image)
         return test_image
 

--- a/tests/items/cache_test.py
+++ b/tests/items/cache_test.py
@@ -1,0 +1,781 @@
+import os
+
+import pytest
+
+# from cobbler import enums
+from cobbler.items.package import Package
+from cobbler.items.file import File
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.repo import Repo
+from cobbler.items.distro import Distro
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+from cobbler.items.item import Item
+from cobbler.settings import Settings
+from tests.conftest import does_not_raise
+from cobbler.cexceptions import CX
+from cobbler.decorator import InheritableProperty, InheritableDictProperty
+
+
+def test_collection_types(cobbler_api):
+    # Arrange
+    mgr = cobbler_api._collection_mgr
+
+    # Act
+    result = mgr.__dict__.items()
+
+    # Assert
+    print(result)
+    assert len(result) == 11
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_package_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_package = Package(cobbler_api)
+    test_package.name = "test_package"
+    cobbler_api.add_package(test_package)
+
+    # Act
+    with expected_exception:
+        result1 = test_package.to_dict(resolved=True)
+        result2 = test_package.to_dict(resolved=False)
+        cached_result1 = test_package.cache.get_dict_cache(True)
+        cached_result2 = test_package.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_file_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_file = File(cobbler_api)
+    test_file.name = "test_file"
+    test_file.path = "test path"
+    test_file.owner = "test owner"
+    test_file.group = "test group"
+    test_file.mode = "test mode"
+    test_file.is_dir = True
+    cobbler_api.add_file(test_file)
+
+    # Act
+    with expected_exception:
+        result1 = test_file.to_dict(resolved=True)
+        result2 = test_file.to_dict(resolved=False)
+        cached_result1 = test_file.cache.get_dict_cache(True)
+        cached_result2 = test_file.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_mgmtclass_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_mgmtclass = Mgmtclass(cobbler_api)
+    test_mgmtclass.name = "test_mgmtclass"
+    cobbler_api.add_mgmtclass(test_mgmtclass)
+
+    # Act
+    with expected_exception:
+        result1 = test_mgmtclass.to_dict(resolved=True)
+        result2 = test_mgmtclass.to_dict(resolved=False)
+        cached_result1 = test_mgmtclass.cache.get_dict_cache(True)
+        cached_result2 = test_mgmtclass.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_repo_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_repo"
+    cobbler_api.add_repo(test_repo)
+
+    # Act
+    with expected_exception:
+        result1 = test_repo.to_dict(resolved=True)
+        result2 = test_repo.to_dict(resolved=False)
+        cached_result1 = test_repo.cache.get_dict_cache(True)
+        cached_result2 = test_repo.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_distro_dict_cache_load(
+    cobbler_api, create_distro, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+
+    # Act
+    with expected_exception:
+        result1 = test_distro.to_dict(resolved=True)
+        result2 = test_distro.to_dict(resolved=False)
+        cached_result1 = test_distro.cache.get_dict_cache(True)
+        cached_result2 = test_distro.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_image_dict_cache_load(
+    cobbler_api, create_image, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_image = create_image()
+
+    # Act
+    with expected_exception:
+        result1 = test_image.to_dict(resolved=True)
+        result2 = test_image.to_dict(resolved=False)
+        cached_result1 = test_image.cache.get_dict_cache(True)
+        cached_result2 = test_image.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_menu_dict_cache_load(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_menu = Menu(cobbler_api)
+    test_menu.name = "test_menu"
+    cobbler_api.add_menu(test_menu)
+
+    # Act
+    with expected_exception:
+        result1 = test_menu.to_dict(resolved=True)
+        result2 = test_menu.to_dict(resolved=False)
+        cached_result1 = test_menu.cache.get_dict_cache(True)
+        cached_result2 = test_menu.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_profile_dict_cache_load(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+
+    # Act
+    with expected_exception:
+        result1 = test_profile.to_dict(resolved=True)
+        result2 = test_profile.to_dict(resolved=False)
+        cached_result1 = test_profile.cache.get_dict_cache(True)
+        cached_result2 = test_profile.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_system_dict_cache_load(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    create_system,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+    test_system = create_system(profile_name=test_profile.name)
+
+    # Act
+    with expected_exception:
+        result1 = test_system.to_dict(resolved=True)
+        result2 = test_system.to_dict(resolved=False)
+        cached_result1 = test_system.cache.get_dict_cache(True)
+        cached_result2 = test_system.cache.get_dict_cache(False)
+
+    # Assert
+    assert (cached_result1 == result1) == expected_output
+    assert (cached_result2 == result2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_package_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_package = Package(cobbler_api)
+    test_package.name = "test_package"
+    cobbler_api.add_package(test_package)
+    test_package.to_dict(resolved=True)
+    test_package.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_package.cache.set_dict_cache(test_cache1, True)
+        test_package.cache.set_dict_cache(test_cache2, False)
+        result1 = test_package.cache.get_dict_cache(True)
+        result2 = test_package.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_file_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_file = File(cobbler_api)
+    test_file.name = "test_file"
+    test_file.path = "test path"
+    test_file.owner = "test owner"
+    test_file.group = "test group"
+    test_file.mode = "test mode"
+    test_file.is_dir = True
+    cobbler_api.add_file(test_file)
+    test_file.to_dict(resolved=True)
+    test_file.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_file.cache.set_dict_cache(test_cache1, True)
+        test_file.cache.set_dict_cache(test_cache2, False)
+        result1 = test_file.cache.get_dict_cache(True)
+        result2 = test_file.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_mgmtclass_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_mgmtclass = Mgmtclass(cobbler_api)
+    test_mgmtclass.name = "test_mgmtclass"
+    cobbler_api.add_mgmtclass(test_mgmtclass)
+    test_mgmtclass.to_dict(resolved=True)
+    test_mgmtclass.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_mgmtclass.cache.set_dict_cache(test_cache1, True)
+        test_mgmtclass.cache.set_dict_cache(test_cache2, False)
+        result1 = test_mgmtclass.cache.get_dict_cache(True)
+        result2 = test_mgmtclass.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_repo_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_repo"
+    cobbler_api.add_repo(test_repo)
+    test_repo.to_dict(resolved=True)
+    test_repo.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_repo.cache.set_dict_cache(test_cache1, True)
+        test_repo.cache.set_dict_cache(test_cache2, False)
+        result1 = test_repo.cache.get_dict_cache(True)
+        result2 = test_repo.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_distro_dict_cache_use(
+    cobbler_api, create_distro, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.to_dict(resolved=True)
+    test_distro.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_distro.cache.set_dict_cache(test_cache1, True)
+        test_distro.cache.set_dict_cache(test_cache2, False)
+        result1 = test_distro.cache.get_dict_cache(True)
+        result2 = test_distro.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_image_dict_cache_use(
+    cobbler_api, create_image, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_image = create_image()
+    test_image.to_dict(resolved=True)
+    test_image.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_image.cache.set_dict_cache(test_cache1, True)
+        test_image.cache.set_dict_cache(test_cache2, False)
+        result1 = test_image.cache.get_dict_cache(True)
+        result2 = test_image.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_menu_dict_cache_use(
+    cobbler_api, input_value, expected_exception, expected_output
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_menu = Menu(cobbler_api)
+    test_menu.name = "test_menu"
+    cobbler_api.add_menu(test_menu)
+    test_menu.to_dict(resolved=True)
+    test_menu.to_dict(resolved=False)
+    test_cache1 = "test1"
+    test_cache2 = "test2"
+
+    # Act
+    with expected_exception:
+        test_menu.cache.set_dict_cache(test_cache1, True)
+        test_menu.cache.set_dict_cache(test_cache2, False)
+        result1 = test_menu.cache.get_dict_cache(True)
+        result2 = test_menu.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_profile_dict_cache_use(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+    test_profile.to_dict(resolved=True)
+    test_profile.to_dict(resolved=False)
+    test_cache1 = {"test": True}
+    test_cache2 = {"test": False}
+
+    # Act
+    with expected_exception:
+        test_profile.cache.set_dict_cache(test_cache1, True)
+        test_profile.cache.set_dict_cache(test_cache2, False)
+        result1 = test_profile.cache.get_dict_cache(True)
+        result2 = test_profile.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_system_dict_cache_use(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    create_system,
+    input_value,
+    expected_exception,
+    expected_output,
+):
+    # Arrange
+    cobbler_api.settings().cache_enabled = input_value
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = {"my_value": 5}
+    test_system = create_system(profile_name=test_profile.name)
+    test_system.to_dict(resolved=True)
+    test_system.to_dict(resolved=False)
+    test_cache1 = {"test": True}
+    test_cache2 = {"test": False}
+
+    # Act
+    with expected_exception:
+        test_system.cache.set_dict_cache(test_cache1, True)
+        test_system.cache.set_dict_cache(test_cache2, False)
+        result1 = test_system.cache.get_dict_cache(True)
+        result2 = test_system.cache.get_dict_cache(False)
+
+    # Assert
+    assert (result1 == test_cache1) == expected_output
+    assert (result2 == test_cache2) == expected_output
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,expected_exception,expected_output",
+    [
+        (True, pytest.raises(CX), True),
+        (False, pytest.raises(CX), False),
+    ],
+)
+def test_dict_cache_invalidate(
+    cobbler_api,
+    create_distro,
+    create_image,
+    create_profile,
+    create_system,
+    cache_enabled,
+    expected_exception,
+    expected_output,
+):
+    def validate_caches(test_api, objs, obj_test, dep):
+        for obj in objs:
+            obj.to_dict(resolved=False)
+            obj.to_dict(resolved=True)
+        remain_objs = set(objs) - set(dep)
+        if isinstance(obj_test, Item):
+            remain_objs.remove(obj_test)
+            obj_test.owners = "test"
+            if (
+                obj_test.cache.get_dict_cache(True) is not None
+                or obj_test.cache.get_dict_cache(False) is not None
+            ):
+                return False
+        elif obj_test == test_api.settings():
+            test_api.clean_items_cache(obj_test)
+        elif obj_test == test_api.get_signatures():
+            test_api.signature_update()
+        for obj in dep:
+            if obj.cache.get_dict_cache(True) is not None:
+                return False
+            if obj.cache.get_dict_cache(False) is None:
+                return False
+        for obj in remain_objs:
+            if obj.cache.get_dict_cache(True) is None:
+                return False
+            if obj.cache.get_dict_cache(False) is None:
+                return False
+        return True
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    test_package = Package(cobbler_api)
+    test_package.name = "test_package"
+    cobbler_api.add_package(test_package)
+    objs = [test_package]
+    test_file = File(cobbler_api)
+    test_file.name = "test_file"
+    test_file.path = "test path"
+    test_file.owner = "test owner"
+    test_file.group = "test group"
+    test_file.mode = "test mode"
+    test_file.is_dir = True
+    cobbler_api.add_file(test_file)
+    objs.append(test_file)
+    test_mgmtclass = Mgmtclass(cobbler_api)
+    test_mgmtclass.name = "test_mgmtclass"
+    test_mgmtclass.packages = [test_package.name]
+    test_mgmtclass.files = [test_file.name]
+    cobbler_api.add_mgmtclass(test_mgmtclass)
+    objs.append(test_mgmtclass)
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_repo"
+    cobbler_api.add_repo(test_repo)
+    objs.append(test_repo)
+    test_menu1 = Menu(cobbler_api)
+    test_menu1.name = "test_menu1"
+    cobbler_api.add_menu(test_menu1)
+    objs.append(test_menu1)
+    test_menu2 = Menu(cobbler_api)
+    test_menu2.name = "test_menu2"
+    test_menu2.parent = test_menu1.name
+    cobbler_api.add_menu(test_menu2)
+    objs.append(test_menu2)
+    test_distro = create_distro()
+    test_distro.mgmt_classes = test_mgmtclass.name
+    test_distro.source_repos = [test_repo.name]
+    objs.append(test_distro)
+    test_profile1 = create_profile(distro_name=test_distro.name, name="test_profile1")
+    test_profile1.enable_menu = False
+    objs.append(test_profile1)
+    test_profile2 = create_profile(
+        profile_name=test_profile1.name, name="test_profile2"
+    )
+    test_profile2.enable_menu = False
+    test_profile2.menu = test_menu2.name
+    objs.append(test_profile2)
+    test_profile3 = create_profile(
+        profile_name=test_profile1.name, name="test_profile3"
+    )
+    test_profile3.enable_menu = False
+    test_profile3.mgmt_classes = test_mgmtclass.name
+    test_profile3.repos = [test_repo.name]
+    objs.append(test_profile3)
+    test_image = create_image()
+    test_image.menu = test_menu1.name
+    objs.append(test_image)
+    test_system1 = create_system(profile_name=test_profile1.name, name="test_system1")
+    objs.append(test_system1)
+    test_system2 = create_system(image_name=test_image.name, name="test_system2")
+    objs.append(test_system2)
+
+    # Act
+    package_dep = test_package.descendants
+    file_dep = test_file.descendants
+    mgmtclass_dep = test_mgmtclass.descendants
+    repo_dep = test_repo.descendants
+    menu1_dep = test_menu1.descendants
+    menu2_dep = test_menu2.descendants
+    distro_dep = test_distro.descendants
+    profile1_dep = test_profile1.descendants
+    profile2_dep = test_profile2.descendants
+    profile3_dep = test_profile3.descendants
+    image_dep = test_image.descendants
+    system1_dep = test_system1.descendants
+    system2_dep = test_system2.descendants
+
+    settings_dep = objs
+    signatures_dep = [
+        test_distro,
+        test_profile1,
+        test_profile2,
+        test_profile3,
+        test_image,
+        test_system1,
+        test_system2,
+    ]
+
+    # Assert
+    assert (
+        validate_caches(cobbler_api, objs, test_package, package_dep) == expected_output
+    )
+    assert validate_caches(cobbler_api, objs, test_file, file_dep) == expected_output
+    assert (
+        validate_caches(cobbler_api, objs, test_mgmtclass, mgmtclass_dep)
+        == expected_output
+    )
+    assert validate_caches(cobbler_api, objs, test_repo, repo_dep) == expected_output
+    assert validate_caches(cobbler_api, objs, test_menu1, menu1_dep) == expected_output
+    assert validate_caches(cobbler_api, objs, test_menu2, menu2_dep) == expected_output
+    assert (
+        validate_caches(cobbler_api, objs, test_distro, distro_dep) == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_profile1, profile1_dep)
+        == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_profile2, profile2_dep)
+        == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_profile3, profile3_dep)
+        == expected_output
+    )
+    assert validate_caches(cobbler_api, objs, test_image, image_dep) == expected_output
+    assert (
+        validate_caches(cobbler_api, objs, test_system1, system1_dep) == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, test_system2, system2_dep) == expected_output
+    )
+
+    assert (
+        validate_caches(cobbler_api, objs, cobbler_api.settings(), settings_dep)
+        == expected_output
+    )
+    assert (
+        validate_caches(cobbler_api, objs, cobbler_api.get_signatures(), signatures_dep)
+        == expected_output
+    )
+    with expected_exception:
+        cobbler_api.clean_items_cache(True)

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -47,7 +47,7 @@ def test_to_dict(cobbler_api, cleanup_to_dict):
     result = profile.to_dict()
 
     # Assert
-    assert len(result) == 45
+    assert len(result) == 44
     assert result["distro"] == "test_to_dict_distro"
     assert result.get("boot_loaders") == enums.VALUE_INHERITED
 

--- a/tests/modules/managers/genders_test.py
+++ b/tests/modules/managers/genders_test.py
@@ -37,6 +37,7 @@ def api_genders_mock():
     settings_mock.manage_genders = True
     settings_mock.jinja2_includedir = ""
     settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
     api_mock = MagicMock(autospec=True, spec=CobblerAPI)
     api_mock.settings.return_value = settings_mock
     test_distro = Distro(api_mock)

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -40,6 +40,7 @@ def api_mock_tftp():
     settings_mock.default_virt_disk_driver = "raw"
     settings_mock.tftpboot_location = "/var/lib/tftpboot"
     settings_mock.webdir = "/srv/www/cobbler"
+    settings_mock.cache_enabled = False
     api_mock_tftp.settings.return_value = settings_mock
     test_distro = Distro(api_mock_tftp)
     test_distro.name = "test"

--- a/tests/modules/managers/isc_test.py
+++ b/tests/modules/managers/isc_test.py
@@ -35,6 +35,7 @@ def api_isc_mock():
     settings_mock.manage_dhcp_v6 = True
     settings_mock.jinja2_includedir = ""
     settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
     api_mock = MagicMock(autospec=True, spec=CobblerAPI)
     api_mock.settings.return_value = settings_mock
     test_distro = Distro(api_mock)

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -1,0 +1,260 @@
+"""
+Module that contains a helper class which supports the performance testsuite. This is not a pytest style fixture but
+rather related pytest-benchmark. Thus the different style in usage.
+"""
+
+from typing import Callable
+from cobbler.api import CobblerAPI
+
+from cobbler.items.package import Package
+from cobbler.items.file import File
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.repo import Repo
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+
+class CobblerTree:
+    """
+    Helper class that defines methods that can be used during benchmark testing.
+    """
+
+    objs_count = 2
+    test_rounds = 1
+    tree_levels = 3
+
+    @staticmethod
+    def create_packages(api: CobblerAPI):
+        """
+        Create a number of packages for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = Package(api)
+            test_item.name = f"test_package_{i}"
+            api.add_package(test_item)
+
+    @staticmethod
+    def create_files(api: CobblerAPI):
+        """
+        Create a number of files for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = File(api)
+            test_item.name = f"test_file_{i}"
+            test_item.path = "test path"
+            test_item.owner = "test owner"
+            test_item.group = "test group"
+            test_item.mode = "test mode"
+            test_item.is_dir = True
+            api.add_file(test_item)
+
+    @staticmethod
+    def create_mgmtclasses(api: CobblerAPI):
+        """
+        Create a number of managemment classes for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = Mgmtclass(api)
+            test_item.name = f"test_mgmtclass_{i}"
+            test_item.package = f"test_package_{i}"
+            test_item.file = f"test_file_{i}"
+            api.add_mgmtclass(test_item)
+
+    @staticmethod
+    def create_repos(api: CobblerAPI):
+        """
+        Create a number of repos for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = Repo(api)
+            test_item.name = f"test_repo_{i}"
+            api.add_repo(test_item)
+
+    @staticmethod
+    def create_distros(api: CobblerAPI, create_distro: Callable[[str], Distro]):
+        """
+        Create a number of distros for benchmark testing. This pairs the distros with the repositories and mgmt classes.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = create_distro(name=f"test_distro_{i}")
+            test_item.source_repos = [f"test_repo_{i}"]
+            test_item.mgmt_classes = [f"test_mgmtclass_{i}"]
+
+    @staticmethod
+    def create_menus(api: CobblerAPI):
+        """
+        Create a number of menus for benchmark testing. Depending on the menu depth this method also adds children for
+        the menus.
+        """
+        for l in range(CobblerTree.tree_levels):
+            for i in range(CobblerTree.objs_count):
+                test_item = Menu(api)
+                test_item.name = f"level_{l}_test_menu_{i}"
+                if l > 0:
+                    test_item.parent = f"level_{l - 1}_test_menu_{i}"
+                else:
+                    test_item.parent = ""
+                api.add_menu(test_item)
+
+    @staticmethod
+    def create_profiles(
+        api: CobblerAPI, create_profile: Callable[[str, str, str], Profile]
+    ):
+        """
+        Create a number of profiles for benchmark testing. Depending on the menu depth this method also pairs the
+        profile with a menu.
+        """
+        for l in range(CobblerTree.tree_levels):
+            for i in range(CobblerTree.objs_count):
+                if l > 0:
+                    test_item = create_profile(
+                        profile_name=f"level_{l - 1}_test_profile_{i}",
+                        name=f"level_{l}_test_profile_{i}",
+                    )
+                else:
+                    test_item = create_profile(
+                        distro_name=f"test_distro_{i}",
+                        name=f"level_{l}_test_profile_{i}",
+                    )
+                test_item.menu = f"level_{l}_test_menu_{i}"
+                test_item.autoinstall = "sample.ks"
+
+    @staticmethod
+    def create_images(api: CobblerAPI, create_image: Callable[[str], Image]):
+        """
+        Create a number of images for benchmark testing.
+        """
+        for i in range(CobblerTree.objs_count):
+            test_item = create_image(name=f"test_image_{i}")
+            test_item.menu = f"level_{CobblerTree.tree_levels - 1}_test_menu_{i}"
+            test_item.autoinstall = "sample.ks"
+
+    @staticmethod
+    def create_systems(
+        api: CobblerAPI, create_system: Callable[[str, str, str], System]
+    ):
+        """
+        Create a number of systems for benchmark testing. Depending on the strategy the system is paired with a profile
+        or image.
+        """
+        for i in range(CobblerTree.objs_count):
+            if i % 2 == 0:
+                test_item = create_system(
+                    name=f"test_system_{i}",
+                    profile_name=f"level_{CobblerTree.tree_levels - 1}_test_profile_{i}",
+                )
+            else:
+                test_item = create_system(
+                    name=f"test_system_{i}", image_name=f"test_image_{i}"
+                )
+
+    @staticmethod
+    def create_all_objs(
+        api: CobblerAPI,
+        create_distro: Callable[[str], Distro],
+        create_profile: Callable[[str, str, str], Profile],
+        create_image: Callable[[str], Image],
+        create_system: Callable[[str, str, str], System],
+    ):
+        """
+        Method that collectively creates all items at the same time.
+        """
+        CobblerTree.create_packages(api)
+        CobblerTree.create_files(api)
+        CobblerTree.create_mgmtclasses(api)
+        CobblerTree.create_repos(api)
+        CobblerTree.create_distros(api, create_distro)
+        CobblerTree.create_menus(api)
+        CobblerTree.create_profiles(api, create_profile)
+        CobblerTree.create_images(api, create_image)
+        CobblerTree.create_systems(api, create_system)
+
+    @staticmethod
+    def remove_packages(api: CobblerAPI):
+        """
+        Method that removes all packages.
+        """
+        for test_item in api.packages():
+            api.remove_package(test_item.name)
+
+    @staticmethod
+    def remove_files(api: CobblerAPI):
+        """
+        Method that removes all files.
+        """
+        for test_item in api.files():
+            api.remove_file(test_item.name)
+
+    @staticmethod
+    def remove_mgmtclasses(api: CobblerAPI):
+        """
+        Method that removes all management classes.
+        """
+        for test_item in api.mgmtclasses():
+            api.remove_mgmtclass(test_item.name)
+
+    @staticmethod
+    def remove_repos(api: CobblerAPI):
+        """
+        Method that removes all repositories.
+        """
+        for test_item in api.repos():
+            api.remove_repo(test_item.name)
+
+    @staticmethod
+    def remove_distros(api: CobblerAPI):
+        """
+        Method that removes all distributions.
+        """
+        for test_item in api.distros():
+            api.remove_distro(test_item.name)
+
+    @staticmethod
+    def remove_menus(api: CobblerAPI):
+        """
+        Method that removes all menus.
+        """
+        while len(api.menus()) > 0:
+            api.remove_menu(list(api.menus())[0], recursive=True)
+
+    @staticmethod
+    def remove_profiles(api: CobblerAPI):
+        """
+        Method that removes all profiles.
+        """
+        while len(api.profiles()) > 0:
+            api.remove_profile(list(api.profiles())[0], recursive=True)
+
+    @staticmethod
+    def remove_images(api: CobblerAPI):
+        """
+        Method that removes all images.
+        """
+        for test_item in api.images():
+            api.remove_image(test_item.name)
+
+    @staticmethod
+    def remove_systems(api: CobblerAPI):
+        """
+        Method that removes all systems.
+        """
+        for test_item in api.systems():
+            api.remove_system(test_item.name)
+
+    @staticmethod
+    def remove_all_objs(api: CobblerAPI):
+        """
+        Method that collectively removes all items at the same time.
+        """
+        CobblerTree.remove_systems(api)
+        CobblerTree.remove_images(api)
+        CobblerTree.remove_profiles(api)
+        CobblerTree.remove_menus(api)
+        CobblerTree.remove_distros(api)
+        CobblerTree.remove_repos(api)
+        CobblerTree.remove_mgmtclasses(api)
+        CobblerTree.remove_files(api)
+        CobblerTree.remove_packages(api)

--- a/tests/performance/deserialize_test.py
+++ b/tests/performance/deserialize_test.py
@@ -1,0 +1,82 @@
+"""
+Test module to assert the performance of deserializing the object tree.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_deserialize(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that benchmarks the file based deserialization process of Cobbler.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (), {}
+
+    def deserialize():
+        # pylint: disable=protected-access
+        CobblerAPI.__shared_state = {}  # pyright: ignore [reportPrivateUsage]
+        CobblerAPI.__has_loaded = False  # pyright: ignore [reportPrivateUsage]
+        api = CobblerAPI()
+        api.deserialize()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        deserialize, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/get_autoinstall_test.py
+++ b/tests/performance/get_autoinstall_test.py
@@ -1,0 +1,74 @@
+"""
+Test module to assert the performance of retrieving an autoinstallation file.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler import autoinstall_manager
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "profile",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        False,
+        True,
+    ],
+)
+def test_get_autoinstall(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    what: str,
+):
+    """
+    Test that asserts if retrieving rendered autoinstallation templates is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_get_autoinstall(api: CobblerAPI, what: str):
+        autoinstall_mgr = autoinstall_manager.AutoInstallationManager(cobbler_api)
+        for test_item in api.get_items(what):
+            if what == "profile":
+                autoinstall_mgr.generate_autoinstall(profile=test_item.name)
+            elif what == "system":
+                autoinstall_mgr.generate_autoinstall(system=test_item.name)
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = False
+
+    # Act
+    result = benchmark.pedantic(
+        item_get_autoinstall, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -1,0 +1,431 @@
+"""
+Test module to assert the performance of adding different kinds of items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_packages_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a package is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_packages, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_files_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a package is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_files, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_mgmtclasses_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a package is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_mgmtclasses, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_repos_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a repository is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_repos, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_distros_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    cache_enabled: bool,
+):
+    """
+    Test that asserts if creating a distro is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_packages(cobbler_api)
+        CobblerTree.create_files(cobbler_api)
+        CobblerTree.create_mgmtclasses(cobbler_api)
+        CobblerTree.create_repos(cobbler_api)
+        return (cobbler_api, create_distro), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_distros, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_menus_create(
+    benchmark: BenchmarkFixture, cobbler_api: CobblerAPI, cache_enabled: bool
+):
+    """
+    Test that asserts if creating a menu is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (cobbler_api,), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_menus, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_profiles_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating a profile is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_packages(cobbler_api)
+        CobblerTree.create_files(cobbler_api)
+        CobblerTree.create_mgmtclasses(cobbler_api)
+        CobblerTree.create_repos(cobbler_api)
+        CobblerTree.create_distros(cobbler_api, create_distro)
+        CobblerTree.create_menus(cobbler_api)
+        return (cobbler_api, create_profile), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_profiles, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled",
+    [
+        (False,),
+        (True,),
+    ],
+)
+def test_images_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], Image],
+    cache_enabled: bool,
+):
+    """
+    Test that asserts if creating an image is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_menus(cobbler_api)
+        return (cobbler_api, create_image), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_images, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_systems_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating a system is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_packages(cobbler_api)
+        CobblerTree.create_files(cobbler_api)
+        CobblerTree.create_mgmtclasses(cobbler_api)
+        CobblerTree.create_repos(cobbler_api)
+        CobblerTree.create_distros(cobbler_api, create_distro)
+        CobblerTree.create_menus(cobbler_api)
+        CobblerTree.create_images(cobbler_api, create_image)
+        CobblerTree.create_profiles(cobbler_api, create_profile)
+        return (cobbler_api, create_system), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_systems, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_all_items_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating all items at once is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        return (
+            cobbler_api,
+            create_distro,
+            create_profile,
+            create_image,
+            create_system,
+        ), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        CobblerTree.create_all_objs, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -1,0 +1,92 @@
+"""
+Test module to assert the performance of copying items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_copy(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    what: str,
+):
+    """
+    Test that asserts if copying an item is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_copy(api: CobblerAPI, what: str):
+        for test_item in api.get_items(what):
+            api.copy_item(what, test_item, test_item.name + "_copy")
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_copy, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -1,0 +1,102 @@
+"""
+Test module to assert the performance of editing items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "inherit_property",
+    [
+        False,
+        True,
+    ],
+)
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_edit(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    inherit_property: bool,
+    what: str,
+):
+    """
+    Test that asserts if editing items is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_edit(api: CobblerAPI, what: str):
+        for test_item in api.get_items(what):
+            if inherit_property:
+                test_item.owners = "test owners"
+            else:
+                test_item.comment = "test commect"
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_edit, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -1,0 +1,92 @@
+"""
+Test module to assert the performance of removing items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_remove(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    what: str,
+):
+    """
+    Test that asserts if removing one or more items is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_remove(api: CobblerAPI, what: str):
+        while len(api.get_items(what)) > 0:
+            api.remove_item(what, list(api.get_items(what))[0], recursive=True)
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_remove, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/item_rename_test.py
+++ b/tests/performance/item_rename_test.py
@@ -1,0 +1,92 @@
+"""
+Test module to assert the performance of renaming items.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+
+import pytest
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "what",
+    [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "profile",
+        "image",
+        "system",
+    ],
+)
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_item_rename(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+    what: str,
+):
+    """
+    Test that asserts if renaming an item is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(
+            cobbler_api, create_distro, create_profile, create_image, create_system
+        )
+        return (cobbler_api, what), {}
+
+    def item_rename(api: CobblerAPI, what: str):
+        for test_item in api.get_items(what):
+            api.rename_item(what, test_item, test_item.name + "_renamed")
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        item_rename, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/make_pxe_menu_test.py
+++ b/tests/performance/make_pxe_menu_test.py
@@ -1,0 +1,78 @@
+"""
+Test module to assert the performance of creating the PXE menu.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_make_pxe_menu(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating the PXE menu is running wihtout a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (cobbler_api,), {}
+
+    def make_pxe_menu(api: CobblerAPI):
+        api.tftpgen.make_pxe_menu()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        make_pxe_menu, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/start_test.py
+++ b/tests/performance/start_test.py
@@ -1,0 +1,80 @@
+"""
+Test module to assert the performance of the startup of the daemon.
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_start(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if the startup of Cobbler is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (), {}
+
+    def start_cobbler():
+        CobblerAPI.__shared_state = {}
+        CobblerAPI.__has_loaded = False
+        api = CobblerAPI()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(
+        start_cobbler, setup=setup_func, rounds=CobblerTree.test_rounds
+    )
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/performance/sync_test.py
+++ b/tests/performance/sync_test.py
@@ -1,0 +1,76 @@
+"""
+Test module to assert the performance of "cobbler sync".
+"""
+
+from typing import Any, Callable, Dict, Tuple
+import pytest
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+from tests.performance import CobblerTree
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
+def test_sync(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[[str, str, str], Profile],
+    create_image: Callable[[str], Image],
+    create_system: Callable[[str, str, str], System],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if "cobbler sync" without arguments is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        api = cobbler_api
+        CobblerTree.remove_all_objs(api)
+        CobblerTree.create_all_objs(
+            api, create_distro, create_profile, create_image, create_system
+        )
+        del api
+        return (cobbler_api,), {}
+
+    def sync(api: CobblerAPI):
+        api.sync()
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(sync, setup=setup_func, rounds=CobblerTree.test_rounds)
+
+    # Cleanup
+    CobblerTree.remove_all_objs(cobbler_api)
+
+    # Assert

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -190,4 +190,6 @@ def test_normalize_v3_4_0_full():
     # Assert
     assert "mongodb" in new_settings
     assert new_settings["mongodb"] == {"host": "localhost", "port": 27017}
-    assert len(V3_4_0.normalize(new_settings)) == 133
+    assert "cache_enabled" in new_settings
+    assert new_settings["cache_enabled"] == False
+    assert len(V3_4_0.normalize(new_settings)) == 134

--- a/tests/test_data/V3_4_0/settings.yaml
+++ b/tests/test_data/V3_4_0/settings.yaml
@@ -618,5 +618,9 @@ mongodb:
   host: "localhost"
   port: 27017
 
+# A cache of some internal operations can speed up their execution, but can slow down
+# editing objects.
+cache_enabled: false
+
 # list settings keys to exclude from validation - helpful to validate and migrate custom settings
 extra_settings_list: []


### PR DESCRIPTION
## Linked Items

Fixes #3259

## Description

Since `item.py:to_dict` is too slow and there are no ways to speed it up, it is possible to cache the item's dict representation in the object itself.

## Behaviour changes

Old: Item.to_dict results were not cached.

New: Allowed to enable caching of Item.to_dict results.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
