### PR TITLE
Backport windows BCD fix from PR #2575 for 3.2

### DIFF
--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -92,32 +92,21 @@ def bcdedit(orig_bcd, new_bcd, wim, sdi, startoptions=None):
     h.node_set_value(e1, {"key": "Element", "t": REG_BINARY, "value": b"\x01"})
     e1 = h.node_add_child(e, "11000001")
     guid = guid2binary("{ae5534e0-a924-466c-b836-758539a3ee3a}")
-    h.node_set_value(e1, {"key": "Element",
-                          "t": REG_BINARY,
-                          "value": guid + b"\x00\x00\x00\x00\x01\x00\x00\x00"
-                                        + winpath_length(wim, 126)
-                                        + b"\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00 "
-                                        + winpath_length(wim, 86)
-                                        + b"\x00\x00\x00\x05\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x48\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00" + wim.encode(encoding="utf_16_le")
-                                        + b"\x00\x00"})
+    wimval = {"key": "Element",
+              "t": REG_BINARY,
+              "value": guid + b"\x00\x00\x00\x00\x01\x00\x00\x00" + winpath_length(wim, 126)
+                            + b"\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00"
+                            + winpath_length(wim, 86)
+                            + b"\x00\x00\x00\x05\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x48\x00\x00"
+                              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                              b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
+                              b"\x00\x00\x00\x00\x00\x00\x00" + wim.encode(encoding="utf_16_le")
+                            + b"\x00\x00"}
+    h.node_set_value(e1, wimval)
     e1 = h.node_add_child(e, "21000001")
-    h.node_set_value(e1, {"key": "Element",
-                          "t": REG_BINARY,
-                          "value": guid + b"\x00\x00\x00\x00\x01\x00\x00\x00" + winpath_length(wim, 126)
-                                        + b"\x00\x00\x00\x00\x00\x00\x00\x03\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00 "
-                                        + winpath_length(wim, 86)
-                                        + b"\x00\x00\x00\x05\x00\x00\x00\x05\x00\x00\x00\x00\x00\x00\x00\x48\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"
-                                          b"\x00\x00\x00\x00\x00\x00\x00" + wim.encode(encoding="utf_16_le")
-                                        + b"\x00\x00"})
+    h.node_set_value(e1, wimval)
 
     if startoptions:
         e1 = h.node_add_child(e, "12000030")


### PR DESCRIPTION
## Linked Items

Fixes #3473

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->

## Behaviour changes

Old: Because of the extra space in the line, sync_post_wingen.py puts the wrong path to the WIM image in the BCD file. Therefore, the Windows installation ends with an error.

New: Windows installation completes successfully.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
