### PR TITLE
API: Auto-create directories during startup

### DIFF
--- a/changelog.d/3444.fixed
+++ b/changelog.d/3444.fixed
@@ -1,0 +1,1 @@
+Auto-create required directories during daemon startup.

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -278,16 +278,15 @@ class CobblerAPI:
         """
         self.logger.debug("Creating necessary directories")
         required_directories = [
-            "/var/lib/cobbler",
-            "/etc/cobbler",
-            self.settings().webdir,
-            self.settings().tftpboot_location,
+            pathlib.Path("/var/lib/cobbler"),
+            pathlib.Path("/etc/cobbler"),
+            pathlib.Path(self.settings().webdir),
+            pathlib.Path(self.settings().tftpboot_location),
         ]
         for directory in required_directories:
-            if not pathlib.Path(directory).is_dir():
-                raise FileNotFoundError(
-                    f'Required directory "{directory}" for operation is missing! Aborting startup of Cobbler!'
-                )
+            if not directory.is_dir():
+                directory.mkdir()
+                self.logger.info('Created required directory: "%s"', str(directory))
         filesystem_helpers.create_tftpboot_dirs(self)
         filesystem_helpers.create_web_dirs(self)
         filesystem_helpers.create_trigger_dirs(self)


### PR DESCRIPTION
## Linked Items

Fixes #3444 

## Description

Automatically create directories during daemon startup instead of crashing it.

## Behaviour changes

Old: The daemon crashed when the required directories were not present.

New: Cobbler emits an informational message into the log about the automatically created directory.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
