### PR TITLE
Fix buildiso with efi firmware

### DIFF
--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
@@ -34,7 +34,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
@@ -53,7 +53,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
@@ -72,7 +72,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Pull Docker Test Container
         run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -173,6 +173,7 @@ Requires:       %{createrepo_pkg}
 Requires:       fence-agents
 Requires:       rsync
 Requires:       xorriso
+Requires:       dosfstools
 %{?python_enable_dependency_generator}
 %if ! (%{defined python_enable_dependency_generator} || %{defined python_disable_dependency_generator})
 Requires:       %{py3_module_cheetah}
@@ -335,6 +336,7 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
 %config(noreplace) %{_sysconfdir}/cobbler/iso/isolinux_menuentry.template
+%config(noreplace) %{_sysconfdir}/cobbler/iso/grub_menuentry.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf
 %config(noreplace) %{_sysconfdir}/cobbler/named.template
 %config(noreplace) %{_sysconfdir}/cobbler/ndjbdns.template

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -334,6 +334,7 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %config(noreplace) %{_sysconfdir}/cobbler/import_rsync_whitelist
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
+%config(noreplace) %{_sysconfdir}/cobbler/iso/isolinux_menuentry.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf
 %config(noreplace) %{_sysconfdir}/cobbler/named.template
 %config(noreplace) %{_sysconfdir}/cobbler/ndjbdns.template

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -11,9 +11,9 @@ import logging
 import os
 import pathlib
 import shutil
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, NamedTuple, Optional
 
-from cobbler import utils
+from cobbler import templar, utils
 from cobbler.enums import Archs
 from cobbler.utils import filesystem_helpers, input_converters
 
@@ -41,6 +41,29 @@ def add_remaining_kopts(kopts: dict) -> str:
     return " ".join(append_line)
 
 
+class BootFilesCopyset(NamedTuple):
+    src_kernel: str
+    src_initrd: str
+    new_filename: str
+
+
+class LoaderCfgsParts(NamedTuple):
+    isolinux: List[str]
+    bootfiles_copysets: List[BootFilesCopyset]
+
+
+class BuildisoDirs(NamedTuple):
+    root: pathlib.Path
+    isolinux: pathlib.Path
+    autoinstall: pathlib.Path
+    repo: pathlib.Path
+
+
+class Autoinstall(NamedTuple):
+    config: str
+    repos: List[str]
+
+
 class BuildIso:
     """
     Handles conversion of internal state to the isolinux tree layout
@@ -54,8 +77,7 @@ class BuildIso:
         self.distmap = {}
         self.distctr = 0
         self.logger = logging.getLogger()
-
-        self.profiles: List[str] = []
+        self.templar = templar.Templar(api)
         self.isolinuxdir = ""
 
         # grab the header from buildiso.header file
@@ -64,24 +86,35 @@ class BuildIso:
             .joinpath("buildiso.template")
             .read_text(encoding="UTF-8")
         )
+        self.isolinux_menuentry_template = (
+            pathlib.Path(api.settings().iso_template_dir)
+            .joinpath("isolinux_menuentry.template")
+            .read_text(encoding="UTF-8")
+        )
 
-    def copy_boot_files(self, distro, destdir: str, new_filename: str = ""):
+    def _copy_boot_files(
+        self, kernel_path, initrd_path, destdir: str, new_filename: str = ""
+    ):
         """Copy kernel/initrd to destdir with (optional) newfile prefix
