### PR TITLE
Buildiso: copy grub into ESP without mounting it for container case

### DIFF
--- a/changelog.d/3457.changed
+++ b/changelog.d/3457.changed
@@ -1,0 +1,1 @@
+Copy grub into ESP using mtools

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -7,7 +7,6 @@ memory.
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import contextlib
 import logging
 import os
 import pathlib
@@ -340,12 +339,13 @@ class BuildIso:
         """
         grub_name = self.calculate_grub_name(arch)
         efi_name = self.efi_fallback_renames.get(grub_name, grub_name)
-        with self._mount_esp(esp_image_location) as mountpoint:
-            esp_efi_boot = self._create_efi_boot_dir(mountpoint)
-            grub_binary = (
-                pathlib.Path(self.api.settings().bootloaders_dir) / "grub" / grub_name
-            )
-            filesystem_helpers.copyfile(str(grub_binary), f"{esp_efi_boot}/{efi_name}")
+        esp_efi_boot = self._create_efi_boot_dir(esp_image_location)
+        grub_binary = (
+            pathlib.Path(self.api.settings().bootloaders_dir) / "grub" / grub_name
+        )
+        filesystem_helpers.copyfileimage(
+            str(grub_binary), esp_image_location, f"{esp_efi_boot}/{efi_name}"
+        )
 
     def calculate_grub_name(self, desired_arch: Archs) -> str:
         """
@@ -356,7 +356,7 @@ class BuildIso:
         loader_formats = self.api.settings().bootloaders_formats
         grub_binary_names: Dict[str, str] = {}
 
-        for (loader_format, values) in loader_formats.items():
+        for loader_format, values in loader_formats.items():
             name = values.get("binary_name", None)
             if name is not None and isinstance(name, str):
                 grub_binary_names[loader_format.lower()] = name
@@ -423,38 +423,10 @@ class BuildIso:
             raise Exception  # TODO: use proper exception
         return str(esp)
 
-    @contextlib.contextmanager
-    def _mount_esp(self, esp_path: str):
-        def mount(esp_path: str, mountpoint: pathlib.Path) -> None:
-            mp.mkdir()
-
-            mount_cmd: List[str] = ["mount", "-o", "loop", esp_path, str(mountpoint)]
-            rc = utils.subprocess_call(mount_cmd, shell=False)
-            if rc != 0:
-                self.logger.error(
-                    "Could not mount ESP image file %s at %s", esp_path, mountpoint
-                )
-                raise Exception  # TODO: use concrete exception
-
-        def umount(mountpoint: pathlib.Path) -> None:
-            unmount_cmd: List[str] = ["umount", str(mountpoint)]
-            rc = utils.subprocess_call(unmount_cmd, shell=False)
-            if rc != 0:
-                self.logger.error("Could not unmount ESP image file at %s", mountpoint)
-                raise Exception  # TODO: use concrete exception
-            mountpoint.rmdir()
-
-        mp = pathlib.Path(esp_path + "_mounted")
-        try:
-            mount(esp_path, mp)
-            yield str(mp)
-        finally:
-            umount(mp)
-
     def _create_efi_boot_dir(self, esp_mountpoint: str) -> str:
-        efi_boot = pathlib.Path(esp_mountpoint) / "EFI" / "BOOT"
+        efi_boot = pathlib.Path("EFI") / "BOOT"
         self.logger.info("Creating %s", efi_boot)
-        efi_boot.mkdir(parents=True)
+        filesystem_helpers.mkdirimage(efi_boot, esp_mountpoint)
         return str(efi_boot)
 
     def _find_esp(self, root_dir: pathlib.Path) -> Optional[str]:

--- a/cobbler/utils/filesystem_helpers.py
+++ b/cobbler/utils/filesystem_helpers.py
@@ -10,6 +10,7 @@ import logging
 import os
 import pathlib
 import shutil
+import subprocess
 import urllib.request
 from typing import TYPE_CHECKING, Dict, Optional, Tuple, Union
 
@@ -244,6 +245,24 @@ def copyremotefile(src: str, dst1: str, api: Optional["CobblerAPI"] = None) -> N
         ) from error
 
 
