### PR TITLE
Support for older anaconda boot line options

### DIFF
--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -204,7 +204,10 @@ class AppendLineBuilder:
             self.append_line += (
                 f" proxy={self.data['proxy']} http_proxy={self.data['proxy']}"
             )
-        self.append_line += f" inst.ks={self.data['autoinstall']}"
+        if self.dist.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+            self.append_line += " ks=%s" % self.data["autoinstall"]
+        else:
+            self.append_line += " inst.ks=%s" % self.data["autoinstall"]
 
     def _generate_append_debian(self, system):
         """
@@ -366,10 +369,13 @@ class AppendLineBuilder:
         self.append_line += buildiso.add_remaining_kopts(self.data["kernel_options"])
         return self.append_line
 
-    def generate_profile(self, distro_breed: str, protocol: str = "http") -> str:
+    def generate_profile(
+        self, distro_breed: str, os_version: str, protocol: str = "http"
+    ) -> str:
         """
         Generate the append line for the kernel for a network installation.
         :param distro_breed: The name of the distribution breed.
+        :param os_version: The OS version of the distribution.
         :param protocol: The scheme that is used to read the autoyast file from the server
         :return: The generated append line.
         """
@@ -400,7 +406,10 @@ class AppendLineBuilder:
                 self.append_line += (
                     f" proxy={self.data['proxy']} http_proxy={self.data['proxy']}"
                 )
-            self.append_line += f" inst.ks={self.data['autoinstall']}"
+            if os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+                self.append_line += " ks=%s" % self.data["autoinstall"]
+            else:
+                self.append_line += " inst.ks=%s" % self.data["autoinstall"]
         elif distro_breed in ["ubuntu", "debian"]:
             self.append_line += (
                 f" auto-install/enable=true url={self.data['autoinstall']}"
@@ -513,7 +522,7 @@ class NetbootBuildiso(buildiso.BuildIso):
             )
 
         append_builder = AppendLineBuilder(distro_name=distname, data=data)
-        append_line = append_builder.generate_profile(dist.breed)
+        append_line = append_builder.generate_profile(dist.breed, dist.os_version)
         cfglines.append(append_line)
 
     def generate_netboot_iso(

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -25,7 +25,10 @@ def _generate_append_line_standalone(data: dict, distro, descendant) -> str:
     """
     append_line = f"  APPEND initrd={os.path.basename(distro.initrd)}"
     if distro.breed == "redhat":
-        append_line += f" inst.ks=cdrom:/isolinux/{descendant.name}.cfg"
+        if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+            append_line += f" ks=cdrom:/isolinux/{descendant.name}.cfg"
+        else:
+            append_line += f" inst.ks=cdrom:/isolinux/{descendant.name}.cfg"
     elif distro.breed == "suse":
         append_line += (
             f" autoyast=file:///isolinux/{descendant.name}.cfg install=cdrom:///"

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1090,8 +1090,10 @@ class TFTPGen:
 
             if distro.breed is None or distro.breed == "redhat":
 
-                append_line += " inst.kssendmac"
-                append_line = f"{append_line} inst.ks={autoinstall_path}"
+                if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
+                    append_line += " kssendmac ks=%s" % autoinstall_path
+                else:
+                    append_line += " inst.ks.sendmac inst.ks=%s" % autoinstall_path
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace(

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -31,6 +31,27 @@ def test_generate_system(
     )
 
 
+def test_generate_system_redhat(
+    cobbler_api, create_distro, create_profile, create_system
+):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.breed = "redhat"
+    cobbler_api.add_distro(test_distro)
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(profile_name=test_profile.name)
+    blendered_data = utils.blender(cobbler_api, False, test_system)
+    test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+    # Act
+    result = test_builder.generate_system(test_distro, test_system, False)
+
+    # Assert
+    # Very basic test yes but this is the expected result atm
+    # TODO: Make tests more sophisticated
+    assert result == f"  APPEND initrd={test_distro.name}.img inst.ks=default.ks"
+
+
 def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     # Arrange
     test_distro = create_distro()
@@ -39,7 +60,7 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     test_builder = AppendLineBuilder(test_distro.name, blendered_data)
 
     # Act
-    result = test_builder.generate_profile("suse")
+    result = test_builder.generate_profile("suse", "opensuse15generic")
 
     # Assert
     # Very basic test yes but this is the expected result atm
@@ -49,3 +70,39 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
         == " append initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
         % (request.node.originalname, request.node.originalname)
     )
+
+
+def test_generate_profile_rhel7(cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.breed = "redhat"
+    cobbler_api.add_distro(test_distro)
+    test_profile = create_profile(test_distro.name)
+    blendered_data = utils.blender(cobbler_api, False, test_profile)
+    test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+    # Act
+    result = test_builder.generate_profile("redhat", "rhel7")
+
+    # Assert
+    # Very basic test yes but this is the expected result atm
+    # TODO: Make tests more sophisticated
+    assert result == f" append initrd={test_distro.name}.img inst.ks=default.ks"
+
+
+def test_generate_profile_rhel6(cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.breed = "redhat"
+    cobbler_api.add_distro(test_distro)
+    test_profile = create_profile(test_distro.name)
+    blendered_data = utils.blender(cobbler_api, False, test_profile)
+    test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+    # Act
+    result = test_builder.generate_profile("redhat", "rhel6")
+
+    # Assert
+    # Very basic test yes but this is the expected result atm
+    # TODO: Make tests more sophisticated
+    assert result == f" append initrd={test_distro.name}.img ks=default.ks"


### PR DESCRIPTION
## Linked Items

Fixes #3334

## Description

The support was broken by 902d0c4. This commit restores the support for both new and old style options.

CC @xavierba please have a look at this rebased version of your PR.

## Behaviour changes

Old: Systems older then RHEL 7 (and derivates) cannot be installed anymore.

New: Systems older then RHEL 7 can be installed again.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
