### PR TITLE
CI: Add issort

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -38,3 +38,12 @@ jobs:
         with:
           options: "--check --safe --verbose"
           version: "22.3.0"
+  python_isort:
+    name: isort formatter
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: isort/isort-action@v1.1.0
+        with:
+          configuration: --check-only --diff --profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,9 @@ repos:
         # https://pre-commit.com/#top_level-default_language_version
         language_version: python3.10
         additional_dependencies: ['click==8.0.4']
+  - repo: https://github.com/pycqa/isort
+    # Configuration for isort is in "pyproject.toml"
+    rev: 5.6.4
+    hooks:
+      - id: isort
+        args: ["--filter-files"]

--- a/bin/cobbler
+++ b/bin/cobbler
@@ -7,8 +7,9 @@ Wrapper for cobbler
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import cobbler.cli as app
 import sys
+
+import cobbler.cli as app
 
 PROFILING = False
 

--- a/bin/cobbler-ext-nodes
+++ b/bin/cobbler-ext-nodes
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
-import yaml
-import requests
 import sys
 
+import requests
+import yaml
 
 if __name__ == "__main__":
     hostname = None

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -12,8 +12,10 @@ Tool to manage the settings of Cobbler without the daemon running.
 import argparse
 import sys
 from typing import List
-from schema import Optional, SchemaError
+
 import yaml
+from schema import Optional, SchemaError
+
 from cobbler import settings
 from cobbler.settings import migrations
 from cobbler.settings.migrations import EMPTY_VERSION, helper

--- a/bin/cobblerd
+++ b/bin/cobblerd
@@ -7,14 +7,14 @@ Wrapper for cobbler's remote syslog watching daemon.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import logging
-import sys
-import os
-import traceback
 import argparse
-import cobbler.cobblerd as app
-import cobbler.api as cobbler_api
+import logging
+import os
+import sys
+import traceback
 
+import cobbler.api as cobbler_api
+import cobbler.cobblerd as app
 
 logger = logging.getLogger()
 

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -14,8 +14,8 @@ import shutil
 from typing import Dict, List, Optional, Union
 
 from cobbler import utils
-from cobbler.utils import input_converters, filesystem_helpers
 from cobbler.enums import Archs
+from cobbler.utils import filesystem_helpers, input_converters
 
 
 def add_remaining_kopts(kopts: dict) -> str:

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -6,11 +6,11 @@ This module contains the specific code to generate a network bootable ISO.
 
 import os
 import re
-from typing import Optional, List
+from typing import List, Optional
 
 from cobbler import utils
-from cobbler.utils import input_converters
 from cobbler.actions import buildiso
+from cobbler.utils import input_converters
 
 
 class AppendLineBuilder:

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -6,10 +6,9 @@ This module contains the specific code for generating standalone or airgapped IS
 
 import os
 import re
-from typing import Optional, Dict, List
+from typing import Dict, List, Optional
 
 from cobbler import utils
-
 from cobbler.actions import buildiso
 
 cdregex = re.compile(r"^\s*url .*\n", re.IGNORECASE | re.MULTILINE)

--- a/cobbler/actions/check.py
+++ b/cobbler/actions/check.py
@@ -11,7 +11,6 @@ import logging
 import os
 import re
 from typing import List
-
 from xmlrpc.client import ServerProxy
 
 from cobbler import utils

--- a/cobbler/actions/log.py
+++ b/cobbler/actions/log.py
@@ -7,9 +7,9 @@ Cobbler Trigger Module that managed the logs associated with a Cobbler system.
 # SPDX-FileCopyrightText: Bill Peck <bpeck@redhat.com>
 
 import glob
+import logging
 import os
 import os.path
-import logging
 import pathlib
 
 

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -11,14 +11,14 @@ import logging
 import os
 import os.path
 import pipes
-import stat
 import shutil
+import stat
 from typing import Any, Dict, Optional, Tuple
 
 from cobbler import utils
-from cobbler.enums import RepoArchs, RepoBreeds, MirrorType
-from cobbler.utils import filesystem_helpers, os_release
 from cobbler.cexceptions import CX
+from cobbler.enums import MirrorType, RepoArchs, RepoBreeds
+from cobbler.utils import filesystem_helpers, os_release
 
 HAS_LIBREPO = False
 try:

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -11,17 +11,15 @@ import glob
 import logging
 import os
 import time
-from typing import Optional, List, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Optional
 
+from cobbler import templar, tftpgen, utils
 from cobbler.cexceptions import CX
-from cobbler import templar
-from cobbler import tftpgen
-from cobbler import utils
 from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:
-    from cobbler.items.system import System
     from cobbler.items.profile import Profile
+    from cobbler.items.system import System
 
 
 class CobblerSync:

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -18,22 +18,6 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from schema import SchemaError
 
