### PR TITLE
Fix generating kernel command line for buildiso netiso

### DIFF
--- a/changelog.d/3472.fixed
+++ b/changelog.d/3472.fixed
@@ -1,0 +1,1 @@
+Fix buildiso netiso to construct blended data from profile

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -546,11 +546,11 @@ class NetbootBuildiso(buildiso.BuildIso):
         if distro is None:
             raise ValueError("Distro of a Profile must not be None!")
         distroname = self.make_shorter(distro.name)
-        data = utils.blender(self.api, False, distro)
-        # SUSE uses 'textmode' instead of 'text'
-        utils.kopts_overwrite(
-            data["kernel_options"], self.api.settings().server, distro.breed
-        )
+        data = utils.blender(self.api, False, profile)
+        if distro is not None:  # SUSE uses 'textmode' instead of 'text'
+            utils.kopts_overwrite(
+                data["kernel_options"], self.api.settings().server, distro.breed
+            )
 
         if not re.match(r"[a-z]+://.*", data["autoinstall"]):
             autoinstall_scheme = self.api.settings().autoinstall_scheme

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -547,10 +547,10 @@ class NetbootBuildiso(buildiso.BuildIso):
             raise ValueError("Distro of a Profile must not be None!")
         distroname = self.make_shorter(distro.name)
         data = utils.blender(self.api, False, profile)
-        if distro is not None:  # SUSE uses 'textmode' instead of 'text'
-            utils.kopts_overwrite(
-                data["kernel_options"], self.api.settings().server, distro.breed
-            )
+        # SUSE uses 'textmode' instead of 'text'
+        utils.kopts_overwrite(
+            data["kernel_options"], self.api.settings().server, distro.breed
+        )
 
         if not re.match(r"[a-z]+://.*", data["autoinstall"]):
             autoinstall_scheme = self.api.settings().autoinstall_scheme

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -95,9 +95,11 @@ def test_netboot_generate_boot_loader_configs(
     cobbler_api, create_distro, create_profile, create_system
 ):
     test_distro = create_distro()
+    test_distro.kernel_options = 'test_distro_option=distro'
     test_profile = create_profile(test_distro.name)
-    test_profile.kernel_options = 'test_option=present'
+    test_profile.kernel_options = 'test_profile_option=profile'
     test_system = create_system(test_profile.name)
+    test_system.kernel_options = 'test_system_option=system'
     build_iso = NetbootBuildiso(cobbler_api)
 
     # Act
@@ -112,11 +114,23 @@ def test_netboot_generate_boot_loader_configs(
     ]
     matching_grub_kernel = [part for part in result.grub if "linux /1.krn" in part]
     matching_grub_initrd = [part for part in result.grub if "initrd /1.img" in part]
-    matching_grub_kerneloption = [
-        part for part in result.grub if "test_option=present" in part
+    matching_grub_distro_kopts = [
+        part for part in result.grub if "test_distro_option=distro" in part
     ]
-    matching_isolinux_kerneloption = [
-        part for part in result.isolinux if "test_option=present" in part
+    matching_grub_profile_kopts = [
+        part for part in result.grub if "test_profile_option=profile" in part
+    ]
+    matching_grub_system_kopts = [
+        part for part in result.grub if "test_system_option=system" in part
+    ]
+    matching_isolinux_distro_kopts = [
+        part for part in result.isolinux if "test_distro_option=distro" in part
+    ]
+    matching_isolinux_profile_kopts = [
+        part for part in result.isolinux if "test_profile_option=profile" in part
+    ]
+    matching_isolinux_system_kopts = [
+        part for part in result.isolinux if "test_system_option=system" in part
     ]
 
     # Assert
@@ -126,14 +140,19 @@ def test_netboot_generate_boot_loader_configs(
         matching_isolinux_initrd,
         matching_grub_kernel,
         matching_grub_initrd,
-        matching_grub_kerneloption,
-        matching_isolinux_kerneloption,
         result.bootfiles_copysets,
+        matching_grub_distro_kopts,
+        matching_grub_profile_kopts,
+        matching_isolinux_distro_kopts,
+        matching_isolinux_profile_kopts
     ]:
         print(iterable_to_check)
         # one entry for the profile, one for the system
         assert len(iterable_to_check) == 2
 
+    # only system entries have system kernel opts
+    assert len(matching_grub_system_kopts) == 1
+    assert len(matching_isolinux_system_kopts) == 1
 
 def test_filter_system(
     cobbler_api, create_distro, create_profile, create_system, create_image

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -95,11 +95,11 @@ def test_netboot_generate_boot_loader_configs(
     cobbler_api, create_distro, create_profile, create_system
 ):
     test_distro = create_distro()
-    test_distro.kernel_options = 'test_distro_option=distro'
+    test_distro.kernel_options = "test_distro_option=distro"
     test_profile = create_profile(test_distro.name)
-    test_profile.kernel_options = 'test_profile_option=profile'
+    test_profile.kernel_options = "test_profile_option=profile"
     test_system = create_system(test_profile.name)
-    test_system.kernel_options = 'test_system_option=system'
+    test_system.kernel_options = "test_system_option=system"
     build_iso = NetbootBuildiso(cobbler_api)
 
     # Act
@@ -144,7 +144,7 @@ def test_netboot_generate_boot_loader_configs(
         matching_grub_distro_kopts,
         matching_grub_profile_kopts,
         matching_isolinux_distro_kopts,
-        matching_isolinux_profile_kopts
+        matching_isolinux_profile_kopts,
     ]:
         print(iterable_to_check)
         # one entry for the profile, one for the system
@@ -153,6 +153,7 @@ def test_netboot_generate_boot_loader_configs(
     # only system entries have system kernel opts
     assert len(matching_grub_system_kopts) == 1
     assert len(matching_isolinux_system_kopts) == 1
+
 
 def test_filter_system(
     cobbler_api, create_distro, create_profile, create_system, create_image

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -96,6 +96,7 @@ def test_netboot_generate_boot_loader_configs(
 ):
     test_distro = create_distro()
     test_profile = create_profile(test_distro.name)
+    test_profile.kernel_options = 'test_option=present'
     test_system = create_system(test_profile.name)
     build_iso = NetbootBuildiso(cobbler_api)
 
@@ -111,6 +112,12 @@ def test_netboot_generate_boot_loader_configs(
     ]
     matching_grub_kernel = [part for part in result.grub if "linux /1.krn" in part]
     matching_grub_initrd = [part for part in result.grub if "initrd /1.img" in part]
+    matching_grub_kerneloption = [
+        part for part in result.grub if "test_option=present" in part
+    ]
+    matching_isolinux_kerneloption = [
+        part for part in result.isolinux if "test_option=present" in part
+    ]
 
     # Assert
     assert isinstance(result, LoaderCfgsParts)
@@ -119,6 +126,8 @@ def test_netboot_generate_boot_loader_configs(
         matching_isolinux_initrd,
         matching_grub_kernel,
         matching_grub_initrd,
+        matching_grub_kerneloption,
+        matching_isolinux_kerneloption,
         result.bootfiles_copysets,
     ]:
         print(iterable_to_check)


### PR DESCRIPTION
## Linked Items

Port of https://github.com/openSUSE/cobbler/pull/54
Fixes https://github.com/SUSE/spacewalk/issues/20331

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

buildiso action for netiso was constructing blended data from distro instead of profile which resulted in profile kernel options to be lost. This PR fixes it.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
