### PR TITLE
tftpgen: Use ENUM value

### DIFF
--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -479,7 +479,7 @@ class TFTPGen:
             arch_menu_items = arch_metadata["menu_items"]
 
             boot_menu["grub"] = arch_menu_items
-            outfile = os.path.join(self.bootloc, "grub", f"{arch}_menu_items.cfg")
+            outfile = os.path.join(self.bootloc, "grub", f"{arch.value}_menu_items.cfg")
             with open(outfile, "w+") as fd:
                 fd.write(arch_menu_items.get("grub", ""))
 


### PR DESCRIPTION
## Linked Items

Fixes #3355

## Description

<!-- What does this PR do? -->

## Behaviour changes

Old: Was using enum member in for loop

```Archs.X86_64_menu_items.cfg```

New: Will use enum member VALUE in for loop (drops "Archs" keyword also, that is not needed here)

```x86_64_menu_items.cfg```

It should normalise grub menu_items files generation (with lower case where needed) 
## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
