### PR TITLE
Fix parm files for s390 systems when there are long kernel options values

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -163,7 +163,7 @@ class TFTPGen:
         s390_name = "linux" + short_name[7:10]
         self.logger.info("Writing s390x pxe config for %s", short_name)
         # Always write a system specific _conf and _parm file
-        pxe_f = os.path.join(self.bootloc, "s390x", f"s_{s390_name}")
+        pxe_f = os.path.join(self.bootloc, enums.Archs.S390X.value, f"s_{s390_name}")
         conf_f = f"{pxe_f}_conf"
         parm_f = f"{pxe_f}_parm"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,7 @@
+"""
+Top most "conftest.py" which is available for all tests of our codebase.
+"""
+
 import os
 import shutil
 from contextlib import contextmanager
@@ -58,7 +62,11 @@ def reset_items(cobbler_api: CobblerAPI):
 
 @pytest.fixture(scope="function")
 def create_testfile(tmp_path: Path):
-    def _create_testfile(filename: str):
+    """
+    Provides a method that creates a testfile inside the directory for one single test with a given name.
+    """
+
+    def _create_testfile(filename: str) -> str:
         path = os.path.join(tmp_path, filename)
         if not os.path.exists(path):
             Path(path).touch()
@@ -69,7 +77,12 @@ def create_testfile(tmp_path: Path):
 
 @pytest.fixture(scope="function")
 def create_kernel_initrd(create_testfile: Callable[[str], str]):
-    def _create_kernel_initrd(name_kernel: str, name_initrd: str) -> str:
+    """
+    Provides a method that touches two empty files that can act as a kernel and initrd. The folder with the two files
+    is returned.
+    """
+
+    def _create_kernel_initrd(name_kernel: str, name_initrd: str):
         create_testfile(name_kernel)
         return os.path.dirname(create_testfile(name_initrd))
 
@@ -89,9 +102,9 @@ def create_distro(
     the CobblerAPI.
     """
 
-    def _create_distro():
+    def _create_distro() -> Distro:
         test_folder = create_kernel_initrd(fk_kernel, fk_initrd)
-        test_distro = Distro(cobbler_api)
+        test_distro = cobbler_api.new_distro()
         test_distro.name = (
             request.node.originalname
             if request.node.originalname
@@ -113,7 +126,7 @@ def create_profile(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
 
     def _create_profile(distro_name: str) -> Profile:
-        test_profile = Profile(cobbler_api)
+        test_profile = cobbler_api.new_profile()
         test_profile.name = (
             request.node.originalname
             if request.node.originalname
@@ -134,7 +147,7 @@ def create_image(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
 
     def _create_image() -> Image:
-        test_image = Image(cobbler_api)
+        test_image = cobbler_api.new_image()
         test_image.name = (
             request.node.originalname
             if request.node.originalname
@@ -153,8 +166,10 @@ def create_system(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     already added to the CobblerAPI.
     """
 
-    def _create_system(profile_name: str = "", image_name: str = "", name: str = ""):
-        test_system = System(cobbler_api)
+    def _create_system(
+        profile_name: str = "", image_name: str = "", name: str = ""
+    ) -> System:
+        test_system = cobbler_api.new_system()
         if name == "":
             test_system.name = (
                 request.node.originalname


### PR DESCRIPTION
## Description

The previous code was not handling well the cases where kernel option is longer than 78 characters. It was causing the generated parm file no not fit the expect format form parmfiles.

parm file format is fixed to 80 chars per line.
All the lines are concatenated without spaces when being passed to the kernel.

Recommendation: one parameter per line (ending with whitespace)

NOTE: If a parameter is too long to fit into the 80 characters limit it can simply be continued in the first column of the next line.

More info:
https://www.debian.org/releases/stable/s390x/ch05s01.en.html
https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-zseries.html#sec-appdendix-parm-examples
https://wiki.ubuntu.com/S390X/InstallationGuide

## Behaviour changes

Old: The generated `/srv/tftpboot/s390x/s_linuxite_parm` is not correct as it exceeed 80 characters per line:

```console
# cat /srv/tftpboot/s390x/s_linuxite_parm
foobar1=whatever 
autoyast=http://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/this-is-a-long-string-that-need-to-be-splitted/zzzzzzzzzzzzzzzzz 
foobar2=woohooo 
```

New: The generated `/srv/tftpboot/s390x/s_linuxite_parm` looks correct now:

```console
# cat /srv/tftpboot/s390x/s_linuxite_parm 
foobar1=whatever 
autoyast=http://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/this-is-a-
long-string-that-need-to-be-splitted/zzzzzzzzzzzzzzzzz 
foobar2=woohooo
```

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 