### PR TITLE
Use Python 3.11 instead of Python 3.10 in develop container (openSUSE Tumbleweed)

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -28,7 +28,7 @@ RUN zypper install --no-recommends -y \
     apache2                    \
     apache2-devel              \
     apache2-mod_wsgi           \
-    python310-gunicorn         \
+    python311-gunicorn         \
     bash-completion            \
     createrepo_c               \
     fence-agents               \
@@ -40,25 +40,25 @@ RUN zypper install --no-recommends -y \
     curl                       \
     wget2                      \
     openssl                    \
-    python310                  \
-    python310-Sphinx           \
-    python310-coverage         \
-    python310-devel            \
-    python310-distro           \
-    python310-schema           \
-    python310-setuptools       \
-    python310-pip              \
-    python310-wheel            \
-    python310-Cheetah3         \
-    python310-distro           \
-    python310-dnspython        \
-    python310-Jinja2           \
-    python310-requests         \
-    python310-PyYAML           \
-    python310-pykickstart      \
-    python310-netaddr          \
-    python310-pymongo          \
-    python310-pytest-benchmark \
+    python311                  \
+    python311-Sphinx           \
+    python311-coverage         \
+    python311-devel            \
+    python311-distro           \
+    python311-schema           \
+    python311-setuptools       \
+    python311-pip              \
+    python311-wheel            \
+    python311-Cheetah3         \
+    python311-distro           \
+    python311-dnspython        \
+    python311-Jinja2           \
+    python311-requests         \
+    python311-PyYAML           \
+    python311-pykickstart      \
+    python311-netaddr          \
+    python311-pymongo          \
+    python311-pytest-benchmark \
     python3-librepo            \
     rpm-build                  \
     rsync                      \
@@ -98,7 +98,7 @@ RUN zypper install --no-recommends -y \
     openldap2                         \
     openldap2-client                  \
     hostname                          \
-    python310-ldap
+    python311-ldap
 
 # Dependencies for system-tests
 RUN zypper install --no-recommends -y \
@@ -109,13 +109,13 @@ RUN zypper install --no-recommends -y \
 
 # Install packages and dependencies via pip
 RUN zypper install --no-recommends -y \
-    python310-codecov            \
-    python310-magic              \
-    python310-pycodestyle        \
-    python310-pyflakes           \
-    python310-pytest             \
-    python310-pytest-cov         \
-    python310-pytest-mock
+    python311-codecov            \
+    python311-magic              \
+    python311-pycodestyle        \
+    python311-pyflakes           \
+    python311-pytest             \
+    python311-pytest-cov         \
+    python311-pytest-mock
 
 # Required for reposync tests
 RUN zypper install --no-recommends -y \


### PR DESCRIPTION
## Description

This PR makes `develop` container to use Python 3.11 instead of Python 3.10, which is now latest version in Tumbleweed.

This way we fix the current issue we see in develop container (and current CI tests), as tests run with Python 3.11 but dependencies were installed for Python 3.10:

```console
Show Cobbler version
Traceback (most recent call last):
  File "/usr/bin/cobbler", line 12, in <module>
    import cobbler.cli as app
  File "/usr/lib/python3.11/site-packages/cobbler/cli.py", line 17, in <module>
    from cobbler import enums, power_manager, utils
  File "/usr/lib/python3.11/site-packages/cobbler/power_manager.py", line 20, in <module>
    from cobbler import utils
  File "/usr/lib/python3.11/site-packages/cobbler/utils/__init__.py", line 36, in <module>
    from netaddr.ip import IPAddress, IPNetwork
ModuleNotFoundError: No module named 'netaddr'
```

After rebuilding "develop" container with this changes, the tests are able to run.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
