### PR TITLE
Update tftpgen.py to fix issue with pxelinux configs

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1152,7 +1152,7 @@ class TFTPGen:
                     append_line += f" netdevice={management_mac}"
             elif distro.breed in ("debian", "ubuntu"):
                 append_line = (
-                    f"{append_line} auto-install/enable=true priority=critical"
+                    f"{append_line}auto-install/enable=true priority=critical "
                     f"netcfg/choose_interface=auto url={autoinstall_path}"
                 )
                 if management_interface:


### PR DESCRIPTION
## Linked Items

Fixes #3370

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->
PR deletes the space between `}` and `auto`, followed by inserting space between `critical` and `"` in the following line of tftpgen.py:

`f"{append_line} auto-install/enable=true priority=critical"`

so that, after the change, it looks as follows:

`f"{append_line}auto-install/enable=true priority=critical "`

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->
The issue prevented automatic install of the target system.

`priority=criticalnetcfg/choose_interface=auto`

New: <!-- This is the new way Cobbler behaves -->
The change makes it possible to perform automatic install of the target system (note the space between `critical` and `netcfg`)

`priority=critical netcfg/choose_interface=auto`

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
