### PR TITLE
Backport PR #2590 autoinstall_templates fix for 3.2

### DIFF
--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -179,7 +179,7 @@ class CobblerSync:
                 if x not in self.settings.webdir_whitelist:
                     # delete directories that shouldn't exist
                     utils.rmtree(path, logger=self.logger)
-                if x in ["autoinstall_templates", "autoinstall_templates_sys", "images", "systems", "distros", "profiles", "repo_profile", "repo_system", "rendered"]:
+                if x in ["templates", "images", "systems", "distros", "profiles", "repo_profile", "repo_system", "rendered"]:
                     # clean out directory contents
                     utils.rmtree_contents(path, logger=self.logger)
         #

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -77,7 +77,7 @@ cheetah_import_whitelist:
 createrepo_flags: "-c cache -s sha"
 
 # if no autoinstall template is specified to profile add, use this template
-default_autoinstall: /var/lib/cobbler/autoinstall_templates/default.ks
+default_autoinstall: /var/lib/cobbler/templates/default.ks
 
 # configure all installed systems to use these nameservers by default
 # unless defined differently in the profile.  For DHCP configurations
@@ -92,7 +92,7 @@ default_ownership:
  - "admin"
 
 # Cobbler has various sample automatic installation templates stored
-# in /var/lib/cobbler/autoinstall_templates/.  This controls
+# in /var/lib/cobbler/templates/.  This controls
 # what install (root) password is set up for those
 # systems that reference this variable.  The factory
 # default is "cobbler" and Cobbler check will warn if

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -257,7 +257,7 @@ default_autoinstall
 
 If no autoinstall template is specified to profile add, use this template.
 
-default: ``/var/lib/cobbler/autoinstall_templates/default.ks``
+default: ``/var/lib/cobbler/templates/default.ks``
 
 default_name_*
 ==============
@@ -284,7 +284,7 @@ default:
 default_password_crypted
 ========================
 
-Cobbler has various sample automatic installation templates stored in ``/var/lib/cobbler/autoinstall_templates/``. This
+Cobbler has various sample automatic installation templates stored in ``/var/lib/cobbler/templates/``. This
 controls what install (root) password is set up for those systems that reference this variable. The factory default is
 "cobbler" and Cobbler check will warn if this is not changed. The simplest way to change the password is to run
 ``openssl passwd -1`` and put the output between the ``""``.

--- a/tests/test_data/settings_old
+++ b/tests/test_data/settings_old
@@ -92,7 +92,7 @@ cheetah_import_whitelist:
 createrepo_flags: "-c cache -s sha"
 
 # if no autoinstall template is specified to profile add, use this template
-default_autoinstall: /var/lib/cobbler/autoinstall_templates/default.ks
+default_autoinstall: /var/lib/cobbler/templates/default.ks
 
 # configure all installed systems to use these nameservers by default
 # unless defined differently in the profile.  For DHCP configurations
@@ -107,7 +107,7 @@ default_ownership:
  - "admin"
 
 # cobbler has various sample automatic installation templates stored
-# in /var/lib/cobbler/autoinstall_templates/.  This controls
+# in /var/lib/cobbler/templates/.  This controls
 # what install (root) password is set up for those
 # systems that reference this variable.  The factory
 # default is "cobbler" and cobbler check will warn if


### PR DESCRIPTION
## Linked Items

Fixes #3398

## Description

Backport PR #2590 autoinstall_templates fix for 3.2

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