-        :param distro: Distro object to return the boot files for.
+        :param kernel_path: Path to a a distro's kernel.
+        :param initrd_path: Path to a a distro's initrd.
         :param destdir: The destination directory.
         :param new_filename: The file new filename. Kernel and Initrd have different extensions to seperate them from
                              each another.
         """
-        self.logger.info("copying kernels and initrds for standalone distro")
-        kernel = pathlib.Path(distro.kernel)
-        initrd = pathlib.Path(distro.initrd)
+        kernel_source = pathlib.Path(kernel_path)
+        initrd_source = pathlib.Path(initrd_path)
         path_destdir = pathlib.Path(destdir)
-        if not new_filename:
-            shutil.copyfile(kernel, path_destdir.joinpath(kernel.name))
-            shutil.copyfile(initrd, path_destdir.joinpath(initrd.name))
+
+        if new_filename:
+            kernel_dest = str(path_destdir / f"{new_filename}.krn")
+            initrd_dest = str(path_destdir / f"{new_filename}.img")
         else:
-            shutil.copyfile(kernel, path_destdir.joinpath(f"{new_filename}.krn"))
-            shutil.copyfile(initrd, path_destdir.joinpath(f"{new_filename}.img"))
+            kernel_dest = str(path_destdir / kernel_source.name)
+            initrd_dest = str(path_destdir / initrd_source.name)
+
+        filesystem_helpers.copyfile(str(kernel_source), kernel_dest)
+        filesystem_helpers.copyfile(str(initrd_source), initrd_dest)
 
     def filter_profiles(self, selected_items: Optional[List[str]] = None) -> list:
         """
@@ -122,7 +155,32 @@ class BuildIso:
 
         return filtered_objects
 
-    def __copy_files(self, iso_distro, buildisodir: str = ""):
+    def parse_distro(self, distro_name):
+        """Find and return distro object.
+
+        Raises ValueError if the distro is not found.
+        """
+        distro_obj = self.api.find_distro(name=distro_name)
+        if distro_obj is None:
+            raise ValueError(f"Distribution {distro_name} not found.")
+        return distro_obj
+
+    def parse_profiles(self, profiles, distro_obj):
+        profile_names = input_converters.input_string_or_list_no_inherit(profiles)
+        if profile_names:
+            orphans = set(profile_names) - set(distro_obj.children)
+            if len(orphans) > 0:
+                raise ValueError(
+                    "When building a standalone ISO, all --profiles must be"
+                    " under --distro. Extra --profiles: {}".format(
+                        ",".join(sorted(str(o for o in orphans)))
+                    )
+                )
+            return self.filter_profiles(profile_names)
+        else:
+            return self.filter_profiles(distro_obj.children)
+
+    def _copy_isolinux_files(self):
         """
         This method copies the required and optional files from syslinux into the directories we use for building the
         ISO.
@@ -172,20 +230,21 @@ class BuildIso:
                 "Required file(s) not found. Please check your syslinux installation"
             )
 
-        self.logger.info("copying GRUB2 files")
-        bootloader_directory = pathlib.Path(self.api.settings().bootloaders_dir)
-        grub_efi = bootloader_directory.joinpath(
-            "grub", self.calculate_grub_name(iso_distro)
+    def _render_isolinux_entry(
+        self, append_line: str, menu_name: str, kernel_path: str, menu_indent: int = 0
+    ) -> str:
+        """Render a single isolinux.cfg menu entry."""
+        return self.templar.render(
+            self.isolinux_menuentry_template,
+            out_path=None,
+            search_table={
+                "menu_name": menu_name,
+                "kernel_path": kernel_path,
+                "append_line": append_line.lstrip(),
+                "menu_indent": menu_indent,
+            },
+            template_type="jinja2",
         )
-        buildiso_directory = pathlib.Path(buildisodir)
-        grub_target = buildiso_directory.joinpath("grub", "grub.efi")
-        if grub_efi.exists():
-            filesystem_helpers.copyfile(str(grub_efi), str(grub_target), symlink=True)
-        else:
-            self.logger.error('The following files were not found: "%s"', grub_efi)
-            raise FileNotFoundError(
-                "Required file(s) not found. Please check your GRUB 2 installation"
-            )
 
     def calculate_grub_name(self, distro) -> str:
         """
@@ -231,7 +290,20 @@ class BuildIso:
             f' Found: "{str(matches.values())}"'
         )
 
