### PR TITLE
Item: delayed reading of collections at the start.

### DIFF
--- a/cobbler/actions/replicate.py
+++ b/cobbler/actions/replicate.py
@@ -136,8 +136,7 @@ class Replicate:
 
             if not rdata["uid"] in local_objects:
                 creator = getattr(self.api, f"new_{obj_type}")
-                newobj = creator()
-                newobj.from_dict(utils.revert_strip_none(rdata))
+                newobj = creator(utils.revert_strip_none(rdata))
                 try:
                     self.logger.info("adding %s %s", obj_type, rdata["name"])
                     if not self.api.add_item(obj_type, newobj):
@@ -170,8 +169,7 @@ class Replicate:
                         self.logger.info("removing %s %s", obj_type, ldata["name"])
                         self.api.remove_item(obj_type, ldata["name"], recursive=True)
                     creator = getattr(self.api, f"new_{obj_type}")
-                    newobj = creator()
-                    newobj.from_dict(utils.revert_strip_none(rdata))
+                    newobj = creator(utils.revert_strip_none(rdata))
                     try:
                         self.logger.info("updating %s %s", obj_type, rdata["name"])
                         if not self.api.add_item(obj_type, newobj):

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -14,7 +14,7 @@ import tempfile
 import threading
 from configparser import ConfigParser
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from schema import SchemaError
 
@@ -61,6 +61,7 @@ from cobbler.cexceptions import CX
 
 if TYPE_CHECKING:
     from cobbler.settings import Settings
+    from cobbler.items import item
 
 
 # notes on locking:
@@ -76,7 +77,7 @@ class CobblerAPI:
     Cli apps and daemons should import api.py, and no other Cobbler code.
     """
 
-    __shared_state = {}
+    __shared_state: Dict[str, Any] = {}
     __has_loaded = False
 
     def __init__(
@@ -957,7 +958,7 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    def new_item(self, what: str = "", is_subobject: bool = False):
+    def new_item(self, what: str = "", is_subobject: bool = False, **kwargs: Any):
         """
         Creates a new (unconfigured) object. The object is not persisted.
 
@@ -968,22 +969,22 @@ class CobblerAPI:
         """
         try:
             enums.ItemTypes(what)  # verify that <what> is an ItemTypes member
-            return getattr(self, f"new_{what}")(is_subobject=is_subobject)
+            return getattr(self, f"new_{what}")(is_subobject, **kwargs)
         except (ValueError, AttributeError) as error:
             raise Exception(f"internal error, collection name is {what}") from error
 
-    def new_distro(self, is_subobject: bool = False):
+    def new_distro(self, is_subobject: bool = False, **kwargs: Any) -> distro.Distro:
         """
         Returns a new empty distro object. This distro is not automatically persisted. Persistance is achieved via
         ``save()``.
 
-        :param is_subobject: If the object created is a subobject or not.
+        :param is_subobject: If the object is a subobject of an already existing object or not.
         :return: An empty Distro object.
         """
-        self.log("new_distro", [is_subobject])
-        return distro.Distro(self, is_subobject=is_subobject)
+        self.log("new_distro", kwargs)
+        return distro.Distro(self, is_subobject, **kwargs)
 
-    def new_profile(self, is_subobject: bool = False):
+    def new_profile(self, is_subobject: bool = False, **kwargs: Any) -> profile.Profile:
         """
         Returns a new empty profile object. This profile is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -991,10 +992,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty Profile object.
         """
-        self.log("new_profile", [is_subobject])
-        return profile.Profile(self, is_subobject=is_subobject)
+        self.log("new_profile", kwargs)
+        return profile.Profile(self, is_subobject, kwargs)
 
-    def new_system(self, is_subobject: bool = False):
+    def new_system(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty system object. This system is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1002,10 +1003,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty System object.
         """
-        self.log("new_system", [is_subobject])
-        return system.System(self, is_subobject=is_subobject)
+        self.log("new_system", kwargs)
+        return system.System(self, is_subobject, kwargs)
 
