### PR TITLE
Fixed issue with profile and pxe menu

### DIFF
--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -162,7 +162,7 @@ V2.8.5:
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 import copy
-from typing import TYPE_CHECKING, Any, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from cobbler import autoinstall_manager, enums, validate
 from cobbler.cexceptions import CX
@@ -279,6 +279,26 @@ class Profile(item.Item):
         distro = self.get_conceptual_parent()
         if distro is None:
             raise CX(f"Error with profile {self.name} - distro is required")
+
+    def find_match_single_key(
+        self, data: Dict[str, Any], key: str, value: Any, no_errors: bool = False
+    ) -> bool:
+        """
+        Look if the data matches or not. This is an alternative for ``find_match()``.
+
+        :param data: The data to search through.
+        :param key: The key to look for int the item.
+        :param value: The value for the key.
+        :param no_errors: How strict this matching is.
+        :return: Whether the data matches or not.
+        """
+        # special case for profile, since arch is a derived property from the parent distro
+        if key == "arch":
+            if self.arch:
+                return self.arch.value == value
+            return value is None
+
+        return super().find_match_single_key(data, key, value, no_errors)
 
     #
     # specific methods for item.Profile

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ import pytest
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.image import Image
+from cobbler.items.menu import Menu
 from cobbler.items.profile import Profile
 from cobbler.items.system import NetworkInterface, System
 
@@ -211,6 +212,31 @@ def create_system(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
         return test_system
 
     return _create_system
+
+
+@pytest.fixture(scope="function")
+def create_menu(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Returns a function which has the profile name as an argument. The function returns a system object. The system is
+    already added to the CobblerAPI.
+    """
+
+    def _create_menu(name: str = "", display_name: str = "") -> Menu:
+        test_menu = cobbler_api.new_menu()
+
+        if name == "":
+            test_menu.name = (
+                request.node.originalname  # type: ignore
+                if request.node.originalname  # type: ignore
+                else request.node.name
+            )
+
+        test_menu.display_name = display_name
+
+        cobbler_api.add_menu(test_menu)
+        return test_menu
+
+    return _create_menu
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -524,23 +524,51 @@ def test_sort_key(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     ]
 
 
-@pytest.mark.skip("Test not yet implemented")
-def test_find_match(cobbler_api: CobblerAPI):
+@pytest.mark.parametrize(
+    "in_keys, check_keys, expect_match",
+    [
+        ({"uid": "test-uid"}, {"uid": "test-uid"}, True),
+        ({"name": "test-object"}, {"name": "test-object"}, True),
+        ({"comment": "test-comment"}, {"comment": "test-comment"}, True),
+        ({"uid": "test-uid"}, {"uid": ""}, False),
+    ],
+)
+def test_find_match(
+    cobbler_api: CobblerAPI,
+    in_keys: Dict[str, Any],
+    check_keys: Dict[str, Any],
+    expect_match: bool,
+):
     """
     Assert that given a desired amount of key-value pairs is matching the item or not.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Item(cobbler_api, **in_keys)
 
     # Act
-    titem.find_match({})
+    result = titem.find_match(check_keys)
 
     # Assert
-    assert False
+    assert expect_match == result
 
 
-@pytest.mark.skip("Test not yet implemented")
-def test_find_match_single_key(cobbler_api: CobblerAPI):
+@pytest.mark.parametrize(
+    "data_keys, check_key, check_value, expect_match",
+    [
+        ({"uid": "test-uid"}, "uid", "test-uid", True),
+        ({"menu": "testmenu0"}, "menu", "testmenu0", True),
+        ({"uid": "test", "name": "test-name"}, "uid", "test", True),
+        ({"depth": "1"}, "name", "test", False),
+        ({"uid": "test", "name": "test-name"}, "menu", "testmenu0", False),
+    ],
+)
+def test_find_match_single_key(
+    cobbler_api: CobblerAPI,
+    data_keys: Dict[str, Any],
+    check_key: str,
+    check_value: Any,
+    expect_match: bool,
+):
     """
     Assert that a single given key and value match the object or not.
     """
@@ -548,10 +576,10 @@ def test_find_match_single_key(cobbler_api: CobblerAPI):
     titem = Item(cobbler_api)
 
     # Act
-    titem.find_match_single_key({}, "", "")
+    result = titem.find_match_single_key(data_keys, check_key, check_value)
 
     # Assert
-    assert False
+    assert expect_match == result
 
 
 def test_dump_vars(cobbler_api: CobblerAPI):

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -2,7 +2,7 @@
 Test module to validate the functionallity of the Cobbler Profile item.
 """
 
-from typing import Any, Callable, List
+from typing import Any, Callable, Dict, List
 
 import pytest
 
@@ -684,3 +684,39 @@ def test_display_name(cobbler_api: CobblerAPI):
 
     # Assert
     assert profile.display_name == ""
+
+
+@pytest.mark.parametrize(
+    "data_keys, check_key, check_value, expect_match",
+    [
+        ({"uid": "test-uid"}, "uid", "test-uid", True),
+        ({"menu": "testmenu0"}, "menu", "testmenu0", True),
+        ({"uid": "test", "name": "test-name"}, "uid", "test", True),
+        ({"uid": "test"}, "arch", "x86_64", True),
+        ({"uid": "test"}, "arch", "aarch64", False),
+        ({"depth": "1"}, "name", "test", False),
+        ({"uid": "test", "name": "test-name"}, "menu", "testmenu0", False),
+    ],
+)
+def test_find_match_single_key(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    data_keys: Dict[str, Any],
+    check_key: str,
+    check_value: Any,
+    expect_match: bool,
+):
+    """
+    Assert that a single given key and value match the object or not.
+    """
+    # Arrange
+    test_distro_obj = create_distro()
+    test_distro_obj.arch = enums.Archs.X86_64
+    profile = Profile(cobbler_api)
+    profile.distro = test_distro_obj.name
+
+    # Act
+    result = profile.find_match_single_key(data_keys, check_key, check_value)
+
+    # Assert
+    assert expect_match == result


### PR DESCRIPTION
## Linked Items

Fixes #3410 

## Description

This PR is a possible fix for the problem reported in #3410, but is only one of many possible ways to solve this issue. My fix directly addresses the fact that the profile module has differing behaviour due to this `arch` key. It might be better to instead fix the problem at the item level and correctly handle Python properties in addition to using an object's `__dict__`.

From my minimal research, it might be difficult to try and handle these minor differences at the item.py level, but that is a design decision - my PR is just a suggestion!

## Behaviour changes

Old: PXE menu entries are never generated, because no profiles are found to be matching any requested architectures.

New: PXE menu entries are generated, because the profiles which support the requested architecture will be found by the Cobbler API.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

I do not know the state of tests for this module, but if none exist it might certainly be a good idea to add that at the same time as a similar issue to this could easily be affecting other data classes.
