### PR TITLE
Add BaseOS folder to import_rsync_whitelist

### DIFF
--- a/config/rsync/import_rsync_whitelist
+++ b/config/rsync/import_rsync_whitelist
@@ -18,6 +18,7 @@
 + CentOS/
 + Packages/
 + Packages/*/
++ BaseOS/
 + Server/
 + Client/
 + SL/


### PR DESCRIPTION
RHEL8 stores the rpms in the BaseOS folder

## Linked Items

Fixes #3288

## Description

Add BaseOS to import_rsync_whitelist

## Behaviour changes

Same as before

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
