### PR TITLE
[3.2] Backport fix for CVE-2022-0860

### DIFF
--- a/cobbler/modules/authentication/pam.py
+++ b/cobbler/modules/authentication/pam.py
@@ -114,6 +114,10 @@ PAM_AUTHENTICATE = LIBPAM.pam_authenticate
 PAM_AUTHENTICATE.restype = c_int
 PAM_AUTHENTICATE.argtypes = [PamHandle, c_int]
 
+PAM_ACCT_MGMT = LIBPAM.pam_acct_mgmt
+PAM_ACCT_MGMT.restype = c_int
+PAM_ACCT_MGMT.argtypes = [PamHandle, c_int]
+
 
 def authenticate(api_handle, username: str, password: str) -> bool:
     """
@@ -155,4 +159,8 @@ def authenticate(api_handle, username: str, password: str) -> bool:
         return False
 
     retval = PAM_AUTHENTICATE(handle, 0)
+
+    if retval == 0:
+        retval = PAM_ACCT_MGMT(handle, 0)
+
     return retval == 0


### PR DESCRIPTION
## Linked Items

Fixes #3400 

## Description

Fixes PAM security problems.

## Behaviour changes

Old: Users terminated in PAM can still authenticate in Cobbler if the correct password is known.

New: Users that are terminated in PAM can no longer log in.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
