### PR TITLE
Address issue #3445 - Fix issue with web.ss file ownership for restarts

### DIFF
--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -23,10 +23,9 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import binascii
 import logging.config
 import os
-import pwd
 import time
 
-from cobbler import remote, utils
+from cobbler import remote
 from cobbler.api import CobblerAPI
 
 if os.geteuid() == 0 and os.path.exists('/etc/cobbler/logging_config.conf'):
@@ -60,14 +59,6 @@ def regen_ss_file():
 
     with open(ssfile, 'wb', 0o660) as fd:
         fd.write(binascii.hexlify(data))
-
-    http_user = "apache"
-    family = utils.get_family()
-    if family == "debian":
-        http_user = "www-data"
-    elif family == "suse":
-        http_user = "wwwrun"
-    os.lchown("/var/lib/cobbler/web.ss", pwd.getpwnam(http_user)[2], -1)
 
 
 def do_xmlrpc_rw(cobbler_api: CobblerAPI, port):


### PR DESCRIPTION
- Address the fact that /var/lib/cobbler/web.ss is unwritable by root when the cobbler daemon restarts, due to it unnecessarily being chown()'ed to the apache user. This file is created by cobblerd and only read by the CLI and web interfaces for authentication purposes, lacking a robust XMLRPC authentication.

## Linked Items

Fixes #3445

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This fix removes the chown() call performed after cobblerd creates the /var/lib/cobbler/web.ss file. This is possible since outside of cobblerd, this file is only read to authenticate the XMLRPC connection.

## Behaviour changes

Old: Cobblerd fails to restart, giving an errno 13 trying to open the web.ss file for writing.
New: Cobblerd restarts correctly

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
