### PR TITLE
Include setup files for tests container subpackage

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -283,6 +283,12 @@ Requires:       cobbler = %{version}-%{release}
 %description tests
 Unit test files from the Cobbler project
 
+%package tests-containers
+Summary:        Dockerfiles and scripts to setup testing containers
+Requires:       cobbler = %{version}-%{release}
+
+%description tests-containers
+Dockerfiles and scripts to setup testing containers
 
 %prep
 %setup
@@ -484,6 +490,10 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %files tests
 %dir %{_datadir}/cobbler/tests
 %{_datadir}/cobbler/tests/*
+
+%files tests-containers
+%dir %{_datadir}/cobbler/docker
+%{_datadir}/cobbler/docker/*
 
 %changelog
 * Thu Dec 19 2019 Neal Gompa <ngompa13@gmail.com>

--- a/setup.py
+++ b/setup.py
@@ -704,5 +704,76 @@ if __name__ == "__main__":
             ("%s/tests/modules" % datadir, glob("tests/modules/*.py")),
             ("%s/tests/modules/authentication" % datadir, glob("tests/modules/authentication/*.py")),
             ("%s/tests/xmlrpcapi" % datadir, glob("tests/xmlrpcapi/*.py")),
+            # tests containers subpackage
+            ("%s/docker" % datadir, glob("docker/*")),
+            ("%s/docker/debs" % datadir, glob("docker/debs/*")),
+            ("%s/docker/debs/Debian_10" % datadir, glob("docker/debs/Debian_10/*")),
+            (
+                "%s/docker/debs/Debian_10/supervisord" % datadir,
+                glob("docker/debs/Debian_10/supervisord/*"),
+            ),
+            (
+                "%s/docker/debs/Debian_10/supervisord/conf.d" % datadir,
+                glob("docker/debs/Debian_10/supervisord/conf.d/*"),
+            ),
+            ("%s/docker/debs/Debian_11" % datadir, glob("docker/debs/Debian_11/*")),
+            (
+                "%s/docker/debs/Debian_11/supervisord" % datadir,
+                glob("docker/debs/Debian_11/supervisord/*"),
+            ),
+            (
+                "%s/docker/debs/Debian_11/supervisord/conf.d" % datadir,
+                glob("docker/debs/Debian_11/supervisord/conf.d/*"),
+            ),
+            ("%s/docker/develop" % datadir, glob("docker/develop/*")),
+            ("%s/docker/develop/openldap" % datadir, glob("docker/develop/openldap/*")),
+            ("%s/docker/develop/pam" % datadir, glob("docker/develop/pam/*")),
+            ("%s/docker/develop/scripts" % datadir, glob("docker/develop/scripts/*")),
+            (
+                "%s/docker/develop/supervisord" % datadir,
+                glob("docker/develop/supervisord/*"),
+            ),
+            (
+                "%s/docker/develop/supervisord/conf.d" % datadir,
+                glob("docker/develop/supervisord/conf.d/*"),
+            ),
+            ("%s/docker/rpms" % datadir, glob("docker/rpms/*")),
+            ("%s/docker/rpms/Fedora_34" % datadir, glob("docker/rpms/Fedora_34/*")),
+            (
+                "%s/docker/rpms/Fedora_34/supervisord" % datadir,
+                glob("docker/rpms/Fedora_34/supervisord/*"),
+            ),
+            (
+                "%s/docker/rpms/Fedora_34/supervisord/conf.d" % datadir,
+                glob("docker/rpms/Fedora_34/supervisord/conf.d/*"),
+            ),
+            (
+                "%s/docker/rpms/Rocky_Linux_8" % datadir,
+                glob("docker/rpms/Rocky_Linux_8/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_leap" % datadir,
+                glob("docker/rpms/opensuse_leap/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_leap/supervisord" % datadir,
+                glob("docker/rpms/opensuse_leap/supervisord/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_leap/supervisord/conf.d" % datadir,
+                glob("docker/rpms/opensuse_leap/supervisord/conf.d/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_tumbleweed" % datadir,
+                glob("docker/rpms/opensuse_tumbleweed/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_tumbleweed/supervisord" % datadir,
+                glob("docker/rpms/opensuse_tumbleweed/supervisord/*"),
+            ),
+            (
+                "%s/docker/rpms/opensuse_tumbleweed/supervisord/conf.d" % datadir,
+                glob("docker/rpms/opensuse_tumbleweed/supervisord/conf.d/*"),
+            ),
         ],
     )


### PR DESCRIPTION
## Linked Items

Fixes #3368 

## Description

Cobbler files required to build a test container are not shipped with the application.

## Behaviour changes

Old: Cobbler didn't ship its files for building a test container.

New: Cobbler includes its files for building test containers under `/usr/share/cobbler/`

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
