### PR TITLE
Skip wrong/inconsistent collections instead of crashing

### DIFF
--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -203,8 +203,13 @@ class Collection:
         if _list is None:
             return
         for item_dict in _list:
-            item = self.factory_produce(self.api, item_dict)
-            self.add(item)
+            try:
+                item = self.factory_produce(self.api, item_dict)
+                self.add(item)
+            except Exception as exc:
+                self.logger.error(
+                    f"Error while loading a collection: {exc}. Skipping this collection!"
+                )
 
     def copy(self, ref, newname):
         """

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -480,9 +480,10 @@ def blender(api_handle, remove_dicts: bool, root_obj):
         for key in child_names:
             child = api_handle.find_items("", name=key, return_list=False)
             if child is None:
-                raise ValueError(
-                    f'Child with the name "{key}" of parent object "{root_obj.name}" did not exist!'
+                logger.error(
+                    f'Child with the name "{key}" did not exist! This child is referenced in consolidated object "{root_obj.name}".'
                 )
+                continue
             results["children"][key] = child.to_dict()
 
     # sanitize output for koan and kernel option lines, etc


### PR DESCRIPTION
## Description

This PR makes Cobbler service more tolerant to any unexpected issue when loading collections.

Instead of making Cobbler to crash, this PR makes it to skip collections that cannot be loaded and keep the service running.

This way, we are not blocking other collections and particularly the entire Cobbler service to work in case of a problem with a particular collection.

<!-- What does this PR do? -->

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
