### PR TITLE
[Backport] Fixup incorrect dhcpd filename option

### DIFF
--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -20,8 +20,8 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import uuid
 from typing import List, Optional
 
-from cobbler.items import item
 from cobbler.cexceptions import CX
+from cobbler.items import item
 
 
 class Menu(item.Item):
@@ -64,7 +64,7 @@ class Menu(item.Item):
         super().from_dict(dictionary)
 
     @property
-    def parent(self) -> Optional['Menu']:
+    def parent(self) -> Optional["Menu"]:
         """
         Parent menu of a menu instance.
 
@@ -83,6 +83,8 @@ class Menu(item.Item):
         :param value: The name of the parent to set.
         :raises CX: Raised in case of self parenting or if the menu with value ``value`` is not found.
         """
+        if not isinstance(value, str):  # type: ignore
+            raise TypeError('Property "parent" must be of type str!')
         old_parent = self._parent
         if isinstance(old_parent, item.Item):
             old_parent.children.remove(self.name)
@@ -123,15 +125,20 @@ class Menu(item.Item):
             raise TypeError("Field children of object menu must be of type list.")
         if isinstance(value, list):
             if not all(isinstance(x, str) for x in value):
-                raise TypeError("Field children of object menu must be of type list and all items need to be menu "
-                                "names (str).")
+                raise TypeError(
+                    "Field children of object menu must be of type list and all items need to be menu "
+                    "names (str)."
+                )
             self._children = []
             for name in value:
                 menu = self.api.find_menu(name=name)
                 if menu is not None:
                     self._children.append(name)
                 else:
-                    self.logger.warning("Menu with the name \"%s\" did not exist. Skipping setting as a child!", name)
+                    self.logger.warning(
+                        'Menu with the name "%s" did not exist. Skipping setting as a child!',
+                        name,
+                    )
 
     #
     # specific methods for item.Menu

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -1,6 +1,7 @@
 import pytest
 
 from cobbler import enums
+from cobbler.cexceptions import CX
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from tests.conftest import does_not_raise
@@ -53,7 +54,7 @@ def test_to_dict(cobbler_api, cleanup_to_dict):
 # Properties Tests
 
 
-def test_parent(cobbler_api):
+def test_parent_empty(cobbler_api):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -62,6 +63,48 @@ def test_parent(cobbler_api):
 
     # Assert
     assert profile.parent is None