-    def __prepare_buildisodir(self, buildisodir: str = "") -> str:
+    def _write_isolinux_cfg(
+        self, cfg_parts: List[str], output_dir: pathlib.Path
+    ) -> None:
+        """Write isolinux.cfg.
+
+        :param cfg_parts: List of str that is written to the config, joined by newlines.
+        :param output_dir: pathlib.Path that the isolinux.cfg file is written into.
+        """
+        output_file = output_dir / "isolinux.cfg"
+        self.logger.info("Writing %s", output_file)
+        with open(output_file, "w") as f:
+            f.write("\n".join(cfg_parts))
+
+    def _prepare_buildisodir(self, buildisodir: str = "") -> str:
         """
         This validated the path and type of the buildiso directory and then (re-)creates the apropiate directories.
         :param buildisodir: The directory in which the build of the ISO takes place. If an empty string then the default
@@ -258,40 +330,23 @@ class BuildIso:
         os.makedirs(buildisodir)
 
         self.isolinuxdir = os.path.join(buildisodir, "isolinux")
-
-        self.logger.info("building tree for isolinux")
-        if not os.path.exists(self.isolinuxdir):
-            os.makedirs(self.isolinuxdir)
-        self.logger.info("building tree for GRUB 2")
-        grub_dir = os.path.join(buildisodir, "grub")
-        if not os.path.exists(grub_dir):
-            os.makedirs(grub_dir)
         return buildisodir
 
-    def _prepare_iso(
-        self,
-        buildisodir: str = "",
-        iso_distro: str = "",
-        profiles: Optional[Union[str, list]] = None,
-    ):
-        """
-        Validates the directories we use for building the ISO and copies files to the right place.
-        :param buildisodir: The directory to use for building the ISO. If an empty string then the default directory is
-                            used.
-        :param iso_distro: The distro to use for building the ISO.
-        :param profiles: The profiles to generate the ISO for.
-        :return: The normalized directory for further processing.
-        """
-        try:
-            iso_distro = self.api.find_distro(name=iso_distro)
-        except ValueError as value_error:
-            raise ValueError(
-                'Not existent distribution name passed to "cobbler buildiso"!'
-            ) from value_error
-        buildisodir = self.__prepare_buildisodir(buildisodir)
-        self.__copy_files(iso_distro, buildisodir)
-        self.profiles = input_converters.input_string_or_list_no_inherit(profiles)
-        return buildisodir
+    def create_buildiso_dirs(self, buildiso_root: str) -> BuildisoDirs:
+        """Create directories in the buildiso root."""
+        root = pathlib.Path(buildiso_root)
+        isolinuxdir = root / "isolinux"
+        autoinstalldir = root / "autoinstall"
+        repodir = root / "repo_mirror"
+        for d in [isolinuxdir, autoinstalldir, repodir]:
+            d.mkdir(parents=True)
+
+        return BuildisoDirs(
+            root=root,
+            isolinux=isolinuxdir,
+            autoinstall=autoinstalldir,
+            repo=repodir,
+        )
 
     def _generate_iso(self, xorrisofs_opts: str, iso: str, buildisodir: str):
         """

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -7,9 +7,11 @@ memory.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
+import contextlib
 import logging
 import os
 import pathlib
+import re
 import shutil
 from typing import Dict, List, NamedTuple, Optional
 
@@ -49,12 +51,14 @@ class BootFilesCopyset(NamedTuple):
 
 class LoaderCfgsParts(NamedTuple):
     isolinux: List[str]
+    grub: List[str]
     bootfiles_copysets: List[BootFilesCopyset]
 
 
 class BuildisoDirs(NamedTuple):
     root: pathlib.Path
     isolinux: pathlib.Path
+    grub: pathlib.Path
     autoinstall: pathlib.Path
     repo: pathlib.Path
 
@@ -80,6 +84,13 @@ class BuildIso:
         self.templar = templar.Templar(api)
         self.isolinuxdir = ""
 
+        # based on https://uefi.org/sites/default/files/resources/UEFI%20Spec%202.8B%20May%202020.pdf
+        # FIXME: PowerPC is missing from the table
+        self.efi_fallback_renames = {
+            "grubaa64": "bootaa64.efi",
+            "grubx64.efi": "bootx64.efi",
+        }
+
         # grab the header from buildiso.header file
         self.iso_template = (
             pathlib.Path(self.api.settings().iso_template_dir)
@@ -91,6 +102,38 @@ class BuildIso:
             .joinpath("isolinux_menuentry.template")
             .read_text(encoding="UTF-8")
         )
