### PR TITLE
Fix filename inheritence

### DIFF
--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -401,14 +401,8 @@ class Profile(item.Item):
         """
         if not isinstance(filename, str):  # type: ignore
             raise TypeError("Field filename of object profile needs to be of type str!")
-        parent = self.parent
-        if filename == enums.VALUE_INHERITED and parent is None:
+        if filename == enums.VALUE_INHERITED and not self.is_subobject:
             filename = ""
-        if not filename:
-            if parent:
-                filename = enums.VALUE_INHERITED
-            else:
-                filename = ""
         self._filename = filename
 
     @InheritableProperty


### PR DESCRIPTION
## Description

The check for parent in profile item setter is wrong: profile always has a parent (distro).

It has to be checked whether the parent is (not) of type profile anymore (is_subobject). In this case we know we are at the end of inheritance hierarchy and we have to set filename=""

## Behaviour changes

Old: filename might end up in <<inherited>> string, even the end of inheritance hierarchy was reached. This e.g. could end up in bad dhcpd.conf generation inside a host declaration:
    filename <<inherited>>

New: Make sure a system or profile item always returns the defined filename value or an empty string, but not "<<inherited>>"

## Category

- Bugfix