+def copyfileimage(src: str, image_location: str, dst: str) -> None:
+    """
+    Copy a file from source to the destination in the image.
+
+    :param src: The source file.
+    :param image_location: The location of the image.
+    :param dst: The destination for the file.
+    """
+    cmd = ["mcopy", "-n", "-i", image_location, src, "::/" + dst]
+    try:
+        logger.info('running: "%s"', cmd)
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as error:
+        raise OSError(
+            f"Error while copying file to image ({src} -> {dst}):\n{error.output}"
+        ) from error
+
+
 def rmfile(path: str) -> None:
     """
     Delete a single file.
@@ -315,6 +334,28 @@ def mkdir(path: str, mode: int = 0o755) -> None:
         if os_error.errno != 17:
             log_exc()
             raise CX(f"Error creating {path}") from os_error
+
+
+def mkdirimage(path: pathlib.Path, image_location: str) -> None:
+    """
+    Create a directory in an image.
+
+    :param path: The path to create the directory at.
+    :param image_location: The location of the image.
+    """
+
+    path_parts = path.parts
+    cmd = ["mmd", "-i", image_location, path]
+    try:
+        # Create all parent directories one by one inside the image
+        for parent_directory in range(1, len(path_parts) + 1):
+            cmd[-1] = "/".join(path_parts[:parent_directory])
+            logger.info('running: "%s"', cmd)
+            subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as error:
+        raise OSError(
+            f"Error while creating directory ({cmd[-1]}) in image {image_location}.\n{error.output}"
+        ) from error
 
 
 def path_tail(apath: str, bpath: str) -> str:

--- a/cobbler/utils/filesystem_helpers.py
+++ b/cobbler/utils/filesystem_helpers.py
@@ -256,7 +256,7 @@ def copyfileimage(src: str, image_location: str, dst: str) -> None:
     cmd = ["mcopy", "-n", "-i", image_location, src, "::/" + dst]
     try:
         logger.info('running: "%s"', cmd)
-        subprocess.run(cmd, check=True)
+        utils.subprocess_call(cmd, shell=False)
     except subprocess.CalledProcessError as error:
         raise OSError(
             f"Error while copying file to image ({src} -> {dst}):\n{error.output}"
@@ -345,13 +345,13 @@ def mkdirimage(path: pathlib.Path, image_location: str) -> None:
     """
 
     path_parts = path.parts
-    cmd = ["mmd", "-i", image_location, path]
+    cmd = ["mmd", "-i", image_location, str(path)]
     try:
         # Create all parent directories one by one inside the image
         for parent_directory in range(1, len(path_parts) + 1):
             cmd[-1] = "/".join(path_parts[:parent_directory])
             logger.info('running: "%s"', cmd)
-            subprocess.run(cmd, check=True)
+            utils.subprocess_call(cmd, shell=False)
     except subprocess.CalledProcessError as error:
         raise OSError(
             f"Error while creating directory ({cmd[-1]}) in image {image_location}.\n{error.output}"

--- a/tests/utils/filesystem_helpers_test.py
+++ b/tests/utils/filesystem_helpers_test.py
@@ -1,9 +1,13 @@
 import os
+import pathlib
 import shutil
 from pathlib import Path
+from typing import Any
 
 import pytest
+from pytest_mock import MockerFixture
 
+from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.utils import filesystem_helpers
 
@@ -19,7 +23,11 @@ from tests.conftest import does_not_raise
     ],
 )
 def test_is_safe_to_hardlink(
-    cobbler_api, test_src, is_symlink, test_dst, expected_result
+    cobbler_api: CobblerAPI,
+    test_src: str,
+    is_symlink: bool,
+    test_dst: str,
+    expected_result: bool,
 ):
     # Arrange
     if is_symlink and test_src:
@@ -56,7 +64,6 @@ def test_cachefile():
     # Arrange
     cache_src = ""
     cache_dst = ""
-    api = None
 
     # Act
     filesystem_helpers.cachefile(cache_src, cache_dst)
@@ -68,7 +75,7 @@ def test_cachefile():
 
 
 @pytest.mark.skip("This calls a lot of os-specific stuff. Let's fix this test later.")
-def test_linkfile(cobbler_api):
+def test_linkfile(cobbler_api: CobblerAPI):
     # Arrange
     test_source = ""
     test_destination = ""
@@ -107,23 +114,10 @@ def test_copyremotefile():
 
 
 @pytest.mark.skip("This calls a lot of os-specific stuff. Let's fix this test later.")
-def test_copyfile_pattern():
-    # Arrange
-    test_pattern = ""
-    test_destination = ""
-
-    # Act
-    filesystem_helpers.copyfile_pattern(test_pattern, test_destination)
-
-    # Assert
-    assert False
-
-
-@pytest.mark.skip("This calls a lot of os-specific stuff. Let's fix this test later.")
 def test_mkdirimage():
     # Arrange
-    test_path = ""
-    test_imagelocation = ""
+    test_path = pathlib.Path("/tmp")
+    test_image_location = ""
 
     # Act
     filesystem_helpers.mkdirimage(test_path, test_image_location)
@@ -136,7 +130,7 @@ def test_mkdirimage():
 def test_copyfileimage():
     # Arrange
     test_src = ""
-    test_imagelocation = ""
+    test_image_location = ""
     test_dst = ""
 
     # Act
@@ -146,24 +140,24 @@ def test_copyfileimage():
     assert False
 
 
-def test_rmfile(tmpdir: Path):
+def test_rmfile(tmp_path: Path):
     # Arrange
-    tfile = tmpdir.join("testfile")
+    tfile = tmp_path / "testfile"
 
     # Act