+        self.grub_menuentry_template = (
+            pathlib.Path(api.settings().iso_template_dir)
+            .joinpath("grub_menuentry.template")
+            .read_text(encoding="UTF-8")
+        )
+
+    def _find_distro_source(self, known_file: str, distro_mirror: str) -> str:
+        """
+        Find a distro source tree based on a known file.
+
+        :param known_file: Path to a file that's known to be part of the distribution,
+            commonly the path to the kernel.
+        :raises ValueError: When no installation source was not found.
+        :return: Root of the distribution's source tree.
+        """
+        self.logger.debug("Trying to locate source.")
+        (source_head, source_tail) = os.path.split(known_file)
+        filesource = None
+        while source_tail != "":
+            if source_head == distro_mirror:
+                filesource = os.path.join(source_head, source_tail)
+                self.logger.debug("Found source in %s", filesource)
+                break
+            (source_head, source_tail) = os.path.split(source_head)
+
+        if filesource:
+            return filesource
+        else:
+            raise ValueError(
+                "No installation source found. When building a standalone (incl. airgapped) ISO"
+                " you must specify a --source if the distro install tree is not hosted locally"
+            )
 
     def _copy_boot_files(
         self, kernel_path, initrd_path, destdir: str, new_filename: str = ""
@@ -230,6 +273,20 @@ class BuildIso:
                 "Required file(s) not found. Please check your syslinux installation"
             )
 
+    def _render_grub_entry(
+        self, append_line, menu_name, kernel_path, initrd_path
+    ) -> str:
+        return self.templar.render(
+            self.grub_menuentry_template,
+            out_path=None,
+            search_table={
+                "menu_name": menu_name,
+                "kernel_path": kernel_path,
+                "initrd_path": initrd_path,
+                "kernel_options": re.sub(r".*initrd=\S+", "", append_line),
+            },
+        )
+
     def _render_isolinux_entry(
         self, append_line: str, menu_name: str, kernel_path: str, menu_indent: int = 0
     ) -> str:
@@ -246,7 +303,22 @@ class BuildIso:
             template_type="jinja2",
         )
 
-    def calculate_grub_name(self, distro) -> str:
+    def _copy_grub_into_esp(self, esp_image_location: str, arch: Archs):
+        """Copy grub boot loader into EFI System Partition.
+
+        :param esp_image_location: Path to EFI System Partition.
+        :param arch: Distribution architecture
+        """
+        grub_name = self.calculate_grub_name(arch)
+        efi_name = self.efi_fallback_renames.get(grub_name, grub_name)
+        with self._mount_esp(esp_image_location) as mountpoint:
+            esp_efi_boot = self._create_efi_boot_dir(mountpoint)
+            grub_binary = (
+                pathlib.Path(self.api.settings().bootloaders_dir) / "grub" / grub_name
+            )
+            filesystem_helpers.copyfile(str(grub_binary), f"{esp_efi_boot}/{efi_name}")
+
+    def calculate_grub_name(self, desired_arch: Archs) -> str:
         """
         This function checks the bootloaders_formats in our settings and then checks if there is a match between the
         architectures and the distribution architecture.
@@ -254,7 +326,6 @@ class BuildIso:
         """
         loader_formats = self.api.settings().bootloaders_formats
         grub_binary_names: Dict[str, str] = {}
-        desired_arch = distro.arch
 
         for (loader_format, values) in loader_formats.items():
             name = values.get("binary_name", None)
@@ -303,6 +374,73 @@ class BuildIso:
         with open(output_file, "w") as f:
             f.write("\n".join(cfg_parts))
 
