### PR TITLE
Address issue #3450: Pass argument type parameter to optparse add_option() call

### DIFF
--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -696,6 +696,9 @@ def _add_parser_option_from_field(parser, field, settings):
         raise Exception("field %s default value (%s) is not listed in choices (%s)" % (name, default, str(choices)))
     if tooltip != "":
         description += " (%s)" % tooltip
+    field_type = field[7]
+    if field_type != "int" and field_type != 'float':
+        field_type = "string"
 
     # generate option string
     option_string = "--%s" % name.replace("_", "-")
@@ -705,7 +708,7 @@ def _add_parser_option_from_field(parser, field, settings):
         description += " (valid options: %s)" % ",".join(choices)
         parser.add_option(option_string, dest=name, help=description, choices=choices)
     else:
-        parser.add_option(option_string, dest=name, help=description)
+        parser.add_option(option_string, dest=name, help=description, type=field_type)
 
 
 def add_options_from_fields(object_type, parser, fields, network_interface_fields, settings, object_action):


### PR DESCRIPTION
- Pass through types derived from field lists to the call to optparse's add_option() call in _add_parser_option_from_field(). Specifically, this will result in the option argument from string to integer or float in those fields, allowing for later type assertion by setters or other code.

## Linked Items

Fixes #3450
<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Uses the type given in a field declaration to create a type for integer/float type options, resulting in the conversion to type during the option parsing so that type assertions in certain setters will not throw exception. These assertions were noted in the following fields
  - ctime
  - mtime
  - image:network_count
  - repo:priority
  
(More may exist without this change, but were not noted in clearing up issues with these fields)

## Behaviour changes

Old:  Validators would report errors on the field and the command would fail.

New: Validators succeed and command processing continues.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
I am currently working on getting a build environment working for cobbler under Rocky 9 Linux, and these were tested by running an extracted CLI script of my cobbler 2.8 objects.