### PR TITLE
Use Fedora Rawhide for tests

### DIFF
--- a/tests/actions/reposync_test.py
+++ b/tests/actions/reposync_test.py
@@ -53,17 +53,17 @@ class TestRepoSync:
         [
             (
                 enums.MirrorType.BASEURL,
-                "http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os",
+                "http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os",
                 does_not_raise()
             ),
             (
                 enums.MirrorType.MIRRORLIST,
-                "https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-35&arch=x86_64",
+                "https://mirrors.fedoraproject.org/mirrorlist?repo=rawhide&arch=x86_64",
                 does_not_raise()
             ),
             (
                 enums.MirrorType.METALINK,
-                "https://mirrors.fedoraproject.org/metalink?repo=fedora-35&arch=x86_64",
+                "https://mirrors.fedoraproject.org/metalink?repo=rawhide&arch=x86_64",
                 does_not_raise()
             ),
             (
@@ -189,17 +189,17 @@ class TestRepoSync:
         [
             (
                 enums.MirrorType.BASEURL,
-                "http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/2",
+                "http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/2",
                 does_not_raise()
             ),
             (
                 enums.MirrorType.MIRRORLIST,
-                "http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/2",
+                "http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/2",
                 pytest.raises(cexceptions.CX)
             ),
             (
                 enums.MirrorType.METALINK,
-                "http://download.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/Packages/2",
+                "http://download.fedoraproject.org/pub/fedora/linux/development/rawhide/Everything/x86_64/os/Packages/2",
                 pytest.raises(cexceptions.CX)
             ),
             (


### PR DESCRIPTION
## Linked Items

Fixes tests that use Fedora 35 that is now EOL/archived.

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Avoid using specific Fedora versions for tests that continually need to be updated.  This is a backport of #3467 

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [x] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
