### PR TITLE
Include files under "docker" into the package to build "cobbler-tests-containers" subpackage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,8 @@ debs: authors ## Creates native debs in a directory called deb-build. The releas
 	@source distro_build_configs.sh; \
     debuild -us -uc
 	@mkdir -p deb-build; \
-    cp ../cobbler_* deb-build/
+    cp ../cobbler_* deb-build/; \
+    cp ../cobbler-tests* deb-build/
 
 eraseconfig: ## Deletes the cobbler data jsons which are created when using the file provider.
 	-rm /var/lib/cobbler/cobbler_collections/distros/*

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -225,6 +225,13 @@ Requires:       cobbler = %{version}-%{release}
 %description tests
 Unit test files from the Cobbler project
 
+%package tests-containers
+Summary:        Dockerfiles and scripts to setup testing containers
+Requires:       cobbler = %{version}-%{release}
+
+%description tests-containers
+Dockerfiles and scripts to setup testing containers
+
 
 %prep
 %setup
@@ -371,6 +378,10 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %files tests
 %dir %{_datadir}/cobbler/tests
 %{_datadir}/cobbler/tests/*
+
+%files tests-containers
+%dir %{_datadir}/cobbler/docker
+%{_datadir}/cobbler/docker/*
 
 %changelog
 * Thu Dec 19 2019 Neal Gompa <ngompa13@gmail.com>

--- a/debian/clean
+++ b/debian/clean
@@ -1,0 +1,1 @@
+python3-cobbler

--- a/debian/cobbler-tests-containers.install
+++ b/debian/cobbler-tests-containers.install
@@ -1,0 +1,1 @@
+usr/share/cobbler/docker/

--- a/debian/cobbler-tests.install
+++ b/debian/cobbler-tests.install
@@ -1,0 +1,1 @@
+usr/share/cobbler/tests/

--- a/debian/cobbler.install
+++ b/debian/cobbler.install
@@ -1,0 +1,8 @@
+etc/
+usr/bin/
+usr/lib/
+var/log/
+var/lib/
+usr/share/man/
+usr/share/bash-completion
+usr/share/cobbler/bin/

--- a/debian/control
+++ b/debian/control
@@ -43,3 +43,21 @@ Description: Install server
  integrated yum mirroring, and built-in DHCP/DNS Management.
  Cobbler has a Python and XMLRPC API for integration with other
  applications. There is also a web interface available.
+
+Package: cobbler-tests
+Architecture: all
+Depends:
+ cobbler,
+ ${python3:Depends},
+ ${misc:Depends}
+Description: Unit test for Cobbler
+ Unit test files from the Cobbler project
+
+Package: cobbler-tests-containers
+Architecture: all
+Depends:
+ cobbler,
+ ${python3:Depends},
+ ${misc:Depends}
+Description: Files to test Cobbler in containers
+ Dockerfiles and scripts to setup testing containers

--- a/debian/rules
+++ b/debian/rules
@@ -25,3 +25,6 @@ override_dh_auto_clean:
 override_dh_auto_install:
 	@source ./distro_build_configs.sh; \
 	dh_auto_install
+
+override_dh_install:
+	dh_install --sourcedir="debian/python3-cobbler"

--- a/setup.py
+++ b/setup.py
@@ -761,5 +761,76 @@ if __name__ == "__main__":
             ("%s/tests/xmlrpcapi" % datadir, glob("tests/xmlrpcapi/*.py")),
             ("%s/tests/test_data/V3_4_0" % datadir, glob("tests/test_data/V3_4_0/*")),
             ("%s/tests/utils" % datadir, glob("tests/utils/*.py")),
+            # tests containers subpackage
+            ("%s/docker" % datadir, glob("docker/*")),
+            ("%s/docker/debs" % datadir, glob("docker/debs/*")),
+            ("%s/docker/debs/Debian_10" % datadir, glob("docker/debs/Debian_10/*")),
+            (
+                "%s/docker/debs/Debian_10/supervisord" % datadir,
+                glob("docker/debs/Debian_10/supervisord/*"),
+            ),
+            (
+                "%s/docker/debs/Debian_10/supervisord/conf.d" % datadir,
+                glob("docker/debs/Debian_10/supervisord/conf.d/*"),
+            ),
+            ("%s/docker/debs/Debian_11" % datadir, glob("docker/debs/Debian_11/*")),
+            (
+                "%s/docker/debs/Debian_11/supervisord" % datadir,
+                glob("docker/debs/Debian_11/supervisord/*"),
+            ),
+            (
+                "%s/docker/debs/Debian_11/supervisord/conf.d" % datadir,
+                glob("docker/debs/Debian_11/supervisord/conf.d/*"),
+            ),
+            ("%s/docker/develop" % datadir, glob("docker/develop/*")),
+            ("%s/docker/develop/openldap" % datadir, glob("docker/develop/openldap/*")),
+            ("%s/docker/develop/pam" % datadir, glob("docker/develop/pam/*")),
+            ("%s/docker/develop/scripts" % datadir, glob("docker/develop/scripts/*")),
+            (
+                "%s/docker/develop/supervisord" % datadir,
+                glob("docker/develop/supervisord/*"),
+            ),
+            (
+                "%s/docker/develop/supervisord/conf.d" % datadir,
+                glob("docker/develop/supervisord/conf.d/*"),
+            ),
+            ("%s/docker/rpms" % datadir, glob("docker/rpms/*")),
+            ("%s/docker/rpms/Fedora_34" % datadir, glob("docker/rpms/Fedora_34/*")),
+            (
+                "%s/docker/rpms/Fedora_34/supervisord" % datadir,
+                glob("docker/rpms/Fedora_34/supervisord/*"),
+            ),
+            (
+                "%s/docker/rpms/Fedora_34/supervisord/conf.d" % datadir,
+                glob("docker/rpms/Fedora_34/supervisord/conf.d/*"),
+            ),
+            (
+                "%s/docker/rpms/Rocky_Linux_8" % datadir,
+                glob("docker/rpms/Rocky_Linux_8/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_leap" % datadir,
+                glob("docker/rpms/opensuse_leap/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_leap/supervisord" % datadir,
+                glob("docker/rpms/opensuse_leap/supervisord/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_leap/supervisord/conf.d" % datadir,
+                glob("docker/rpms/opensuse_leap/supervisord/conf.d/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_tumbleweed" % datadir,
+                glob("docker/rpms/opensuse_tumbleweed/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_tumbleweed/supervisord" % datadir,
+                glob("docker/rpms/opensuse_tumbleweed/supervisord/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_tumbleweed/supervisord/conf.d" % datadir,
+                glob("docker/rpms/opensuse_tumbleweed/supervisord/conf.d/*"),
+            ),
         ],
     )


### PR DESCRIPTION
## Description

This PR include dockerfiles and configuration files under `docker` into the `setup.py` script in order to build a `cobbler-tests-containers` package to easily consume in order to run Cobbler tests in containers.

## Behaviour changes

Old: files under `docker` folder were not shipped.

New: files under `docker` are shipped as part of `cobbler-tests-containers` package.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
