### PR TITLE
Fix: rename item

### DIFF
--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -260,16 +260,15 @@ class Collection:
 
         # Save the old name
         oldname = ref.name
-        # Reserve the new name
-        self.listing[newname] = None
-        # Delete the old item
-        self.collection_mgr.serialize_delete_one_item(ref)
-        self.listing.pop(oldname)
-        # Change the name of the object
-        ref.name = newname
-        # Save just this item
-        self.collection_mgr.serialize_one_item(ref)
-        self.listing[newname] = ref
+        with self.lock:
+            # Delete the old item
+            self.collection_mgr.serialize_delete_one_item(ref)
+            self.listing.pop(oldname.lower())
+            # Change the name of the object
+            ref.name = newname
+            # Save just this item
+            self.collection_mgr.serialize_one_item(ref)
+            self.listing[newname.lower()] = ref
 
         # for mgmt classes, update all objects that use it
         if ref.COLLECTION_TYPE == "mgmtclass":

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -51,8 +51,6 @@ class Distros(collection.Collection):
         :raises CX: In case any subitem (profiles or systems) would be orphaned. If the option ``recursive`` is set then
                     the orphaned items would be removed automatically.
         """
-        name = name.lower()
-
         obj = self.find(name=name)
 
         if obj is None:
@@ -61,7 +59,7 @@ class Distros(collection.Collection):
         # first see if any Groups use this distro
         if not recursive:
             for profile in self.api.profiles():
-                if profile.distro and profile.distro.name.lower() == name:
+                if profile.distro and profile.distro.name == name:
                     raise CX(f"removal would orphan profile: {profile.name}")
 
         kernel = obj.kernel

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -45,7 +45,6 @@ class Files(collection.Collection):
 
         :raises CX: In case a non existent object should be deleted.
         """
-        name = name.lower()
         obj = self.find(name=name)
 
         if obj is None:

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -48,7 +48,6 @@ class Images(collection.Collection):
         :raises CX: In case object does not exist or it would orhan a system.
         """
         # NOTE: with_delete isn't currently meaningful for repos but is left in for consistency in the API. Unused.
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX(f"cannot delete an object that does not exist: {name}")
@@ -56,7 +55,7 @@ class Images(collection.Collection):
         # first see if any Groups use this distro
         if not recursive:
             for system in self.api.systems():
-                if system.image is not None and system.image.lower() == name:
+                if system.image is not None and system.image == name:
                     raise CX(f"removal would orphan system: {system.name}")
 
         if recursive:

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -7,7 +7,7 @@ Repository of the Cobbler object model
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import weakref
-from typing import Union, Dict, Any
+from typing import TYPE_CHECKING, Union, Dict, Any
 
 from cobbler.cexceptions import CX
 from cobbler import serializer
@@ -23,6 +23,10 @@ from cobbler.cobbler_collections.systems import Systems
 from cobbler.cobbler_collections.menus import Menus
 
 
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
 class CollectionManager:
     """
     Manages a definitive copy of all data cobbler_collections with weakrefs pointing back into the class so they can
@@ -32,7 +36,7 @@ class CollectionManager:
     has_loaded = False
     __shared_state: Dict[str, Any] = {}
 
-    def __init__(self, api):
+    def __init__(self, api: "CobblerAPI"):
         """
         Constructor which loads all content if this action was not performed before.
         """
@@ -40,7 +44,7 @@ class CollectionManager:
         if not CollectionManager.has_loaded:
             self.__load(api)
 
-    def __load(self, api):
+    def __load(self, api: "CobblerAPI"):
         """
         Load all collections from the disk into Cobbler.
 

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -54,16 +54,15 @@ class Menus(collection.Collection):
         :param recursive: In case you want to delete all objects this menu references.
         :raises CX: Raised in case you want to delete a none existing menu.
         """
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX(f"cannot delete an object that does not exist: {name}")
 
         for profile in self.api.profiles():
-            if profile.menu and profile.menu.lower() == name:
+            if profile.menu and profile.menu == name:
                 profile.menu = ""
         for image in self.api.images():
