### PR TITLE
Fix Cobbler package building with Sphinx >= 7.0.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include COPYING AUTHORS
 include cobbler.spec config/service/cobblerd.service
 include AUTHORS.in README.md
 include distro_build_configs.sh
+include Makefile
 recursive-include misc *
 recursive-include bin *
 recursive-include config *

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,9 @@ doc: ## Creates the documentation with sphinx in html form.
 	@echo "creating: documentation"
 	@cd docs; make html > /dev/null 2>&1
 
+man: ## Creates documentation and man pages using Sphinx
+	@${PYTHON} -m sphinx -b man -j auto ./docs ./build/sphinx/man
+
 qa: ## If black is found then it is run.
 ifeq ($(strip $(BLACK)),)
 	@echo "No black found"

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -254,6 +254,7 @@ Dockerfiles and scripts to setup testing containers
 [ "${TFTPROOT}" != %{tftpboot_dir} ] && echo "ERROR: TFTPROOT: ${TFTPROOT} does not match %{tftpboot_dir}"
 
 %py3_build
+make man
 
 %install
 . distro_build_configs.sh

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ from setuptools import Distribution as _Distribution
 from setuptools import dep_util, find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.install import install as _install
-from sphinx.setup_command import BuildDoc
 
 VERSION = "3.4.0"
 OUTPUT_DIR = "config"
@@ -165,21 +164,6 @@ class Build(_build):
 
     def run(self):
         _build.run(self)
-
-
-#####################################################################
-# # Build man pages using Sphinx  ###################################
-#####################################################################
-
-
-class BuildMan(BuildDoc):  # type: ignore
-    """
-    TODO
-    """
-
-    def initialize_options(self):
-        BuildDoc.initialize_options(self)  # type: ignore
-        self.builder = "man"
 
 
 #####################################################################
@@ -343,14 +327,7 @@ def has_configure_files(build: Build):
     return bool(build.distribution.configure_files)  # type: ignore
 
 
-def has_man_pages(build: Build):
-    """Check if the distribution has configuration files to work on."""
-    return bool(build.distribution.man_pages)  # type: ignore
-
-
-Build.sub_commands.extend(
-    (("build_man", has_man_pages), ("build_cfg", has_configure_files))
-)
+Build.sub_commands.extend((("build_cfg", has_configure_files),))
 
 
 #####################################################################
@@ -569,7 +546,6 @@ if __name__ == "__main__":
             "savestate": Savestate,
             "restorestate": Restorestate,
             "build_cfg": BuildCfg,
-            "build_man": BuildMan,
         },
         name="cobbler",
         version=VERSION,


### PR DESCRIPTION
## Description

Sphinx has dropped the integration with `setuptools` in version 7.0.0:
https://www.sphinx-doc.org/en/master/changes.html#release-7-0-0-released-apr-29-2023

This removal is currently causing issues when building Cobbler package, as the `setup.py` script is making use of removed code:

```
[   28s] + /usr/bin/python3 setup.py build '--executable=/usr/bin/python3 -s'
[   28s] Traceback (most recent call last):
[   28s]   File "/home/abuild/rpmbuild/BUILD/cobbler-3.3.3.0+git.5c498dbf/setup.py", line 17, in <module>
[   28s]     from sphinx.setup_command import BuildDoc
[   28s] ModuleNotFoundError: No module named 'sphinx.setup_command'
[   28s] error: Bad exit status from /var/tmp/rpm-tmp.mAzLcE (%build)
``` 

This PR simply makes documentation and man pages to be built outside of `setup.py` script.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