+    def _write_grub_cfg(self, cfg_parts: List[str], output_dir: pathlib.Path) -> None:
+        """Write grub.cfg.
+
+        :param cfg_parts: List of str that is written to the config, joined by newlines.
+        :param output_dir: pathlib.Path that the grub.cfg file is written into.
+        """
+        output_file = output_dir / "grub.cfg"
+        self.logger.info("Writing %s", output_file)
+        with open(output_file, "w") as f:
+            f.write("\n".join(cfg_parts))
+
+    def _create_esp_image_file(self, tmpdir: str) -> str:
+        esp = pathlib.Path(tmpdir) / "efi"
+        mkfs_cmd = ["mkfs.fat", "-C", str(esp), "3528"]
+        rc = utils.subprocess_call(mkfs_cmd, shell=False)
+        if rc != 0:
+            self.logger.error("Could not create ESP image file")
+            raise Exception  # TODO: use proper exception
+        return str(esp)
+
+    @contextlib.contextmanager
+    def _mount_esp(self, esp_path: str):
+        def mount(esp_path: str, mountpoint: pathlib.Path) -> None:
+            mp.mkdir()
+
+            mount_cmd = ["mount", "-o", "loop", esp_path, mountpoint]
+            rc = utils.subprocess_call(mount_cmd, shell=False)
+            if rc != 0:
+                self.logger.error(
+                    "Could not mount ESP image file %s at %s", esp_path, mountpoint
+                )
+                raise Exception  # TODO: use concrete exception
+
+        def umount(mountpoint: pathlib.Path) -> None:
+            unmount_cmd = ["umount", mountpoint]
+            rc = utils.subprocess_call(unmount_cmd, shell=False)
+            if rc != 0:
+                self.logger.error("Could not unmount ESP image file at %s", mountpoint)
+                raise Exception  # TODO: use concrete exception
+            mountpoint.rmdir()
+
+        mp = pathlib.Path(esp_path + "_mounted")
+        try:
+            mount(esp_path, mp)
+            yield str(mp)
+        finally:
+            umount(mp)
+
+    def _create_efi_boot_dir(self, esp_mountpoint: str) -> str:
+        efi_boot = pathlib.Path(esp_mountpoint) / "EFI" / "BOOT"
+        self.logger.info("Creating %s", efi_boot)
+        efi_boot.mkdir(parents=True)
+        return str(efi_boot)
+
+    def _find_esp(self, root_dir: pathlib.Path) -> Optional[str]:
+        """Walk root directory and look for an ESP."""
+        candidates = [str(match) for match in root_dir.glob("**/efi")]
+        if len(candidates) == 0:
+            return None
+        elif len(candidates) == 1:
+            return candidates[0]
+        else:
+            self.logger.info(
+                "Found multiple ESP (%s), choosing %s", candidates, candidates[0]
+            )
+            return candidates[0]
+
     def _prepare_buildisodir(self, buildisodir: str = "") -> str:
         """
         This validated the path and type of the buildiso directory and then (re-)creates the apropiate directories.
@@ -336,24 +474,29 @@ class BuildIso:
         """Create directories in the buildiso root."""
         root = pathlib.Path(buildiso_root)
         isolinuxdir = root / "isolinux"
+        grubdir = root / "EFI" / "BOOT"
         autoinstalldir = root / "autoinstall"
         repodir = root / "repo_mirror"
-        for d in [isolinuxdir, autoinstalldir, repodir]:
+        for d in [isolinuxdir, grubdir, autoinstalldir, repodir]:
             d.mkdir(parents=True)
 
         return BuildisoDirs(
             root=root,
             isolinux=isolinuxdir,
+            grub=grubdir,
             autoinstall=autoinstalldir,
             repo=repodir,
         )
 
-    def _generate_iso(self, xorrisofs_opts: str, iso: str, buildisodir: str):
+    def _generate_iso(
+        self, xorrisofs_opts: str, iso: str, buildisodir: str, esp_path: str
+    ):
         """
         Build the final xorrisofs command which is then executed on the disk.
         :param xorrisofs_opts: The additional options for xorrisofs.
         :param iso: The name of the output iso.
         :param buildisodir: The directory in which we build the ISO.
