### PR TITLE
Netiso install option fix

### DIFF
--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -424,7 +424,7 @@ class AppendLineBuilder:
                 ]
                 if isinstance(install_options, list):
                     install_options = install_options[0]
-                    self.append_line += f" install={install_options}"
+                self.append_line += f" install={install_options}"
                 del self.data["kernel_options"]["install"]
             else:
                 self.append_line += (

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -17,6 +17,7 @@ def test_generate_system(
     test_system = create_system(profile_name=test_profile.name)
     blendered_data = utils.blender(cobbler_api, False, test_system)
     test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+    originalname = request.node.originalname or request.node.name
 
     # Act
     result = test_builder.generate_system(test_distro, test_system, False)
@@ -27,7 +28,7 @@ def test_generate_system(
     assert (
         result
         == "  APPEND initrd=/%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
-        % (request.node.originalname, request.node.originalname)
+        % (originalname, originalname)
     )
 
 
@@ -58,6 +59,7 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     test_profile = create_profile(test_distro.name)
     blendered_data = utils.blender(cobbler_api, False, test_profile)
     test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+    originalname = request.node.originalname or request.node.name
 
     # Act
     result = test_builder.generate_profile("suse", "opensuse15generic")
@@ -68,7 +70,32 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     assert (
         result
         == " append initrd=/%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
-        % (request.node.originalname, request.node.originalname)
+        % (originalname, originalname)
+    )
+
+
+def test_generate_profile_install(request, cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    originalname = request.node.originalname or request.node.name
+
+    test_distro.kernel_options = (
+        "install=http://192.168.40.1:80/cblr/links/%s" % originalname
+    )
+    test_profile = create_profile(test_distro.name)
+    blendered_data = utils.blender(cobbler_api, False, test_profile)
+    test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+    # Act
+    result = test_builder.generate_profile("suse", "opensuse15generic")
+
+    # Assert
+    # Very basic test yes but this is the expected result atm
+    # TODO: Make tests more sophisticated
+    assert (
+        result
+        == " append initrd=/%s.img install=http://192.168.40.1:80/cblr/links/%s autoyast=default.ks"
+        % (originalname, originalname)
     )
 
 

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -1,26 +1,48 @@
+"""
+TODO
+"""
+
+from typing import Callable
+
+import pytest
+
 from cobbler import utils
 from cobbler.actions.buildiso.netboot import AppendLineBuilder
+from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
 
 
 def test_init():
+    """
+    TODO
+    """
     assert isinstance(AppendLineBuilder("", {}), AppendLineBuilder)
 
 
 def test_generate_system(
-    request, cobbler_api, create_distro, create_profile, create_system
+    request: "pytest.FixtureRequest",
+    cobbler_api: "CobblerAPI",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str, str, str], System],
 ):
+    """
+    TODO
+    """
     # Arrange
     test_distro = create_distro()
     test_distro.breed = "suse"
     cobbler_api.add_distro(test_distro)
     test_profile = create_profile(test_distro.name)
-    test_system = create_system(profile_name=test_profile.name)
-    blendered_data = utils.blender(cobbler_api, False, test_system)
+    test_system = create_system(profile_name=test_profile.name)  # type: ignore
+    blendered_data = utils.blender(cobbler_api, False, test_system)  # type: ignore
     test_builder = AppendLineBuilder(test_distro.name, blendered_data)
-    originalname = request.node.originalname or request.node.name
+    originalname = request.node.originalname or request.node.name  # type: ignore
 
     # Act
-    result = test_builder.generate_system(test_distro, test_system, False)
+    result = test_builder.generate_system(test_distro, test_system, False)  # type: ignore
 
     # Assert
     # Very basic test yes but this is the expected result atm
@@ -33,19 +55,25 @@ def test_generate_system(
 
 
 def test_generate_system_redhat(
-    cobbler_api, create_distro, create_profile, create_system
+    cobbler_api: "CobblerAPI",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str, str, str], System],
 ):
+    """
+    TODO
+    """
     # Arrange
     test_distro = create_distro()
     test_distro.breed = "redhat"
     cobbler_api.add_distro(test_distro)
     test_profile = create_profile(test_distro.name)
-    test_system = create_system(profile_name=test_profile.name)
-    blendered_data = utils.blender(cobbler_api, False, test_system)
+    test_system = create_system(profile_name=test_profile.name)  # type: ignore
+    blendered_data = utils.blender(cobbler_api, False, test_system)  # type: ignore
     test_builder = AppendLineBuilder(test_distro.name, blendered_data)
 
     # Act
-    result = test_builder.generate_system(test_distro, test_system, False)
+    result = test_builder.generate_system(test_distro, test_system, False)  # type: ignore
 
     # Assert
     # Very basic test yes but this is the expected result atm
@@ -53,13 +81,21 @@ def test_generate_system_redhat(
     assert result == f"  APPEND initrd=/{test_distro.name}.img inst.ks=default.ks"
 
 
-def test_generate_profile(request, cobbler_api, create_distro, create_profile):
+def test_generate_profile(
+    request: "pytest.FixtureRequest",
+    cobbler_api: "CobblerAPI",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    TODO
+    """
     # Arrange
     test_distro = create_distro()
     test_profile = create_profile(test_distro.name)
     blendered_data = utils.blender(cobbler_api, False, test_profile)
     test_builder = AppendLineBuilder(test_distro.name, blendered_data)
-    originalname = request.node.originalname or request.node.name
+    originalname = request.node.originalname or request.node.name  # type: ignore
 
     # Act
     result = test_builder.generate_profile("suse", "opensuse15generic")
@@ -74,13 +110,21 @@ def test_generate_profile(request, cobbler_api, create_distro, create_profile):
     )
 
 
-def test_generate_profile_install(request, cobbler_api, create_distro, create_profile):
+def test_generate_profile_install(
+    request: "pytest.FixtureRequest",
+    cobbler_api: "CobblerAPI",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    TODO
+    """
     # Arrange
     test_distro = create_distro()
-    originalname = request.node.originalname or request.node.name
+    originalname = request.node.originalname or request.node.name  # type: ignore
 
     test_distro.kernel_options = (
-        "install=http://192.168.40.1:80/cblr/links/%s" % originalname
+        "install=http://192.168.40.1:80/cblr/links/%s" % originalname  # type: ignore
     )
     test_profile = create_profile(test_distro.name)
     blendered_data = utils.blender(cobbler_api, False, test_profile)
@@ -99,7 +143,14 @@ def test_generate_profile_install(request, cobbler_api, create_distro, create_pr
     )
 
 
-def test_generate_profile_rhel7(cobbler_api, create_distro, create_profile):
+def test_generate_profile_rhel7(
+    cobbler_api: "CobblerAPI",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    TODO
+    """
     # Arrange
     test_distro = create_distro()
     test_distro.breed = "redhat"
@@ -117,7 +168,14 @@ def test_generate_profile_rhel7(cobbler_api, create_distro, create_profile):
     assert result == f" append initrd=/{test_distro.name}.img inst.ks=default.ks"
 
 
-def test_generate_profile_rhel6(cobbler_api, create_distro, create_profile):
+def test_generate_profile_rhel6(
+    cobbler_api: "CobblerAPI",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    TODO
+    """
     # Arrange
     test_distro = create_distro()
     test_distro.breed = "redhat"


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/cobbler/cobbler/issues/3361

There is a wrong indentation in building kernel command line for `install=` option which caused it to be added only if provided data are a list.

## Description

Fixes indentation

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