-    def new_repo(self, is_subobject: bool = False):
+    def new_repo(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty repo object. This repository is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1013,10 +1014,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty repo object.
         """
-        self.log("new_repo", [is_subobject])
-        return repo.Repo(self, is_subobject=is_subobject)
+        self.log("new_repo", kwargs)
+        return repo.Repo(self, is_subobject, kwargs)
 
-    def new_image(self, is_subobject: bool = False):
+    def new_image(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty image object. This image is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1024,10 +1025,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty image object.
         """
-        self.log("new_image", [is_subobject])
-        return image.Image(self, is_subobject=is_subobject)
+        self.log("new_image", kwargs)
+        return image.Image(self, is_subobject, kwargs)
 
-    def new_mgmtclass(self, is_subobject: bool = False):
+    def new_mgmtclass(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty mgmtclass object. This mgmtclass is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1035,10 +1036,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty mgmtclass object.
         """
-        self.log("new_mgmtclass", [is_subobject])
-        return mgmtclass.Mgmtclass(self, is_subobject=is_subobject)
+        self.log("new_mgmtclass", kwargs)
+        return mgmtclass.Mgmtclass(self, is_subobject, kwargs)
 
-    def new_package(self, is_subobject: bool = False):
+    def new_package(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty package object. This package is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1046,10 +1047,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty Package object.
         """
-        self.log("new_package", [is_subobject])
-        return package.Package(self, is_subobject=is_subobject)
+        self.log("new_package", kwargs)
+        return package.Package(self, is_subobject, kwargs)
 
-    def new_file(self, is_subobject: bool = False):
+    def new_file(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty file object. This file is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1057,10 +1058,10 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty File object.
         """
-        self.log("new_file", [is_subobject])
-        return file.File(self, is_subobject=is_subobject)
+        self.log("new_file", kwargs)
+        return file.File(self, is_subobject, kwargs)
 
-    def new_menu(self, is_subobject: bool = False):
+    def new_menu(self, is_subobject: bool = False, **kwargs: Any):
         """
         Returns a new empty menu object. This file is not automatically persisted. Persistence is achieved via
         ``save()``.
@@ -1068,8 +1069,8 @@ class CobblerAPI:
         :param is_subobject: If the object created is a subobject or not.
         :return: An empty File object.
         """
-        self.log("new_menu", [is_subobject])
-        return menu.Menu(self, is_subobject=is_subobject)
+        self.log("new_menu", kwargs)
+        return menu.Menu(self, is_subobject, kwargs)
 
     # ==========================================================================
 
@@ -2028,6 +2029,13 @@ class CobblerAPI:
         Cobbler internal use only.
         """
         return self._collection_mgr.deserialize()
+
+    def deserialize_item(self, obj: "item.Item") -> Dict[str, Any]:
+        """
+        Load cobbler item from disk.
+        Cobbler internal use only.
+        """
+        return self._collection_mgr.deserialize_one_item(obj)
 
     # ==========================================================================
 

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -5,10 +5,14 @@ Cobbler module that at runtime holds all files in Cobbler.
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2010, Kelsey Hightower <kelsey.hightower@gmail.com>
 
+from typing import TYPE_CHECKING, Any, Dict
 from cobbler.cobbler_collections import collection
-from cobbler.items import file as file
+from cobbler.items import file
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Files(collection.Collection):
@@ -24,17 +28,19 @@ class Files(collection.Collection):
     def collection_types() -> str:
         return "files"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a File forged from item_dict
+        Return a File forged from seed_data
+
+        :param api: Parameter is skipped.
+        :param seed_data: Data to seed the object with.
+        :returns: The created object.
         """
-        new_file = file.File(api)
-        new_file.from_dict(item_dict)
-        return new_file
+        return file.File(api, **seed_data)
 
     def remove(
         self,
-        name,
+        name: str,
         with_delete: bool = True,
         with_sync: bool = True,
         with_triggers: bool = True,

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -6,10 +6,14 @@ Cobbler module that at runtime holds all images in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
+from typing import TYPE_CHECKING, Any, Dict
 from cobbler.cobbler_collections import collection
-from cobbler.items import image as image
+from cobbler.items import image
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Images(collection.Collection):
@@ -26,17 +30,19 @@ class Images(collection.Collection):
     def collection_types() -> str:
         return "images"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a Distro forged from item_dict
+        Return a Distro forged from seed_data
+
+        :param api: Parameter is skipped.
+        :param seed_data: Data to seed the object with.
+        :returns: The created object.
         """
-        new_image = image.Image(api)
-        new_image.from_dict(item_dict)
-        return new_image
+        return image.Image(self.api, **seed_data)
 
     def remove(
         self,
-        name,
+        name: str,
         with_delete: bool = True,
         with_sync: bool = True,
         with_triggers: bool = True,

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -13,6 +13,7 @@ from cobbler.cexceptions import CX
 from cobbler import serializer
 from cobbler import validate
 from cobbler.settings import Settings
+from cobbler.items.item import Item
 from cobbler.cobbler_collections.distros import Distros
 from cobbler.cobbler_collections.files import Files
 from cobbler.cobbler_collections.images import Images
@@ -185,8 +186,6 @@ class CollectionManager:
 
         :raises CX: if there is an error in deserialization
         """
-        old_cache_enabled = self.api.settings().cache_enabled
-        self.api.settings().cache_enabled = False
         for collection in (
             self._menus,
             self._distros,
@@ -205,7 +204,15 @@ class CollectionManager:
                     f"serializer: error loading collection {collection.collection_type()}: {error}."
                     f"Check your settings!"
                 ) from error
-        self.api.settings().cache_enabled = old_cache_enabled
+
+    def deserialize_one_item(self, obj: Item) -> dict:
+        """
+        Load a collection item from disk
+
+        :param obj: collection item
+        """
+        collection_type = self.get_items(obj.COLLECTION_TYPE).collection_types()
+        return self.__serializer.deserialize_item(collection_type, obj.name)
 
     def get_items(
         self, collection_type: str

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -5,10 +5,14 @@ Cobbler module that at runtime holds all menus in Cobbler.
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2021 Yuriy Chelpanov <yuriy.chelpanov@gmail.com>
 
+from typing import TYPE_CHECKING, Any, Dict
 from cobbler.items import menu
 from cobbler.cobbler_collections import collection
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Menus(collection.Collection):
@@ -24,17 +28,15 @@ class Menus(collection.Collection):
     def collection_types() -> str:
         return "menus"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a Menu forged from item_dict
+        Return a Menu forged from seed_data
 
-        :param api: The cobblerd API.
-        :param item_dict: The seed data.
-        :return: A new menu instance.
+        :param api: Parameter is skipped.
+        :param seed_data: Data to seed the object with.
+        :returns: The created object.
         """
-        new_menu = menu.Menu(api)
-        new_menu.from_dict(item_dict)
-        return new_menu
+        return menu.Menu(self.api, **seed_data)
 
     def remove(
         self,

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -5,10 +5,14 @@ Cobbler module that at runtime holds all mgmtclasses in Cobbler.
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2010, Kelsey Hightower <kelsey.hightower@gmail.com>
 
+from typing import TYPE_CHECKING, Any, Dict
 from cobbler.cobbler_collections import collection
-from cobbler.items import mgmtclass as mgmtclass
+from cobbler.items import mgmtclass
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Mgmtclasses(collection.Collection):
@@ -24,21 +28,19 @@ class Mgmtclasses(collection.Collection):
     def collection_types() -> str:
         return "mgmtclasses"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a mgmtclass forged from item_dict
+        Return a mgmtclass forged from seed_data
 
-        :param api: TODO
-        :param item_dict: TODO
-        :returns: TODO
+        :param api: Parameter is skipped.
+        :param seed_data: Data to seed the object with.
+        :returns: The created object.
         """
-        new_mgmtclass = mgmtclass.Mgmtclass(api)
-        new_mgmtclass.from_dict(item_dict)
-        return new_mgmtclass
+        return mgmtclass.Mgmtclass(self.api, **seed_data)
 
     def remove(
         self,
-        name,
+        name: str,
         with_delete: bool = True,
         with_sync: bool = True,
         with_triggers: bool = True,

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -5,10 +5,15 @@ Cobbler module that at runtime holds all packages in Cobbler.
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2010, Kelsey Hightower <kelsey.hightower@gmail.com>
 
+from typing import TYPE_CHECKING, Any, Dict
+
 from cobbler.cobbler_collections import collection
-from cobbler.items import package as package
+from cobbler.items import package
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Packages(collection.Collection):
@@ -24,17 +29,19 @@ class Packages(collection.Collection):
     def collection_types() -> str:
         return "packages"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a Package forged from item_dict
+        Return a Package forged from seed_data.
+
+        :param api: Parameter is skipped.
+        :param seed_data: Data to seed the object with.
+        :returns: The created object.
         """
-        new_package = package.Package(api)
-        new_package.from_dict(item_dict)
-        return new_package
+        return package.Package(self.api, **seed_data)
 
     def remove(
         self,
-        name,
+        name: str,
         with_delete: bool = True,
         with_sync: bool = True,
         with_triggers: bool = True,

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -6,10 +6,14 @@ Cobbler module that at runtime holds all profiles in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
+from typing import TYPE_CHECKING, Any, Dict
 from cobbler.cobbler_collections import collection
-from cobbler.items import profile as profile
+from cobbler.items import profile
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Profiles(collection.Collection):
@@ -25,13 +29,11 @@ class Profiles(collection.Collection):
     def collection_types() -> str:
         return "profiles"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a Distro forged from item_dict
+        Return a Distro forged from seed_data
         """
-        new_profile = profile.Profile(api)
-        new_profile.from_dict(item_dict)
-        return new_profile
+        return profile.Profile(self.api, **seed_data)
 
     def remove(
         self,

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -7,12 +7,16 @@ Cobbler module that at runtime holds all repos in Cobbler.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import os.path
+from typing import TYPE_CHECKING, Any, Dict
 
 from cobbler.cobbler_collections import collection
 from cobbler.items import repo
 from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler.utils import filesystem_helpers
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Repos(collection.Collection):
@@ -30,17 +34,19 @@ class Repos(collection.Collection):
     def collection_types() -> str:
         return "repos"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[str, Any]):
         """
-        Return a Distro forged from item_dict
+        Return a Distro forged from seed_data
+
+        :param api: Parameter is skipped.
+        :param seed_data: The data the object is initalized with.
+        :returns: The created repository.
         """
-        new_repo = repo.Repo(api)
-        new_repo.from_dict(item_dict)
-        return new_repo
+        return repo.Repo(self.api, **seed_data)
 
     def remove(
         self,
-        name,
+        name: str,
         with_delete: bool = True,
         with_sync: bool = True,
         with_triggers: bool = True,

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -6,10 +6,14 @@ Cobbler module that at runtime holds all systems in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2008-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
+from typing import TYPE_CHECKING, Any, Dict
 from cobbler.cobbler_collections import collection
-from cobbler.items import system as system
+from cobbler.items import system
 from cobbler import utils
 from cobbler.cexceptions import CX
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
 
 
 class Systems(collection.Collection):
@@ -26,17 +30,17 @@ class Systems(collection.Collection):
     def collection_types() -> str:
         return "systems"
 
-    def factory_produce(self, api, item_dict):
+    def factory_produce(
+        self, api: "CobblerAPI", seed_data: Dict[str, Any]
+    ) -> system.System:
         """
-        Return a Distro forged from item_dict
+        Return a Distro forged from seed_data
 
-        :param api: TODO
-        :param item_dict: TODO
-        :returns: TODO
+        :param api: Parameter is skipped.
+        :param seed_data: Data to seed the object with.
+        :returns: The created object.
         """
-        new_system = system.System(api)
-        new_system.from_dict(item_dict)
-        return new_system
+        return system.System(self.api, **seed_data)
 
     def remove(
         self,

--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -7,6 +7,7 @@ Cobbler daemon for logging remote syslog traffic during automatic installation
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import binascii
+import logging
 import logging.config
 import os
 import pwd
@@ -55,7 +56,7 @@ def regen_ss_file():
     os.lchown("/var/lib/cobbler/web.ss", pwd.getpwnam(http_user)[2], -1)
 
 
-def do_xmlrpc_rw(cobbler_api: CobblerAPI, port):
+def do_xmlrpc_rw(cobbler_api: CobblerAPI, port: int):
     """
     This trys to bring up the Cobbler xmlrpc_api and restart it if it fails.
 

--- a/cobbler/decorator.py
+++ b/cobbler/decorator.py
@@ -3,8 +3,28 @@ This module provides decorators that are required for Cobbler to work as expecte
 """
 # The idea for the subclassed property decorators is from: https://stackoverflow.com/a/59313599/4730773
 
+from typing import Any, Optional
+from cobbler.items import item
 
-class InheritableProperty(property):
+
+class LazyProperty(property):
+    """
+    This property is supposed to provide a way to override the lazy-read value getter.
+    """
+
+    def __get__(self, obj: Any, objtype: Optional[type] = None):
+        if obj is None:
+            return self
+        if (
+            isinstance(obj, item.Item)
+            and not obj.inmemory
+            and obj._has_initialized  # pyright: ignore [reportPrivateUsage]
+        ):
+            obj.deserialize()
+        return self.fget(obj)
+
+
+class InheritableProperty(LazyProperty):
     """
     This property is supposed to provide a way to identify properties in code that can be set to inherit.
     """

--- a/cobbler/modules/serializers/__init__.py
+++ b/cobbler/modules/serializers/__init__.py
@@ -66,6 +66,19 @@ class StorageBase:
             "The implementation for the configured serializer is missing!"
         )
 
+    def deserialize_item(self, collection_type: str, name: str) -> dict:
+        """
+        Get a collection item from database and parse it into an object.
+
+        :param collection_type: The collection type to fetch.
+        :param item: collection item
+        :param topological: If the collection list should be sorted by the collection dict depth value or not.
+        :return: The first element of the collection requested.
+        """
+        raise NotImplementedError(
+            "The implementation for the configured serializer is missing!"
+        )
+
 
 def register() -> str:
     """

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -283,6 +283,7 @@ class Settings:
         self.windows_template_dir = "/etc/cobbler/windows"
         self.samba_distro_share = "DISTRO"
         self.cache_enabled = False
+        self.lazy_start = False
 
     def to_string(self) -> str:
         """

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -168,6 +168,7 @@ schema = Schema(
         },
         Optional("cache_enabled"): bool,
         Optional("autoinstall_scheme"): str,
+        Optional("lazy_start"): bool,
     },
     ignore_extra_keys=False,
 )

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -627,3 +627,12 @@ cache_enabled: false
 # This is setting does not setup your api for https it just changes the way the url for your profiles and systems are
 # generated.
 autoinstall_scheme: "http"
+
+# Set to true to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+# of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+# collections in the database, a projection query is made that includes only the names of the collection elements.
+# The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+# performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+# also launched, which, when idle, fills in all the properties of the elements of the collections.
+# Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+lazy_start: false

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -1135,3 +1135,16 @@ cache_enabled
 If set to ``True``, allows the results of some internal operations to be cached, but may slow down editing of objects.
 
 default: ``False``
+
+lazy_start
+##########
+
+Set to ``True`` to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+collections in the database, a projection query is made that includes only the names of the collection elements.
+The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+also launched, which, when idle, fills in all the properties of the elements of the collections.
+Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+
+default: ``False``

--- a/tests/items/inmemory_test.py
+++ b/tests/items/inmemory_test.py
@@ -1,0 +1,252 @@
+"""
+TODO
+"""
+
+from typing import Callable
+import pytest
+
+import os
+import pathlib
+
+from cobbler.api import CobblerAPI
+from cobbler.items.package import Package
+from cobbler.items.file import File
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.repo import Repo
+from cobbler.items.image import Image
+from cobbler.items.distro import Distro
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+from cobbler.cobbler_collections import manager
+
+
+@pytest.fixture(scope="function")
+def inmemory_api() -> CobblerAPI:
+    """
+    TODO
+    """
+    CobblerAPI.__shared_state = {}
+    CobblerAPI.__has_loaded = False
+    api = CobblerAPI()
+    api.settings().lazy_start = True
+    manager.CollectionManager.has_loaded = False
+    manager.CollectionManager.__shared_state = {}
+    api._collection_mgr = manager.CollectionManager(api)
+    return api
+
+
+def test_inmemory(
+    inmemory_api: CobblerAPI,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
+):
+    """
+    TODO
+    """
+    # Arrange
+    test_package = Package(
+        inmemory_api, **{"name": "test_package", "comment": "test comment"}
+    )
+    inmemory_api.add_package(test_package)
+    test_file = File(
+        inmemory_api,
+        **{
+            "name": "test_file",
+            "path": "test path",
+            "owner": "test owner",
+            "group": "test group",
+            "mode": "test mode",
+            "is_dir": True,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_file(test_file)
+    test_mgmtclass = Mgmtclass(
+        inmemory_api,
+        **{
+            "name": "test_mgmtclass",
+            "packages": [test_package.name],
+            "files": [test_file.name],
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_mgmtclass(test_mgmtclass)
+    test_repo = Repo(inmemory_api, **{"name": "test_repo", "comment": "test comment"})
+    inmemory_api.add_repo(test_repo)
+    test_menu1 = Menu(inmemory_api, **{"name": "test_menu1", "comment": "test comment"})
+    inmemory_api.add_menu(test_menu1)
+    test_menu2 = Menu(
+        inmemory_api,
+        **{
+            "name": "test_menu2",
+            "parent": test_menu1.name,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_menu(test_menu2)
+
+    directory = create_kernel_initrd(fk_kernel, fk_initrd)
+    (pathlib.Path(directory) / "images").mkdir()
+    test_distro = Distro(
+        inmemory_api,
+        **{
+            "name": "test_distro",
+            "kernel": str(os.path.join(directory, fk_kernel)),
+            "initrd": str(os.path.join(directory, fk_initrd)),
+            "mgmt_classes": test_mgmtclass.name,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_distro(test_distro)
+
+    test_profile1 = Profile(
+        inmemory_api,
+        **{
+            "name": "test_profile1",
+            "distro": test_distro.name,
+            "enable_menu": False,
+            "repos": [test_repo.name],
+            "menu": test_menu1.name,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_profile(test_profile1)
+    test_profile2 = Profile(
+        inmemory_api,
+        **{
+            "name": "test_profile2",
+            "parent": test_profile1.name,
+            "enable_menu": False,
+            "menu": test_menu2.name,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_profile(test_profile2)
+    test_profile3 = Profile(
+        inmemory_api,
+        **{
+            "name": "test_profile3",
+            "parent": test_profile1.name,
+            "enable_menu": False,
+            "mgmt_classes": test_mgmtclass.name,
+            "repos": [test_repo.name],
+            "menu": test_menu1.name,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_profile(test_profile3)
+    test_image = Image(
+        inmemory_api,
+        **{"name": "test_image", "menu": test_menu1.name, "comment": "test comment"},
+    )
+    inmemory_api.add_image(test_image)
+    test_system1 = System(
+        inmemory_api,
+        **{
+            "name": "test_system1",
+            "profile": test_profile1.name,
+            "comment": "test comment",
+        },
+    )
+    inmemory_api.add_system(test_system1)
+    test_system2 = System(
+        inmemory_api,
+        **{"name": "test_system2", "image": test_image.name, "comment": "test comment"},
+    )
+    inmemory_api.add_system(test_system2)
+
+    inmemory_api.systems().listing.pop(test_system2.name)
+    inmemory_api.systems().listing.pop(test_system1.name)
+    inmemory_api.images().listing.pop(test_image.name)
+    inmemory_api.profiles().listing.pop(test_profile3.name)
+    inmemory_api.profiles().listing.pop(test_profile2.name)
+    inmemory_api.profiles().listing.pop(test_profile1.name)
+    inmemory_api.distros().listing.pop(test_distro.name)
+    inmemory_api.menus().listing.pop(test_menu2.name)
+    inmemory_api.menus().listing.pop(test_menu1.name)
+    inmemory_api.repos().listing.pop(test_repo.name)
+    inmemory_api.mgmtclasses().listing.pop(test_mgmtclass.name)
+    inmemory_api.files().listing.pop(test_file.name)
+    inmemory_api.packages().listing.pop(test_package.name)
+
+    inmemory_api.deserialize()
+
+    test_package = inmemory_api.find_package("test_package")
+    test_file = inmemory_api.find_file("test_file")
+    test_mgmtclass = inmemory_api.find_mgmtclass("test_mgmtclass")
+    test_repo = inmemory_api.find_repo("test_repo")
+    test_menu1 = inmemory_api.find_menu("test_menu1")
+    test_menu2 = inmemory_api.find_menu("test_menu2")
+    test_distro = inmemory_api.find_distro("test_distro")
+    test_profile1 = inmemory_api.find_profile("test_profile1")
+    test_profile2 = inmemory_api.find_profile("test_profile2")
+    test_profile3 = inmemory_api.find_profile("test_profile3")
+    test_image = inmemory_api.find_image("test_image")
+    test_system1 = inmemory_api.find_system("test_system1")
+    test_system2 = inmemory_api.find_system("test_system2")
+
+    # Act
+    result = True
+    for collection in [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "image",
+        "profile",
+        "system",
+    ]:
+        for obj in inmemory_api.get_items(collection):
+            result = obj.inmemory is False if result else result
+            result = obj.__dict__["_comment"] == "" if result else result
+
+    comment = test_system1.comment if result else result
+    result = test_package.inmemory if result else result
+    result = test_file.inmemory if result else result
+    result = test_mgmtclass.inmemory if result else result
+    result = test_repo.inmemory if result else result
+    result = test_menu1.inmemory if result else result
+    result = not test_menu2.inmemory if result else result
+    result = test_distro.inmemory if result else result
+    result = test_profile1.inmemory if result else result
+    result = not test_profile2.inmemory if result else result
+    result = not test_profile3.inmemory if result else result
+    result = not test_image.inmemory if result else result
+    result = test_system1.inmemory if result else result
+    result = not test_system2.inmemory if result else result
+
+    result = test_package.__dict__["_comment"] == "test comment" if result else result
+    result = test_file.__dict__["_comment"] == "test comment" if result else result
+    result = test_mgmtclass.__dict__["_comment"] == "test comment" if result else result
+    result = test_repo.__dict__["_comment"] == "test comment" if result else result
+    result = test_menu1.__dict__["_comment"] == "test comment" if result else result
+    result = test_menu2.__dict__["_comment"] == "" if result else result
+    result = test_distro.__dict__["_comment"] == "test comment" if result else result
+    result = test_profile1.__dict__["_comment"] == "test comment" if result else result
+    result = test_profile2.__dict__["_comment"] == "" if result else result
+    result = test_profile3.__dict__["_comment"] == "" if result else result
+    result = test_image.__dict__["_comment"] == "" if result else result
+    result = test_system1.__dict__["_comment"] == "test comment" if result else result
+    result = test_system2.__dict__["_comment"] == "" if result else result
+
+    # Cleanup
+    inmemory_api.remove_system(test_system1)
+    inmemory_api.remove_system(test_system2)
+    inmemory_api.remove_image(test_image)
+    inmemory_api.remove_profile(test_profile3)
+    inmemory_api.remove_profile(test_profile2)
+    inmemory_api.remove_profile(test_profile1)
+    inmemory_api.remove_distro(test_distro)
+    inmemory_api.remove_menu(test_menu2)
+    inmemory_api.remove_menu(test_menu1)
+    inmemory_api.remove_repo(test_repo)
+    inmemory_api.remove_mgmtclass(test_mgmtclass)
+    inmemory_api.remove_package(test_package)
+    inmemory_api.remove_file(test_file)
+
+    # Assert
+    assert result

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -454,7 +454,7 @@ def test_dump_vars(cobbler_api):
     print(result)
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 152
+    assert len(result) == 153
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/serializer/file_test.py
+++ b/tests/modules/serializer/file_test.py
@@ -9,6 +9,7 @@ from cobbler.cobbler_collections.collection import Collection
 from cobbler.modules.serializers import file
 from cobbler.cexceptions import CX
 from cobbler.settings import Settings
+from tests.conftest import does_not_raise
 
 
 @pytest.fixture()
@@ -242,3 +243,42 @@ def test_deserialize(
     # Assert
     assert stub_from.called
     stub_from.assert_called_with(expected_result)
+
+
+@pytest.mark.parametrize(
+    "input_collection_type,input_item,expected_result,expected_exception",
+    [
+        (
+            "distros",
+            {"name": "test"},
+            {"name": "test", "inmemory": True},
+            does_not_raise(),
+        ),
+        (
+            "distros",
+            {"name": "test"},
+            {"name": "fake", "inmemory": True},
+            pytest.raises(CX),
+        ),
+    ],
+)
+def test_deserialize_item(
+    mocker,
+    input_collection_type,
+    input_item,
+    expected_result,
+    expected_exception,
+    serializer_obj,
+):
+    # Arrange
+    mocked_input = mocker.mock_open(read_data=json.dumps(input_item))()
+    mocker.patch("builtins.open", return_value=mocked_input)
+
+    # Act
+    with expected_exception:
+        result = serializer_obj.deserialize_item(
+            input_collection_type, expected_result["name"]
+        )
+
+        # Assert
+        assert result == expected_result

--- a/tests/serializer_test.py
+++ b/tests/serializer_test.py
@@ -81,3 +81,18 @@ def test_deserialize(mocker, serializer_obj):
 
     # Assert
     storage_object_mock.deserialize.assert_called_with(input_collection, True)
+
+
+def test_deserialize_item(mocker, serializer_obj):
+    # Arrange
+    storage_object_mock = mocker.patch.object(serializer_obj, "storage_object")
+    input_collection_type = mocker.MagicMock()
+    input_name = mocker.MagicMock()
+
+    # Act
+    serializer_obj.deserialize_item(input_collection_type, input_name)
+
+    # Assert
+    storage_object_mock.deserialize_item.assert_called_with(
+        input_collection_type, input_name
+    )

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -192,4 +192,5 @@ def test_normalize_v3_4_0_full():
     assert new_settings["mongodb"] == {"host": "localhost", "port": 27017}
     assert "cache_enabled" in new_settings
     assert new_settings["cache_enabled"] == False
-    assert len(V3_4_0.normalize(new_settings)) == 134
+    assert new_settings["lazy_start"] == False
+    assert len(V3_4_0.normalize(new_settings)) == 135

--- a/tests/test_data/V3_4_0/settings.yaml
+++ b/tests/test_data/V3_4_0/settings.yaml
@@ -622,5 +622,15 @@ mongodb:
 # editing objects.
 cache_enabled: false
 
+
+# Set to true to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+# of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+# collections in the database, a projection query is made that includes only the names of the collection elements.
+# The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+# performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+# also launched, which, when idle, fills in all the properties of the elements of the collections.
+# Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+lazy_start: false
+
 # list settings keys to exclude from validation - helpful to validate and migrate custom settings
 extra_settings_list: []

--- a/tests/xmlrpcapi/conftest.py
+++ b/tests/xmlrpcapi/conftest.py
@@ -286,8 +286,8 @@ def remove_testdistro(remote: CobblerXMLRPCInterface, token: str):
 def create_testdistro(
     remote: CobblerXMLRPCInterface,
     token: str,
-    fk_kernel,
-    fk_initrd,
+    fk_kernel: str,
+    fk_initrd: str,
     create_kernel_initrd: Callable[[str, str], str],
 ):
     """

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -286,10 +286,6 @@ class TestSystem:
         "create_testmenu",
         "create_testprofile",
         "create_testsystem",
-        "remove_testdistro",
-        "remove_testmenu",
-        "remove_testprofile",
-        "remove_testsystem",
     )
     def test_copy_system(self, remote, token):
         """
@@ -303,9 +299,6 @@ class TestSystem:
 
         # Assert
         assert result
-
-        # Cleanup
-        remote.remove_system("testsytemcopy", token)
 
     @pytest.mark.usefixtures(
         "create_testdistro",


### PR DESCRIPTION
## Linked Items

Fixes #3360

## Description

The background task loads them later during idle time, or they can be loaded when accessing the properties of the elements.

## Behaviour changes

Old: Cobbler was only available to serve requests after it loaded all items.

New: Cobbler is able to lazy load collections and load required items on demand.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
