### PR TITLE
README: Update Gitter to Matrix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/cobbler.svg)](https://badge.fury.io/py/cobbler)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/cobbler)
 [![Documentation Status](https://readthedocs.org/projects/cobbler/badge/?version=latest)](https://cobbler.readthedocs.io/en/latest/)
-[![Gitter chat](https://badges.gitter.im/cobbler/gitter.png)](https://gitter.im/cobbler/community)
+[![Matrix](https://img.shields.io/matrix/cobbler-community:matrix.org?label=Chat%20on%20Matrix&logo=matrix)](https://gitter.im/cobbler/community)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/c8c0c787c4854aba925d361eacc15811)](https://www.codacy.com/gh/cobbler/cobbler/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cobbler/cobbler&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/c8c0c787c4854aba925d361eacc15811)](https://www.codacy.com/gh/cobbler/cobbler/dashboard?utm_source=github.com&utm_medium=referral&utm_content=cobbler/cobbler&utm_campaign=Badge_Coverage)
 [![Asciinema](https://img.shields.io/badge/asciinema-Cobbler-success)](https://asciinema.org/~Cobbler)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![PyPI version](https://badge.fury.io/py/cobbler.svg)](https://badge.fury.io/py/cobbler)
 ![PyPI - Downloads](https://img.shields.io/pypi/dm/cobbler)
 [![Documentation Status](https://readthedocs.org/projects/cobbler/badge/?version=latest)](https://cobbler.readthedocs.io/en/latest/)
-[![Matrix](https://img.shields.io/matrix/cobbler-community:matrix.org?label=Chat%20on%20Matrix&logo=matrix)](https://gitter.im/cobbler/community)
+[![Matrix](https://img.shields.io/matrix/cobbler-community:matrix.org?label=Chat%20on%20Matrix&logo=matrix)](https://app.element.io/#/room/#cobbler_community:gitter.im)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/c8c0c787c4854aba925d361eacc15811)](https://www.codacy.com/gh/cobbler/cobbler/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=cobbler/cobbler&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/c8c0c787c4854aba925d361eacc15811)](https://www.codacy.com/gh/cobbler/cobbler/dashboard?utm_source=github.com&utm_medium=referral&utm_content=cobbler/cobbler&utm_campaign=Badge_Coverage)
 [![Asciinema](https://img.shields.io/badge/asciinema-Cobbler-success)](https://asciinema.org/~Cobbler)


### PR DESCRIPTION
## Description

Replace the link to the cobbler matrix room with a default matrix link instead of the old gitter url

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [x] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
