### PR TITLE
Fix reposync --tries argument

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -2582,7 +2582,11 @@ class CobblerCLI:
                 "--only", dest="only", help="update only this repository name"
             )
             self.parser.add_option(
-                "--tries", dest="tries", help="try each repo this many times", default=1
+                "--tries",
+                dest="tries",
+                help="try each repo this many times",
+                default=1,
+                type="int",
             )
             self.parser.add_option(
                 "--no-fail",


### PR DESCRIPTION
Currently this argument is parsed as a string, which is problematic as background_reposync() and RepoSync expect an integer. This causes the command to fail when `--tries` is passed on Python 3.9, as it attempts to add an integer to a string value.

Note: I do not have a GPG key assigned to my account, and therefore this commit is unsigned.

## Linked Items

Fixes #3377

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This PR changes the `--tries` argument of reposync to be parsed as an integer, instead of a string. This should fix the failure that occurs when Cobbler expects it to be an integer in `cobbler/actions/reposync.py`.

## Behaviour changes

Old: Cobbler fails when running `cobbler reposync --tries=3`

New: Cobbler runs reposync with three attempts when running `cobbler reposync --tries=3`

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