+
+
+def test_parent_profile(cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_dist = create_distro()
+    test_profile = create_profile(test_dist.name)
+    profile = Profile(cobbler_api)
+
+    # Act
+    profile.parent = test_profile.name
+
+    # Assert
+    assert profile.parent is test_profile
+
+
+def test_parent_other_object_type(cobbler_api, create_image):
+    # Arrange
+    test_image = create_image()
+    profile = Profile(cobbler_api)
+
+    # Act
+    with pytest.raises(CX):
+        profile.parent = test_image.name
+
+
+def test_parent_invalid_type(cobbler_api):
+    # Arrange
+    profile = Profile(cobbler_api)
+
+    # Act & Assert
+    with pytest.raises(TypeError):
+        profile.parent = 0
+
+
+def test_parent_self(cobbler_api):
+    # Arrange
+    profile = Profile(cobbler_api)
+    profile.name = "testname"
+
+    # Act & Assert
+    with pytest.raises(CX):
+        profile.parent = profile.name
 
 
 def test_distro(cobbler_api):
@@ -108,9 +151,7 @@ def test_proxy(cobbler_api):
     assert profile.proxy == ""
 
 
-@pytest.mark.parametrize("value,expected_exception", [
-    (False, does_not_raise())
-])
+@pytest.mark.parametrize("value,expected_exception", [(False, does_not_raise())])
 def test_enable_ipxe(cobbler_api, value, expected_exception):
     # Arrange
     profile = Profile(cobbler_api)
@@ -123,12 +164,15 @@ def test_enable_ipxe(cobbler_api, value, expected_exception):
         assert profile.enable_ipxe is value
 
 
-@pytest.mark.parametrize("value,expected_exception", [
-    (True, does_not_raise()),
-    (False, does_not_raise()),
-    ("", does_not_raise()),
-    (0, does_not_raise())
-])
+@pytest.mark.parametrize(
+    "value,expected_exception",
+    [
+        (True, does_not_raise()),
+        (False, does_not_raise()),
+        ("", does_not_raise()),
+        (0, does_not_raise()),
+    ],
+)
 def test_enable_menu(cobbler_api, value, expected_exception):
     # Arrange
     profile = Profile(cobbler_api)
@@ -206,6 +250,44 @@ def test_filename(cobbler_api):
     assert profile.filename == "<<inherit>>"
 
 
+@pytest.mark.parametrize(
+    "input_filename,expected_result,is_subitem,expected_exception",
+    [
+        ("", "", False, does_not_raise()),
+        ("", "", True, does_not_raise()),
+        ("<<inherit>>", "", False, does_not_raise()),
+        ("<<inherit>>", "", True, does_not_raise()),
+        ("test", "test", False, does_not_raise()),
+        ("test", "test", True, does_not_raise()),
+        (0, "", True, pytest.raises(TypeError)),
+    ],
+)
+def test_filename(
+    cobbler_api,
+    create_distro,
+    create_profile,
+    input_filename,
+    expected_result,
+    is_subitem,
+    expected_exception,
+):
+    # Arrange
+    test_dist = create_distro()
+    profile = Profile(cobbler_api)
+    profile.name = "filename_test_profile"
+    if is_subitem:
+        test_profile = create_profile(test_dist.name)
+        profile.parent = test_profile.name
+    profile.distro = test_dist.name
+
+    # Act
+    with expected_exception:
+        profile.filename = input_filename
+
+        # Assert
+        assert profile.filename == expected_result
+
+
 def test_autoinstall(cobbler_api):
     # Arrange
     profile = Profile(cobbler_api)
@@ -239,13 +321,16 @@ def test_virt_auto_boot(cobbler_api, value, expected_exception, expected_result)
         assert profile.virt_auto_boot is expected_result
 
 
-@pytest.mark.parametrize("value,expected_exception, expected_result", [
-    ("", does_not_raise(), 0),
-    # FIXME: (False, pytest.raises(TypeError)), --> does not raise
-    (-5, pytest.raises(ValueError), -5),
-    (0, does_not_raise(), 0),
-    (5, does_not_raise(), 5)
-])
+@pytest.mark.parametrize(
+    "value,expected_exception, expected_result",
+    [
+        ("", does_not_raise(), 0),
+        # FIXME: (False, pytest.raises(TypeError)), --> does not raise
+        (-5, pytest.raises(ValueError), -5),
+        (0, does_not_raise(), 0),
+        (5, does_not_raise(), 5),
+    ],
+)
 def test_virt_cpus(cobbler_api, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
@@ -258,14 +343,17 @@ def test_virt_cpus(cobbler_api, value, expected_exception, expected_result):
         assert profile.virt_cpus == expected_result
 
 
-@pytest.mark.parametrize("value,expected_exception,expected_result", [
-    ("5", does_not_raise(), 5.0),
-    ("<<inherit>>", does_not_raise(), 5.0),
-    # FIXME: (False, pytest.raises(TypeError)), --> does not raise
-    (-5, pytest.raises(ValueError), 0),
-    (0, does_not_raise(), 0.0),
-    (5, does_not_raise(), 5.0)
-])
+@pytest.mark.parametrize(
+    "value,expected_exception,expected_result",
+    [
+        ("5", does_not_raise(), 5.0),
+        ("<<inherit>>", does_not_raise(), 5.0),
+        # FIXME: (False, pytest.raises(TypeError)), --> does not raise
+        (-5, pytest.raises(ValueError), 0),
+        (0, does_not_raise(), 0.0),
+        (5, does_not_raise(), 5.0),
+    ],
+)
 def test_virt_file_size(cobbler_api, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
@@ -300,12 +388,15 @@ def test_virt_disk_driver(cobbler_api, value, expected_exception, expected_resul
         assert profile.virt_disk_driver == expected_result
 
 
-@pytest.mark.parametrize("value,expected_exception,expected_result", [
-    ("", does_not_raise(), 0),
-    ("<<inherit>>", does_not_raise(), 512),
-    (0, does_not_raise(), 0),
-    (0.0, pytest.raises(TypeError), 0)
-])
+@pytest.mark.parametrize(
+    "value,expected_exception,expected_result",
+    [
+        ("", does_not_raise(), 0),
+        ("<<inherit>>", does_not_raise(), 512),
+        (0, does_not_raise(), 0),
+        (0.0, pytest.raises(TypeError), 0),
+    ],
+)
 def test_virt_ram(cobbler_api, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
@@ -318,13 +409,16 @@ def test_virt_ram(cobbler_api, value, expected_exception, expected_result):
         assert profile.virt_ram == expected_result
 
 
-@pytest.mark.parametrize("value,expected_exception,expected_result", [
-    ("<<inherit>>", does_not_raise(), enums.VirtType.XENPV),
-    ("qemu", does_not_raise(), enums.VirtType.QEMU),
-    (enums.VirtType.QEMU, does_not_raise(), enums.VirtType.QEMU),
-    ("", pytest.raises(ValueError), None),
-    (False, pytest.raises(TypeError), None)
-])
+@pytest.mark.parametrize(
+    "value,expected_exception,expected_result",
+    [
+        ("<<inherit>>", does_not_raise(), enums.VirtType.XENPV),
+        ("qemu", does_not_raise(), enums.VirtType.QEMU),
+        (enums.VirtType.QEMU, does_not_raise(), enums.VirtType.QEMU),
+        ("", pytest.raises(ValueError), None),
+        (False, pytest.raises(TypeError), None),
+    ],
+)
 def test_virt_type(cobbler_api, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)


### PR DESCRIPTION
## Linked Items

Fixes #3367

## Description

This PR is responsible that the `dhcpd.conf` file is correctly generated again.

## Behaviour changes

Old: Generated `dhcpd.conf` has filename `<<inherit>>`; for a system if filename has not been set in profile/system

New: Generated `dhcpd.conf` behaves correctly again.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
