### PR TITLE
CI: Add coverage also to Codacy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,8 +29,8 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           scandir: './scripts'
-  linter_name:
-    name: runner/black formatter
+  python_black:
+    name: black formatter
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Run the Tests inside the Docker Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-skip && git config --global --add safe.directory /code && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"
+          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-skip && git config --global --add safe.directory /code && coverage xml && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"
       - name: Stop and remove the container
         run: docker stop cobbler && docker rm cobbler
+      # https://github.com/codacy/codacy-coverage-reporter-action
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.xml


### PR DESCRIPTION
## Linked Items

Fixes #3365 

## Description

Add coverage in Codacy so we have to be dependent on one tool less.

## Behaviour changes

Old: Coverage is maintained in Codecov and Code quality in Codacy.

New: Both code quality and coverage are in Codacy.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
