### PR TITLE
Use dhcp manager's restart_service method in sync

### DIFF
--- a/changelog.d/3463.fixed
+++ b/changelog.d/3463.fixed
@@ -1,0 +1,1 @@
+Restart dhcpd6 service in `cobbler sync`

--- a/setup.py
+++ b/setup.py
@@ -501,7 +501,6 @@ class Restorestate(Statebase):
 
 
 class Savestate(Statebase):
-
     description = "Backup the current configuration to /tmp/cobbler_settings."
 
     def _copy(self, frm: str, to: str) -> None:
@@ -602,6 +601,7 @@ if __name__ == "__main__":
                 "types-PyYAML",
                 "types-psutil",
                 "types-netaddr",
+                "types-mock",
                 "isort",
             ],
             "test": [

--- a/tests/modules/sync_post_restart_services_test.py
+++ b/tests/modules/sync_post_restart_services_test.py
@@ -1,7 +1,10 @@
-from unittest.mock import MagicMock
+from typing import TYPE_CHECKING
 
 from cobbler.api import CobblerAPI
 from cobbler.modules import sync_post_restart_services
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_register():
@@ -12,19 +15,19 @@ def test_register():
     assert result == "/var/lib/cobbler/triggers/sync/post/*"
 
 
-def test_run(mocker):
+def test_run(mocker: "MockerFixture"):
     # Arrange
     restart_mock = mocker.patch(
         "cobbler.utils.process_management.service_restart", return_value=0
     )
-    api = MagicMock(spec=CobblerAPI)
-    api.get_module_name_from_file.side_effect = ["managers.isc", "managers.bind"]
-    args = None
+    api = mocker.MagicMock(spec=CobblerAPI)
+    api.get_module_name_from_file.side_effect = ["managers.isc", "managers.bind"]  # type: ignore
+    args = []
 
     # Act
     result = sync_post_restart_services.run(api, args)
 
     # Assert
     # FIXME improve assert
-    assert restart_mock.call_count == 2
+    assert restart_mock.call_count == 1
     assert result == 0


### PR DESCRIPTION
## Description

Currently when executing `cobber sync` it doesn't invoke the manager's restart_service method and instead does some custom stuff. This is unnecessary code duplication and also e.g. currently `cobbler sync` doesn't restart the dhcpd6 service even if `manage_dhcp6` is set to `true`

Fixes #3463

## Behaviour changes

Old: dhcpd6 service didn't restart with `cobbler sync`

New: dhcpd6 service restarts with `cobbler sync`

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

I don't really know pytest and I haven't found an easy way to integrate this into the existing test. The existing mocking method doesn't seem to work with this change, so I just made a minimal change that made the test pass. Let me know if that isn't acceptable.