### PR TITLE
Fix Ubuntu 22 server support

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -102,6 +102,11 @@
 %define grub2_ia32_efi_pkg grub-efi-ia32
 %define system_release_pkg base-files
 
+# Ubuntu 22.04 and later moved to the C implementation of createrepo
+%if 0%{?ubuntu} >= 22
+%define createrepo_pkg createrepo-c
+%endif
+
 # Debian 11 moved to the C implementation of createrepo
 %if 0%{?debian} == 11
 %define createrepo_pkg createrepo-c


### PR DESCRIPTION
## Linked Items

Fixes #3413

## Description

Switches from `creatrepo` to `createrepo_c` for Ubuntu versions newer then 22.

## Behaviour changes

Old: Cobbler cannot be installed on Ubuntu 22.xx

New: Cobbler can be installed on Ubuntu 22.xx

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
