### PR TITLE
multi: template + snippets improvements

### DIFF
--- a/autoinstall_snippets/network_disable_interfaces
+++ b/autoinstall_snippets/network_disable_interfaces
@@ -1,0 +1,10 @@
+#set $mac = $interfaces['default']["mac_address"]
+## Disable all interfaces that is not used
+default_mac="$mac"
+#raw
+for interface in $(find /sys/class/net -type l -not -lname '*virtual*' -printf '%f\n'); do
+  if ! ip a show "$interface" | grep link/ether | awk '{print $2}' |grep -q "$default_mac"; then
+    sed -i 's/ONBOOT=\("\)\?yes\("\)\?/ONBOOT=\1no\2/g' /etc/sysconfig/network-scripts/ifcfg-"$interface"
+  fi
+done
+#end raw

--- a/autoinstall_snippets/partition_rhel
+++ b/autoinstall_snippets/partition_rhel
@@ -1,0 +1,63 @@
+## Can be used to create a partition layout for RHEL 7 and 8 dinamycally
+## using variables in systems `autoinstall_meta` section.
+##
+##    "autoinstall_meta": {
+##       "filesystem_type": "ext4",
+##       "root_device": "sda",
+##       "uefi_create": false,
+##
+##
+#
+# main partition selection
+#
+#set $disk_label = $getVar('disk_label', 'mbr')
+#
+#set $uefi_create = $getVar('uefi_create', 'False')
+#
+#set $fstype = $getVar('filesystem_type', 'ext4')
+#
+#set $tmp_create = $getVar('tmp_create', 'False')
+#set $tmp_size = $getVar('tmp_size', '1024')
+#set $tmp_device = $getVar('tmp_device', '')
+#
+#set $boot_create = $getVar('boot_create', 'False')
+#set $boot_size = $getVar('boot_size', '1024')
+#set $boot_device = $getVar('boot_device', '')
+# 
+#set $swap_create = $getVar('swap_create', 'False')
+#set $swap_size = $getVar('swap_size', '1024')
+#set $swap_device = $getVar('swap_device', '')
+# 
+#set $home_create = $getVar('home_create', 'False')
+#set $home_size = $getVar('home_size', '1 --grow')
+#set $home_device = $getVar('home_device', '')
+#set $home_fsoptions = $getVar('home_fsoptions', 'defaults')
+# 
+#set $root_size = $getVar('root_size', '1 --grow')
+#set $root_device = $getVar('root_device', 'sda')
+#set $root_fsoptions = $getVar('root_fsoptions', 'defaults')
+#
+#if $disk_label == "gpt" and not $uefi_create
+part biosboot --fstype=biosboot --size=1
+#end if
+#
+#if $tmp_create and $tmp_size and $tmp_device
+part /tmp --fstype=$fstype --ondisk=$tmp_device --size=$tmp_size
+#end if
+#
+#if $boot_create and $boot_size and $boot_device
+part /boot --fstype=$fstype --ondisk=$boot_device --size=$boot_size
+#end if
+#
+#if $uefi_create
+part /boot/efi --fstype=efi  --size=200
+#end if
+#
+#if $swap_create and $swap_size and $swap_device
+part swap --fstype=swap --ondisk=$swap_device --size=$swap_size
+#end if
+#if $home_create and $home_device
+part /home --fstype=$fstype --ondisk=$home_device --size=$home_size --fsoptions=$home_fsoptions --label=home
+#end if
+# 
+part / --fstype=$fstype --ondisk=$root_device  --size=$root_size --fsoptions=$root_fsoptions --label=root