-    filesystem_helpers.rmfile(tfile)
+    filesystem_helpers.rmfile(str(tfile))
 
     # Assert
     assert not os.path.exists(tfile)
 
 
-def test_rmglob_files(tmpdir: Path):
+def test_rmglob_files(tmp_path: Path):
     # Arrange
-    tfile1 = tmpdir.join("file1.tfile")
-    tfile2 = tmpdir.join("file2.tfile")
+    tfile1 = tmp_path / "file1.tfile"
+    tfile2 = tmp_path / "file2.tfile"
 
     # Act
-    filesystem_helpers.rmglob_files(tmpdir, "*.tfile")
+    filesystem_helpers.rmglob_files(str(tmp_path), "*.tfile")
 
     # Assert
     assert not os.path.exists(tfile1)
@@ -224,7 +218,7 @@ def test_mkdir():
     "test_first_path,test_second_path,expected_result",
     [("/tmp/test/a", "/tmp/test/a/b/c", "/b/c"), ("/tmp/test/a", "/opt/test/a", "")],
 )
-def test_path_tail(test_first_path, test_second_path, expected_result):
+def test_path_tail(test_first_path: str, test_second_path: str, expected_result: str):
     # Arrange
     # TODO: Check if this actually makes sense...
 
@@ -243,13 +237,13 @@ def test_path_tail(test_first_path, test_second_path, expected_result):
         ("Test..Test", pytest.raises(CX)),
     ],
 )
-def test_safe_filter(test_input, expected_exception):
+def test_safe_filter(test_input: str, expected_exception: Any):
     # Arrange, Act & Assert
     with expected_exception:
         assert filesystem_helpers.safe_filter(test_input) is None
 
 
-def test_create_web_dirs(mocker, cobbler_api):
+def test_create_web_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     # Arrange
     settings_mock = mocker.MagicMock()
     settings_mock.webdir = "/my/custom/webdir"
@@ -266,7 +260,7 @@ def test_create_web_dirs(mocker, cobbler_api):
     assert mock_copyfile.call_count == 2
 
 
-def test_create_tftpboot_dirs(mocker, cobbler_api):
+def test_create_tftpboot_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     # Arrange
     settings_mock = mocker.MagicMock()
     settings_mock.tftpboot_location = "/srv/tftpboot"
@@ -284,25 +278,25 @@ def test_create_tftpboot_dirs(mocker, cobbler_api):
     assert mock_path_symlink_to.call_count == 3
 
 
-def test_create_trigger_dirs(mocker):
+def test_create_trigger_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     # Arrange
     mock_mkdir = mocker.patch("cobbler.utils.filesystem_helpers.mkdir")
     mocker.patch("pathlib.Path.exists", return_value=False)
 
     # Act
-    filesystem_helpers.create_trigger_dirs(None)
+    filesystem_helpers.create_trigger_dirs(cobbler_api)
 
     # Assert
     assert mock_mkdir.call_count == 84
 
 
-def test_create_json_database_dirs(mocker):
+def test_create_json_database_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     # Arrange
     mock_mkdir = mocker.patch("cobbler.utils.filesystem_helpers.mkdir")
     mocker.patch("pathlib.Path.exists", return_value=False)
 
     # Act
-    filesystem_helpers.create_json_database_dirs(None)
+    filesystem_helpers.create_json_database_dirs(cobbler_api)
 
     # Assert
     mock_mkdir.assert_any_call("/var/lib/cobbler/collections")

--- a/tests/utils/filesystem_helpers_test.py
+++ b/tests/utils/filesystem_helpers_test.py
@@ -119,6 +119,33 @@ def test_copyfile_pattern():
     assert False
 
 
+@pytest.mark.skip("This calls a lot of os-specific stuff. Let's fix this test later.")
+def test_mkdirimage():
+    # Arrange
+    test_path = ""
+    test_imagelocation = ""
+
+    # Act
+    filesystem_helpers.mkdirimage(test_path, test_image_location)
+
+    # Assert
+    assert False
+
+
+@pytest.mark.skip("This calls a lot of os-specific stuff. Let's fix this test later.")
+def test_copyfileimage():
+    # Arrange
+    test_src = ""
+    test_imagelocation = ""
+    test_dst = ""
+
+    # Act
+    filesystem_helpers.copyfileimage(test_src, test_image_location, test_dst)
+
+    # Assert
+    assert False
+
+
 def test_rmfile(tmpdir: Path):
     # Arrange
     tfile = tmpdir.join("testfile")


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/cobbler/cobbler/issues/3457

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->

Allows to call `cobbler buildiso` inside an unprivileged container by eliminating the need to mount an ESP under the hood. 

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->
During the execution of the cobbler buildiso another call to `mount -o loop <efi>` was executed to copy a grub into an ESP.

New: <!-- This is the new way Cobbler behaves -->
Now we use mtools utility to copy the grub into the ESP without mounting it. The utility allows to interact with FAT32 partitions directly. 

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [X] Code is already covered by Unit-Tests
- [X] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
