### PR TITLE
fix the error report when starting service

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -284,6 +284,8 @@ class CobblerAPI:
             self.settings().tftpboot_location,
         ]
         for directory in required_directories:
+            if not pathlib.Path(directory).exists():
+                os.makedirs(directory)
             if not pathlib.Path(directory).is_dir():
                 raise FileNotFoundError(
                     f'Required directory "{directory}" for operation is missing! Aborting startup of Cobbler!'


### PR DESCRIPTION
## Linked Items

Fixes #3444 

## Description

Determine whether this directory exists before the daemon wants to process the current, and create it if it does not exist

## Behaviour changes

Old:service error

New: cobblerd service running

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