-from cobbler.actions import importer
-from cobbler import validate
-from cobbler.actions import (
-    status,
-    hardlink,
-    sync,
-    replicate,
-    report,
-    log,
-    acl,
-    check,
-    reposync,
-    mkloaders,
-)
-from cobbler.actions.buildiso.standalone import StandaloneBuildiso
-from cobbler.actions.buildiso.netboot import NetbootBuildiso
 from cobbler import (
     autoinstall_manager,
     autoinstallgen,
@@ -41,10 +25,30 @@ from cobbler import (
     enums,
     module_loader,
     power_manager,
+    settings,
+    tftpgen,
+    utils,
+    validate,
+    yumgen,
 )
-from cobbler import settings, tftpgen, utils, yumgen
-from cobbler.utils import input_converters, signatures, filesystem_helpers
+from cobbler.actions import (
+    acl,
+    check,
+    hardlink,
+    importer,
+    log,
+    mkloaders,
+    replicate,
+    report,
+    reposync,
+    status,
+    sync,
+)
+from cobbler.actions.buildiso.netboot import NetbootBuildiso
+from cobbler.actions.buildiso.standalone import StandaloneBuildiso
+from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import manager
+from cobbler.decorator import InheritableDictProperty
 from cobbler.items import (
     distro,
     file,
@@ -56,12 +60,11 @@ from cobbler.items import (
     repo,
     system,
 )
-from cobbler.decorator import InheritableDictProperty
-from cobbler.cexceptions import CX
+from cobbler.utils import filesystem_helpers, input_converters, signatures
 
 if TYPE_CHECKING:
-    from cobbler.settings import Settings
     from cobbler.items import item
+    from cobbler.settings import Settings
 
 
 # notes on locking:

--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -6,8 +6,7 @@ or preseed files.
 import logging
 import os
 
-from cobbler import autoinstallgen
-from cobbler import utils
+from cobbler import autoinstallgen, utils
 from cobbler.utils import filesystem_helpers
 
 TEMPLATING_ERROR = 1

--- a/cobbler/autoinstallgen.py
+++ b/cobbler/autoinstallgen.py
@@ -9,9 +9,7 @@ Builds out filesystem trees/data based on the object tree. This is the code behi
 import urllib.parse
 import xml.dom.minidom
 
-from cobbler import templar
-from cobbler import utils
-from cobbler import validate
+from cobbler import templar, utils, validate
 from cobbler.cexceptions import CX
 
 

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -14,9 +14,7 @@ import traceback
 import xmlrpc.client
 from typing import Optional
 
-from cobbler import enums
-from cobbler import power_manager
-from cobbler import utils
+from cobbler import enums, power_manager, utils
 from cobbler.utils import signatures
 
 INVALID_TASK = "<<invalid>>"

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -7,31 +7,21 @@ This module contains the code for the abstract base collection that powers all t
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import logging
-import time
 import os
+import time
 from threading import Lock
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from cobbler import utils
-from cobbler.items import (
-    package,
-    system,
-    item as item_base,
-    image,
-    profile,
-    repo,
-    mgmtclass,
-    distro,
-    file,
-    menu,
-)
-
 from cobbler.cexceptions import CX
+from cobbler.items import distro, file, image
+from cobbler.items import item as item_base
+from cobbler.items import menu, mgmtclass, package, profile, repo, system
 
 if TYPE_CHECKING:
+    from cobbler.actions.sync import CobblerSync
     from cobbler.api import CobblerAPI
     from cobbler.cobbler_collections.manager import CollectionManager
-    from cobbler.actions.sync import CobblerSync
 
 
 class Collection:

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -6,14 +6,14 @@ Cobbler module that at runtime holds all distros in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import os.path
 import glob
+import os.path
 from typing import TYPE_CHECKING, Any, Dict
 
-from cobbler.cobbler_collections import collection
-from cobbler.items import distro
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import distro
 from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -6,10 +6,11 @@ Cobbler module that at runtime holds all files in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2010, Kelsey Hightower <kelsey.hightower@gmail.com>
 
 from typing import TYPE_CHECKING, Any, Dict
-from cobbler.cobbler_collections import collection
-from cobbler.items import file
+
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import file
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -7,10 +7,11 @@ Cobbler module that at runtime holds all images in Cobbler.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 from typing import TYPE_CHECKING, Any, Dict
-from cobbler.cobbler_collections import collection
-from cobbler.items import image
+
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import image
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -7,23 +7,21 @@ Repository of the Cobbler object model
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import weakref
-from typing import TYPE_CHECKING, Union, Dict, Any
+from typing import TYPE_CHECKING, Any, Dict, Union
 
+from cobbler import serializer, validate
 from cobbler.cexceptions import CX
-from cobbler import serializer
-from cobbler import validate
-from cobbler.settings import Settings
-from cobbler.items.item import Item
 from cobbler.cobbler_collections.distros import Distros
 from cobbler.cobbler_collections.files import Files
 from cobbler.cobbler_collections.images import Images
+from cobbler.cobbler_collections.menus import Menus
 from cobbler.cobbler_collections.mgmtclasses import Mgmtclasses
 from cobbler.cobbler_collections.packages import Packages
 from cobbler.cobbler_collections.profiles import Profiles
 from cobbler.cobbler_collections.repos import Repos
 from cobbler.cobbler_collections.systems import Systems
-from cobbler.cobbler_collections.menus import Menus
-
+from cobbler.items.item import Item
+from cobbler.settings import Settings
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -6,10 +6,11 @@ Cobbler module that at runtime holds all menus in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2021 Yuriy Chelpanov <yuriy.chelpanov@gmail.com>
 
 from typing import TYPE_CHECKING, Any, Dict
-from cobbler.items import menu
-from cobbler.cobbler_collections import collection
+
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import menu
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -6,10 +6,11 @@ Cobbler module that at runtime holds all mgmtclasses in Cobbler.
 # SPDX-FileCopyrightText: Copyright 2010, Kelsey Hightower <kelsey.hightower@gmail.com>
 
 from typing import TYPE_CHECKING, Any, Dict
-from cobbler.cobbler_collections import collection
-from cobbler.items import mgmtclass
+
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import mgmtclass
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -7,10 +7,10 @@ Cobbler module that at runtime holds all packages in Cobbler.
 
 from typing import TYPE_CHECKING, Any, Dict
 
-from cobbler.cobbler_collections import collection
-from cobbler.items import package
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import package
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -7,10 +7,11 @@ Cobbler module that at runtime holds all profiles in Cobbler.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 from typing import TYPE_CHECKING, Any, Dict
-from cobbler.cobbler_collections import collection
-from cobbler.items import profile
+
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import profile
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -9,10 +9,10 @@ Cobbler module that at runtime holds all repos in Cobbler.
 import os.path
 from typing import TYPE_CHECKING, Any, Dict
 
-from cobbler.cobbler_collections import collection
-from cobbler.items import repo
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import repo
 from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -7,10 +7,11 @@ Cobbler module that at runtime holds all systems in Cobbler.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 from typing import TYPE_CHECKING, Any, Dict
-from cobbler.cobbler_collections import collection
-from cobbler.items import system
+
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import collection
+from cobbler.items import system
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/configgen.py
+++ b/cobbler/configgen.py
@@ -12,9 +12,8 @@ import json
 import string
 from typing import Dict, Union
 
+from cobbler import template_api, utils
 from cobbler.cexceptions import CX
-from cobbler import template_api
-from cobbler import utils
 
 # FIXME: This is currently getting the blendered data. Make use of the object and only process the required data.
 # FIXME: Obsolete this class. All methods are wrappers or tailcalls except gen_config_data and this can be integrated

--- a/cobbler/decorator.py
+++ b/cobbler/decorator.py
@@ -4,6 +4,7 @@ This module provides decorators that are required for Cobbler to work as expecte
 # The idea for the subclassed property decorators is from: https://stackoverflow.com/a/59313599/4730773
 
 from typing import Any, Optional
+
 from cobbler.items import item
 
 

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -5,18 +5,17 @@ Cobbler module that contains the code for a Cobbler distro object.
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
+
+import copy
 import glob
 import os
-import copy
 from typing import TYPE_CHECKING, Any, List, Union
 
-from cobbler import enums, validate
-from cobbler.items import item
-from cobbler import utils
-from cobbler.utils import input_converters, signatures
+from cobbler import enums, grub, utils, validate
 from cobbler.cexceptions import CX
-from cobbler import grub
-from cobbler.decorator import LazyProperty, InheritableProperty
+from cobbler.decorator import InheritableProperty, LazyProperty
+from cobbler.items import item
+from cobbler.utils import input_converters, signatures
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -9,10 +9,10 @@ Cobbler module that contains the code for a Cobbler file object.
 import copy
 from typing import TYPE_CHECKING, Any
 
-from cobbler.utils import input_converters
-from cobbler.items import resource
-from cobbler.decorator import LazyProperty
 from cobbler.cexceptions import CX
+from cobbler.decorator import LazyProperty
+from cobbler.items import resource
+from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -6,13 +6,13 @@ Cobbler module that contains the code for a Cobbler image object.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-from typing import TYPE_CHECKING, List, Union, Any
 import copy
+from typing import TYPE_CHECKING, Any, List, Union
 
 from cobbler import autoinstall_manager, enums, validate
 from cobbler.cexceptions import CX
+from cobbler.decorator import InheritableProperty, LazyProperty
 from cobbler.items import item
-from cobbler.decorator import LazyProperty, InheritableProperty
 from cobbler.utils import input_converters, signatures
 
 if TYPE_CHECKING:

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -13,14 +13,14 @@ import logging
 import pprint
 import re
 import uuid
-from typing import TYPE_CHECKING, Any, Dict, List, Type, Union, Tuple, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, Union
 
 import yaml
 
-from cobbler import utils, enums
-from cobbler.utils import input_converters
+from cobbler import enums, utils
 from cobbler.cexceptions import CX
-from cobbler.decorator import LazyProperty, InheritableProperty, InheritableDictProperty
+from cobbler.decorator import InheritableDictProperty, InheritableProperty, LazyProperty
+from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -8,8 +8,8 @@ Cobbler module that contains the code for a Cobbler menu object.
 import copy
 from typing import TYPE_CHECKING, Any
 
-from cobbler.items import item
 from cobbler.decorator import LazyProperty
+from cobbler.items import item
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -8,9 +8,9 @@ Cobbler module that contains the code for a Cobbler mgmtclass object.
 import copy
 from typing import TYPE_CHECKING, Any, Dict, List, Union
 
+from cobbler.decorator import LazyProperty
 from cobbler.items import item
 from cobbler.utils import input_converters
-from cobbler.decorator import LazyProperty
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -9,8 +9,8 @@ Cobbler module that contains the code for a Cobbler package object.
 import copy
 from typing import TYPE_CHECKING, Any
 
-from cobbler.items import resource
 from cobbler.decorator import LazyProperty
+from cobbler.items import resource
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -7,14 +7,13 @@ Cobbler module that contains the code for a Cobbler profile object.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import copy
-from typing import TYPE_CHECKING, List, Union, Any
+from typing import TYPE_CHECKING, Any, List, Union
 
-from cobbler import autoinstall_manager
-from cobbler.items import item
-from cobbler import validate, enums
-from cobbler.utils import input_converters
+from cobbler import autoinstall_manager, enums, validate
 from cobbler.cexceptions import CX
-from cobbler.decorator import LazyProperty, InheritableProperty
+from cobbler.decorator import InheritableProperty, LazyProperty
+from cobbler.items import item
+from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -10,10 +10,10 @@ import copy
 from typing import TYPE_CHECKING, Any, Union
 
 from cobbler import enums
-from cobbler.utils import input_converters
 from cobbler.cexceptions import CX
+from cobbler.decorator import InheritableProperty, LazyProperty
 from cobbler.items import item
-from cobbler.decorator import LazyProperty, InheritableProperty
+from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -10,8 +10,8 @@ import copy
 from typing import TYPE_CHECKING, Any, Union
 
 from cobbler import enums
-from cobbler.items import item
 from cobbler.decorator import LazyProperty
+from cobbler.items import item
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -5,18 +5,17 @@ All code belonging to Cobbler systems. This includes network interfaces.
 # SPDX-FileCopyrightText: Copyright 2006-2008, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
+import copy
 import enum
 import logging
-import copy
+from ipaddress import AddressValueError
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
-from ipaddress import AddressValueError
-
 from cobbler import autoinstall_manager, enums, power_manager, utils, validate
-from cobbler.utils import input_converters, filesystem_helpers
 from cobbler.cexceptions import CX
+from cobbler.decorator import InheritableProperty, LazyProperty
 from cobbler.items.item import Item
-from cobbler.decorator import LazyProperty, InheritableProperty
+from cobbler.utils import filesystem_helpers, input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/manager.py
+++ b/cobbler/manager.py
@@ -7,6 +7,7 @@ Base class for modules.managers.* classes
 # SPDX-FileCopyrightText: Thomas Renninger <trenn@suse.de>
 
 import logging
+
 from cobbler import templar
 
 

--- a/cobbler/module_loader.py
+++ b/cobbler/module_loader.py
@@ -7,18 +7,17 @@ Module loader, adapted for Cobbler usage
 # SPDX-FileCopyrightText: Adrian Likins <alikins@redhat.com>
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import logging
-from importlib import import_module
-
 import glob
+import logging
 import os
-from typing import Optional, Dict, Any
+from importlib import import_module
+from typing import Any, Dict, Optional
 
 from cobbler.cexceptions import CX
 from cobbler.utils import log_exc
 
 # add cobbler/modules to python path
-import cobbler
+import cobbler  # isort: skip
 
 
 class ModuleLoader:

--- a/cobbler/modules/authentication/ldap.py
+++ b/cobbler/modules/authentication/ldap.py
@@ -10,8 +10,8 @@ Choice of authentication module is in /etc/cobbler/modules.conf
 
 import traceback
 
-from cobbler.cexceptions import CX
 from cobbler import enums
+from cobbler.cexceptions import CX
 
 
 def register() -> str:

--- a/cobbler/modules/authentication/pam.py
+++ b/cobbler/modules/authentication/pam.py
@@ -24,8 +24,20 @@ Implemented using ctypes, so no compilation is necessary.
 # FIXME: Move to the dedicated library python-pam
 
 
-from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
-from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
+from ctypes import (
+    CDLL,
+    CFUNCTYPE,
+    POINTER,
+    Structure,
+    c_char,
+    c_char_p,
+    c_int,
+    c_uint,
+    c_void_p,
+    cast,
+    pointer,
+    sizeof,
+)
 from ctypes.util import find_library
 
 LIBPAM = CDLL(find_library("pam"))

--- a/cobbler/modules/authentication/spacewalk.py
+++ b/cobbler/modules/authentication/spacewalk.py
@@ -7,9 +7,10 @@ Any org_admin or kickstart_admin can get in.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 
+from xmlrpc.client import Error, ServerProxy
+
 from cobbler.cexceptions import CX
 from cobbler.utils import log_exc
-from xmlrpc.client import ServerProxy, Error
 
 
 def register() -> str:

--- a/cobbler/modules/authorization/configfile.py
+++ b/cobbler/modules/authorization/configfile.py
@@ -9,9 +9,8 @@ not authz_allowall, which will most likely NOT do what you want.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 
-from configparser import SafeConfigParser
-
 import os
+from configparser import SafeConfigParser
 from typing import Dict
 
 CONFIG_FILE = "/etc/cobbler/users.conf"

--- a/cobbler/modules/authorization/ownership.py
+++ b/cobbler/modules/authorization/ownership.py
@@ -9,9 +9,8 @@ allow certain users/groups to access those specific objects.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 
-from configparser import ConfigParser
-
 import os
+from configparser import ConfigParser
 from typing import Dict
 
 

--- a/cobbler/modules/installation/post_power.py
+++ b/cobbler/modules/installation/post_power.py
@@ -5,8 +5,8 @@ Post install trigger for Cobbler to power cycle the guest if needed
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2010 Bill Peck <bpeck@redhat.com>
 
-from threading import Thread
 import time
+from threading import Thread
 
 
 class RebootSystemThread(Thread):

--- a/cobbler/modules/installation/post_puppet.py
+++ b/cobbler/modules/installation/post_puppet.py
@@ -8,6 +8,7 @@ https://www.ithiriel.com/content/2010/03/29/writing-install-triggers-cobbler
 """
 import logging
 import re
+
 from cobbler import utils
 
 logger = logging.getLogger()

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -6,11 +6,11 @@ Post install trigger for Cobbler to send out a pretty email report that contains
 # SPDX-FileCopyrightText: Copyright 2008-2009 Bill Peck <bpeck@redhat.com>
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-from builtins import str
 import smtplib
+from builtins import str
+
+from cobbler import templar, utils
 from cobbler.cexceptions import CX
-from cobbler import templar
-from cobbler import utils
 
 
 def register() -> str:

--- a/cobbler/modules/installation/pre_clear_anamon_logs.py
+++ b/cobbler/modules/installation/pre_clear_anamon_logs.py
@@ -11,8 +11,8 @@ import glob
 import logging
 import os
 
-from cobbler.utils import filesystem_helpers
 from cobbler.cexceptions import CX
+from cobbler.utils import filesystem_helpers
 
 PATH_PREFIX = "/var/log/cobbler/anamon/"
 

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -9,8 +9,8 @@ This is some of the code behind 'cobbler sync'.
 
 import time
 
-from cobbler.utils import process_management
 from cobbler.manager import ManagerModule
+from cobbler.utils import process_management
 
 MANAGER = None
 

--- a/cobbler/modules/managers/genders.py
+++ b/cobbler/modules/managers/genders.py
@@ -5,9 +5,10 @@ Cobbler Module that manages the cluster configuration tool from CHAOS. For more 
 
 import distutils.sysconfig
 import logging
-import sys
 import os
+import sys
 import time
+
 from cobbler.templar import Templar
 
 plib = distutils.sysconfig.get_python_lib()

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -8,8 +8,6 @@ OS and version.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 # SPDX-FileCopyrightText: John Eckersberg <jeckersb@redhat.com>
 
-from typing import Dict, Callable, Any, Optional
-
 import glob
 import gzip
 import os
@@ -17,13 +15,13 @@ import os.path
 import re
 import shutil
 import stat
+from typing import Any, Callable, Dict, Optional
 
 import magic
 
-from cobbler.cexceptions import CX
 from cobbler import enums, utils
+from cobbler.cexceptions import CX
 from cobbler.manager import ManagerModule
-
 from cobbler.utils import filesystem_helpers
 
 HAS_HIVEX = True

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -9,10 +9,7 @@ import os.path
 import shutil
 from typing import List
 
-from cobbler import templar
-from cobbler import utils
-from cobbler import tftpgen
-
+from cobbler import templar, tftpgen, utils
 from cobbler.cexceptions import CX
 from cobbler.manager import ManagerModule
 from cobbler.utils import filesystem_helpers

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -10,11 +10,10 @@ This is some of the code behind 'cobbler sync'.
 import shutil
 import time
 
-from cobbler import utils
-from cobbler import enums
-from cobbler.utils import process_management
+from cobbler import enums, utils
 from cobbler.enums import Archs
 from cobbler.manager import ManagerModule
+from cobbler.utils import process_management
 
 MANAGER = None
 

--- a/cobbler/modules/nsupdate_add_system_post.py
+++ b/cobbler/modules/nsupdate_add_system_post.py
@@ -9,11 +9,12 @@ Replace (or remove) records in DNS zone for systems created (or removed) by Cobb
 #   - python-dnspython (Debian)
 #   - python-dns (RH/CentOS)
 
+import time
+
 import dns.query
+import dns.resolver
 import dns.tsigkeyring
 import dns.update
-import dns.resolver
-import time
 
 from cobbler.cexceptions import CX
 

--- a/cobbler/modules/nsupdate_delete_system_pre.py
+++ b/cobbler/modules/nsupdate_delete_system_pre.py
@@ -9,11 +9,12 @@ Replace (or remove) records in DNS zone for systems created (or removed) by Cobb
 #   - python-dnspython (Debian)
 #   - python-dns (RH/CentOS)
 
+import time
+
 import dns.query
+import dns.resolver
 import dns.tsigkeyring
 import dns.update
-import dns.resolver
-import time
 
 from cobbler.cexceptions import CX
 

--- a/cobbler/modules/scm_track.py
+++ b/cobbler/modules/scm_track.py
@@ -11,7 +11,6 @@ Cobbler Trigger Module that puts the content of the Cobbler data directory under
 import os
 
 from cobbler import utils
-
 from cobbler.cexceptions import CX
 
 

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -8,10 +8,10 @@ It uses multiple JSON files in /var/lib/cobbler/collections/distros, profiles, e
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import os
 import glob
 import json
 import logging
+import os
 from typing import Any, Dict
 
 import cobbler.api as capi

--- a/cobbler/modules/serializers/mongodb.py
+++ b/cobbler/modules/serializers/mongodb.py
@@ -15,7 +15,7 @@ from cobbler.modules.serializers import StorageBase
 
 try:
     from pymongo import MongoClient
-    from pymongo.errors import ConnectionFailure, ConfigurationError
+    from pymongo.errors import ConfigurationError, ConnectionFailure
 
     PYMONGO_LOADED = True
 except ModuleNotFoundError:

--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -2,26 +2,21 @@
 TODO
 """
 
-import os
-import re
 import binascii
 import logging
+import os
+import re
 import tempfile
 from typing import Optional
 
-from cobbler import utils
-from cobbler import templar
-from cobbler import tftpgen
+from cobbler import templar, tftpgen, utils
 from cobbler.utils import filesystem_helpers
 
 HAS_HIVEX = True
 try:
-    import pefile
     import hivex
-    from hivex.hive_types import REG_DWORD
-    from hivex.hive_types import REG_BINARY
-    from hivex.hive_types import REG_SZ
-    from hivex.hive_types import REG_MULTI_SZ
+    import pefile
+    from hivex.hive_types import REG_BINARY, REG_DWORD, REG_MULTI_SZ, REG_SZ
 except Exception:
     HAS_HIVEX = False
 

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -7,18 +7,18 @@ to remember different power management tools syntaxes.  This makes rebooting a s
 # SPDX-FileCopyrightText: Copyright 2008-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import json
 import glob
+import json
 import logging
 import os
-from pathlib import Path
-import stat
 import re
+import stat
 import time
+from pathlib import Path
 from typing import Optional
 
-from cobbler.cexceptions import CX
 from cobbler import utils
+from cobbler.cexceptions import CX
 
 # Try the power command 3 times before giving up. Some power switches are flaky.
 POWER_RETRIES = 3

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -13,27 +13,20 @@ import keyword
 import logging
 import os
 import random
+import re
 import stat
 import time
-import re
 import xmlrpc.server
 from socketserver import ThreadingMixIn
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 from xmlrpc.server import SimpleXMLRPCRequestHandler
 
-from cobbler import enums
-from cobbler import autoinstall_manager
-from cobbler import configgen
-from cobbler.items import (
-    item,
-    system,
-)
-from cobbler import tftpgen
-from cobbler import utils
+from cobbler import autoinstall_manager, configgen, enums, tftpgen, utils
+from cobbler.cexceptions import CX
+from cobbler.items import item, system
 from cobbler.utils import signatures
 from cobbler.utils.event import CobblerEvent
 from cobbler.utils.thread import CobblerThread
-from cobbler.cexceptions import CX
 from cobbler.validate import (
     validate_autoinstall_script_name,
     validate_obj_name,

--- a/cobbler/services.py
+++ b/cobbler/services.py
@@ -10,6 +10,7 @@ import json
 import time
 import urllib
 import xmlrpc.client
+
 import yaml
 
 from cobbler import download_manager

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -17,11 +17,12 @@ import shutil
 import traceback
 from pathlib import Path
 from typing import Any, Dict, Hashable, List, Optional
+
 import yaml
 from schema import SchemaError, SchemaMissingKeyError, SchemaWrongKeyError
 
-from cobbler.utils import input_converters
 from cobbler.settings import migrations
+from cobbler.utils import input_converters
 
 
 class Settings:

--- a/cobbler/settings/migrations/V3_0_0.py
+++ b/cobbler/settings/migrations/V3_0_0.py
@@ -11,8 +11,8 @@ import os
 import shutil
 
 from schema import Optional, Or, Schema, SchemaError
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V2_8_5
+
+from cobbler.settings.migrations import V2_8_5, helper
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/V3_0_1.py
+++ b/cobbler/settings/migrations/V3_0_1.py
@@ -7,6 +7,7 @@ Migration from V3.0.0 to V3.0.1
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
 from schema import SchemaError
+
 from cobbler.settings.migrations import V3_0_0
 
 # schema identical to V3_0_0

--- a/cobbler/settings/migrations/V3_1_0.py
+++ b/cobbler/settings/migrations/V3_1_0.py
@@ -8,6 +8,7 @@ Migration from V3.0.1 to V3.1.0
 
 
 from schema import SchemaError
+
 from cobbler.settings.migrations import V3_0_1
 
 # schema identical to V3_0_1

--- a/cobbler/settings/migrations/V3_1_1.py
+++ b/cobbler/settings/migrations/V3_1_1.py
@@ -8,6 +8,7 @@ Migration from V3.1.0 to V3.1.1
 
 
 from schema import SchemaError
+
 from cobbler.settings.migrations import V3_1_0
 
 # schema identical to V3_1_0

--- a/cobbler/settings/migrations/V3_1_2.py
+++ b/cobbler/settings/migrations/V3_1_2.py
@@ -8,8 +8,7 @@ Migration from V3.1.1 to V3.1.2
 
 from schema import Optional, Or, Schema, SchemaError
 
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V3_1_1
+from cobbler.settings.migrations import V3_1_1, helper
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/V3_2_0.py
+++ b/cobbler/settings/migrations/V3_2_0.py
@@ -7,8 +7,8 @@ Migration from V3.1.2 to V3.2.0
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
 from schema import Optional, Or, Schema, SchemaError
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V3_1_2
+
+from cobbler.settings.migrations import V3_1_2, helper
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/V3_2_1.py
+++ b/cobbler/settings/migrations/V3_2_1.py
@@ -10,9 +10,8 @@ import os
 
 from schema import Optional, Schema, SchemaError
 
+from cobbler.settings.migrations import V3_2_0, helper
 from cobbler.utils import input_converters
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V3_2_0
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/V3_3_0.py
+++ b/cobbler/settings/migrations/V3_3_0.py
@@ -14,8 +14,7 @@ import socket
 
 from schema import Optional, Schema, SchemaError
 
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V3_2_1
+from cobbler.settings.migrations import V3_2_1, helper
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/V3_3_1.py
+++ b/cobbler/settings/migrations/V3_3_1.py
@@ -8,8 +8,7 @@ Migration from V3.3.0 to V3.3.1
 
 from schema import Optional, Schema, SchemaError
 
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V3_3_0
+from cobbler.settings.migrations import V3_3_0, helper
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/V3_3_2.py
+++ b/cobbler/settings/migrations/V3_3_2.py
@@ -7,6 +7,7 @@ Migration from V3.3.1 to V3.3.2
 
 
 from schema import SchemaError
+
 from cobbler.settings.migrations import V3_3_1
 
 schema = V3_3_1.schema

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -5,16 +5,15 @@ Migration from V3.3.1 to V3.3.2
 # SPDX-FileCopyrightText: 2022 Dominik Gedon <dgedon@suse.de>
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 import configparser
-import pathlib
 import glob
-import os
 import json
+import os
+import pathlib
 from configparser import ConfigParser
 
 from schema import Optional, Schema, SchemaError
 
-from cobbler.settings.migrations import helper
-from cobbler.settings.migrations import V3_3_3
+from cobbler.settings.migrations import V3_3_3, helper
 
 schema = Schema(
     {

--- a/cobbler/settings/migrations/__init__.py
+++ b/cobbler/settings/migrations/__init__.py
@@ -23,7 +23,7 @@ from importlib import import_module
 from inspect import signature
 from pathlib import Path
 from types import ModuleType
-from typing import Tuple, Dict, List, Union, Optional
+from typing import Dict, List, Optional, Tuple, Union
 
 from schema import Schema
 

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -12,7 +12,7 @@ import os
 import os.path
 import pprint
 import re
-from typing import Optional, Union, TextIO
+from typing import Optional, TextIO, Union
 
 from cobbler import utils
 from cobbler.cexceptions import CX

--- a/cobbler/template_api.py
+++ b/cobbler/template_api.py
@@ -17,7 +17,6 @@ from Cheetah.Template import Template
 
 from cobbler import utils
 
-
 # This class is defined using the Cheetah language. Using the 'compile' function we can compile the source directly into
 # a Python class. This class will allow us to define the cheetah builtins.
 

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -18,9 +18,8 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 from cobbler import enums, templar, utils
 from cobbler.cexceptions import CX
 from cobbler.enums import Archs, ImageTypes
-from cobbler.utils import input_converters
+from cobbler.utils import filesystem_helpers, input_converters
 from cobbler.validate import validate_autoinstall_script_name
-from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/utils/filesystem_helpers.py
+++ b/cobbler/utils/filesystem_helpers.py
@@ -8,14 +8,14 @@ import hashlib
 import json
 import logging
 import os
+import pathlib
 import shutil
 import urllib
-import pathlib
 from typing import Union
 
+from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler.utils import log_exc, mtab
-from cobbler import utils
 
 logger = logging.getLogger()
 

--- a/cobbler/utils/thread.py
+++ b/cobbler/utils/thread.py
@@ -5,10 +5,9 @@ This module is responsible for managing the custom common threading logic Cobble
 import logging
 import pathlib
 from threading import Thread
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Callable, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
 
-from cobbler import enums
-from cobbler import utils
+from cobbler import enums, utils
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -7,16 +7,16 @@ Cobbler module that is related to validating data for other internal Cobbler mod
 
 import re
 import shlex
-from urllib.parse import urlparse
 from ipaddress import AddressValueError, NetmaskValueError
 from typing import Union
+from urllib.parse import urlparse
 from uuid import UUID
 
 import netaddr
 
 from cobbler import enums, utils
-from cobbler.utils import input_converters, signatures
 from cobbler.items import item
+from cobbler.utils import input_converters, signatures
 
 RE_HOSTNAME = re.compile(
     r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])"

--- a/cobbler/yumgen.py
+++ b/cobbler/yumgen.py
@@ -9,8 +9,7 @@ This is the code behind 'cobbler sync'.
 
 import pathlib
 
-from cobbler import templar
-from cobbler import utils
+from cobbler import templar, utils
 
 
 class YumGen:

--- a/contrib/api-examples/create_snippet.py
+++ b/contrib/api-examples/create_snippet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from xmlrpc.client import ServerProxy
 import optparse
+from xmlrpc.client import ServerProxy
 
 p = optparse.OptionParser()
 p.add_option("-u", "--user", dest="user", default="test")

--- a/contrib/api-examples/demo_connect.py
+++ b/contrib/api-examples/demo_connect.py
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-from xmlrpc.client import ServerProxy
 import optparse
+from xmlrpc.client import ServerProxy
 
 if __name__ == "__main__":
     p = optparse.OptionParser()

--- a/contrib/api-examples/read_snippet.py
+++ b/contrib/api-examples/read_snippet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from xmlrpc.client import ServerProxy
 import optparse
+from xmlrpc.client import ServerProxy
 
 p = optparse.OptionParser()
 p.add_option("-u", "--user", dest="user", default="test")

--- a/contrib/api-examples/remove_snippet.py
+++ b/contrib/api-examples/remove_snippet.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 
-from xmlrpc.client import ServerProxy
 import optparse
+from xmlrpc.client import ServerProxy
 
 p = optparse.OptionParser()
 p.add_option("-u", "--user", dest="user", default="test")

--- a/misc/anamon
+++ b/misc/anamon
@@ -23,13 +23,13 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-import os
-import sys
-import string
-import time
-import re
 import base64
+import os
+import re
 import shlex
+import string
+import sys
+import time
 
 try:
     from xmlrpc.client import Server

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,8 @@
 [build-system]
 requires = ["coverage", "distro", "sphinx", "setuptools", "wheel"]
+
+[tool.isort]
+profile = "black"
+known_cobbler="cobbler"
+known_tests="tests"
+sections="FUTURE,STDLIB,FIRSTPARTY,THIRDPARTY,LOCALFOLDER,COBBLER,TESTS"

--- a/setup.py
+++ b/setup.py
@@ -1,27 +1,23 @@
 #!/usr/bin/env python3
 
-import os
-import sys
-import time
-import glob as _glob
-
-from setuptools import setup
-from setuptools import Command
-from setuptools.command.install import install as _install
-from setuptools import Distribution as _Distribution
-from setuptools.command.build_py import build_py as _build_py
-from setuptools import dep_util
-from distutils.command.build import build as _build
-from configparser import ConfigParser
-from setuptools import find_packages
-from sphinx.setup_command import BuildDoc
-
 import codecs
-from coverage import Coverage
+import glob as _glob
+import os
 import pwd
 import shutil
 import subprocess
+import sys
+import time
+from configparser import ConfigParser
+from distutils.command.build import build as _build
 
+from coverage import Coverage
+from setuptools import Command
+from setuptools import Distribution as _Distribution
+from setuptools import dep_util, find_packages, setup
+from setuptools.command.build_py import build_py as _build_py
+from setuptools.command.install import install as _install
+from sphinx.setup_command import BuildDoc
 
 VERSION = "3.4.0"
 OUTPUT_DIR = "config"

--- a/tests/actions/acl_test.py
+++ b/tests/actions/acl_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from cobbler.cexceptions import CX
 from cobbler.actions import acl
+from cobbler.cexceptions import CX
 
 from tests.conftest import does_not_raise
 

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -1,5 +1,5 @@
-from cobbler.actions.buildiso.netboot import AppendLineBuilder
 from cobbler import utils
+from cobbler.actions.buildiso.netboot import AppendLineBuilder
 
 
 def test_init():

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -6,6 +6,7 @@ from cobbler import enums
 from cobbler.actions import buildiso
 from cobbler.actions.buildiso.netboot import NetbootBuildiso
 from cobbler.actions.buildiso.standalone import StandaloneBuildiso
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/actions/report_test.py
+++ b/tests/actions/report_test.py
@@ -3,6 +3,7 @@ import contextlib
 import pytest
 
 from cobbler.actions import report
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/actions/reposync_test.py
+++ b/tests/actions/reposync_test.py
@@ -2,10 +2,10 @@ import os
 
 import pytest
 
-from cobbler import enums
+from cobbler import cexceptions, enums
 from cobbler.actions import reposync
 from cobbler.items.repo import Repo
-from cobbler import cexceptions
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/actions/status_test.py
+++ b/tests/actions/status_test.py
@@ -1,7 +1,7 @@
 import pytest
 
-from cobbler.actions.status import InstallStatus
 from cobbler.actions import status
+from cobbler.actions.status import InstallStatus
 
 
 def test_collect_logfiles(mocker):

--- a/tests/api/add_test.py
+++ b/tests/api/add_test.py
@@ -2,11 +2,11 @@
 Tests that are ensuring the correct functionality of the CobblerAPI in regard to adding items via it.
 """
 
-from pathlib import Path
 import pathlib
+from pathlib import Path
 from typing import Callable
-from cobbler.api import CobblerAPI
 
+from cobbler.api import CobblerAPI
 from cobbler.items.image import Image
 
 

--- a/tests/api/miscellaneous_test.py
+++ b/tests/api/miscellaneous_test.py
@@ -3,11 +3,11 @@ from unittest.mock import create_autospec
 
 import pytest
 
-from cobbler import enums
-from cobbler import settings
-from cobbler.api import CobblerAPI
+from cobbler import enums, settings
 from cobbler.actions.buildiso.netboot import NetbootBuildiso
 from cobbler.actions.buildiso.standalone import StandaloneBuildiso
+from cobbler.api import CobblerAPI
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/api/sync_test.py
+++ b/tests/api/sync_test.py
@@ -1,10 +1,12 @@
+from unittest.mock import MagicMock, Mock, PropertyMock, create_autospec
+
 import pytest
-from unittest.mock import Mock, MagicMock, create_autospec, PropertyMock
 
 import cobbler.actions.sync
 import cobbler.modules.managers.bind
 import cobbler.modules.managers.isc
 from cobbler.items.image import Image
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/autoinstallation_manager_test.py
+++ b/tests/autoinstallation_manager_test.py
@@ -2,12 +2,12 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cobbler.api import CobblerAPI
-from cobbler.settings import Settings
 from cobbler import autoinstall_manager
+from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.system import System
+from cobbler.settings import Settings
 
 
 @pytest.fixture

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+
 from cobbler.cli import CobblerCLI
 
 

--- a/tests/cobbler_collections/distro_collection_test.py
+++ b/tests/cobbler_collections/distro_collection_test.py
@@ -2,8 +2,8 @@ import os.path
 from typing import Callable
 
 import pytest
-from cobbler.api import CobblerAPI
 
+from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import distros
 from cobbler.cobbler_collections.manager import CollectionManager

--- a/tests/configgen_test.py
+++ b/tests/configgen_test.py
@@ -7,7 +7,6 @@ from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.system import System
 
-
 # TODO: If the action items of the configgen class are done then the tests need to test the robustness of the class.
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,9 +12,9 @@ import pytest
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
+from cobbler.items.image import Image
 from cobbler.items.profile import Profile
 from cobbler.items.system import NetworkInterface, System
-from cobbler.items.image import Image
 
 
 @contextmanager

--- a/tests/enums_test.py
+++ b/tests/enums_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cobbler import enums
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/grub_test.py
+++ b/tests/grub_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cobbler import grub
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/cache_test.py
+++ b/tests/items/cache_test.py
@@ -1,21 +1,14 @@
-import os
-
 import pytest
 
-# from cobbler import enums
-from cobbler.items.package import Package
-from cobbler.items.file import File
-from cobbler.items.mgmtclass import Mgmtclass
-from cobbler.items.repo import Repo
-from cobbler.items.distro import Distro
-from cobbler.items.menu import Menu
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
-from cobbler.items.item import Item
-from cobbler.settings import Settings
-from tests.conftest import does_not_raise
 from cobbler.cexceptions import CX
-from cobbler.decorator import InheritableProperty, InheritableDictProperty
+from cobbler.items.file import File
+from cobbler.items.item import Item
+from cobbler.items.menu import Menu
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.package import Package
+from cobbler.items.repo import Repo
+
+from tests.conftest import does_not_raise
 
 
 def test_collection_types(cobbler_api):

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -3,8 +3,9 @@ import os
 import pytest
 
 from cobbler import enums
-from cobbler.utils import signatures
 from cobbler.items.distro import Distro
+from cobbler.utils import signatures
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/file_test.py
+++ b/tests/items/file_test.py
@@ -2,6 +2,7 @@ import pytest
 
 from cobbler import enums
 from cobbler.items.file import File
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -1,10 +1,12 @@
 from typing import Callable
+
 import pytest
 
 from cobbler import enums
 from cobbler.api import CobblerAPI
-from cobbler.utils import signatures
 from cobbler.items.image import Image
+from cobbler.utils import signatures
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/inmemory_test.py
+++ b/tests/items/inmemory_test.py
@@ -2,23 +2,23 @@
 TODO
 """
 
-from typing import Callable
-import pytest
-
 import os
 import pathlib
+from typing import Callable
+
+import pytest
 
 from cobbler.api import CobblerAPI
-from cobbler.items.package import Package
-from cobbler.items.file import File
-from cobbler.items.mgmtclass import Mgmtclass
-from cobbler.items.repo import Repo
-from cobbler.items.image import Image
-from cobbler.items.distro import Distro
-from cobbler.items.menu import Menu
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
 from cobbler.cobbler_collections import manager
+from cobbler.items.distro import Distro
+from cobbler.items.file import File
+from cobbler.items.image import Image
+from cobbler.items.menu import Menu
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.package import Package
+from cobbler.items.profile import Profile
+from cobbler.items.repo import Repo
+from cobbler.items.system import System
 
 
 @pytest.fixture(scope="function")

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -3,15 +3,16 @@ import os
 import pytest
 
 from cobbler import enums
-from cobbler.items.package import Package
-from cobbler.items.file import File
-from cobbler.items.mgmtclass import Mgmtclass
-from cobbler.items.repo import Repo
 from cobbler.items.distro import Distro
-from cobbler.items.menu import Menu
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
+from cobbler.items.file import File
 from cobbler.items.item import Item
+from cobbler.items.menu import Menu
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.package import Package
+from cobbler.items.profile import Profile
+from cobbler.items.repo import Repo
+from cobbler.items.system import System
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from cobbler import enums
 from cobbler.items.system import NetworkInterface
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -1,9 +1,10 @@
 import pytest
 
-from cobbler.cexceptions import CX
 from cobbler import enums
+from cobbler.cexceptions import CX
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/items/repo_test.py
+++ b/tests/items/repo_test.py
@@ -1,6 +1,7 @@
+import pytest
+
 from cobbler import enums
 from cobbler.items.repo import Repo
-import pytest
 
 from tests.conftest import does_not_raise
 

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -1,9 +1,10 @@
 import pytest
 
 from cobbler import enums
+from cobbler.cexceptions import CX
 from cobbler.items.profile import Profile
 from cobbler.items.system import NetworkInterface, System
-from cobbler.cexceptions import CX
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/module_loader_test.py
+++ b/tests/module_loader_test.py
@@ -1,7 +1,8 @@
 import pytest
 
-from cobbler.cexceptions import CX
 from cobbler import module_loader
+from cobbler.cexceptions import CX
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/modules/managers/dnsmasq_test.py
+++ b/tests/modules/managers/dnsmasq_test.py
@@ -1,10 +1,10 @@
 import time
 from unittest.mock import MagicMock
 
-from cobbler.modules.managers import dnsmasq
-from cobbler.items.system import NetworkInterface, System
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
+from cobbler.items.system import NetworkInterface, System
+from cobbler.modules.managers import dnsmasq
 from cobbler.templar import Templar
 
 

--- a/tests/modules/managers/genders_test.py
+++ b/tests/modules/managers/genders_test.py
@@ -4,12 +4,12 @@ from unittest.mock import MagicMock
 import pytest
 
 from cobbler.api import CobblerAPI
-from cobbler.modules.managers import genders
-from cobbler.settings import Settings
 from cobbler.items.distro import Distro
+from cobbler.items.mgmtclass import Mgmtclass
 from cobbler.items.profile import Profile
 from cobbler.items.system import System
-from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.modules.managers import genders
+from cobbler.settings import Settings
 
 
 @pytest.fixture

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -3,12 +3,12 @@ from unittest.mock import MagicMock, Mock
 import pytest
 
 from cobbler.api import CobblerAPI
-from cobbler.modules.managers import in_tftpd
-from cobbler.tftpgen import TFTPGen
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.system import System
+from cobbler.modules.managers import in_tftpd
 from cobbler.settings import Settings
+from cobbler.tftpgen import TFTPGen
 
 
 @pytest.fixture

--- a/tests/modules/managers/isc_test.py
+++ b/tests/modules/managers/isc_test.py
@@ -4,10 +4,10 @@ from unittest.mock import MagicMock
 import pytest
 
 from cobbler.api import CobblerAPI
-from cobbler.modules.managers import isc
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.system import System
+from cobbler.modules.managers import isc
 from cobbler.settings import Settings
 
 

--- a/tests/modules/managers/ndjbdns_test.py
+++ b/tests/modules/managers/ndjbdns_test.py
@@ -1,5 +1,5 @@
-from cobbler.modules.managers import ndjbdns
 from cobbler.items.system import NetworkInterface, System
+from cobbler.modules.managers import ndjbdns
 from cobbler.templar import Templar
 
 

--- a/tests/modules/scm_track_test.py
+++ b/tests/modules/scm_track_test.py
@@ -2,8 +2,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from cobbler.cexceptions import CX
 from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
 from cobbler.modules import scm_track
 from cobbler.settings import Settings
 

--- a/tests/modules/serializer/file_test.py
+++ b/tests/modules/serializer/file_test.py
@@ -5,10 +5,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from cobbler.cexceptions import CX
 from cobbler.cobbler_collections.collection import Collection
 from cobbler.modules.serializers import file
-from cobbler.cexceptions import CX
 from cobbler.settings import Settings
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/modules/serializer/mongodb_test.py
+++ b/tests/modules/serializer/mongodb_test.py
@@ -1,10 +1,11 @@
+import copy
 from typing import ContextManager
+
 import pytest
 
-import copy
-
-from cobbler.modules.serializers import mongodb
 from cobbler.cexceptions import CX
+from cobbler.modules.serializers import mongodb
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -4,16 +4,16 @@ rather related pytest-benchmark. Thus the different style in usage.
 """
 
 from typing import Callable
-from cobbler.api import CobblerAPI
 
-from cobbler.items.package import Package
-from cobbler.items.file import File
-from cobbler.items.mgmtclass import Mgmtclass
-from cobbler.items.repo import Repo
+from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
+from cobbler.items.file import File
 from cobbler.items.image import Image
 from cobbler.items.menu import Menu
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.package import Package
 from cobbler.items.profile import Profile
+from cobbler.items.repo import Repo
 from cobbler.items.system import System
 
 

--- a/tests/performance/get_autoinstall_test.py
+++ b/tests/performance/get_autoinstall_test.py
@@ -3,8 +3,8 @@ Test module to assert the performance of retrieving an autoinstallation file.
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from cobbler import autoinstall_manager
@@ -13,6 +13,7 @@ from cobbler.items.distro import Distro
 from cobbler.items.image import Image
 from cobbler.items.profile import Profile
 from cobbler.items.system import System
+
 from tests.performance import CobblerTree
 
 

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -3,8 +3,8 @@ Test module to assert the performance of adding different kinds of items.
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from cobbler.api import CobblerAPI

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -3,8 +3,8 @@ Test module to assert the performance of copying items.
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from cobbler.api import CobblerAPI

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -3,9 +3,10 @@ Test module to assert the performance of editing items.
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
+
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.image import Image

--- a/tests/performance/make_pxe_menu_test.py
+++ b/tests/performance/make_pxe_menu_test.py
@@ -3,8 +3,8 @@ Test module to assert the performance of creating the PXE menu.
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from cobbler.api import CobblerAPI

--- a/tests/performance/start_test.py
+++ b/tests/performance/start_test.py
@@ -3,8 +3,8 @@ Test module to assert the performance of the startup of the daemon.
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from cobbler.api import CobblerAPI

--- a/tests/performance/sync_test.py
+++ b/tests/performance/sync_test.py
@@ -3,8 +3,8 @@ Test module to assert the performance of "cobbler sync".
 """
 
 from typing import Any, Callable, Dict, Tuple
-import pytest
 
+import pytest
 from pytest_benchmark.fixture import BenchmarkFixture
 
 from cobbler.api import CobblerAPI

--- a/tests/settings/migrations/helper_test.py
+++ b/tests/settings/migrations/helper_test.py
@@ -7,7 +7,9 @@ Tests for the Cobbler settings migration helpers
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
 import copy
+
 import pytest
+
 from cobbler.settings.migrations import helper
 
 

--- a/tests/settings/migrations/migrations_test.py
+++ b/tests/settings/migrations/migrations_test.py
@@ -14,20 +14,19 @@ import yaml
 from cobbler import settings
 from cobbler.settings import migrations
 from cobbler.settings.migrations import (
-    V3_3_0,
-    V3_2_1,
-    V3_2_0,
-    V3_1_2,
-    V3_1_1,
-    V3_1_0,
-    V3_0_1,
     V3_0_0,
+    V3_0_1,
+    V3_1_0,
+    V3_1_1,
+    V3_1_2,
+    V3_2_0,
+    V3_2_1,
+    V3_3_0,
     V3_3_1,
     V3_3_2,
     V3_3_3,
     V3_4_0,
 )
-
 
 modules_conf_location = "/etc/cobbler/modules.conf"
 

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -9,14 +9,14 @@ Tests for the Cobbler settings normalizations
 import yaml
 
 from cobbler.settings.migrations import (
-    V3_3_0,
-    V3_2_1,
-    V3_2_0,
-    V3_1_2,
-    V3_1_1,
-    V3_1_0,
-    V3_0_1,
     V3_0_0,
+    V3_0_1,
+    V3_1_0,
+    V3_1_1,
+    V3_1_2,
+    V3_2_0,
+    V3_2_1,
+    V3_3_0,
     V3_3_1,
     V3_3_2,
     V3_3_3,

--- a/tests/settings/settings_test.py
+++ b/tests/settings/settings_test.py
@@ -8,6 +8,7 @@ from schema import SchemaError
 
 from cobbler import settings
 from cobbler.settings import Settings
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/special_cases/security_test.py
+++ b/tests/special_cases/security_test.py
@@ -12,9 +12,8 @@ import xmlrpc.client
 import pytest
 
 from cobbler.api import CobblerAPI
-from cobbler.utils import get_shared_secret
 from cobbler.modules.authentication import pam
-
+from cobbler.utils import get_shared_secret
 
 # ==================== Start tnpconsultants ====================
 

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -10,8 +10,7 @@ from typing import TYPE_CHECKING, Any, Callable, List, Tuple
 
 import pytest
 
-from cobbler import enums
-from cobbler import tftpgen
+from cobbler import enums, tftpgen
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.image import Image

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -6,10 +6,10 @@ from pathlib import Path
 import pytest
 from netaddr.ip import IPAddress
 
-from cobbler import enums
-from cobbler import utils
+from cobbler import enums, utils
 from cobbler.cexceptions import CX
 from cobbler.items.distro import Distro
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/utils/filesystem_helpers_test.py
+++ b/tests/utils/filesystem_helpers_test.py
@@ -6,6 +6,7 @@ import pytest
 
 from cobbler.cexceptions import CX
 from cobbler.utils import filesystem_helpers
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/utils/input_converters_test.py
+++ b/tests/utils/input_converters_test.py
@@ -1,8 +1,8 @@
 import pytest
 
-from tests.conftest import does_not_raise
-
 from cobbler.utils import input_converters
+
+from tests.conftest import does_not_raise
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/mtab_test.py
+++ b/tests/utils/mtab_test.py
@@ -1,4 +1,5 @@
 import os
+
 from cobbler.utils import mtab
 
 

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -5,6 +5,7 @@ import pytest
 
 from cobbler import enums, validate
 from cobbler.utils import signatures
+
 from tests.conftest import does_not_raise
 
 

--- a/tests/xmlrpcapi/conftest.py
+++ b/tests/xmlrpcapi/conftest.py
@@ -6,8 +6,8 @@ from typing import Any, Callable, Dict, Tuple, Union
 import pytest
 
 from cobbler.api import CobblerAPI
-from cobbler.utils import get_shared_secret
 from cobbler.remote import CobblerXMLRPCInterface
+from cobbler.utils import get_shared_secret
 
 
 @pytest.fixture(scope="function")

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -5,8 +5,8 @@ import time
 from typing import Any, Callable, Dict, List, Union
 
 import pytest
-from cobbler.remote import CobblerXMLRPCInterface
 
+from cobbler.remote import CobblerXMLRPCInterface
 from cobbler.utils import get_shared_secret
 
 

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -1,8 +1,8 @@
 import os
+import re
+import time
 
 import pytest
-import time
-import re
 
 from tests.conftest import does_not_raise
 


### PR DESCRIPTION
## Linked Items

Partly fixes #3314

## Description

Add [isort](https://pycqa.github.io/isort/) to our codebase to have a common way to organize our imports.

## Behaviour changes

Old: Imports for Cobbler were unordered

New: All imports in Cobbler are now sorted

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [x] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