+        :param esp_path: The absolute path to the EFI system partition.
         """
         running_on, _ = utils.os_release()
         if running_on in ("suse", "centos", "virtuozzo", "redhat"):
@@ -364,7 +507,7 @@ class BuildIso:
             isohdpfx_location = pathlib.Path(self.api.settings().syslinux_dir).joinpath(
                 "mbr/isohdpfx.bin"
             )
-        efi_img_location = "grub/grub.efi"
+        esp_relative_path = pathlib.Path(esp_path).relative_to(buildisodir)
         cmd = [
             "xorriso",
             "-as",
@@ -385,7 +528,7 @@ class BuildIso:
             "-boot-info-table",
             "-eltorito-alt-boot",
             "-e",
-            efi_img_location,
+            str(esp_relative_path),
             "-no-emul-boot",
             "-isohybrid-gpt-basdat",
             "-V",

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -560,6 +560,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         distro_name: str = "",
         systems: Optional[List[str]] = None,
         exclude_dns: bool = False,
+        **kwargs,
     ):
         """
         Run the whole iso generation from bottom to top. Per default this builds an ISO for all available systems
@@ -575,6 +576,8 @@ class NetbootBuildiso(buildiso.BuildIso):
                         systems.
         :param exclude_dns: Whether the repositories have to be locally available or the internet is reachable.
         """
+        del kwargs  # just accepted for polymorphism
+
         buildisodir = self._prepare_iso(buildisodir, distro_name, profiles)
         systems = input_converters.input_string_or_list_no_inherit(systems)
         self.generate_netboot_iso(systems, exclude_dns)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -325,6 +325,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         distro_name: str = "",
         airgapped: bool = False,
         source="",
+        **kwargs,
     ):
         """
         Run the whole iso generation from bottom to top. Per default this builds an ISO for all available systems
