### PR TITLE
Make: Improve clean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ clean: ## Cleans Python bytecode, build artifacts and the temp files.
 	@rm -f cobbler/modules/*.pyc
 	@rm -f cobbler/web/*.pyc
 	@rm -f cobbler/web/templatetags/*.pyc
+	@rm -rf cobbler/__pycache__
+	@rm -rf cobbler/**/__pycache__
 	@echo "cleaning: build artifacts"
 	@rm -rf build release dist cobbler.egg-info
 	@rm -rf rpm-build/*
@@ -40,11 +42,14 @@ clean: ## Cleans Python bytecode, build artifacts and the temp files.
 	@rm -f MANIFEST AUTHORS
 	@rm -f config/version
 	@rm -f docs/*.1.gz
+	@rm -rf docs/_build
 	@echo "cleaning: temp files"
 	@rm -f *~
 	@rm -rf buildiso
 	@rm -f *.tmp
 	@rm -f *.log
+	@rm -f supervisord.pid
+	@rm -rf .pytest_cache
 
 cleandoc: ## Cleans the docs directory.
 	@echo "cleaning: documentation"


### PR DESCRIPTION
## Linked Items

Fixes #3441 

## Description

Add multiple temporary directories and files to the `clean` target of our `Makefile`.

## Behaviour changes

Old: Leftover directories after `make clean` execution.

New: Temporary files are fully removed.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
