### PR TITLE
Fix issues found on "mongodb" serializer module on latest pymongo versions

### DIFF
--- a/cobbler/modules/serializers/mongodb.py
+++ b/cobbler/modules/serializers/mongodb.py
@@ -102,7 +102,7 @@ class MongoDBSerializer(StorageBase):
             return settings.read_settings_file()
 
         collection = self.mongodb_database[collection_type]
-        return collection.find()
+        return list(collection.find({}, {"_id": False}))
 
     def deserialize(self, collection, topological: bool = True):
         datastruct = self.deserialize_raw(collection.collection_type())

--- a/cobbler/modules/serializers/mongodb.py
+++ b/cobbler/modules/serializers/mongodb.py
@@ -82,7 +82,7 @@ class MongoDBSerializer(StorageBase):
         collection = self.mongodb_database[collection.collection_type()]
         data = collection.find_one({"name": item.name})
         if data:
-            collection.update({"name": item.name}, item.serialize())
+            collection.replace_one({"name": item.name}, item.serialize())
         else:
             collection.insert_one(item.serialize())
 

--- a/tests/modules/serializer/mongodb_test.py
+++ b/tests/modules/serializer/mongodb_test.py
@@ -79,12 +79,16 @@ def test_deserialize_raw(mongodb_obj):
     mongodb_obj.mongodb["cobbler"][collection_type].insert_one(
         {"name": "testitem", "arch": "x86_64"}
     )
+    mongodb_obj.mongodb["cobbler"][collection_type].insert_one(
+        {"name": "testitem2", "arch": "x86_64"}
+    )
 
     # Act
     result = mongodb_obj.deserialize_raw(collection_type)
 
     # Assert
-    assert len(list(result)) == 1
+    assert isinstance(result, list)
+    assert len(result) == 2
 
 
 def test_deserialize(mocker, mongodb_obj):


### PR DESCRIPTION
## Description

This PR fixes some issues found when running the `mongodb` serializer module with latest pymongo and MongoDB versions:

- pymongo 4.1.1 (latest with Python 3.6 support) [1]
- mongoDB 6.0.4

The errors fixes:
- Make sure `deserialize_raw` returns a list and not a `Cursor` (which made available distros not to be loaded after cobblerd restart)
- Ensure internal mongoDB `_id` attribute is excluded from mongoDB `find` results (as they are not valid item attributes and break validation)

[1] https://pymongo.readthedocs.io/en/stable/changelog.html#changes-in-version-4-2

## Behaviour changes

Old: there were some issues found preventing mongodb serializer to work as expected:

```
exception on server: 'Collection' object is not callable. If you meant to call the 'update' method on a 'Collection' object it is failing because no such method exists.
...
```

New: No errors and items are successfully created, edited and removed, and also successfully loaded after cobbler startup.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