-            if image.menu and image.menu.lower() == name:
+            if image.menu and image.menu == name:
                 image.menu = ""
 
         if recursive:

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -49,7 +49,6 @@ class Mgmtclasses(collection.Collection):
 
         :raises CX: In case the object does not exist.
         """
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX(f"cannot delete an object that does not exist: {name}")

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -45,7 +45,6 @@ class Packages(collection.Collection):
 
         :raises CX: In case the object does not exist.
         """
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX(f"cannot delete an object that does not exist: {name}")

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -46,10 +46,9 @@ class Profiles(collection.Collection):
 
         :raises CX: In case the name of the object was not given or any other descendant would be orphaned.
         """
-        name = name.lower()
         if not recursive:
             for system in self.api.systems():
-                if system.profile is not None and system.profile.lower() == name:
+                if system.profile is not None and system.profile == name:
                     raise CX(f"removal would orphan system: {system.name}")
 
         obj = self.find(name=name)

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -53,7 +53,6 @@ class Repos(collection.Collection):
         """
         # NOTE: with_delete isn't currently meaningful for repos
         # but is left in for consistancy in the API.  Unused.
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX(f"cannot delete an object that does not exist: {name}")

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -51,7 +51,6 @@ class Systems(collection.Collection):
 
         :raises CX: In case the name of the object was not given.
         """
-        name = name.lower()
         obj = self.find(name=name)
 
         if obj is None:

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -97,7 +97,7 @@ def run(api, args) -> int:
 
         sendmail = True
         for prefix in settings.build_reporting_ignorelist:
-            if prefix != "" and name.lower().startswith(prefix):
+            if prefix != "" and name.startswith(prefix):
                 sendmail = False
 
         if sendmail:

--- a/tests/api/add_test.py
+++ b/tests/api/add_test.py
@@ -1,9 +1,16 @@
+"""
+Tests that are ensuring the correct functionality of the CobblerAPI in regard to adding items via it.
+"""
+
 from pathlib import Path
+import pathlib
+from typing import Callable
+from cobbler.api import CobblerAPI
 
 from cobbler.items.image import Image
 
 
-def test_image_add(cobbler_api):
+def test_image_add(cobbler_api: CobblerAPI):
     # Arrange
     test_image = Image(cobbler_api)
     test_image.name = "test_cobbler_api_add_image"
@@ -16,3 +23,36 @@ def test_image_add(cobbler_api):
 
     # Assert
     assert expected_result.exists()
+
+
+def test_case_sensitive_add(
+    cobbler_api: CobblerAPI,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+):
+    """
+    Test that two items with the same characters in different casing can be successfully added and edited.
+    """
+    # Arrange
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    name = "TestName"
+    item1 = cobbler_api.new_distro()
+    item1.name = name
+    item1.kernel = str(pathlib.Path(folder) / fk_kernel)
+    item1.initrd = str(pathlib.Path(folder) / fk_initrd)
+    cobbler_api.add_distro(item1)
+    item2 = cobbler_api.new_distro()
+    item2.name = name.lower()
+    item2.kernel = str(pathlib.Path(folder) / fk_kernel)
+    item2.initrd = str(pathlib.Path(folder) / fk_initrd)
+
+    # Act
+    cobbler_api.add_distro(item2)
+    cobbler_api.remove_distro(item1.name)
+    result_item = cobbler_api.get_item("distro", item2.name)
+
+    # Assert
+    assert result_item is not None
+    assert result_item.uid == item2.uid
+    assert cobbler_api.get_item("distro", item1.name) is None

--- a/tests/cobbler_collections/conftest.py
+++ b/tests/cobbler_collections/conftest.py
@@ -1,6 +1,17 @@
+"""
+Fixtures that are common for testing the cobbler collections.
+"""
+
 import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cobbler_collections.manager import CollectionManager
 
 
 @pytest.fixture()
-def collection_mgr(cobbler_api):
-    return cobbler_api._collection_mgr
+def collection_mgr(cobbler_api: CobblerAPI) -> CollectionManager:
+    """
+    Fixture that provides access to the collection manager instance for testing.
+    """
+    # pylint: disable=protected-access
+    return cobbler_api._collection_mgr  # pyright: ignore [reportPrivateUsage]

--- a/tests/cobbler_collections/distro_collection_test.py
+++ b/tests/cobbler_collections/distro_collection_test.py
@@ -117,20 +117,27 @@ def test_copy(
     assert new_item_name in distro_collection.listing
 
 
-def test_rename(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    cobbler_api: CobblerAPI, distro_collection: distros.Distros, input_new_name: str
+):
     # Arrange
-    name = "to_be_renamed"
     item1 = distro.Distro(cobbler_api)
-    item1.name = name
+    item1.name = "old_name"
     distro_collection.add(item1)
 
     # Act
-    new_name = "new_name"
-    distro_collection.rename(item1, new_name)
+    distro_collection.rename(item1, input_new_name)
 
     # Assert
-    assert new_name in distro_collection.listing
-    assert distro_collection.listing.get(new_name).name == new_name
+    assert input_new_name in distro_collection.listing
+    assert distro_collection.listing.get(input_new_name).name == input_new_name
 
 
 def test_collection_add(cobbler_api: CobblerAPI, distro_collection: distros.Distros):

--- a/tests/cobbler_collections/distro_collection_test.py
+++ b/tests/cobbler_collections/distro_collection_test.py
@@ -1,18 +1,24 @@
 import os.path
+from typing import Callable
 
 import pytest
+from cobbler.api import CobblerAPI
 
 from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import distros
+from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.items import distro
 
 
 @pytest.fixture
-def distro_collection(collection_mgr):
+def distro_collection(collection_mgr: CollectionManager):
+    """
+    Fixture to provide a concrete implementation (Distros) of a generic collection.
+    """
     return distros.Distros(collection_mgr)
 
 
-def test_obj_create(collection_mgr):
+def test_obj_create(collection_mgr: CollectionManager):
     # Arrange & Act
     distro_collection = distros.Distros(collection_mgr)
 
@@ -20,7 +26,7 @@ def test_obj_create(collection_mgr):
     assert isinstance(distro_collection, distros.Distros)
 
 
-def test_factory_produce(cobbler_api, distro_collection):
+def test_factory_produce(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange & Act
     result_distro = distro_collection.factory_produce(cobbler_api, {})
 
@@ -28,7 +34,7 @@ def test_factory_produce(cobbler_api, distro_collection):
     assert isinstance(result_distro, distro.Distro)
 
 
-def test_get(cobbler_api, distro_collection):
+def test_get(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "test_get"
     item1 = distro.Distro(cobbler_api)
@@ -43,7 +49,7 @@ def test_get(cobbler_api, distro_collection):
     assert item.name == name
 
 
-def test_find(cobbler_api, distro_collection):
+def test_find(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "test_find"
     item1 = distro.Distro(cobbler_api)
@@ -59,7 +65,7 @@ def test_find(cobbler_api, distro_collection):
     assert result[0].name == name
 
 
-def test_to_list(cobbler_api, distro_collection):
+def test_to_list(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "test_to_list"
     item1 = distro.Distro(cobbler_api)
@@ -74,7 +80,7 @@ def test_to_list(cobbler_api, distro_collection):
     assert result[0].get("name") == name
 
 
-def test_from_list(distro_collection):
+def test_from_list(distro_collection: distros.Distros):
     # Arrange
     item_list = [{"name": "test_from_list"}]
 
@@ -86,7 +92,11 @@ def test_from_list(distro_collection):
 
 
 def test_copy(
-    cobbler_api, distro_collection, create_kernel_initrd, fk_initrd, fk_kernel
+    cobbler_api: CobblerAPI,
+    distro_collection: distros.Distros,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
 ):
     # Arrange
     folder = create_kernel_initrd(fk_kernel, fk_initrd)
@@ -107,7 +117,7 @@ def test_copy(
     assert new_item_name in distro_collection.listing
 
 
-def test_rename(cobbler_api, distro_collection):
+def test_rename(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "to_be_renamed"
     item1 = distro.Distro(cobbler_api)
@@ -123,7 +133,7 @@ def test_rename(cobbler_api, distro_collection):
     assert distro_collection.listing.get(new_name).name == new_name
 
 
-def test_collection_add(cobbler_api, distro_collection):
+def test_collection_add(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "collection_add"
     item1 = distro.Distro(cobbler_api)
@@ -136,7 +146,7 @@ def test_collection_add(cobbler_api, distro_collection):
     assert name in distro_collection.listing
 
 
-def test_duplicate_add(cobbler_api, distro_collection):
+def test_duplicate_add(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "duplicate_name"
     item1 = distro.Distro(cobbler_api)
@@ -150,7 +160,7 @@ def test_duplicate_add(cobbler_api, distro_collection):
         distro_collection.add(item2, check_for_duplicate_names=True)
 
 
-def test_remove(cobbler_api, distro_collection):
+def test_remove(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "to_be_removed"
     item1 = distro.Distro(cobbler_api)
@@ -166,7 +176,7 @@ def test_remove(cobbler_api, distro_collection):
 
 
 @pytest.mark.skip("Method which is under test is broken!")
-def test_to_string(cobbler_api, distro_collection):
+def test_to_string(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "to_string"
     item1 = distro.Distro(cobbler_api)


### PR DESCRIPTION
## Linked Items

Fixes #3350 

## Description

Fixes renaming items with uppercase characters.

## Behaviour changes

Old:

- Items with uppercase letters could not be renamed.
- Renaming items was not thread safe

New:

- Items that have uppercase letters can be renamed
- Renaming items is not thread safe

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
