### PR TITLE
Fix missing inheritable properties

### DIFF
--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -52,7 +52,7 @@ class Distro(item.Item):
         self._remote_grub_kernel = ""
         self._remote_boot_initrd = ""
         self._remote_grub_initrd = ""
-        self._supported_boot_loaders = []
+        self._supported_boot_loaders: List[str] = []
 
     def __getattr__(self, name):
         if name == "ks_meta":
@@ -403,7 +403,7 @@ class Distro(item.Item):
         self._arch = enums.Archs.to_enum(arch)
 
     @property
-    def supported_boot_loaders(self):
+    def supported_boot_loaders(self) -> List[str]:
         """
         Some distributions, particularly on powerpc, can only be netbooted using specific bootloaders.
 

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -54,7 +54,7 @@ class NetworkInterface:
         self._netmask = ""
         self._static = False
         self._static_routes = []
-        self._virt_bridge = ""
+        self._virt_bridge = enums.VALUE_INHERITED
 
     def from_dict(self, dictionary: dict):
         """
@@ -88,7 +88,6 @@ class NetworkInterface:
                 continue
             if key.startswith("_"):
                 new_key = key[1:].lower()
-                key_value = key_value
                 if isinstance(key_value, enum.Enum):
                     result[new_key] = key_value.name.lower()
                 elif (
@@ -359,7 +358,7 @@ class NetworkInterface:
         """
         self._if_gateway = validate.ipv4_address(gateway)
 
-    @property
+    @InheritableProperty
     def virt_bridge(self) -> str:
         """
         virt_bridge property. If set to ``<<inherit>>`` this will read the value from the setting "default_virt_bridge".
@@ -1187,6 +1186,8 @@ class System(Item):
         :getter: Returns the value for ``filename``.
         :setter: Sets the value for the property ``filename``.
         """
+        if self.image != "":
+            return ""
         return self._resolve("filename")
 
     @filename.setter

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -2594,7 +2594,7 @@ class CobblerXMLRPCInterface:
         data = utils.blender(self.api, True, obj)
         return self.xmlrpc_hacks(data)
 
-    def get_settings(self, token=None, **rest) -> dict:
+    def get_settings(self, token=None, **rest) -> Dict[str, Any]:
         """
         Return the contents of our settings file, which is a dict.
 

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -293,7 +293,7 @@ class Settings:
         buf += f"kernel options  : {self.__dict__['kernel_options']}\n"
         return buf
 
-    def to_dict(self, resolved: bool = False) -> dict:
+    def to_dict(self, resolved: bool = False) -> Dict[str, Any]:
         """
         Return an easily serializable representation of the config.
 

--- a/cobbler/utils/signatures.py
+++ b/cobbler/utils/signatures.py
@@ -3,13 +3,21 @@ TODO
 """
 
 import json
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from cobbler import utils
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+    from cobbler.items.distro import Distro
+    from cobbler.items.image import Image
 
 SIGNATURE_CACHE = {}
 
 
-def get_supported_distro_boot_loaders(distro, api_handle=None):
+def get_supported_distro_boot_loaders(
+    distro: Union["Distro", "Image"], api_handle: Optional["CobblerAPI"] = None
+) -> List[str]:
     """
     This is trying to return you the list of known bootloaders if all resorts fail. Otherwise this returns a list which
     contains only the subset of bootloaders which are available by the distro in the argument.

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -3271,7 +3271,7 @@
         "kernel_options_post": "",
         "boot_files": []
       },
-      "XP": {
+      "xp": {
         "signatures": [
           "amd64",
           "i386",

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -85,7 +85,24 @@ def test_to_dict(cobbler_api):
     assert isinstance(result, dict)
     assert "autoinstall_meta" in result
     assert "ks_meta" in result
+    assert result.get("boot_loaders") == enums.VALUE_INHERITED
     # TODO check more fields
+
+
+def test_to_dict_resolved(cobbler_api, create_distro):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    cobbler_api.add_distro(test_distro)
+
+    # Act
+    result = test_distro.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("kernel_options") == {"test": True}
+    assert result.get("boot_loaders") == ["grub", "pxe", "ipxe"]
+    assert enums.VALUE_INHERITED not in str(result)
 
 
 # Properties Tests

--- a/tests/items/file_test.py
+++ b/tests/items/file_test.py
@@ -1,5 +1,6 @@
 import pytest
 
+from cobbler import enums
 from cobbler.items.file import File
 from tests.conftest import does_not_raise
 
@@ -23,6 +24,29 @@ def test_make_clone(cobbler_api):
 
     # Assert
     assert clone != file
+
+
+def test_to_dict(cobbler_api):
+    # Arrange
+    titem = File(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = File(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)
 
 
 # Properties Tests

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -1,6 +1,8 @@
+from typing import Callable
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.utils import signatures
 from cobbler.items.image import Image
 from tests.conftest import does_not_raise
@@ -245,3 +247,28 @@ def test_boot_loaders(cobbler_api):
 
     # Assert
     assert image.boot_loaders == []
+
+
+def test_to_dict(create_image: Callable[[], Image]):
+    # Arrange
+    test_image = create_image()
+
+    # Act
+    result = test_image.to_dict(resolved=False)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("autoinstall") == enums.VALUE_INHERITED
+
+
+def test_to_dict_resolved(create_image: Callable[[], Image]):
+    # Arrange
+    test_image = create_image()
+
+    # Act
+    result = test_image.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("autoinstall") == "default.ks"
+    assert enums.VALUE_INHERITED not in str(result)

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -452,25 +452,7 @@ def test_to_dict_resolved(cobbler_api):
     # Assert
     assert isinstance(result, dict)
     assert result.get("owners") == ["admin"]
-
-
-def test_to_dict_resolved_dict(cobbler_api, create_distro):
-    # Arrange
-    test_distro = create_distro()
-    test_distro.kernel_options = {"test": True}
-    cobbler_api.add_distro(test_distro)
-    titem = Profile(cobbler_api)
-    titem.name = "to_dict_resolved_profile"
-    titem.distro = test_distro.name
-    titem.kernel_options = {"my_value": 5}
-    cobbler_api.add_profile(titem)
-
-    # Act
-    result = titem.to_dict(resolved=True)
-
-    # Assert
-    assert isinstance(result, dict)
-    assert result.get("kernel_options") == {"test": True, "my_value": 5}
+    assert enums.VALUE_INHERITED not in str(result)
 
 
 def test_serialize(cobbler_api):

--- a/tests/items/menu_test.py
+++ b/tests/items/menu_test.py
@@ -1,3 +1,4 @@
+from cobbler import enums
 from cobbler.items.menu import Menu
 
 
@@ -31,3 +32,26 @@ def test_display_name(cobbler_api):
 
     # Assert
     assert menu.display_name == ""
+
+
+def test_to_dict(cobbler_api):
+    # Arrange
+    titem = Menu(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = Menu(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)

--- a/tests/items/mgmtclass_test.py
+++ b/tests/items/mgmtclass_test.py
@@ -1,3 +1,4 @@
+from cobbler import enums
 from cobbler.items.mgmtclass import Mgmtclass
 
 
@@ -87,3 +88,26 @@ def test_class_name(cobbler_api):
 
     # Assert
     assert mgmtclass.class_name == ""
+
+
+def test_to_dict(cobbler_api):
+    # Arrange
+    titem = Mgmtclass(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = Mgmtclass(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -29,7 +29,21 @@ def test_network_interface_to_dict(cobbler_api):
     assert isinstance(result, dict)
     assert "logger" not in result
     assert "api" not in result
+    assert result.get("virt_bridge") == enums.VALUE_INHERITED
     assert len(result) == 23
+
+
+def test_network_interface_to_dict_resolved(cobbler_api):
+    # Arrange
+    interface = NetworkInterface(cobbler_api)
+
+    # Act
+    result = interface.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("virt_bridge") == "xenbr0"
+    assert enums.VALUE_INHERITED not in str(result)
 
 
 @pytest.mark.parametrize(

--- a/tests/items/package_test.py
+++ b/tests/items/package_test.py
@@ -1,3 +1,4 @@
+from cobbler import enums
 from cobbler.items.package import Package
 
 
@@ -42,3 +43,26 @@ def test_version(cobbler_api):
 
     # Assert
     assert package.version == ""
+
+
+def test_to_dict(cobbler_api):
+    # Arrange
+    titem = Package(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = Package(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -49,6 +49,28 @@ def test_to_dict(cobbler_api, cleanup_to_dict):
     # Assert
     assert len(result) == 45
     assert result["distro"] == "test_to_dict_distro"
+    assert result.get("boot_loaders") == enums.VALUE_INHERITED
+
+
+def test_to_dict_resolved(cobbler_api, create_distro):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.kernel_options = {"test": True}
+    cobbler_api.add_distro(test_distro)
+    titem = Profile(cobbler_api)
+    titem.name = "to_dict_resolved_profile"
+    titem.distro = test_distro.name
+    titem.kernel_options = {"my_value": 5}
+    cobbler_api.add_profile(titem)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("kernel_options") == {"test": True, "my_value": 5}
+    assert result.get("boot_loaders") == ["grub", "pxe", "ipxe"]
+    assert enums.VALUE_INHERITED not in str(result)
 
 
 # Properties Tests

--- a/tests/items/repo_test.py
+++ b/tests/items/repo_test.py
@@ -26,6 +26,31 @@ def test_make_clone(cobbler_api):
     assert result != repo
 
 
+def test_to_dict(cobbler_api):
+    # Arrange
+    titem = Repo(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("proxy") == enums.VALUE_INHERITED
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = Repo(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("proxy") == ""
+    assert enums.VALUE_INHERITED not in str(result)
+
+
 # Properties Tests
 
 

--- a/tests/items/resource_test.py
+++ b/tests/items/resource_test.py
@@ -23,6 +23,29 @@ def test_make_clone(cobbler_api):
     assert result != resource
 
 
+def test_to_dict(cobbler_api):
+    # Arrange
+    titem = Resource(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api):
+    # Arrange
+    titem = Resource(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)
+
+
 # Properties Tests
 
 

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -226,7 +226,7 @@ def test_get_random_mac(remote, token):
                     "netmask": "",
                     "static": False,
                     "static_routes": [],
-                    "virt_bridge": "",
+                    "virt_bridge": "xenbr0",
                 }
             },
             does_not_raise(),


### PR DESCRIPTION
## Linked Items

Fixes #3354

Split-Out of #3301

## Description

Not all property values for images, profiles and systems that could be inherited from settings or from images and profiles for systems can be inherited. This creates additional difficulties in maintaining these objects.

This PR changes the properties that were not correctly ported to being able to inherit.

## Behaviour changes

Old: Maintenance of images, profiles and systems was more complicated due to non-inheriting properties.

New: Improved ease when maintaining images, profiles and systems because inheritance should work now as expected.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