--- a/autoinstall_snippets/pre_install_network_config
+++ b/autoinstall_snippets/pre_install_network_config
@@ -65,6 +65,9 @@ get_ifname() {
         #set $iface_type    = $idata["interface_type"]
         #set $iface_master  = $idata["interface_master"]
         #set $static_routes = $idata["static_routes"]
+        #set $ip6           = $idata["ipv6_address"]
+        #set $ip6_prefix    = $idata["ipv6_prefix"]
+        #set $ip6_gw        = $idata["ipv6_default_gateway"]
         #set $devfile       = "/etc/sysconfig/network-scripts/ifcfg-" + $iname
         #if $vlanpattern.match($iname)
             ## If this is a VLAN interface, skip it, anaconda doesn't know
@@ -105,12 +108,16 @@ get_ifname() {
                     #end if
                 #end for
             #end if
-            #if $static and $ip != ""
-                #if $netmask == ""
-                    ## Netmask not provided, default to /24.
-                    #set $netmask = "255.255.255.0"
+            #if $static and ($ip != "" or $ip6 != "")
+                ## Set static proto, don't know yet if ipv4 or ipv6 or both
+                #set $netinfo = "--bootproto=static"
+                #if $ip != ""
+                    #if $netmask == ""
+                        ## Netmask not provided, default to /24.
+                        #set $netmask = "255.255.255.0"
+                    #end if
+                    #set $netinfo = "%s --ip=%s --netmask=%s" % ($netinfo, $ip, $netmask)
                 #end if
-                #set $netinfo = "--bootproto=static --ip=%s --netmask=%s" % ($ip, $netmask)
                 #if $if_gateway != ""
 	                #if $if_gateway == $gateway
 	                   #set $netinfo = "%s --gateway=%s" % ($netinfo, $if_gateway)
@@ -122,6 +129,13 @@ get_ifname() {
     	        #end if
     	        #if $len($name_servers) > 0
     	            #set $netinfo = "%s --nameserver=%s" % ($netinfo, $name_servers[0])
+                #end if
+    	        #if $ip6 != "" and $ip6_gw != ""
+                    #if $ip6_prefix == ""
+                        ## Prefix not provided, default to /64.
+                        #set $ip6_prefix = "64"
+                    #end if
+    	            #set $netinfo = "%s --ipv6=%s/%s --ipv6gateway=%s" % ($netinfo, $ip6, $ip6_prefix, $ip6_gw)
                 #end if
             #else if not $static
                 #set $netinfo = "--bootproto=dhcp"

--- a/autoinstall_templates/sample.ks
+++ b/autoinstall_templates/sample.ks
@@ -2,11 +2,14 @@
 
 #platform=x86, AMD64, or Intel EM64T
 # System authorization information
-auth  --useshadow  --enablemd5
+authselect --useshadow --passalgo=SHA512 --kickstart
+# Get install destination disk (default sda)
+#set $install_disk = $getVar('use_disk', 'sda')
 # System bootloader configuration
-bootloader --location=mbr
+# bootloader--location=mbr --boot-drive=$install_disk
 # Partition clearing information
 clearpart --all --initlabel
+ignoredisk --only-use=$install_disk
 # Use text mode install
 text
 # Firewall configuration
@@ -60,7 +63,7 @@ $SNIPPET('log_ks_post')
 $yum_config_stanza
 # End yum configuration
 $SNIPPET('post_install_kernel_options')
-$SNIPPET('post_install_network_config')
+$SNIPPET('network_disable_interfaces')
 $SNIPPET('download_config_files')
 $SNIPPET('koan_environment')
 $SNIPPET('redhat_register')


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

- network_disable_interfaces: Allows to leave enabled "onboot=yes" only desired interface
- partition_rhel: Allows to create partitions using metadata dynamically
- pre_install_network_config: Properly configure ipv6, even if ipv4 is not present (need to set ip_address to 127.0.0.1 since anaconda crashes otherwise)
- sample.ks: Use the new snippets. Change default outdated auth to authselect

## Behaviour changes


Old: <!-- This is the old way Cobbler behaved -->  
Cobbler redundantly configures network interfaces during the POST section of kickstart installations done with anaconda.

New: <!-- This is the new way Cobbler behaves -->
Removed `configure_network` snippet in "POST" since we actually don't need to do that, anaconda configures the interface by default. It can be incorrect for complicated setups (bonds etc etc)

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