@@ -339,6 +340,8 @@ class StandaloneBuildiso(buildiso.BuildIso):
         :param airgapped: This option implies ``standalone=True``.
         :param source: If the iso should be offline available this is the path to the sources of the image.
         """
+        del kwargs  # just accepted for polymorphism
+
         buildisodir = self._prepare_iso(buildisodir, distro_name, profiles)
         self._validate_standalone_args(distro_name, source)
         self.generate_standalone_iso(distro_name, source, airgapped)

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2157,28 +2157,18 @@ class CobblerAPI:
             raise TypeError('Argument "airgapped" needs to be of type bool!')
         if airgapped:
             standalone = True
-        if standalone:
-            standalone_builder = StandaloneBuildiso(self)
-            standalone_builder.run(
-                iso=iso,
-                buildisodir=buildisodir,
-                profiles=profiles,
-                xorrisofs_opts=xorrisofs_opts,
-                distro_name=distro_name,
-                airgapped=airgapped,
-                source=source,
-            )
-        else:
-            netboot_builder = NetbootBuildiso(self)
-            netboot_builder.run(
-                iso=iso,
-                buildisodir=buildisodir,
-                profiles=profiles,
-                xorrisofs_opts=xorrisofs_opts,
-                distro_name=distro_name,
-                systems=systems,
-                exclude_dns=exclude_dns,
-            )
+        Builder = StandaloneBuildiso if standalone else NetbootBuildiso
+        Builder(self).run(
+            iso=iso,
+            buildisodir=buildisodir,
+            profiles=profiles,
+            xorrisofs_opts=xorrisofs_opts,
+            distro_name=distro_name,
+            airgapped=airgapped,
+            source=source,
+            systems=systems,
+            exclude_dns=exclude_dns,
+        )
 
     # ==========================================================================
 

--- a/cobbler/autoinstallgen.py
+++ b/cobbler/autoinstallgen.py
@@ -291,9 +291,9 @@ class AutoInstallationGen:
             return f"# automatic installation file value missing or invalid at {obj_type} {obj.name}"
 
         # get parent distro
-        distro = profile.get_conceptual_parent()
         if system is not None:
-            distro = system.get_conceptual_parent().get_conceptual_parent()
+            profile = system.get_conceptual_parent()
+        distro = profile.get_conceptual_parent()
 
         # make autoinstall_meta metavariable available at top level
         autoinstall_meta = meta["autoinstall_meta"]

--- a/docker/debs/Debian_10/Debian10.dockerfile
+++ b/docker/debs/Debian_10/Debian10.dockerfile
@@ -62,7 +62,8 @@ RUN apt-get update -qq && \
     apache2 \
     iproute2 \
     systemd \
-    supervisor && \
+    supervisor \
+    dosfstools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make /bin/sh point to bash, not dash

--- a/docker/debs/Debian_11/Debian11.dockerfile
+++ b/docker/debs/Debian_11/Debian11.dockerfile
@@ -64,7 +64,8 @@ RUN apt-get update -qq && \
     iproute2 \
     systemd \
     systemd-sysv \
-    supervisor && \
+    supervisor \
+    dosfstools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make /bin/sh point to bash, not dash

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -57,7 +57,8 @@ RUN zypper install --no-recommends -y \
     vim                        \
     wget                       \
     which                      \
-    xorriso
+    xorriso                    \
+    dosfstools
 
 # Add virtualization repository
 RUN zypper ar https://download.opensuse.org/repositories/Virtualization/15.4/Virtualization.repo

--- a/docker/rpms/Fedora_37/Fedora37.dockerfile
+++ b/docker/rpms/Fedora_37/Fedora37.dockerfile
@@ -51,7 +51,8 @@ RUN yum install -y          \
     fence-agents            \
     openldap-servers        \
     openldap-clients        \
-    supervisor
+    supervisor              \
+    dosfstools
 
 # Dependencies for system tests
 RUN dnf install -y          \

--- a/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
+++ b/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
@@ -62,7 +62,8 @@ RUN touch /var/lib/rpm/* &&   \
     syslinux                  \
     tftp-server               \
     fence-agents              \
-    supervisor
+    supervisor                \
+    dosfstools
 
 # Dependencies for system tests
 RUN touch /var/lib/rpm/* &&   \

--- a/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
@@ -47,7 +47,8 @@ RUN zypper install -y          \
     python3-PyYAML             \
     python3-wheel              \
     rpm-build                  \
-    which
+    which                      \
+    dosfstools
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -48,7 +48,8 @@ RUN zypper install -y          \
     python3-PyYAML             \
     python3-wheel              \
     rpm-build                  \
-    which
+    which                      \
+    dosfstools
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \

--- a/templates/iso/grub_menuentry.template
+++ b/templates/iso/grub_menuentry.template
@@ -1,0 +1,7 @@
+menuentry '$menu_name' --class gnu-linux --class gnu --class os {
+  echo 'Loading kernel ...'
+  linux $kernel_path $kernel_options
+  echo 'Loading initial ramdisk ...'
+  initrd $initrd_path
+  echo '...done'
+}

--- a/templates/iso/isolinux_menuentry.template
+++ b/templates/iso/isolinux_menuentry.template
@@ -1,0 +1,8 @@
+LABEL {{ menu_name }}
+{%- if menu_indent %}
+  MENU INDENT {{ menu_indent }}
+{% endif %}
+  MENU LABEL {{ menu_name }}
+  KERNEL {{ kernel_path }}
+  {{ append_line }}
+

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -26,7 +26,7 @@ def test_generate_system(
     # TODO: Make tests more sophisticated
     assert (
         result
-        == "  APPEND initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
+        == "  APPEND initrd=/%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
         % (request.node.originalname, request.node.originalname)
     )
 
@@ -49,7 +49,7 @@ def test_generate_system_redhat(
     # Assert
     # Very basic test yes but this is the expected result atm
     # TODO: Make tests more sophisticated
-    assert result == f"  APPEND initrd={test_distro.name}.img inst.ks=default.ks"
+    assert result == f"  APPEND initrd=/{test_distro.name}.img inst.ks=default.ks"
 
 
 def test_generate_profile(request, cobbler_api, create_distro, create_profile):
@@ -67,7 +67,7 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     # TODO: Make tests more sophisticated
     assert (
         result
-        == " append initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
+        == " append initrd=/%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
         % (request.node.originalname, request.node.originalname)
     )
 
@@ -87,7 +87,7 @@ def test_generate_profile_rhel7(cobbler_api, create_distro, create_profile):
     # Assert
     # Very basic test yes but this is the expected result atm
     # TODO: Make tests more sophisticated
-    assert result == f" append initrd={test_distro.name}.img inst.ks=default.ks"
+    assert result == f" append initrd=/{test_distro.name}.img inst.ks=default.ks"
 
 
 def test_generate_profile_rhel6(cobbler_api, create_distro, create_profile):
@@ -105,4 +105,4 @@ def test_generate_profile_rhel6(cobbler_api, create_distro, create_profile):
     # Assert
     # Very basic test yes but this is the expected result atm
     # TODO: Make tests more sophisticated
-    assert result == f" append initrd={test_distro.name}.img ks=default.ks"
+    assert result == f" append initrd=/{test_distro.name}.img ks=default.ks"

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from cobbler import enums
 from cobbler.actions import buildiso
+from cobbler.actions.buildiso import LoaderCfgsParts
 from cobbler.actions.buildiso.netboot import NetbootBuildiso
 from cobbler.actions.buildiso.standalone import StandaloneBuildiso
 
@@ -88,10 +89,40 @@ def test_copy_boot_files(cobbler_api, create_distro, tmpdir):
     testdistro = create_distro()
 
     # Act
-    build_iso.copy_boot_files(testdistro, target_folder)
+    build_iso._copy_boot_files(testdistro.kernel, testdistro.initrd, target_folder)
 
     # Assert
     assert len(os.listdir(target_folder)) == 2
+
+
+def test_netboot_generate_boot_loader_configs(
+    cobbler_api, create_distro, create_profile, create_system
+):
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(test_profile.name)
+    build_iso = NetbootBuildiso(cobbler_api)
+
+    # Act
+    result = build_iso._generate_boot_loader_configs(
+        [test_profile.name], [test_system.name], True
+    )
+    matching_isolinux_kernel = [
+        part for part in result.isolinux if "KERNEL /1.krn" in part
+    ]
+    matching_isolinux_initrd = [
+        part for part in result.isolinux if "initrd=/1.img" in part
+    ]
+    # Assert
+    assert isinstance(result, LoaderCfgsParts)
+    for iterable_to_check in [
+        matching_isolinux_kernel,
+        matching_isolinux_initrd,
+        result.bootfiles_copysets,
+    ]:
+        print(iterable_to_check)
+        # one entry for the profile, one for the system
+        assert len(iterable_to_check) == 2
 
 
 def test_filter_system(
@@ -133,7 +164,6 @@ def test_filter_profile(cobbler_api, create_distro, create_profile):
 def test_netboot_run(
     cobbler_api,
     create_distro,
-    create_loaders,
     tmpdir,
 ):
     # Arrange
@@ -151,7 +181,6 @@ def test_netboot_run(
 def test_standalone_run(
     cobbler_api,
     create_distro,
-    create_loaders,
     tmpdir_factory,
 ):
     # Arrange

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -30,17 +30,13 @@ def test_calculate_grub_name(
     result_binary_name,
     expected_exception,
     cobbler_api,
-    create_distro,
 ):
     # Arrange
     test_builder = buildiso.BuildIso(cobbler_api)
-    test_distro = create_distro()
-    test_distro.arch = input_arch
-    cobbler_api.add_distro(test_distro)
 
     # Act
     with expected_exception:
-        result = test_builder.calculate_grub_name(test_distro)
+        result = test_builder.calculate_grub_name(input_arch)
 
         # Assert
         assert result == result_binary_name
@@ -113,11 +109,16 @@ def test_netboot_generate_boot_loader_configs(
     matching_isolinux_initrd = [
         part for part in result.isolinux if "initrd=/1.img" in part
     ]
+    matching_grub_kernel = [part for part in result.grub if "linux /1.krn" in part]
+    matching_grub_initrd = [part for part in result.grub if "initrd /1.img" in part]
+
     # Assert
     assert isinstance(result, LoaderCfgsParts)
     for iterable_to_check in [
         matching_isolinux_kernel,
         matching_isolinux_initrd,
+        matching_grub_kernel,
+        matching_grub_initrd,
         result.bootfiles_copysets,
     ]:
         print(iterable_to_check)


### PR DESCRIPTION
## Linked Items

Fixes #3381

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Fix `cobbler buildiso` so that the artifact can be booted by EFI firmware.

This PR is far from done, but it's in a state that shows the approach and it kind-of works for netbootable ISOs. I need to add tests and refactor the sister class as well. Once that's done, I'll move the common code back to the base class.

<!-- What does this PR do? -->

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
