### PR TITLE
Backport: `cobbler-settings modify` fixes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
       with:
         python-version: 3.9
     - name: Install dependencies
-      run:  pip install -U rstcheck doc8
+      run:  pip install -U "rstcheck<6" doc8
     - name: Run rstcheck
       run:  rstcheck -r docs
     - name: Run doc8

--- a/.github/workflows/system_testing.yml
+++ b/.github/workflows/system_testing.yml
@@ -13,9 +13,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker pull registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:release33
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:release33
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -12,9 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Pull Docker Test Container
-        run: docker pull registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker pull registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:release33
       - name: Run previously built Docker Container
-        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/schoolguy/branches/opensuse/templates/images/tumbleweed/containers/opensuse/cobbler-github-ci:latest
+        run: docker run --cap-add=NET_ADMIN -t -d -v $PWD:/code --name cobbler registry.opensuse.org/home/cobbler-project/github-ci/containers/cobbler-test-github:release33
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ PYFLAKES = $(shell { command -v pyflakes-3 || command -v pyflakes3 || command -v
 PYCODESTYLE := $(shell { command -v pycodestyle-3 || command -v pycodestyle3 || command -v pycodestyle; } 2> /dev/null)
 HTTPD = $(shell which httpd)
 APACHE2 = $(shell which apache2)
+EXECUTOR = $(shell { command -v podman || command -v docker; }  2> /dev/null)
+CONTAINER_TAG ?= latest
 
 # Debian / Ubuntu have /bin/sh -> dash
 SHELL = /bin/bash
@@ -94,6 +96,9 @@ release: clean qa authors sdist ## Creates the full release.
 	@cp dist/*.gz release/
 	@cp distro_build_configs.sh release/
 	@cp cobbler.spec release/
+
+test-image: ## Builds the test container image
+	$(EXECUTOR) build -f docker/develop/develop.dockerfile -t cobbler-test:$(CONTAINER_TAG)
 
 test-centos8: ## Executes the testscript for testing cobbler in a docker container on CentOS8.
 	./docker/rpms/build-and-install-rpms.sh el8 docker/rpms/CentOS_8/CentOS8.dockerfile

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -139,8 +139,6 @@ def modify(args: argparse.Namespace) -> int:
         else:
             print("Unsupported type!")
             return 1
-    if isinstance(Optional, key_type):
-        key_type = schema._schema[setting_obj.key_name].name
     if key_type == bool:
         setting_obj.value = utils.input_boolean(setting_obj.value)
     elif key_type == int:

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -136,6 +136,7 @@ def modify(args: argparse.Namespace) -> int:
             key_type = dict
         else:
             print("Unsupported type!")
+            return 1
     if isinstance(Optional, key_type):
         key_type = schema._schema[setting_obj.key_name].name
     if key_type == bool:

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -16,7 +16,7 @@ import yaml
 from cobbler import settings
 from cobbler.settings import migrations
 from cobbler.settings.migrations import EMPTY_VERSION, helper
-from cobbler.utils import input_converters
+from cobbler import utils
 
 
 # TODO: Transform this into a lamda/list comprehension
@@ -134,15 +134,15 @@ def modify(args: argparse.Namespace) -> int:
     if isinstance(Optional, key_type):
         key_type = schema._schema[setting_obj.key_name].name
     if key_type == bool:
-        setting_obj.value = input_converters.input_boolean(setting_obj.value)
+        setting_obj.value = utils.input_boolean(setting_obj.value)
     elif key_type == int:
         setting_obj.value = int(setting_obj.value)
     elif key_type == float:
         setting_obj.value = float(setting_obj.value)
     elif key_type == list:
-        setting_obj.value = input_converters.input_string_or_list(setting_obj.value)
+        setting_obj.value = utils.input_string_or_list(setting_obj.value)
     elif key_type == dict:
-        setting_obj.value = input_converters.input_string_or_dict(setting_obj.value)
+        setting_obj.value = utils.input_string_or_dict(setting_obj.value)
     elif key_type == str:
         setting_obj.value = setting_obj.value
     else:

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -132,6 +132,9 @@ def modify(args: argparse.Namespace) -> int:
             print("Requested key not found in the settings!")
             return 1
     if key_type not in (bool, int, float, str, dict, list):
+        # Schema can have as a valid list type "list" but it may also have
+        # "[str]". The same concept applies to "dict". To cover this case we
+        # need the following if-elif-else block.
         if isinstance(key_type, list):
             key_type = list
         elif isinstance(key_type, dict):

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -119,6 +119,8 @@ def modify(args: argparse.Namespace) -> int:
     try:
         key_type = schema._schema[setting_obj.key_name]
     except KeyError:
+        # There seems to be a bug that causes direct dict lookup to fail when a key is Optional. However the for loop
+        # works as expected.
         key_found = False
         for entry in schema._schema:
             if isinstance(entry, Optional):

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -119,9 +119,14 @@ def modify(args: argparse.Namespace) -> int:
     try:
         key_type = schema._schema[setting_obj.key_name]
     except KeyError:
-        try:
-            key_type = schema._schema[Optional(setting_obj.key_name)]
-        except KeyError:
+        key_found = False
+        for entry in schema._schema:
+            if isinstance(entry, Optional):
+                if entry._schema == setting_obj.key_name:
+                    key_type = schema._schema[entry]
+                    key_found = True
+                    break
+        if not key_found:
             print("Requested key not found in the settings!")
             return 1
     if key_type not in (bool, int, float, str, dict, list):

--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -11,12 +11,12 @@ Tool to manage the settings of Cobbler without the daemon running.
 import argparse
 import sys
 from typing import List
-from schema import SchemaError
+from schema import Optional, SchemaError
 import yaml
 from cobbler import settings
 from cobbler.settings import migrations
 from cobbler.settings.migrations import EMPTY_VERSION, helper
-from cobbler.utils import input_boolean, input_string_or_dict, input_string_or_list
+from cobbler.utils import input_converters
 
 
 # TODO: Transform this into a lamda/list comprehension
@@ -36,9 +36,11 @@ def __check_settings(filepath: str) -> dict:
         print(str(error))
         return {}
 
-    if migrations.get_settings_file_version(result) == EMPTY_VERSION:
+    settings_version = migrations.get_settings_file_version(result)
+    if settings_version == EMPTY_VERSION:
         print("Error detecting settings file version!")
         return {}
+    print("The following version was detected: %s" % settings_version)
     return result
 
 
@@ -114,15 +116,35 @@ def modify(args: argparse.Namespace) -> int:
     schema = migrations.get_schema(migrations.get_installed_version())
     setting_obj = helper.Setting(args.key, args.value)
     # _schema used due to old version of python3-schema in Leap
-    key_type = schema._schema[setting_obj.key_name]
+    try:
+        key_type = schema._schema[setting_obj.key_name]
+    except KeyError:
+        try:
+            key_type = schema._schema[Optional(setting_obj.key_name)]
+        except KeyError:
+            print("Requested key not found in the settings!")
+            return 1
+    if key_type not in (bool, int, float, str, dict, list):
+        if isinstance(key_type, list):
+            key_type = list
+        elif isinstance(key_type, dict):
+            key_type = dict
+        else:
+            print("Unsupported type!")
+    if isinstance(Optional, key_type):
+        key_type = schema._schema[setting_obj.key_name].name
     if key_type == bool:
-        setting_obj.value = input_boolean(setting_obj.value)
+        setting_obj.value = input_converters.input_boolean(setting_obj.value)
     elif key_type == int:
         setting_obj.value = int(setting_obj.value)
+    elif key_type == float:
+        setting_obj.value = float(setting_obj.value)
     elif key_type == list:
-        setting_obj.value = input_string_or_list(setting_obj.value)
+        setting_obj.value = input_converters.input_string_or_list(setting_obj.value)
     elif key_type == dict:
-        setting_obj.value = input_string_or_dict(setting_obj.value)
+        setting_obj.value = input_converters.input_string_or_dict(setting_obj.value)
+    elif key_type == str:
+        setting_obj.value = setting_obj.value
     else:
         print("Unsupported type!")
         return 1
@@ -131,55 +153,87 @@ def modify(args: argparse.Namespace) -> int:
     return __update_settings(settings_dict, args.config)
 
 
-parser = argparse.ArgumentParser(description="Manage the settings of Cobbler without a running daemon.")
-parser.add_argument("-c", "--config",
-                    help="The location of the Cobbler configuration file.",
-                    default="/etc/cobbler/settings.yaml")
-subparsers = parser.add_subparsers(title="Subcommands", help="One of these commands is required.")
-parser_validate = subparsers.add_parser("validate",
-                                        description="Validates if Cobbler would start with the current settings file.")
+parser = argparse.ArgumentParser(
+    description="Manage the settings of Cobbler without a running daemon."
+)
+parser.add_argument(
+    "-c",
+    "--config",
+    help="The location of the Cobbler configuration file.",
+    default="/etc/cobbler/settings.yaml",
+)
+subparsers = parser.add_subparsers(
+    title="Subcommands", help="One of these commands is required."
+)
+parser_validate = subparsers.add_parser(
+    "validate",
+    description="Validates if Cobbler would start with the current settings file.",
+)
 parser_validate.set_defaults(func=validate)
-parser_validate.add_argument("-v", "--version",
-                             help="The version to validate against.",
-                             choices=sorted(__generate_version_choices()),
-                             default=sorted(__generate_version_choices())[-1])
-parser_migrate = subparsers.add_parser("migrate",
-                                       description='Migrates from the current version to the version provided with '
-                                                   '"--new".')
+parser_validate.add_argument(
+    "-v",
+    "--version",
+    help="The version to validate against.",
+    choices=sorted(__generate_version_choices()),
+    default=sorted(__generate_version_choices())[-1],
+)
+parser_migrate = subparsers.add_parser(
+    "migrate",
+    description="Migrates from the current version to the version provided with "
+    '"--new".',
+)
 parser_migrate.set_defaults(func=migrate)
 # TODO: Implement in the future
 # parser_migrate.add_argument("--diff", "-d",
 #                            help="Whether to produce a diff output or not.",
 #                            action="store_true",
 #                            default=False)
-parser_migrate.add_argument("-t", "--target",
-                            help="Write the resulting settings to the target path given in this argument.")
-parser_migrate.add_argument("--new",
-                            help="The new version to migrate to, e.g. 3.3.0",
-                            dest="new",
-                            choices=sorted(__generate_version_choices()),
-                            default=sorted(__generate_version_choices())[-1])
-parser_automigrate = subparsers.add_parser("automigrate",
-                                           description="Enables or disables the automigration on startup of the daemon. "
-                                                       'If no flag is provided, the default is "--disable".')
+parser_migrate.add_argument(
+    "-t",
+    "--target",
+    help="Write the resulting settings to the target path given in this argument.",
+)
+parser_migrate.add_argument(
+    "--new",
+    help="The new version to migrate to, e.g. 3.3.0",
+    dest="new",
+    choices=sorted(__generate_version_choices()),
+    default=sorted(__generate_version_choices())[-1],
+)
+parser_automigrate = subparsers.add_parser(
+    "automigrate",
+    description="Enables or disables the automigration on startup of the daemon. "
+    'If no flag is provided, the default is "--disable".',
+)
 parser_automigrate.set_defaults(func=automigrate)
-parser_automigrate.add_argument("-e", "--enable",
-                                help="Enables settings automigration.",
-                                dest="enable_automigration",
-                                action="store_true")
-parser_automigrate.add_argument("-d", "--disable",
-                                help="Disables settings automigration.",
-                                dest="enable_automigration",
-                                action="store_false")
-parser_modify = subparsers.add_parser("modify", description="Modify the value of a key in the config file.")
+parser_automigrate.add_argument(
+    "-e",
+    "--enable",
+    help="Enables settings automigration.",
+    dest="enable_automigration",
+    action="store_true",
+)
+parser_automigrate.add_argument(
+    "-d",
+    "--disable",
+    help="Disables settings automigration.",
+    dest="enable_automigration",
+    action="store_false",
+)
+parser_modify = subparsers.add_parser(
+    "modify", description="Modify the value of a key in the config file."
+)
 parser_modify.set_defaults(func=modify)
-parser_modify.add_argument("-k", "--key",
-                           help='The name of the key in file to edit. If the key is nested use the format '
-                                '"parent_key.key".',
-                           required=True)
-parser_modify.add_argument("-v", "--value",
-                           help="The new value of the key.",
-                           required=True)
+parser_modify.add_argument(
+    "-k",
+    "--key",
+    help="The name of the key in file to edit. If the key is nested use the format "
+    '"parent_key.key".',
+    required=True,
+)
+parser_modify.add_argument(
+    "-v", "--value", help="The new value of the key.", required=True
+)
 
 
 def main(args: List[str]) -> int:

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -1,11 +1,30 @@
 # vim: ft=dockerfile
+# Define the names/tags of the container
+#!BuildTag: cobbler-test-github:release33 cobbler-test-github:release33.%RELEASE%
+
+# We don't want to version pin our dependencies for testing. Always retrieve what is up to date.
+# hadolint global ignore=DL3037
 
 # WARNING! This is not in any way production ready. It is just for testing!
-FROM registry.opensuse.org/opensuse/leap:15.3
+FROM opensuse/leap:15.3
+
+# Define labels according to https://en.opensuse.org/Building_derived_containers
+# labelprefix=org.opensuse.example
+LABEL org.opencontainers.image.title="cobbler-test-github"
+LABEL org.opencontainers.image.description="This contains the environment to run the testsuites of Cobbler inside a container."
+LABEL org.opencontainers.image.version="release33.%RELEASE%"
+LABEL org.opensuse.reference="registry.opensuse.org/home/cobbler-project/github-ci/cobbler-test-github:release33.%RELEASE%"
+LABEL org.openbuildservice.disturl="%DISTURL%"
+LABEL org.opencontainers.image.created="%BUILDTIME%"
+# endlabelprefix
 
 # ENV Variables we are using.
 ENV container docker
 ENV DISTRO SUSE
+
+# Custom repository
+RUN zypper ar https://download.opensuse.org/repositories/home:/cobbler-project:/release33/15.3/ "Cobbler 3.3.x release project (15.3)" \
+    && zypper --gpg-auto-import-keys refresh
 
 # Runtime & dev dependencies
 RUN zypper install --no-recommends -y \
@@ -48,15 +67,14 @@ RUN zypper install --no-recommends -y \
     vim                        \
     wget                       \
     which                      \
-    xorriso
+    xorriso                    \
+    && zypper clean
 
 # Add virtualization repository
-RUN zypper ar https://download.opensuse.org/repositories/Virtualization/15.3/Virtualization.repo
-RUN zypper --gpg-auto-import-keys install -y --from "Virtualization (15.3)" python3-hivex
-RUN zypper rr "Virtualization (15.3)"
-RUN zypper ar https://download.opensuse.org/repositories/devel:/languages:/python/15.3/devel:languages:python.repo
-RUN zypper --gpg-auto-import-keys install -y --from "Python Modules (15.3)" python3-pefile
-RUN zypper rr "Python Modules (15.3)"
+RUN zypper install -y \
+    python3-hivex     \
+    python3-pefile    \
+    && zypper clean
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \
@@ -66,75 +84,77 @@ RUN zypper install --no-recommends -y \
     grub2 \
     grub2-i386-efi \
     grub2-x86_64-efi \
-    grub2-arm64-efi
+    grub2-arm64-efi \
+    && zypper clean
 
 # Required for dhcpd
 RUN zypper install --no-recommends -y \
     system-user-nobody                \
-    sysvinit-tools
+    sysvinit-tools \
+    && zypper clean
 
 # Required for ldap tests
 RUN zypper install --no-recommends -y \
     openldap2                         \
     openldap2-client                  \
     hostname                          \
-    python3-ldap
+    python3-ldap \
+    && zypper clean
 
 # Required for reposync tests
 RUN zypper install --no-recommends -y \
     python3-librepo                   \
     dnf                               \
     dnf-plugins-core                  \
-    wget
+    && zypper clean
 
 # Required for reposync apt test
 RUN zypper install --no-recommends -y \
     perl-LockFile-Simple              \
     perl-Net-INET6Glue                \
     perl-LWP-Protocol-https           \
-    ed
-RUN dnf install -y http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/d/debmirror-2.35-2.fc35.noarch.rpm
+    ed                                \
+    debmirror                         \
+    && zypper clean
 
 # Dependencies for system-tests
 RUN zypper install --no-recommends -y \
     dhcp-server                       \
     iproute2                          \
     qemu-kvm                          \
-    time
+    time \
+    && zypper clean
 
 # Allow dhcpd to listen on any interface
 RUN sed -i 's/DHCPD_INTERFACE=""/DHCPD_INTERFACE="ANY"/' /etc/sysconfig/dhcpd
 
 # Add Testuser for the PAM tests
-RUN useradd -p $(perl -e 'print crypt("test", "password")') test
+RUN useradd -p "$(perl -e 'print crypt(\"test\", \"password\")')" test
 
 # Add Developer scripts to PATH
 ENV PATH="/code/docker/develop/scripts:${PATH}"
 
-# Update pip
-RUN pip3 install --upgrade pip
-
-# Install packages and dependencies via pip
-RUN pip3 install      \
-    codecov           \
-    file-magic        \
-    pycodestyle       \
-    pyflakes          \
-    pytest            \
-    pytest-cov        \
-    pytest-mock       \
-    pytest-pythonpath
+# Install additional packages
+RUN zypper install --no-recommends -y \
+    python3-codecov                   \
+    python3-magic                     \
+    python3-pycodestyle               \
+    python3-pyflakes                  \
+    python3-pytest                    \
+    python3-pytest-cov                \
+    python3-pytest-mock               \
+    python3-pytest-pythonpath \
+    && zypper clean
 
 # Enable the Apache Modules
-RUN ["a2enmod", "version"]
-RUN ["a2enmod", "proxy"]
-RUN ["a2enmod", "proxy_http"]
-RUN ["a2enmod", "wsgi"]
+RUN a2enmod version \
+    && a2enmod proxy \
+    && a2enmod proxy_http \
+    && a2enmod wsgi
 
 # create working directory
-RUN ["mkdir", "/code"]
-VOLUME ["/code"]
 WORKDIR "/code"
+VOLUME ["/code"]
 
 # Set this as an entrypoint
 CMD ["/bin/bash"]

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -2,6 +2,7 @@
 # Define the names/tags of the container
 #!BuildTag: cobbler-test-github:release33 cobbler-test-github:release33.%RELEASE%
 
+# We are using https://github.com/hadolint/hadolint to lint our Dockerfile.
 # We don't want to version pin our dependencies for testing. Always retrieve what is up to date.
 # hadolint global ignore=DL3037
 

--- a/docker/develop/scripts/setup-reposync.sh
+++ b/docker/develop/scripts/setup-reposync.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-# Dependencies for reposync tests
-zypper install --no-recommends -y dnf python3-librepo dnf dnf-plugins-core wget \
-       perl-LockFile-Simple perl-Net-INET6Glue perl-LWP-Protocol-https ed
-dnf install -y  http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/d/debmirror-2.35-2.fc35.noarch.rpm

--- a/docker/develop/scripts/setup-supervisor.sh
+++ b/docker/develop/scripts/setup-supervisor.sh
@@ -7,9 +7,6 @@ cp /code/docker/develop/supervisord/supervisord.conf /etc/
 echo "Setup openLDAP"
 /code/docker/develop/scripts/setup-openldap.sh
 
-echo "Setup reposync"
-/code/docker/develop/scripts/setup-reposync.sh
-
 echo "Install Cobbler"
 cd /code || exit
 make install

--- a/scripts/settings-migration-v1-to-v2.sh
+++ b/scripts/settings-migration-v1-to-v2.sh
@@ -113,34 +113,34 @@ print_help() {
 }
 
 regex_conversion() {
-  sed -i -e 's/authn_/authentication\./g' $path_modules_conf
-  sed -i -e 's/authz_/authorization\./g' $path_modules_conf
-  sed -i -e 's/manage_/managers\./g' $path_modules_conf
+  sed -i -e 's/authn_/authentication\./g' "$path_modules_conf"
+  sed -i -e 's/authz_/authorization\./g' "$path_modules_conf"
+  sed -i -e 's/manage_/managers\./g' "$path_modules_conf"
 }
 
 static_conversion() {
-  sed -i -e 's/authn_denyall/authentication.denyall/g' $path_modules_conf
-  sed -i -e 's/authn_configfile/authentication.configfile/g' $path_modules_conf
-  sed -i -e 's/authn_passthru/authentication.passthru/g' $path_modules_conf
-  sed -i -e 's/authn_ldap/authentication.ldap/g' $path_modules_conf
-  sed -i -e 's/authn_spacewalk/authentication.spacewalk/g' $path_modules_conf
-  sed -i -e 's/authn_pam/authentication.pam/g' $path_modules_conf
-  sed -i -e 's/authn_testing/authentication.testing/g' $path_modules_conf
-  sed -i -e 's/authz_allowall/authorization.allowall/g' $path_modules_conf
-  sed -i -e 's/authz_ownership/authorization.ownership/g' $path_modules_conf
-  sed -i -e 's/manage_bind/managers.bind/g' $path_modules_conf
-  sed -i -e 's/manage_dnsmasq/managers.dnsmasq/g' $path_modules_conf
-  sed -i -e 's/manage_ndjbdns/managers.ndjbdns/g' $path_modules_conf
-  sed -i -e 's/manage_isc/managers.isc/g' $path_modules_conf
-  sed -i -e 's/manage_dnsmasq/managers.dnsmasq/g' $path_modules_conf
-  sed -i -e 's/manage_in_tftpd/managers.in_tftpd/g' $path_modules_conf
-  sed -i -e 's/manage_tftpd_py/managers.tftpd_py/g' $path_modules_conf
+  sed -i -e 's/authn_denyall/authentication.denyall/g' "$path_modules_conf"
+  sed -i -e 's/authn_configfile/authentication.configfile/g' "$path_modules_conf"
+  sed -i -e 's/authn_passthru/authentication.passthru/g' "$path_modules_conf"
+  sed -i -e 's/authn_ldap/authentication.ldap/g' "$path_modules_conf"
+  sed -i -e 's/authn_spacewalk/authentication.spacewalk/g' "$path_modules_conf"
+  sed -i -e 's/authn_pam/authentication.pam/g' "$path_modules_conf"
+  sed -i -e 's/authn_testing/authentication.testing/g' "$path_modules_conf"
+  sed -i -e 's/authz_allowall/authorization.allowall/g' "$path_modules_conf"
+  sed -i -e 's/authz_ownership/authorization.ownership/g' "$path_modules_conf"
+  sed -i -e 's/manage_bind/managers.bind/g' "$path_modules_conf"
+  sed -i -e 's/manage_dnsmasq/managers.dnsmasq/g' "$path_modules_conf"
+  sed -i -e 's/manage_ndjbdns/managers.ndjbdns/g' "$path_modules_conf"
+  sed -i -e 's/manage_isc/managers.isc/g' "$path_modules_conf"
+  sed -i -e 's/manage_dnsmasq/managers.dnsmasq/g' "$path_modules_conf"
+  sed -i -e 's/manage_in_tftpd/managers.in_tftpd/g' "$path_modules_conf"
+  sed -i -e 's/manage_tftpd_py/managers.tftpd_py/g' "$path_modules_conf"
 }
 
 replace_modules_conf() {
-  rm $path_modules_conf
-  touch $path_modules_conf
-  echo "$default_file" >$path_modules_conf
+  rm "$path_modules_conf"
+  touch "$path_modules_conf"
+  echo "$default_file" >"$path_modules_conf"
 }
 
 run() {

--- a/system-tests/scripts/run-tests
+++ b/system-tests/scripts/run-tests
@@ -6,7 +6,7 @@ topdir=$(realpath $(dirname ${0})/..)
 if [ ${#} -ge 1 ]; then
 	patterns=${@}
 else
-	patterns=(basic-* import-*)
+	patterns=(basic-* import-* settings-cli-*)
 fi
 
 list_selected_tests() {

--- a/system-tests/tests/settings-cli-automigrate-disable
+++ b/system-tests/tests/settings-cli-automigrate-disable
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Check that cobbler-settings can enable/disable the auto-migration of the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings.yaml"
+
+cat <<-END >$TEST_CONFIG
+auto_migrate_settings: true
+END
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" automigrate --disable
+
+# Assert
+grep "auto_migrate_settings: false" "$TEST_CONFIG"

--- a/system-tests/tests/settings-cli-automigrate-disable
+++ b/system-tests/tests/settings-cli-automigrate-disable
@@ -10,6 +10,226 @@ TEST_CONFIG="${tmp}/settings.yaml"
 
 cat <<-END >$TEST_CONFIG
 auto_migrate_settings: true
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '/usr/share/syslinux'
+syslinux_memdisk_folder: '/usr/share/syslinux'
+syslinux_pxelinux_folder: '/usr/share/syslinux'
+grub2_mod_dir: '/usr/share/grub2'
+bootloaders_shim_folder: '/usr/share/efi/*/'
+bootloaders_shim_file: 'shim\.efi'
+bootloaders_ipxe_folder: '/usr/share/ipxe/'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_server: 'puppet'
+puppet_version: 2
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "/var/lib/named"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "/var/lib/tftpboot"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "/var/www/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]
 END
 
 # Act

--- a/system-tests/tests/settings-cli-automigrate-enable
+++ b/system-tests/tests/settings-cli-automigrate-enable
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Check that cobbler-settings can enable/disable the auto-migration of the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings.yaml"
+
+cat <<-END >$TEST_CONFIG
+auto_migrate_settings: false
+END
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" automigrate --enable
+
+# Assert
+grep "auto_migrate_settings: true" "$TEST_CONFIG"

--- a/system-tests/tests/settings-cli-automigrate-enable
+++ b/system-tests/tests/settings-cli-automigrate-enable
@@ -10,6 +10,226 @@ TEST_CONFIG="${tmp}/settings.yaml"
 
 cat <<-END >$TEST_CONFIG
 auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '/usr/share/syslinux'
+syslinux_memdisk_folder: '/usr/share/syslinux'
+syslinux_pxelinux_folder: '/usr/share/syslinux'
+grub2_mod_dir: '/usr/share/grub2'
+bootloaders_shim_folder: '/usr/share/efi/*/'
+bootloaders_shim_file: 'shim\.efi'
+bootloaders_ipxe_folder: '/usr/share/ipxe/'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_server: 'puppet'
+puppet_version: 2
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "/var/lib/named"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "/var/lib/tftpboot"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "/var/www/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]
 END
 
 # Act

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -9,7 +9,7 @@ set -x -e -o pipefail
 OLD_CONFIG="${tmp}/settings-old.yaml"
 NEW_CONFIG="${tmp}/settings-new.yaml"
 EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
-NEW_VERSION="3.3.0"
+NEW_VERSION="3.3.3"
 
 # Test migration from 3.3.2 to 3.3.3
 cat <<-END >$OLD_CONFIG
@@ -236,53 +236,8 @@ signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
 include: [ "/code/tests/test_data/V3_3_2/settings.d/*.settings" ]
 END
 
-cat <<-END >$EXPECTED_CONFIG
-# Cobbler settings file
-# Docs for this file can be found at: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html
-
-bind_zonefile_path: '@@bind_zonefiles@@'
-bootloaders_ipxe_folder: '@@ipxe_folder@@'
-bootloaders_shim_file: '@@shim_file@@'
-bootloaders_shim_folder: '@@shim_folder@@'
-build_reporting_email:
-- root@localhost
-cheetah_import_whitelist:
-- random
-- re
-- time
-- netaddr
-default_password_crypted: /UHC.
-grub2_mod_dir: '@@grub_mod_folder@@'
-ldap_base_dn: DC=example,DC=com
-ldap_server: ldap.example.com
-ldap_tls_reqcert: ''
-puppet_server: ''
-reposync_flags: --newest-only --delete --refresh --remote-time
-reposync_rsync_flags: -rltDv --copy-unsafe-links
-syslinux_dir: '@@syslinux_dir@@'
-syslinux_memdisk_folder: '@@memdisk_folder@@'
-syslinux_pxelinux_folder: '@@pxelinux_folder@@'
-tftpboot_location: '@@tftproot@@'
-webdir: '@@webroot@@/cobbler'
-webdir_whitelist:
-- misc
-- web
-- webui
-- localmirror
-- repo_mirror
-- distro_mirror
-- images
-- links
-- pub
-- repo_profile
-- repo_system
-- svc
-- rendered
-- .link_cache
-END
-
 # Act
 cobbler-settings -c "$OLD_CONFIG" migrate -t "$NEW_CONFIG" --new "$NEW_VERSION"
 
 # Assert
-diff -y $NEW_CONFIG $EXPECTED_CONFIG
+grep "default_virt_file_size: 5.0" $NEW_CONFIG

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -9,9 +9,9 @@ set -x -e -o pipefail
 OLD_CONFIG="${tmp}/settings-old.yaml"
 NEW_CONFIG="${tmp}/settings-new.yaml"
 EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
-NEW_VERSION="3.4.0"
+NEW_VERSION="3.3.0"
 
-# Test migration from 3.3.2 to 3.4.0
+# Test migration from 3.3.2 to 3.3.3
 cat <<-END >$OLD_CONFIG
 auto_migrate_settings: false
 allow_duplicate_hostnames: false

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -1,0 +1,288 @@
+#!/bin/bash
+# Check that cobbler-settings can migrate the YAML file from one version to the next one
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+OLD_CONFIG="${tmp}/settings-old.yaml"
+NEW_CONFIG="${tmp}/settings-new.yaml"
+EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
+NEW_VERSION="3.4.0"
+
+# Test migration from 3.3.2 to 3.4.0
+cat <<-END >$OLD_CONFIG
+auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+grub2_mod_dir: '@@grub_mod_folder@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: '$1$mF86/UHC$WvcIcX2t6crBz2onWxyac.'
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "@@bind_zonefiles@@"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "@@tftproot@@"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "@@webroot@@/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+puppet_server: ""
+puppet_version: 2
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_2/settings.d/*.settings" ]
+END
+
+cat <<-END >$EXPECTED_CONFIG
+# Cobbler settings file
+# Docs for this file can be found at: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html
+
+bind_zonefile_path: '@@bind_zonefiles@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+build_reporting_email:
+- root@localhost
+cheetah_import_whitelist:
+- random
+- re
+- time
+- netaddr
+default_password_crypted: /UHC.
+grub2_mod_dir: '@@grub_mod_folder@@'
+ldap_base_dn: DC=example,DC=com
+ldap_server: ldap.example.com
+ldap_tls_reqcert: ''
+puppet_server: ''
+reposync_flags: --newest-only --delete --refresh --remote-time
+reposync_rsync_flags: -rltDv --copy-unsafe-links
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+tftpboot_location: '@@tftproot@@'
+webdir: '@@webroot@@/cobbler'
+webdir_whitelist:
+- misc
+- web
+- webui
+- localmirror
+- repo_mirror
+- distro_mirror
+- images
+- links
+- pub
+- repo_profile
+- repo_system
+- svc
+- rendered
+- .link_cache
+END
+
+# Act
+cobbler-settings -c "$OLD_CONFIG" migrate -t "$NEW_CONFIG" --new "$NEW_VERSION"
+
+# Assert
+diff -y $NEW_CONFIG $EXPECTED_CONFIG

--- a/system-tests/tests/settings-cli-modify-bool
+++ b/system-tests/tests/settings-cli-modify-bool
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings-bool.yaml"
+cat <<-END >$TEST_CONFIG
+auto_migrate_settings: false
+END
+
+TEST_KEY="enable_ipxe"
+TEST_VALUE="true"
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+grep "$TEST_KEY: $TEST_VALUE" $TEST_CONFIG

--- a/system-tests/tests/settings-cli-modify-bool
+++ b/system-tests/tests/settings-cli-modify-bool
@@ -9,6 +9,227 @@ set -x -e -o pipefail
 TEST_CONFIG="${tmp}/settings-bool.yaml"
 cat <<-END >$TEST_CONFIG
 auto_migrate_settings: false
+
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '/usr/share/syslinux'
+syslinux_memdisk_folder: '/usr/share/syslinux'
+syslinux_pxelinux_folder: '/usr/share/syslinux'
+grub2_mod_dir: '/usr/share/grub2'
+bootloaders_shim_folder: '/usr/share/efi/*/'
+bootloaders_shim_file: 'shim\.efi'
+bootloaders_ipxe_folder: '/usr/share/ipxe/'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_server: 'puppet'
+puppet_version: 2
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "/var/lib/named"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "/var/lib/tftpboot"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "/var/www/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]
 END
 
 TEST_KEY="enable_ipxe"

--- a/system-tests/tests/settings-cli-modify-dict
+++ b/system-tests/tests/settings-cli-modify-dict
@@ -11,6 +11,226 @@ EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
 cat <<-END >$TEST_CONFIG
 mgmt_parameters:
  from_cobbler: true
+
+auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '/usr/share/syslinux'
+syslinux_memdisk_folder: '/usr/share/syslinux'
+syslinux_pxelinux_folder: '/usr/share/syslinux'
+grub2_mod_dir: '/usr/share/grub2'
+bootloaders_shim_folder: '/usr/share/efi/*/'
+bootloaders_shim_file: 'shim\.efi'
+bootloaders_ipxe_folder: '/usr/share/ipxe/'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_server: 'puppet'
+puppet_version: 2
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "/var/lib/named"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "/var/lib/tftpboot"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "/var/www/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]
 END
 
 cat <<-END >$EXPECTED_CONFIG
@@ -27,4 +247,4 @@ TEST_VALUE=""
 cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
 
 # Assert
-diff $TEST_CONFIG $EXPECTED_CONFIG
+grep "$TEST_KEY: {}" $TEST_CONFIG

--- a/system-tests/tests/settings-cli-modify-dict
+++ b/system-tests/tests/settings-cli-modify-dict
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings-dict.yaml"
+EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
+cat <<-END >$TEST_CONFIG
+mgmt_parameters:
+ from_cobbler: true
+END
+
+cat <<-END >$EXPECTED_CONFIG
+# Cobbler settings file
+# Docs for this file can be found at: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html
+
+mgmt_parameters: {}
+END
+
+TEST_KEY="mgmt_parameters"
+TEST_VALUE=""
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+diff $TEST_CONFIG $EXPECTED_CONFIG

--- a/system-tests/tests/settings-cli-modify-float
+++ b/system-tests/tests/settings-cli-modify-float
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings-int.yaml"
+cat <<-END >$TEST_CONFIG
+default_virt_file_size: 5.0
+END
+
+TEST_KEY="default_virt_file_size"
+TEST_VALUE="10.0"
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+grep "$TEST_KEY: $TEST_VALUE" $TEST_CONFIG

--- a/system-tests/tests/settings-cli-modify-float
+++ b/system-tests/tests/settings-cli-modify-float
@@ -9,6 +9,227 @@ set -x -e -o pipefail
 TEST_CONFIG="${tmp}/settings-int.yaml"
 cat <<-END >$TEST_CONFIG
 default_virt_file_size: 5.0
+
+auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+grub2_mod_dir: '@@grub_mod_folder@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: '$1$mF86/UHC$WvcIcX2t6crBz2onWxyac.'
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "@@bind_zonefiles@@"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "@@tftproot@@"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "@@webroot@@/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+puppet_server: ""
+puppet_version: 2
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_2/settings.d/*.settings" ]
 END
 
 TEST_KEY="default_virt_file_size"

--- a/system-tests/tests/settings-cli-modify-int
+++ b/system-tests/tests/settings-cli-modify-int
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings-int.yaml"
+cat <<-END >$TEST_CONFIG
+default_virt_ram: 512
+END
+
+TEST_KEY="default_virt_ram"
+TEST_VALUE="1024"
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+grep "$TEST_KEY: $TEST_VALUE" $TEST_CONFIG

--- a/system-tests/tests/settings-cli-modify-int
+++ b/system-tests/tests/settings-cli-modify-int
@@ -9,6 +9,227 @@ set -x -e -o pipefail
 TEST_CONFIG="${tmp}/settings-int.yaml"
 cat <<-END >$TEST_CONFIG
 default_virt_ram: 512
+
+auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+grub2_mod_dir: '@@grub_mod_folder@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: '$1$mF86/UHC$WvcIcX2t6crBz2onWxyac.'
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "@@bind_zonefiles@@"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "@@tftproot@@"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "@@webroot@@/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+puppet_server: ""
+puppet_version: 2
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_2/settings.d/*.settings" ]
 END
 
 TEST_KEY="default_virt_ram"

--- a/system-tests/tests/settings-cli-modify-list
+++ b/system-tests/tests/settings-cli-modify-list
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings-list.yaml"
+EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
+cat <<-END >$TEST_CONFIG
+build_reporting_email:
+  - 'root@localhost'
+END
+
+cat <<-END >$EXPECTED_CONFIG
+# Cobbler settings file
+# Docs for this file can be found at: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html
+
+build_reporting_email: []
+END
+
+TEST_KEY="build_reporting_email"
+TEST_VALUE=""
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+diff $TEST_CONFIG $EXPECTED_CONFIG

--- a/system-tests/tests/settings-cli-modify-list
+++ b/system-tests/tests/settings-cli-modify-list
@@ -11,13 +11,227 @@ EXPECTED_CONFIG="${tmp}/settings-expected.yaml"
 cat <<-END >$TEST_CONFIG
 build_reporting_email:
   - 'root@localhost'
-END
 
-cat <<-END >$EXPECTED_CONFIG
-# Cobbler settings file
-# Docs for this file can be found at: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html
-
-build_reporting_email: []
+auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+grub2_mod_dir: '@@grub_mod_folder@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: '$1$mF86/UHC$WvcIcX2t6crBz2onWxyac.'
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "@@bind_zonefiles@@"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "@@tftproot@@"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "@@webroot@@/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+puppet_server: ""
+puppet_version: 2
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]
 END
 
 TEST_KEY="build_reporting_email"
@@ -27,4 +241,5 @@ TEST_VALUE=""
 cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
 
 # Assert
-diff $TEST_CONFIG $EXPECTED_CONFIG
+# grep expression needs to be escaped
+grep "$TEST_KEY: \[\]" $TEST_CONFIG

--- a/system-tests/tests/settings-cli-modify-str
+++ b/system-tests/tests/settings-cli-modify-str
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Check that cobbler-settings can modify value from the YAML
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="${tmp}/settings-str.yaml"
+cat <<-END >$TEST_CONFIG
+buildisodir: "/var/cache/cobbler/buildiso"
+END
+
+TEST_KEY="buildisodir"
+TEST_VALUE="/my/custom/directory"
+
+# Act
+cobbler-settings -c "$TEST_CONFIG" modify -k "$TEST_KEY" -v "$TEST_VALUE"
+
+# Assert
+grep "$TEST_KEY: $TEST_VALUE" $TEST_CONFIG

--- a/system-tests/tests/settings-cli-modify-str
+++ b/system-tests/tests/settings-cli-modify-str
@@ -9,6 +9,227 @@ set -x -e -o pipefail
 TEST_CONFIG="${tmp}/settings-str.yaml"
 cat <<-END >$TEST_CONFIG
 buildisodir: "/var/cache/cobbler/buildiso"
+
+auto_migrate_settings: false
+allow_duplicate_hostnames: false
+allow_duplicate_ips: false
+allow_duplicate_macs: false
+allow_dynamic_settings: false
+anamon_enabled: false
+authn_pam_service: "login"
+auth_token_expiration: 3600
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx86.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '@@syslinux_dir@@'
+syslinux_memdisk_folder: '@@memdisk_folder@@'
+syslinux_pxelinux_folder: '@@pxelinux_folder@@'
+grub2_mod_dir: '@@grub_mod_folder@@'
+bootloaders_shim_folder: '@@shim_folder@@'
+bootloaders_shim_file: '@@shim_file@@'
+bootloaders_ipxe_folder: '@@ipxe_folder@@'
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+createrepo_flags: "-c cache -s sha"
+autoinstall: "default.ks"
+default_name_servers: []
+default_name_servers_search: []
+default_ownership:
+ - "admin"
+default_password_crypted: '$1$mF86/UHC$WvcIcX2t6crBz2onWxyac.'
+default_template_type: "cheetah"
+default_virt_bridge: xenbr0
+default_virt_file_size: 5.0
+default_virt_ram: 512
+default_virt_type: xenpv
+enable_ipxe: false
+enable_menu: true
+http_port: 80
+kernel_options: {}
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+puppet_auto_setup: false
+sign_puppet_certs_automatically: false
+puppetca_path: "/usr/bin/puppet"
+remove_old_puppet_certs_automatically: false
+puppet_parameterized_classes: true
+manage_dhcp: false
+manage_dhcp_v6: false
+manage_dhcp_v4: false
+next_server_v4: 127.0.0.1
+next_server_v6: "::1"
+manage_dns: false
+bind_chroot_path: ""
+bind_zonefile_path: "@@bind_zonefiles@@"
+bind_master: 127.0.0.1
+manage_forward_zones: []
+manage_reverse_zones: []
+manage_tftpd: true
+tftpboot_location: "@@tftproot@@"
+manage_rsync: false
+power_management_default_type: 'ipmilanplus'
+pxe_just_once: true
+nopxe_with_triggers: true
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+redhat_management_permissive: false
+redhat_management_key: ""
+register_new_installs: false
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+restart_dns: true
+restart_dhcp: true
+run_install_triggers: true
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+server: 127.0.0.1
+client_use_localhost: false
+client_use_https: false
+virt_auto_boot: true
+webdir: "@@webroot@@/cobbler"
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+xmlrpc_port: 25151
+yum_post_install_mirror: true
+yum_distro_priority: 1
+yumdownloader_flags: "--resolve"
+serializer_pretty_json: false
+replicate_rsync_options: "-avzH"
+replicate_repo_rsync_options: "-avzH"
+always_write_dhcp_entries: false
+proxy_url_ext: ""
+proxy_url_int: ""
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+convert_server_to_ip: false
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+puppet_server: ""
+puppet_version: 2
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]
 END
 
 TEST_KEY="buildisodir"

--- a/system-tests/tests/settings-cli-verify
+++ b/system-tests/tests/settings-cli-verify
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Check that cobbler-settings can verify the YAML configuration
+
+# Arrange
+source ${SYSTESTS_PRELUDE} && prepare
+
+set -x -e -o pipefail
+
+TEST_CONFIG="/code/tests/test_data/V3_0_0/settings.yaml"
+CONFIG_VERSION="3.0.0"
+
+# Act & Assert
+cobbler-settings -c "$TEST_CONFIG" validate -v "$CONFIG_VERSION"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -83,7 +83,11 @@ def create_distro(request, cobbler_api, create_kernel_initrd, fk_kernel, fk_init
     def _create_distro():
         test_folder = create_kernel_initrd(fk_kernel, fk_initrd)
         test_distro = Distro(cobbler_api)
-        test_distro.name = request.node.originalname
+        test_distro.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
         test_distro.kernel = os.path.join(test_folder, fk_kernel)
         test_distro.initrd = os.path.join(test_folder, fk_initrd)
         cobbler_api.add_distro(test_distro)
@@ -101,7 +105,11 @@ def create_profile(request, cobbler_api):
 
     def _create_profile(distro_name):
         test_profile = Profile(cobbler_api)
-        test_profile.name = request.node.originalname
+        test_profile.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
         test_profile.distro = distro_name
         cobbler_api.add_profile(test_profile)
         return test_profile
@@ -118,7 +126,11 @@ def create_image(request, cobbler_api):
 
     def _create_image():
         test_image = Image(cobbler_api)
-        test_image.name = request.node.originalname
+        test_image.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
         cobbler_api.add_image(test_image)
         return test_image
 
@@ -135,7 +147,11 @@ def create_system(request, cobbler_api):
     def _create_system(profile_name="", image_name="", name=""):
         test_system = System(cobbler_api)
         if name == "":
-            test_system.name = request.node.originalname
+            test_system.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
         else:
             test_system.name = name
         if profile_name != "":
@@ -170,7 +186,11 @@ def fk_initrd(request):
 
     :return: A filename as a string.
     """
-    return "initrd_%s.img" % request.node.originalname
+    return "initrd_%s.img" % (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
 
 
 @pytest.fixture(scope="function")
@@ -180,7 +200,11 @@ def fk_kernel(request):
 
     :return: A path as a string.
     """
-    return "vmlinuz_%s" % request.node.originalname
+    return "vmlinuz_%s" % (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
 
 
 @pytest.fixture(scope="function")

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -95,7 +95,11 @@ def test_get_conceptual_parent(request, cobbler_api, create_distro, create_profi
     tmp_distro = create_distro()
     tmp_profile = create_profile(tmp_distro.name)
     titem = Profile(cobbler_api)
-    titem.name = "subprofile_%s" % request.node.originalname
+    titem.name = "subprofile_%s" % (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
     titem.parent = tmp_profile.name
 
     # Act
@@ -296,14 +300,19 @@ def test_fetchable_files(cobbler_api):
 
 def test_sort_key(request, cobbler_api):
     # Arrange
+    item_name = (
+        request.node.originalname
+        if request.node.originalname
+        else request.node.name
+    )
     titem = Item(cobbler_api)
-    titem.name = request.node.originalname
+    titem.name = item_name
 
     # Act
     result = titem.sort_key(sort_fields=["name"])
 
     # Assert
-    assert result == [request.node.originalname]
+    assert result == [item_name]
 
 
 @pytest.mark.skip("Test not yet implemented")
@@ -409,7 +418,11 @@ def test_parent(cobbler_api):
 def test_check_if_valid(request, cobbler_api):
     # Arrange
     titem = Item(cobbler_api)
-    titem.name = request.node.originalname
+    titem.name = (
+            request.node.originalname
+            if request.node.originalname
+            else request.node.name
+        )
 
     # Act
     titem.check_if_valid()

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -87,7 +87,11 @@ def test_boot_loaders(
     tmp_distro = create_distro()
     tmp_profile = create_profile(tmp_distro.name)
     system = System(cobbler_api)
-    system.name = request.node.originalname
+    system.name = (
+        request.node.originalname
+        if request.node.originalname
+        else request.node.name
+    )
     system.profile = tmp_profile.name
 
     # Act


### PR DESCRIPTION
## Linked Items

Fixes #3382

## Description

> Copied from #2992

### Describe the bug

1. `str` values cannot be modified
2. `[str]` values cannot be modified
3. `Optional("key")` values cannot be modified

### Steps to reproduce

1. `cobbler-settings modify -k webdir_whitelist -v "does not matter"`
4. `cobbler-settings modify -k windows_enabled -v True`
5. `cobbler-settings modify -k tftpboot_location -v "/srv/tftpboot"`

## Behaviour changes

Old: `cobbler-settings` fails to edit various keys in `settings.yaml` even though the format is valid.

New: `cobbler-settings` behaves as expected.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [x] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
