### PR TITLE
Fix Windows UEFI

### DIFF
--- a/autoinstall_snippets/Windows/wait_network_online
+++ b/autoinstall_snippets/Windows/wait_network_online
@@ -1,0 +1,15 @@
+:wno10
+set n=0
+
+:wno20
+ping @@http_server@@ -n 3
+set exit_code=%ERRORLEVEL%
+
+IF %exit_code% EQU 0 GOTO wno_exit
+set /a n=n+1
+IF %n% lss 30 goto wno20
+pause
+goto wno10
+
+:wno_exit
+

--- a/autoinstall_templates/win.ks
+++ b/autoinstall_templates/win.ks
@@ -1,1 +1,4 @@
 REM Sample kickstart file for Windows distributions.
+Echo on
+$SNIPPET('wait_network_online')
+exit

--- a/changelog.d/3473.fixed
+++ b/changelog.d/3473.fixed
@@ -1,1 +1,1 @@
-Windows UEFI
+(Windows BCD: fix for UEFI installation, Windows WinPE: fix for "could not apply unattended settings during [offlineServicing]")

--- a/changelog.d/3473.fixed
+++ b/changelog.d/3473.fixed
@@ -1,0 +1,1 @@
+Windows UEFI

--- a/changelog.d/3476.added
+++ b/changelog.d/3476.added
@@ -1,0 +1,2 @@
+Windows BIOS PXE install (via syslinux pxelinux.0, linux.c32 and wimboot tftp/http)
+Windows BIOS PXE install (via grub2 grub.0 and wimboot tftp/http)

--- a/changelog.d/3476.added
+++ b/changelog.d/3476.added
@@ -1,2 +1,1 @@
-Windows BIOS PXE install (via syslinux pxelinux.0, linux.c32 and wimboot tftp/http)
-Windows BIOS PXE install (via grub2 grub.0 and wimboot tftp/http)
+(Windows BIOS PXE install (via syslinux pxelinux.0, linux.c32 and wimboot tftp/http), Windows BIOS PXE install (via grub2 grub.0 and wimboot tftp/http))

--- a/changelog.d/3476.changed
+++ b/changelog.d/3476.changed
@@ -1,5 +1,1 @@
-os_version must be in lowercase
-path for winpe.wim in case of using wimboot
-BCD: Windows Boot Application (13200003) -> Windows Boot Loader \windows\system32\winload.exe
-BCD: Timeout: 30 -> 0
-Windows templates
+(Windows templates have been redesigned for a quick start, Windows installation documentation has been updated)

--- a/changelog.d/3476.changed
+++ b/changelog.d/3476.changed
@@ -1,0 +1,5 @@
+os_version must be in lowercase
+path for winpe.wim in case of using wimboot
+BCD: Windows Boot Application (13200003) -> Windows Boot Loader \windows\system32\winload.exe
+BCD: Timeout: 30 -> 0
+Windows templates

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -167,6 +167,21 @@ class MkLoaders:
             self.bootloaders_dir.joinpath("pxelinux.0"),
             skip_existing=True,
         )
+        # Make linux.c32 for syslinux + wimboot
+        libcom32_c32_path = self.syslinux_folder.joinpath("libcom32.c32")
+        if syslinux_version > 4 and libcom32_c32_path.exists():
+            symlink(
+                self.syslinux_pxelinux_folder.joinpath("linux.c32"),
+                self.bootloaders_dir.joinpath("linux.c32"),
+                skip_existing=True,
+            )
+            # Make libcom32.c32
+            # 'linux.c32' depends on 'libcom32.c32'
+            symlink(
+                self.syslinux_pxelinux_folder.joinpath("libcom32.c32"),
+                self.bootloaders_dir.joinpath("libcom32.c32"),
+                skip_existing=True,
+            )
 
     def make_grub(self) -> None:
         """

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -929,19 +929,53 @@ class _ImportSignatureManager(ManagerModule):
 
     def import_winpe(self) -> None:
         """
-        Extracting winpe.wim and windows bootloaders.
+        Preparing a Windows distro for network boot.
         """
-        if not HAS_HIVEX:
-            error_msg = (
-                "python3-hivex not found. If you need Automatic Windows "
-                "Installation support, please install."
-            )
-            self.logger.error(error_msg)
-            raise CX(error_msg)
+        winpe_path = self.extract_winpe(self.path)
 
-        cmd_path = "/usr/bin/wimexport"
-        bootwim_path = os.path.join(self.path, "sources", "boot.wim")
-        dest_path = os.path.join(self.path, "boot")
+        # For Windows, file paths are case-insensitive within a WinPE image, but for wimlib-utils
+        # they are not. And wimlib-utils does not provide options for case-insensitive search
+        # and extraction of files from this image other than setting the WIMLIB_IMAGEX_IGNORE_CASE
+        # environment variable.
+        wimdir_result = utils.subprocess_get(
+            ["/usr/bin/wimdir", winpe_path, "1"], shell=False
+        )
+        wim_file_list = wimdir_result.split("\n")
+        file_dict = {
+            "/windows/boot/pxe/pxeboot.n12": "",
+            "/windows/boot/pxe/bootmgr.exe": "",
+            "/windows/boot/efi/bootmgr.efi": "",
+            "/windows/system32/config/software": "",
+        }
+        for wim_file in wim_file_list:
+            if wim_file.lower() in file_dict:
+                file_dict[wim_file.lower()] = wim_file
+
+        file_list = [
+            file_dict["/windows/boot/efi/bootmgr.efi"],
+            file_dict["/windows/system32/config/software"],
+        ]
+        if "wimboot" not in self.signature["kernel_file"]:
+            file_list.extend(
+                [
+                    file_dict["/windows/boot/pxe/pxeboot.n12"],
+                    file_dict["/windows/boot/pxe/bootmgr.exe"],
+                ]
+            )
+
+        self.extract_files_from_wim(winpe_path, file_list)
+        self.update_winpe(winpe_path, file_dict["/windows/system32/config/software"])
+
+    def extract_winpe(self, distro_path: str) -> str:
+        """
+        Extracting winpe.wim from boot.win.
+
+        :param distro_path: The directory where the Windows distro is located.
+        :return: The path to the extracted WinPE image.
+        :raises CX
+        """
+        bootwim_path = os.path.join(distro_path, "sources", "boot.wim")
+        dest_path = os.path.join(distro_path, "boot")
 
         if not os.path.exists(bootwim_path):
             error_msg = f"{bootwim_path} not found!"
@@ -953,101 +987,136 @@ class _ImportSignatureManager(ManagerModule):
             filesystem_helpers.mkdir(dest_path)
         if os.path.exists(winpe_path):
             filesystem_helpers.rmfile(winpe_path)
-        return_code = utils.subprocess_call(
-            [cmd_path, bootwim_path, "1", winpe_path, "--boot"], shell=False
+        if (
+            utils.subprocess_call(
+                ["/usr/bin/wimexport", bootwim_path, "1", winpe_path, "--boot"],
+                shell=False,
+            )
+            != 0
+        ):
+            error_msg = f"Cannot extract {winpe_path} from {bootwim_path}!"
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        return winpe_path
+
+    def update_winpe(self, winpe_path: str, win_registry: str) -> None:
+        """
+        Update WinPE image for network boot.
+
+        :param winpe_path: The path to WinPE image.
+        :param win_registry: The path to the Windows registry in the WinPE image.
+        :raises CX
+        """
+        if not HAS_HIVEX:
+            error_msg = (
+                "python3-hivex not found. If you need Automatic Windows "
+                "Installation support, please install."
+            )
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        software = os.path.join(
+            os.path.dirname(winpe_path), os.path.basename(win_registry).lower()
         )
-        if return_code != 0:
-            return
-
-        cmd = ["/usr/bin/wimdir", winpe_path, "1"]
-        wimdir_result = utils.subprocess_get(cmd, shell=False)
-        wimdir_file_list = wimdir_result.split("\n")
-
-        is_wimboot = False
-        pxe_path = "/Windows/Boot/PXE"
-        bootmgr = "bootmgr.exe"
-        if "wimboot" in self.signature["kernel_file"]:
-            is_wimboot = True
-            pxe_path = "/Windows/Boot/EFI"
-            bootmgr = "bootmgr.efi"
-        config_path = "/Windows/System32/config/SOFTWARE"
-
-        for file in wimdir_file_list:
-            if file.lower() == pxe_path.lower():
-                pxe_path = file
-            elif file.lower() == config_path.lower():
-                config_path = file
-
-        cmd_path = "/usr/bin/wimextract"
-        cmd_args = [
-            cmd_path,
-            bootwim_path,
-            "1",
-            os.path.join(pxe_path, "pxeboot.n12"),
-            os.path.join(pxe_path, bootmgr),
-            config_path,
-            f"--dest-dir={dest_path}",
-            "--no-acls",
-            "--no-attributes",
-        ]
-        if is_wimboot:
-            cmd_args.pop(3)
-        return_code = utils.subprocess_call(
-            cmd_args,
-            shell=False,
-        )
-        if return_code != 0:
-            return
-
-        software = os.path.join(dest_path, os.path.basename(config_path))
         hivex_obj = hivex.Hivex(software, write=True)  # type: ignore
-        root = hivex_obj.root()  # type: ignore
-        nodes: List[Any] = [root]
-        pat = "X:\\$windows.~bt"
+        nodes: List[Any] = [hivex_obj.root()]  # type: ignore
 
         while len(nodes) > 0:
-            n = nodes.pop()
-            nodes.extend(hivex_obj.node_children(n))  # type: ignore
+            node = nodes.pop()
+            nodes.extend(hivex_obj.node_children(node))  # type: ignore
+            self.reg_node_update(hivex_obj, node)
 
-            new_values: List[Optional[Dict[str, Any]]] = []
-            update_flag = False
-            key_vals: List[Any] = hivex_obj.node_values(n)  # type: ignore
-            for key_val in key_vals:
-                key: str = hivex_obj.value_key(key_val)  # type: ignore
-                val = hivex_obj.node_get_value(n, key)  # type: ignore
-                val_type: int
-                val_value: bytes
-                val_type, val_value = hivex_obj.value_value(val)  # type: ignore
-                if pat in key:
-                    key = key.replace(pat, "X:")
-                    update_flag = True
-                if val_type in (REG_SZ, REG_EXPAND_SZ):
-                    val_string: str = hivex_obj.value_string(val)  # type: ignore
-                    if pat in val_string:
-                        val_string = val_string.replace(pat, "X:")
-                        val_value = (val_string + "\0").encode(encoding="utf-16le")
-                        update_flag = True
-                new_val = {
-                    "key": key,
-                    "t": val_type,
-                    "value": val_value,
-                }
-                new_values.append(new_val)
-
-            if update_flag:
-                hivex_obj.node_set_values(n, new_values)  # type: ignore
         hivex_obj.commit(software)  # type: ignore
 
-        cmd_path = "/usr/bin/wimupdate"
-        return_code = utils.subprocess_call(
+        utils.subprocess_call(
             [
-                cmd_path,
+                "/usr/bin/wimupdate",
                 winpe_path,
-                f"--command=add {software} {config_path}",
+                f"--command=add {software} {win_registry}",
             ],
             shell=False,
         )
         os.remove(software)
+
+    def reg_node_update(self, hivex_obj: Any, node: Any) -> None:
+        """
+        Replacement of the substring X:\\$windows.~bt with X: in the Windows registry node.
+
+        :param hivex_obj: Hivex object.
+        :param node: The registry node.
+        """
+        new_values: List[Optional[Dict[str, Any]]] = []
+        update_flag = False
+        key_vals: List[Any] = hivex_obj.node_values(node)  # type: ignore
+        pat = "X:\\$windows.~bt"
+
+        for key_val in key_vals:
+            key: str = hivex_obj.value_key(key_val)  # type: ignore
+            val = hivex_obj.node_get_value(node, key)  # type: ignore
+            val_type: int
+            val_value: bytes
+            val_type, val_value = hivex_obj.value_value(val)  # type: ignore
+            if pat in key:
+                key = key.replace(pat, "X:")
+                update_flag = True
+            if val_type in (REG_SZ, REG_EXPAND_SZ):
+                val_string: str = hivex_obj.value_string(val)  # type: ignore
+                if pat in val_string:
+                    val_string = val_string.replace(pat, "X:")
+                    val_value = (val_string + "\0").encode(encoding="utf-16le")
+                    update_flag = True
+            new_values.append(
+                {
+                    "key": key,
+                    "t": val_type,
+                    "value": val_value,
+                }
+            )
+
+        if update_flag:
+            hivex_obj.node_set_values(node, new_values)  # type: ignore
+
+    def extract_files_from_wim(self, winpe_path: str, wim_files: List[str]) -> None:
+        """
+        Extracting files from winpe.win.
+
+        :param winpe_path: The path to the WinPE image.
+        :param wim_files: The list of files to extract.
+        :raises CX
+        """
+        dest_path = os.path.dirname(winpe_path)
+        cmd_args = [
+            "/usr/bin/wimextract",
+            winpe_path,
+            "1",
+        ]
+        cmd_args.extend(wim_files)
+        cmd_args.extend(
+            [
+                f"--dest-dir={dest_path}",
+                "--no-acls",
+                "--no-attributes",
+            ]
+        )
+        if (
+            utils.subprocess_call(
+                cmd_args,
+                shell=False,
+            )
+            != 0
+        ):
+            error_msg = f'Cannot extract "{wim_files}" files from {winpe_path}!'
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        for wim_file_path in wim_files:
+            wim_file = os.path.basename(wim_file_path)
+            if wim_file != wim_file.lower():
+                os.rename(
+                    os.path.join(dest_path, wim_file),
+                    os.path.join(dest_path, wim_file.lower()),
+                )
 
 
 # ==========================================================================

--- a/cobbler/utils/filesystem_helpers.py
+++ b/cobbler/utils/filesystem_helpers.py
@@ -328,7 +328,7 @@ def mkdir(path: str, mode: int = 0o755) -> None:
                 already exists).
     """
     try:
-        pathlib.Path(path).mkdir(mode=mode)
+        pathlib.Path(path).mkdir(mode=mode, parents=True)
     except OSError as os_error:
         # already exists (no constant for 17?)
         if os_error.errno != 17:

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -3835,11 +3835,13 @@
         "boot_loaders":{
           "i386":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -3866,11 +3868,13 @@
         "boot_loaders":{
           "i386":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -3894,7 +3898,8 @@
         "boot_loaders":{
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -3918,7 +3923,8 @@
         "boot_loaders":{
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -3942,7 +3948,8 @@
         "boot_loaders":{
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -3966,7 +3973,8 @@
         "boot_loaders":{
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -3991,11 +3999,13 @@
         "boot_loaders":{
           "i386":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -4022,11 +4032,13 @@
         "boot_loaders":{
           "i386":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -4050,11 +4062,13 @@
         "boot_loaders":{
           "i386":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -4078,11 +4092,13 @@
         "boot_loaders":{
           "i386":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
@@ -4107,11 +4123,12 @@
           "aarch64":[],
           "x86_64":[
             "pxe",
-            "ipxe"
+            "ipxe",
+            "grub"
           ]
         },
         "supported_repo_breeds": [],
-        "kernel_file": "pxeboot\\.n12",
+        "kernel_file": "wimboot",
         "initrd_file": "boot\\.sdi",
         "default_autoinstall": "win.ks",
         "kernel_options": "",

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -7,7 +7,7 @@ User Guide
 
    Configuration Management Integrations <user-guide/configuration-management-integrations>
    Automatic Installation <user-guide/automatic-installation>
-   Automatic Windows installation with Cobbler <user-guide/wingen>
+   Windows installation with Cobbler <user-guide/wingen>
    VMware ESXi installation with cobbler <user-guide/esxi>
    Extending Cobbler <user-guide/extending-cobbler>
    Terraform Provider for Cobbler <user-guide/terraform-provider>

--- a/docs/user-guide/wingen.rst
+++ b/docs/user-guide/wingen.rst
@@ -1,216 +1,331 @@
 .. _wingen:
 
-*******************************************
-Automatic Windows installation with Cobbler
-*******************************************
+*********************************
+Windows installation with Cobbler
+*********************************
 
-One of the challenges for creating your own Windows network installation scenario with Cobbler is preparing the
-necessary files in a Linux environment. However, generating the necessary binaries can be greatly simplified by using
-the Cobbler post trigger on the sync command. Below is an example of such a trigger, which prepares the necessary files
-for legacy BIOS mode boot. Boot to UEFI Mode with iPXE is simpler and can be implemented by replacing the first 2 steps
-and several others with creating an iPXE boot menu.
+Supported installation options:
 
-Trigger ``sync_post_wingen.py``:
+* UEFI iPXE install (via ipxe-shimx64.efi, ipxe.efi and wimboot tftp/http)
+* BIOS iPXE install (via ipxe undionly.kpxe and wimboot tftp/http)
+* BIOS PXE install (via syslinux pxelinux.0, linux.c32 and wimboot tftp/http)
+* BIOS PXE install (via grub2 grub.0 and wimboot tftp/http)
+* BIOS PXE install (via windows pxeboot.n12)
 
-* some of the files are created from standard ones (``pxeboot.n12``, ``bootmgr.exe``) by directly replacing one string
-  with another directly in the binary
-* in the process of changing the ``bootmgr.exe`` file, the checksum of the PE file will change and it needs to be
-  recalculated. The trigger does this with ``python-pefile``
-* ``python3-hivex`` is used to modify Windows boot configuration data (BCD). For pxelinux distro boot_loader in BCD,
-  paths to ``winpe.wim`` and ``boot.sdi`` are generated as ``/images/<distro_name>``, and for iPXE with
-  wimboot - ``\Boot``.
-* uses ``wimlib-tools`` to replace ``startnet.cmd startup`` script in WIM image
-
-Windows answer files (``autounattended.xml``) are generated using Cobbler templates, with all of its conditional code
-generation capabilities, depending on the Windows version, architecture (32 or 64 bit), installation profile, etc.
-
-startup scripts for WIM images (startnet.cmd) and a script that is launched after OS installation (``post_install.cmd``)
-are also generated from templates
-
-Post-installation actions such as installing additional software, etc., are performed using the Automatic Installation
-Template (``win.ks``).
-
-A logically automatic network installation of Windows 7 and newer can be represented as follows:
-
-PXE + Legacy BIOS Boot
-
-.. code-block:: text
-
-    Original files: pxeboot.n12 → bootmgr.exe → BCD → winpe.wim → startnet.cmd → autounattended.xml
-    Cobbler profile 1: pxeboot.001 → boot001.exe → 001 → wi001.wim → startnet.cmd → autounatten001.xml → post_install.cmd profile_name
-    ...
-
-iPXE + UEFI Boot
-
-.. code-block:: text
-
-    Original files: ipxe-x86_64.efi → wimboot → bootmgr.exe → BCD → winpe.wim → startnet.cmd → autounattended.xml
-    Cobbler profile 1: ipxe-x86_64.efi → wimboot → bootmgr.exe → 001 → wi001.wim → startnet.cmd → autounatten001.xml → post_install.cmd profile_name
-    ...
-
-For older versions (Windows XP, 2003) + RIS:
-
-.. code-block:: text
-
-    Original files: pxeboot.n12 → setupldr.exe → winnt.sif → post_install.cmd profile_name
-    Cobbler profile <xxx>: pxeboot.<xxx> → setup<xxx>.exe → wi<xxx>.sif → post_install.cmd profile_name
-
-Additional Windows metadata
-===========================
-
-Additional metadata for preparing Windows boot files can be passed through the ``--autoinstall-meta`` option for
-distro, profile or system.
-
-The source files for Windows boot files should be located in the ``/var/www/cobbler/distro_mirror/<distro_name>/Boot``
-directory. The trigger copies them to ``/var/lib/tftpboot/images/<distro_name>`` with the new names specified in the
-metadata and and changes their contents. The resulting files will be available via tftp and http.
-
-The ``sync_post_wingen`` trigger uses the following set of metadata:
-
-* kernel
-
-    ``kernel`` in autoinstall-meta is only used if the boot kernel is ``pxeboot.n12``
-    (``--kernel=/path_to_kernel/pxeboot.n12`` in distro).
-    In this case, the trigger copies the ``pxeboot.n12`` file into a file with a new name and replaces:
-
-    * ``bootmgr.exe`` substring in it with the value passed through the ``bootmgr`` metadata key in case of using
-      Microsoft ADK/WAIK.
-    * ``NTLDR`` substring in it with the value passed through the ``bootmgr`` metadata key in case of using Legacy RIS.
-      Value of the ``kernel`` key in ``autoinstall-meta`` will be the actual first boot file.
-
-    If ``--kernel=/path_to_kernel/wimboot`` is in distro, then ``kernel`` key is not used in ``autoinstall-meta``.
-
-* bootmgr
-
-    The bootmgr key value is passed the name of the second boot file in the Windows boot chain. The source file to
-    create it can be:
-
-    * ``bootmgr.exe`` in case of using Micrisoft ADK/WAIK
-    * ``setupldr.exe`` for Legacy RIS
-
-    Trigger copies the corresponding source file to a file with the name given by this key and replaces in it:
-
-    * substring ``\Boot\BCD`` to ``\Boot\<bcd_value>``, where ``<bcd_value>`` is the metadata ``bcd`` key value for
-      Microsoft ADK/WAIK.
-    * substring ``winnt.sif`` with the value passed through the ``answerfile`` metadata key in case of using Legacy RIS.
-
-* bcd
-
-    This key is used to pass the value of the ``BCD`` file name in case of using Micrisoft ADK/WAIK. Any ``BCD`` file
-    from the Windows distribution can be used as a source for this file. The trigger copies it, then removes all boot
-    information from the copy and adds new data from the ``initrd`` value of the distro and the value passed through the
-    ``winpe`` metadata key.
-
-* winpe
-
-    This metadata key allows you to specify the name of the WinPE image. The image is copied by the cp utility trigger
-    with the ``--reflink=auto`` option, which allows to reduce copying time and the size of the disk space on CoW file
-    systems.
-    In the copy of the file, the tribger changes the ``/Windows/System32/startnet.cmd`` script to the script generated
-    from the ``startnet.template`` template.
-
-* answerfile
-
-    This is the name of the answer file for the Windows installation. This file is generated from the
-    ``answerfile.template`` template and is used in:
-
-    * ``startnet.cmd`` to start WinPE installation
-    * the file name is written to the binary file ``setupldr.exe`` for RIS
-
-* post_install_script
-
-    This is the name of the script to run immediately after the Windows installation completes. The script is specified
-    in the Windows answer file. All the necessary completing the installation actions can be performed directly in this
-    script, or it can be used to get and start additional steps from
-    ``http://<server>/cblr/svc/op/autoinstall/<profile|system>/name``.
-    To make this script available after the installation is complete, the trigger creates it in
-    ``/var/www/cobbler/distro_mirror/<distro_name>/$OEM$/$1`` from the ``post_inst_cmd.template`` template.
-
-The following metadata does not specify boot file names and is an example of using metadata to generate files from
-Cobbler templates.
-
-* clean_disk
-
-    The presence of this key in the metadata (regardless of its value) leads to the preliminary deletion of all data and
-    the disk partition table before installing the OS.
-    Used in the ``answerfile.template`` and also in ``startnet.template`` in Windows XP and Windows 2003 Server
-    installations using WinPE.
-
-Preparing for an unattended network installation of Windows
-===========================================================
+Installation Quickstart guide
+#############################
 
 * ``dnf install python3-pefile python3-hivex wimlib-utils``
-* enable Windows support in settings ``/etc/cobbler/settings.yaml``:
+* enable Windows support in settings ``/etc/cobbler/settings.d/windows.settings``:
 
-    .. code-block:: yaml
+.. code::
 
-       windows_enabled: true
+    windows_enabled: true
 
-* If you have ``file 5.37`` or newer installed (openSUSE Tumbleweed, Debian 11, RHEL/Rocky Linux 9, Fedora 37)
-  you can easily import the Wibdows distro:
-
-    .. code-block:: shell
-
-       cobbler import --name="Win10_EN-x64" --path="/mnt"
-
-    This command will determine the version and architecture of the Windows distribution, will extract the necessary boot
-    files from the distribution and create a distro and profile named ``Win10_EN-x64``.
-
-    For openSUSE Leap, Debian 10, RHEL/Rocky Linux 8 you need copy files from ``/mnt`` to ``/var/www/cobbler/distro_mirror/Win10_EN-x64``
-    and create a distro and profile with the ``cobbler add distro/profile`` commands.
-
-* For customization winpe.win you need
-
-  * ADK for Windows 10 / 8.1
+* Share ``/var/www/cobbler`` via Samba:
 
 .. code-block:: text
-
-    Start -> Apps -> Windows Kits -> Deployment and Imaging Tools Environment
-
-or
-
-  * WAIK for Windows 7
-
-.. code-block:: text
-
-    Start -> All Programs -> Microsoft Windows AIK -> Deployment Tools Command Prompt
-
-.. code-block:: text
-
-   copype.cmd <amd64|x86|arm> c:\winpe
-
-After executing the command, the WinPE image will be located in ``.\winpe.wim`` for WAIK and in
-``media\sources\boot.wim`` for ADK. You can use either it or replace it with the one that has been obtained as a result
-of the import of the Windows distribution.
-
-  * If necessary, add drivers to the image
-
-Example:
-
-.. code-block:: shell
-
-    dism /mount-wim /wimfile:media\sources\boot.wim /index:1 /mountdir:mount
-    dism /image:mount /add-driver /driver:D:\NetKVM\w10\amd64
-    dism /image:mount /add-driver /driver:D:\viostor\w10\amd64
-    dism /unmount-wim /mountdir:mount /commit
-
-* Copy the resulting WiNPE image from Windows to the ``boot`` directory of the distro
-* Share ``/var/www/cobbler/distro_mirror`` via Samba:
-
-.. code-block:: shell
 
     vi /etc/samba/smb.conf
             [DISTRO]
-            path = /var/www/cobbler/distro_mirror
+            path = /var/www/cobbler
             guest ok = yes
             browseable = yes
             public = yes
             writeable = no
             printable = no
 
+* import the Windows distro:
 
-- You can use ``tftpd.rules`` to indicate the actual locations of the ``bootmgr.exe`` and ``BCD`` files generated by
-  the trigger.
+.. code:: shell
+
+    cobbler import --name=win11 --path=/mnt
+
+This command will determine the version and architecture of the Windows distribution, extract the files ``pxeboot.n12``, ``bootmgr.exe``, ``winpe.wim``
+from the distro into the ``/var/www/cobbler/distro_mirror/win11/boot`` and create a distro and profile named ``win11-x86_64``.
+
+Customization winpe.wim
+=======================
+
+For customization winpe.win you need ADK for Windows.
+
+.. code::
+
+    Start -> Apps -> Windows Kits -> Deployment and Imaging Tools Environment
+
+You can use either ``winpe.wim`` obtained either as a result of cobbler import, or take it from ADK:
+
+.. code:: shell
+
+    copype.cmd <amd64|x86|arm> c:\winpe
+
+If necessary, add drivers to the image:
+
+.. code-block:: shell
+
+    dism /mount-wim /wimfile:media\sources\boot.wim /index:1 /mountdir:mount
+    dism /image:mount /add-driver /driver:D:\NetKVM\w11\amd64
+    dism /image:mount /add-driver /driver:D:\viostor\w11\amd64
+    dism /unmount-wim /mountdir:mount /commit
+
+Copy the resulting WinPE image from Windows to the ``/var/www/cobbler/distro_mirror/win11/boot`` directory of the distro.
+
+UEFI Secure Boot (SB)
+#####################
+
+For SB you can use ``ipxe-shimx64.efi`` (unsigned), ``ipxe.efi`` (unsigned) and ``wimboot`` (signed with a Microsoft key).
+Therefore, in this case, we will need our own keys in order to sign ``ipxe-shimx64.efi``, ``ipxe.efi`` and computer fimware with them.
+
+Creating Secure Boot Keys
+=========================
+
+.. code-block:: shell
+
+    export NAME="DEMO"
+    openssl req -new -x509 -newkey rsa:2048 -subj "/CN=$NAME PK/" -keyout PK.key \
+            -out PK.crt -days 3650 -nodes -sha256
+    openssl req -new -x509 -newkey rsa:2048 -subj "/CN=$NAME KEK/" -keyout KEK.key \
+            -out KEK.crt -days 3650 -nodes -sha256
+    openssl req -new -x509 -newkey rsa:2048 -subj "/CN=$NAME DB/" -keyout DB.key \
+            -out DB.crt -days 3650 -nodes -sha256
+
+    export GUID=`python3 -c 'import uuid; print(str(uuid.uuid1()))'`
+    echo $GUID > myGUID.txt
+
+Provide cobbler with bootloaders
+================================
+
+.. code-block:: shell
+
+    wget https://github.com/ipxe/shim/releases/download/ipxe-15.7/ipxe-shimx64.efi
+    wget https://boot.ipxe.org/ipxe.iso
+    wget https://github.com/ipxe/wimboot/releases/latest/download/wimboot -P /var/lib/cobbler/loaders
+
+    mkdir -p /mnt/{cdrom,disk}
+    mount -o loop,ro ipxe.iso /mnt/cdrom
+    mount -o loop,ro /mnt/cdrom/esp.img /mnt/disk
+
+Signing EFI Binaries and replacing keys in firmware
+===================================================
+
+Signing the bootloaders:
+
+.. code-block:: shell
+
+    sbsign --key DB.key --cert DB.crt --output /var/lib/cobbler/loaders/ipxe-shimx64.efi ipxe-shimx64.efi
+    sbsign --key DB.key --cert DB.crt --output /var/lib/cobbler/loaders/ipxe.efi /mnt/disk/EFI/BOOT/BOOTX64.EFI
+    cobbler sync
+
+Sign the computer firmware with your keys. For VM it can be done like this:
+
+.. code-block:: shell
+
+    rpm -ql python3-virt-firmware | grep '\.pem$'
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/CentOSSecureBootCA2.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/CentOSSecureBootCAkey1.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/MicrosoftCorporationKEKCA2011.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/MicrosoftCorporationUEFICA2011.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/MicrosoftWindowsProductionPCA2011.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/RedHatSecureBootCA3.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/RedHatSecureBootCA5.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/RedHatSecureBootCA6.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/RedHatSecureBootPKKEKkey1.pem
+        /usr/lib/python3.9/site-packages/virt/firmware/certs/fedoraca-20200709.pem
+
+    virt-fw-vars \
+        --input /usr/share/edk2/ovmf/OVMF_VARS.fd \
+        --output /var/lib/libvirt/qemu/nvram/win11_VARS.fd \
+        --set-pk  ${GUID} PK.crt \
+        --add-kek ${GUID} KEK.crt \
+        --add-kek 77fa9abd-0359-4d32-bd60-28f4e78f784b /usr/lib/python3.9/site-packages/virt/firmware/certs/MicrosoftCorporationKEKCA2011.pem \
+        --add-db  ${GUID} DB.crt \
+        --add-db  77fa9abd-0359-4d32-bd60-28f4e78f784b /usr/lib/python3.9/site-packages/virt/firmware/certs/MicrosoftWindowsProductionPCA2011.pem \
+        --add-db  77fa9abd-0359-4d32-bd60-28f4e78f784b /usr/lib/python3.9/site-packages/virt/firmware/certs/MicrosoftCorporationUEFICA2011.pem
+
+Booting from UEFI iPXE HTTP
+###########################
+
+Change ``dhcpd.conf`` to use ``ipxe-shimx64.efi``:
+
+.. code-block:: text
+
+     class "pxeclients" {
+          match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+          next-server 192.168.126.1;
+
+          if exists user-class and option user-class = "iPXE" {
+              filename "/ipxe/default.ipxe";
+          }
+          # UEFI-64-1
+          else if option system-arch = 00:07 {
+              filename "ipxe-shimx64.efi";
+          }
+
+The HTTP protocol is used by default in the profile created with the ``cobbler import`` command:
+
+.. code-block:: shell
+
+    cobbler profile report --name=win11-x86_64 | grep Metadata
+        Automatic Installation Metadata :
+            {'kernel': 'http://@@http_server@@/images/win11-x86_64/wimboot',
+             'bootmgr': 'bootmgr.exe',
+             'bcd': 'bcd',
+             'winpe': 'winpe.wim',
+             'answerfile': 'autounattended.xml',
+             'post_install_script': 'post_install.cmd'}
+
+.. code-block:: shell
+
+    cat /var/lib/tftpboot/ipxe/default.ipxe
+    :win11-x86_64
+    kernel http://192.168.124.1/images/win11-x86_64/wimboot
+    initrd --name boot.sdi  http://192.168.124.1/cobbler/images/win11-x86_64/boot.sdi boot.sdi
+    initrd --name bootmgr.exe  http://192.168.124.1/cobbler/images/win11-x86_64/bootmgr.exe bootmgr.exe
+    initrd --name bcd  http://192.168.124.1/cobbler/images/win11-x86_64/bcd bcd
+    initrd --name winpe.wim  http://192.168.124.1/cobbler/images/win11-x86_64/winpe.wim winpe.wim
+
+Booting from BIOS firmware
+##########################
+
+Booting from BIOS iPXE (via ipxe undionly.kpxe and wimboot tftp/http)
+=====================================================================
+
+Change ``dhcpd.conf`` to use ``undionly.kpxe``:
+
+.. code-block:: text
+
+     class "pxeclients" {
+          match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+          next-server 192.168.126.1;
+
+          if exists user-class and option user-class = "iPXE" {
+              filename "/ipxe/default.ipxe";
+          }
+          else if option system-arch = 00:00 {
+              filename "undionly.pxe";
+          }
+
+Import distro
+
+.. code:: shell
+
+    cobbler import --name=win10 --path=/mnt
+
+By default, an EFI partition is created for the profile ``win10-x86_64`` in the answerfile, and for BIOS boot we can create a profile with ``uefi=False`` in the metadata:
+
+.. code:: shell
+
+    cobbler profile copy \
+        --name=win10-x86_64 \
+        --newname=win10-bios-pxe-wimboot-http-x86_64 \
+        --autoinstall-meta="kernel=http://@@http_server@@/images/win10-x86_64/wimboot bootmgr=bootmg2.exe bcd=bc2 winpe=winp2.wim answerfile=autounattende2.xml uefi=False"
+    cobbler sync
+
+If you do not want to use the HTTP protocol, you can either change an existing profile or create a new one with ``kernel=wimboot`` in the metadata:
+
+.. code:: shell
+
+    cobbler profile copy \
+        --name=win10-x86_64
+        --newname=win10-bios-ipxe-wimboot-tftp-x86_64 \
+        --autoinstall-meta="kernel=wimboot bootmgr=bootmg3.exe bcd=bc3 winpe=winp3.wim answerfile=autounattende3.xml uefi=False"
+    cobbler sync
+
+.. code:: shell
+
+    cat /var/lib/tftpboot/ipxe/default.ipxe
+    :win10-bios-ipxe-wimboot-tftp-x86_64
+    kernel /images/win10-x86_64/wimboot
+    initrd --name boot.sdi  /images/win10-x86_64/boot.sdi boot.sdi
+    initrd --name bootmgr.exe  /images/win10-x86_64/bootmg3.exe bootmgr.exe
+    initrd --name bcd  /images/win10-x86_64/bc3 bcd
+    initrd --name winp3.wim  /images/win10-x86_64/winp3.wim winp3.wim
+    boot
+
+Booting from BIOS PXE (via syslinux pxelinux.0, linux.c32 and wimboot tftp/http)
+=================================================================================
+
+The ``win10-bios-pxe-wimboot-http-x86_64`` and ``win10-bios-ipxe-wimboot-tftp-x86_64`` profiles created earlier are suitable for this boot method.
+You just need to change ``dhcpd.conf`` to boot via ``pxelinux.0``.
+
+.. code-block:: text
+
+     class "pxeclients" {
+          match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+          next-server 192.168.126.1;
+
+          if exists user-class and option user-class = "iPXE" {
+              filename "/ipxe/default.ipxe";
+          }
+          else if option system-arch = 00:00 {
+              filename "pxelinux.0";
+          }
+
+.. code-block:: shell
+
+    cat /var/lib/tftpboot/pxelinux.cfg/default
+    LABEL win10-bios-ipxe-wimboot-tftp-x86_64
+        MENU LABEL win10-bios-ipxe-wimboot-tftp-x86_64
+        kernel linux.c32
+        append /images/win10-x86_64/wimboot initrdfile=/images/win10-x86_64/boot.sdi@boot.sdi initrdfile=/images/win10-x86_64/bootmg3.exe@bootmgr.exe initrdfile=/images/win10-x86_64/bc3@bcd initrdfile=/images/win10-x86_64/winp3.wim@winp3.wim
+    LABEL win10-bios-pxe-wimboot-http-x86_64
+        MENU LABEL win10-bios-pxe-wimboot-http-x86_64
+        kernel linux.c32
+        append http://192.168.124.1/images/win10-x86_64/wimboot initrdfile=http://192.168.124.1/cobbler/images/win10-x86_64/boot.sdi@boot.sdi initrdfile=http://192.168.124.1/cobbler/images/win10-x86_64/bootmg2.exe@bootmgr.exe initrdfile=http://192.168.124.1/cobbler/images/win10-x86_64/bc2@bcd initrdfile=http://192.168.124.1/cobbler/images/win10-x86_64/winp2.wim@winp2.wim
+
+
+Booting from BIOS PXE (via grub2 grub.0 and wimboot tftp/http)
+==============================================================
+
+The ``win10-bios-pxe-wimboot-http-x86_64`` and ``win10-bios-ipxe-wimboot-tftp-x86_64`` profiles created earlier also suitable for this boot method.
+You just need to change ``dhcpd.conf`` to boot via ``grub/grub.0``.
+
+.. code-block:: text
+
+     class "pxeclients" {
+          match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+          next-server 192.168.126.1;
+
+          if exists user-class and option user-class = "iPXE" {
+              filename "/ipxe/default.ipxe";
+          }
+          else if option system-arch = 00:00 {
+              filename "grub/grub.0";
+          }
+
+.. code-block:: shell
+
+    cat /var/lib/tftpboot/grub/x86_64_menu_items.cfg
+    menuentry 'win10-bios-ipxe-wimboot-tftp-x86_64' --class gnu-linux --class gnu --class os {
+      echo 'Loading kernel ...'
+      clinux /images/win10-x86_64/wimboot
+      echo 'Loading initial ramdisk ...'
+      cinitrd  newc:boot.sdi:/images/win10-x86_64/boot.sdi newc:bootmgr.exe:/images/win10-x86_64/bootmg3.exe newc:bcd:/images/win10-x86_64/bc3 newc:winp3.wim:/images/win10-x86_64/winp3.wim
+      echo '...done'
+    }
+    menuentry 'win10-bios-pxe-wimboot-http-x86_64' --class gnu-linux --class gnu --class os {
+      echo 'Loading kernel ...'
+      clinux (http,192.168.124.1)/images/win10-x86_64/wimboot
+      echo 'Loading initial ramdisk ...'
+      cinitrd  newc:boot.sdi:(http,192.168.124.1)/cobbler/images/win10-x86_64/boot.sdi newc:bootmgr.exe:(http,192.168.124.1)/cobbler/images/win10-x86_64/bootmg2.exe newc:bcd:(http,192.168.124.1)/cobbler/images/win10-x86_64/bc2 newc:winp2.wim:(http,192.168.124.1)/cobbler/images/win10-x86_64/winp2.wim
+      echo '...done'
+    }
+
+Booting from  BIOS PXE install (via windows pxeboot.n12)
+========================================================
+
+This is the only boot method that does not require ``wimboot``.
+Booting can be done via syslinux (pxelinux.0) or ipxe (undionly.kpxe).
+
+Create a file ``/etc/tftpd.rules``:
+
+.. code-block:: text
+
+    rg	\\					/ # Convert backslashes to slashes
+    r	(boot1e.\.exe)				/images/win10-x86_64/\1
+    r	(/Boot/)(1E.)				/images/win10-x86_64/\2
+
+Change the tftp service
 
 .. code-block:: shell
 
@@ -224,169 +339,102 @@ Replace the line in the ``/etc/systemd/system/tftp.service``
         to:
     ExecStart=/usr/sbin/in.tftpd -m /etc/tftpd.rules -s /var/lib/tftpboot
 
-Create a file ``/etc/tftpd.rules``:
-
-.. code-block:: shell
-
-    vi /etc/tftpd.rules
-    rg	\\					/ # Convert backslashes to slashes
-    r	(wine.\.sif)				/WinXp_EN-i386/\1
-    r	(xple.)					/WinXp_EN-i386/\1
-
-    r	(wi2k.\.sif)				/Win2k3-Server_EN-x64/\1
-    r	(w2k3.)					/Win2k3-Server_EN-x64/\1
-
-    r	(boot7e.\.exe)				/images/Win7_EN-x64/\1
-    r	(/Boot/)(7E.)				/images/Win7_EN-x64/\2
-
-    r	(boot28.\.exe)				/images/Win2k8-Server_EN-x64/\1
-    r	(/Boot/)(28.)				/images/Win2k8-Server_EN-x64/\2
-
-    r   (boot9r.\.exe)				/images/Win2019-Server_EN-x64/\1
-    r   (/Boot/)(9r.)				/images/Win2019-Server_EN-x64/\2
-
-    r	(boot6e.\.exe)				/images/Win2016-Server_EN-x64/\1
-    r	(/Boot/)(6e.)				/images/Win2016-Server_EN-x64/\2
-
-    r	(boot2e.\.exe)				/images/Win2012-Server_EN-x64/\1
-    r	(/Boot/)(2e.)				/images/Win2012-Server_EN-x64/\2
-
-    r	(boot81.\.exe)				/images/Win8_EN-x64/\1
-    r	(/Boot/)(B8.)				/images/Win8_EN-x64/\2
-
-    r	(boot1e.\.exe)				/images/Win10_EN-x64/\1
-    r	(/Boot/)(1E.)				/images/Win10_EN-x64/\2
-
-    r	(.*)(/WinXp...-i386/)(.*)		/images\2\L\3
-    r	(.*)(/Win2k3-Server_EN-x64/)(.*)	/images\2\L\3
-
-    r	(.*)(bootxea.exe)			/images/WinXp_EN-i386/\2
-    r	(.*)(XEa)				/images/WinXp_EN-i386/\2
-
-    r	(.*)(boot3ea.exe)			/images/Win2k3-Server_EN-x64/\2
-    r	(.*)(3Ea)				/images/Win2k3-Server_EN-x64/\2
-
-Final steps
-===========
-
-- Restart the services:
+Restart the tftp service:
 
 .. code-block:: shell
 
     systemctl daemon-reload
     systemctl restart tftp
-    systemctl restart smb
-    systemctl restart nmb
 
-- add additional distros for PXE boot:
+Create a new profile
 
 .. code-block:: shell
 
-    cobbler distro add --name=Win10_EN-x64 \
-    --kernel=/var/www/cobbler/distro_mirror/Win10_EN-x64/boot/pxeboot.n12 \
-    --initrd=/var/www/cobbler/distro_mirror/Win10_EN-x64/boot/boot.sdi \
-    --arch=x86_64 --breed=windows --os-version=10
+    cobbler profile copy \
+        --name=win10-x86_64 \
+        --newname=win10-bios-syslinux-tftp-x86_64 \
+        --autoinstall-meta="kernel=win10a.0 bootmgr=boot1ea.exe bcd=1Ea winpe=winp5.wim answerfile=autounattende5.xml uefi=False"
+    cobbler sync
 
-or for iPXE:
-
-.. code-block:: shell
-
-    cobbler distro add --name=Win10_EN-x64 \
-    --kernel=/var/lib/tftpboot/wimboot \
-    --initrd=/var/www/cobbler/distro_mirror/Win10_EN-x64/boot/boot.sdi \
-    --remote-boot-kernel=http://@@http_server@@/cobbler/images/@@distro_name@@/wimboot \
-    --remote-boot-initrd=http://@@http_server@@/cobbler/images/@@distro_name@@/boot.sdi \
-    --arch=x86_64 --breed=windows --os-version=10 \
-    --boot-loaders=ipxe
-
-- and additional profiles for PXE boot:
+Boot entries were created for this profile:
 
 .. code-block:: shell
 
-    cobbler profile add --name=Win10_EN-x64 --distro=Win10_EN-x64 --autoinstall=win.ks \
-    --autoinstall-meta='kernel=win10a.0 bootmgr=boot1ea.exe bcd=1Ea winpe=winpe.wim answerfile=autounattended.xml'
+    cat /var/lib/tftpboot/pxelinux.cfg/default
+    LABEL win10-bios-syslinux-tftp-x86_64
+        MENU LABEL win10-bios-syslinux-tftp-x86_64
+        kernel /images/win10-x86_64/win10a.0
 
-    cobbler profile add --name=Win10-profile1 --parent=Win10_EN-x64 \
-    --autoinstall-meta='kernel=win10b.0 bootmgr=boot1eb.exe bcd=1Eb winpe=winp1.wim answerfile=autounattende1.xml'
-
-    cobbler profile add --name=Win10-profile2 --parent=Win10_EN-x64 \
-    --autoinstall-meta='kernel=win10c.0 bootmgr=boot1ec.exe bcd=1Ec winpe=winp2.wim answerfile=autounattende2.xml'
-
-The boot menu will look like this:
-
-.. code-block:: shell
-
-        LABEL Win10_EN-x64
-                MENU LABEL Win10_EN-x64
-                kernel /images/Win10_EN-x64/win10a.0
-        LABEL Win10_EN-x64-profile1
-                MENU LABEL Win10_EN-x64-profile1
-                kernel /images/Win10_EN-x64/win10b.0
-        LABEL Win10_EN-x64-profile1
-                MENU LABEL Win10_EN-x64-profile2
-                kernel /images/Win10_EN-x64/win10c.0
-
-or for iPXE:
-
-.. code-block:: shell
-
-    cobbler profile add --name=Win10_EN-x64 --distro=Win10_EN-x64 --autoinstall=win.ks \
-    --autoinstall-meta='bootmgr=boot1ea.exe bcd=1Ea winpe=winpe.wim answerfile=autounattended.xml' \
-    --boot-loaders=ipxe
-
-    cobbler profile add --name=Win10-profile1 --parent=Win10_EN-x64 \
-    --autoinstall-meta='bootmgr=boot1eb.exe bcd=1Eb winpe=winp1.wim answerfile=autounattende1.xml' \
-    --boot-loaders=ipxe
-
-    cobbler profile add --name=Win10-profile2 --parent=Win10_EN-x64 \
-    --autoinstall-meta='bootmgr=boot1ec.exe bcd=1Ec winpe=winp2.wim answerfile=autounattende2.xml' \
-    --boot-loaders=ipxe
-
-The boot menu will look like this:
-
-.. code-block:: shell
-
-    :Win10_EN-x64
-    kernel http://<http_server>/cobbler/images/Win10_EN-x64/wimboot
-    initrd --name boot.sdi http://<http_server>/cobbler/images/Win10_EN-x64/boot.sdi boot.sdi
-    initrd --name bootmgr.exe http://<http_server>/cobbler/images/Win10_EN-x64/boot1ea.exe bootmgr.exe
-    initrd --name bcd http://<http_server>/cobbler/images/Win10_EN-x64/1Ea bcd
-    initrd --name winpe.wim http://<http_server>/cobbler/images/Win10_EN-x64/winpe.wim winpe.wim
+    cat /var/lib/tftpboot/ipxe/default.ipxe
+    :win10-bios-syslinux-tftp-x86_64
+    kernel /images/win10-x86_64/win10a.0
+    initrd /images/win10-x86_64/boot.sdi
     boot
 
-    :Win10_EN-x64-profile1
-    kernel http://<http_server>/cobbler/images/Win10_EN-x64/wimboot
-    initrd --name boot.sdi http://<http_server>/cobbler/images/Win10_EN-x64/boot.sdi boot.sdi
-    initrd --name bootmgr.exe http://<http_server>/cobbler/images/Win10_EN-x64/boot1eb.exe bootmgr.exe
-    initrd --name bcd http://<http_server>/cobbler/images/Win10_EN-x64/1Eb bcd
-    initrd --name winpe.wim http://<http_server>/cobbler/images/Win10_EN-x64/winp1.wim winpe.wim
-    boot
+Additional Windows metadata
+###########################
 
-    :Win10_EN-x64-profile2
-    kernel http://<http_server>/cobbler/images/Win10_EN-x64/wimboot
-    initrd --name boot.sdi http://<http_server>/cobbler/images/Win10_EN-x64/boot.sdi boot.sdi
-    initrd --name bootmgr.exe http://<http_server>/cobbler/images/Win10_EN-x64/boot1ec.exe bootmgr.exe
-    initrd --name bcd http://<http_server>/cobbler/images/Win10_EN-x64/1Ec bcd
-    initrd --name winpe.wim http://<http_server>/cobbler/images/Win10_EN-x64/winp2.wim winpe.wim
-    boot
+Additional metadata for preparing Windows boot files can be passed through the ``--autoinstall-meta`` option for distro, profile or system.
+The source files for Windows boot files should be located in the ``/var/www/cobbler/distro_mirror/<distro_name>/Boot`` directory.
+The trigger copies them to ``/var/lib/tftpboot/images/<distro_name>`` with the new names specified in the metadata and and changes their contents.
+The resulting files will be available via tftp and http.
 
-* cobbler sync
+The ``sync_post_wingen`` trigger uses the following set of metadata:
 
-  * kernel from ``autoinstall-meta`` of profile or from ``kernel`` of distro property will be copied to
-    ``/var/lib/tftpboot/<distro_name>``
-  * if the kernel is ``pxeboot.n12``, then the ``bootmgr.exe`` substring is replaced in the copied copy of kernel with
-    the value passed via ``bootmgr`` of the ``autoinstall-meta`` profile property
+* kernel
 
-* Install Windows
+    ``kernel`` in autoinstall-meta is only used if the boot kernel is ``pxeboot.n12`` (``--kernel=/path_to_kernel/pxeboot.n12`` in distro).
+    In this case, the trigger copies the ``pxeboot.n12`` file into a file with a new name and replaces:
+
+    - ``bootmgr.exe`` substring in it with the value passed through the ``bootmgr`` metadata key in case of using Micrisoft ADK.
+    - ``NTLDR`` substring in it with the value passed through the ``bootmgr`` metadata key in case of using Legacy RIS.
+
+    Value of the ``kernel`` key in ``autoinstall-meta`` will be the actual first boot file.
+    If ``--kernel=/path_to_kernel/wimboot`` is in distro, then ``kernel`` key is not used in ``autoinstall-meta``.
+
+* bootmgr
+
+    The bootmgr key value is passed the name of the second boot file in the Windows boot chain. The source file to create it can be:
+
+    - ``bootmgr.exe`` in case of using Micrisoft ADK
+    - ``setupldr.exe`` for Legacy RIS
+
+    Trigger copies the corresponding source file to a file with the name given by this key and replaces in it:
+
+    - substring ``\Boot\BCD`` to ``\Boot\<bcd_value>``, where ``<bcd_value>`` is the metadata ``bcd`` key value for Micrisoft ADK.
+    - substring ``winnt.sif`` with the value passed through the ``answerfile`` metadata key in case of using Legacy RIS.
+
+* bcd
+
+    This key is used to pass the value of the ``BCD`` file name in case of using Micrisoft ADK. Any ``BCD`` file from the Windows distribution can be used as a source for this file.
+    The trigger copies it, then removes all boot information from the copy and adds new data from the ``initrd`` value of the distro and the value passed through the ``winpe`` metadata key.
+
+* winpe
+
+    This metadata key allows you to specify the name of the WinPE image. The image is copied by the cp utility trigger with the ``--reflink=auto`` option,
+    which allows to reduce copying time and the size of the disk space on CoW file systems.
+    In the copy of the file, the tribger changes the ``/Windows/System32/startnet.cmd`` script to the script generated from the ``startnet.template`` template.
+
+* answerfile
+
+    This is the name of the answer file for the Windows installation. This file is generated from the ``answerfile.template`` template and is used in:
+
+    - ``startnet.cmd`` to start WinPE installation
+    - the file name is written to the binary file ``setupldr.exe`` for RIS
+
+* post_install_script
+
+    This is the name of the script to run immediately after the Windows installation completes.
+    The script is specified in the Windows answer file. All the necessary completing the installation actions can be performed directly in this script,
+    or it can be used to get and start additional steps from ``http://<server>/cblr/svc/op/autoinstall/<profile|system>/name``.
+    To make this script available after the installation is complete, the trigger creates it in ``/var/www/cobbler/distro_mirror/<distro_name>/$OEM$/$1`` from the ``post_inst_cmd.template`` template.
 
 Legacy Windows XP and Windows 2003 Server
-=========================================
+#########################################
 
-* WinPE 3.0 and winboot can be used to install legacy versions of Windows. ``startnet.template`` contains the code for
-  starting such an installation via ``winnt32.exe``.
+- WinPE 3.0 and wimboot can be used to install legacy versions of Windows. ``startnet.template`` contains the code for starting such an installation via ``winnt32.exe``.
 
-  * copy ``bootmgr.exe``, ``bcd``, ``boot.sdi`` from Windows 7 and ``winpe.wim`` from WAIK to the
-    ``/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot``
+  - copy ``bootmgr.exe``, ``bcd``, ``boot.sdi`` from Windows 7 and ``winpe.wim`` from WAIK to the ``/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot``
 
 .. code-block:: shell
 
@@ -395,7 +443,7 @@ Legacy Windows XP and Windows 2003 Server
     --initrd=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/boot.sdi \
     --remote-boot-kernel=http://@@http_server@@/cobbler/images/@@distro_name@@/wimboot \
     --remote-boot-initrd=http://@@http_server@@/cobbler/images/@@distro_name@@/boot.sdi \
-    --arch=i386 --breed=windows --os-version=XP \
+    --arch=i386 --breed=windows --os-version=xp \
     --boot-loaders=ipxe --autoinstall-meta='clean_disk'
 
     cobbler distro add --name=Win2k3-Server_EN-x64 \
@@ -412,17 +460,16 @@ Legacy Windows XP and Windows 2003 Server
     cobbler profile add --name=Win2k3-Server_EN-x64 --distro=Win2k3-Server_EN-x64 --autoinstall=win.ks \
     --autoinstall-meta='bootmgr=boot3ea.exe bcd=3Ea winpe=winpe.wim answerfile=wi2k3.sif post_install_script=post_install.cmd'
 
-* WinPE 3.0 without ``winboot`` also can be used to install legacy versions of Windows.
+- WinPE 3.0 without ``wimboot`` also can be used to install legacy versions of Windows.
 
-  * copy ``pxeboot.n12``, ``bootmgr.exe``, ``bcd``, ``boot.sdi`` from Windows 7 and ``winpe.wim`` from WAIK to the
-    ``/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot``
+  - copy ``pxeboot.n12``, ``bootmgr.exe``, ``bcd``, ``boot.sdi`` from Windows 7 and ``winpe.wim`` from WAIK to the ``/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot``
 
 .. code-block:: shell
 
     cobbler distro add --name=WinXp_EN-i386 \
     --kernel=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/pxeboot.n12 \
     --initrd=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/boot.sdi \
-    --arch=i386 --breed=windows --os-version=XP \
+    --arch=i386 --breed=windows --os-version=xp \
     --autoinstall-meta='clean_disk'
 
     cobbler distro add --name=Win2k3-Server_EN-x64 \
@@ -437,7 +484,7 @@ Legacy Windows XP and Windows 2003 Server
     cobbler profile add --name=Win2k3-Server_EN-x64 --distro=Win2k3-Server_EN-x64 --autoinstall=win.ks \
     --autoinstall-meta='kernel=w2k0.0 bootmgr=boot3ea.exe bcd=3Ea winpe=winpe.wim answerfile=wi2k3.sif post_install_script=post_install.cmd'
 
-* Although the ris-linux package is no longer supported, it also can still be used to install older Windows versions.
+- Although the ris-linux package is no longer supported, it also can still be used to install older Windows versions.
 
 For example on Fedora 33:
 
@@ -489,8 +536,7 @@ Preparing boot files for RIS and legacy Windows XP and Windows 2003 Server
     cp i386/ntdetect.com /var/lib/tftpboot
     cabextract -dboot i386/setupldr.ex_
 
-If you need to install Windows 2003 Server in addition to Windows XP, then to avoid a conflict, you can rename the
-``ntdetect.com`` file:
+If you need to install Windows 2003 Server in addition to Windows XP, then to avoid a conflict, you can rename the ``ntdetect.com`` file:
 
 .. code-block:: shell
 
@@ -515,7 +561,7 @@ Copy the required drivers to the ``i386``
     --kernel=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/pxeboot.n12 \
     --initrd=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/boot.sdi \
     --boot-files='@@local_img_path@@/i386/=@@web_img_path@@/i386/*.*' \
-    --arch=i386 --breed=windows –os-version=XP
+    --arch=i386 --breed=windows –os-version=xp
 
     cobbler distro add --name=Win2k3-Server_EN-x64 \
     --kernel=/var/www/cobbler/distro_mirror/Win2k3-Server_EN-x64/boot/pxeboot.n12 \
@@ -528,3 +574,8 @@ Copy the required drivers to the ``i386``
 
     cobbler profile add --name=Win2k3-Server_EN-x64 --distro=Win2k3-Server_EN-x64 --autoinstall=win.ks \
     --autoinstall-meta='kernel=w2k0.0 bootmgr=w2k3l answerfile=wi2k3.sif'
+
+Useful links
+############
+
+ `Managing EFI Boot Loaders for Linux: Controlling Secure Boot <https://www.rodsbooks.com/efi-bootloaders/controlling-sb.html>`_

--- a/templates/boot_loader_conf/grub.template
+++ b/templates/boot_loader_conf/grub.template
@@ -10,7 +10,15 @@ set default='local'
 menuentry '$menu_label' --class gnu-linux --class gnu --class os {
   echo 'Loading kernel ...'
   clinux $kernel_path $kernel_options
+#if "wimboot" in $kernel_path
+#set $initrd_path = ""
+#for $init in $initrd
+#set $initrd_path += " " + $init
+#end for
+#end if
+#if $breed != "windows" or "wimboot" in $kernel_path
   echo 'Loading initial ramdisk ...'
   cinitrd $initrd_path
+#end if
   echo '...done'
 }

--- a/templates/boot_loader_conf/pxe.template
+++ b/templates/boot_loader_conf/pxe.template
@@ -16,13 +16,21 @@ LABEL $menu_name
 #if $system_local
 	localboot -1
 #else
+#if "wimboot" in $kernel_path
+	kernel linux.c32
+#set $append_line = "append " + $kernel_path
+#for $init in $initrd
+#set $append_line += " initrdfile=" + $init
+#end for
+#else
 	kernel $kernel_path
-#if $breed != "windows"
+#end if
 #if $breed == "vmware"
 	append -c $bootcfg_path
-#else
+#elif $breed != "windows" or "wimboot" in $kernel_path
 	$append_line
 #end if
+#if $breed != "windows"
 	ipappend 2
 #end if
 #end if

--- a/templates/windows/answerfile.template
+++ b/templates/windows/answerfile.template
@@ -9,40 +9,58 @@
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-International-Core-WinPE" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-#if "locale_num" in $autoinstall_meta
-            <InputLocale>@@locale_num@@</InputLocale>
-#else
-            <InputLocale>0409:00000409</InputLocale>
-#end if
-#if "locale" in $autoinstall_meta
-            <SystemLocale>@@locale@@</SystemLocale>
-            <UILanguage>@@locale@@</UILanguage>
-            <UILanguageFallback>@@locale@@</UILanguageFallback>
-            <UserLocale>@@locale@@</UserLocale>
-#else
-            <SystemLocale>en-US</SystemLocale>
-            <UILanguage>en-US</UILanguage>
-            <UILanguageFallback>en-US</UILanguageFallback>
-            <UserLocale>en-US</UserLocale>
-#end if
+            <SetupUILanguage>
+#set $locale = $getVar('locale', 'en-US')
+                <UILanguage>$locale</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>$locale</InputLocale>
+            <SystemLocale>$locale</SystemLocale>
+            <UILanguage>$locale</UILanguage>
+            <UILanguageFallback>$locale</UILanguageFallback>
+            <UserLocale>$locale</UserLocale>
         </component>
         <component name="Microsoft-Windows-Setup" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-#if "clean_disk"  in $autoinstall_meta
             <DiskConfiguration>
                 <WillShowUI>OnError</WillShowUI>
                 <Disk wcm:action="add">
                     <DiskID>0</DiskID>
                     <WillWipeDisk>true</WillWipeDisk>
+#set $uefi = 'True'
+#if $os_version in ('7', '2008')
+#set $uefi = 'False'
+#end if
+#set $uefi = $getVar('uefi', $uefi)
+#set $part_num = 0
                     <CreatePartitions>
+#if $uefi == 'True'
                         <CreatePartition wcm:action="add">
-                            <Order>1</Order>
+#set $part_num += 1
+                            <Order>$part_num</Order>
+                            <Type>Primary</Type>
+                            <Size>300</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+#set $part_num += 1
+                            <Order>$part_num</Order>
+                            <Type>EFI</Type>
+                            <Size>100</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+#set $part_num += 1
+                            <Order>$part_num</Order>
+                            <Type>MSR</Type>
+                            <Size>128</Size>
+                        </CreatePartition>
+#end if
+                        <CreatePartition wcm:action="add">
+#set $part_num += 1
+                            <Order>$part_num</Order>
                             <Extend>true</Extend>
                             <Type>Primary</Type>
                         </CreatePartition>
                     </CreatePartitions>
                 </Disk>
             </DiskConfiguration>
-#end if
             <ImageInstall>
                 <OSImage>
                     <InstallFrom>
@@ -50,18 +68,55 @@
                             <Domain></Domain>
                         </Credentials>
                         <MetaData wcm:action="add">
-                            <Key>/IMAGE/INDEX</Key>
-                            <Value>1</Value>
+                            <Key>/IMAGE/NAME</Key>
+#if $os_version == '7'
+                            <Value>Windows 7 PROFESSIONAL</Value>
+#else if $os_version == '8'
+                            <Value>Windows 8.1 Pro</Value>
+#else if $os_version == '10'
+                            <Value>Windows 10 Pro</Value>
+#else if $os_version == '11'
+                            <Value>Windows 11 Pro</Value>
+#else if $os_version == '2008'
+                            <Value>Windows Server 2008 R2 SERVERENTERPRISE</Value>
+#else if $os_version == '2012'
+                            <Value>Windows Server 2012 R2 SERVERSTANDARD</Value>
+#else if $os_version == '2016'
+                            <Value>Windows Server 2016 SERVERSTANDARD</Value>
+#else if $os_version == '2019'
+                            <Value>Windows Server 2019 SERVERSTANDARD</Value>
+#else if $os_version == '2022'
+                            <Value>Windows Server 2022 SERVERSTANDARD</Value>
+#end if
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>
                         <DiskID>0</DiskID>
-                        <PartitionID>1</PartitionID>
+                        <PartitionID>$part_num</PartitionID>
                     </InstallTo>
                 </OSImage>
             </ImageInstall>
             <UserData>
                 <ProductKey>
+#if $os_version == '7'
+                    <Key>FJ82H-XT6CR-J8D7P-XQJJ2-GPDD4</Key>
+#else if $os_version == '8'
+                    <Key>GCRJD-8NW9H-F2CDX-CCM8D-9D6T9</Key>
+#else if $os_version == '10'
+                    <Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>
+#else if $os_version == '11'
+                    <Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>
+#else if $os_version == '2008'
+                    <Key>489J6-VHDMP-X63PK-3K798-CPX3Y</Key>
+#else if $os_version == '2012'
+                    <Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
+#else if $os_version == '2016'
+                    <Key>WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY</Key>
+#else if $os_version == '2019'
+                    <Key>N69G4-B89J2-4G8F4-WWYCC-J464C</Key>
+#else if $os_version == '2022'
+                    <Key>VDYBN-27WPP-V4HQT-9VMD4-VMK7H</Key>
+#end if
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
@@ -73,7 +128,8 @@
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DriverPaths>
                 <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-                    <Path>\\@@http_server@@\@@samba_distro_share@@\@@distro_name@@\Drivers\@@os_version@@</Path>
+#set $drivers_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\links\\' + $distro_name + '\\Drivers'
+                    <Path>$drivers_dir</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>
@@ -88,6 +144,7 @@
             <ComputerName>*</ComputerName>
             <RegisteredOrganization>Some Organization</RegisteredOrganization>
             <RegisteredOwner>User</RegisteredOwner>
+            <TimeZone>UTC</TimeZone>
         </component>
         <component name="Microsoft-Windows-UnattendedJoin" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <Identification>
@@ -111,77 +168,79 @@
         </component>
     </settings>
     <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+            <InputLocale>$locale</InputLocale>
+            <SystemLocale>$locale</SystemLocale>
+            <UILanguage>$locale</UILanguage>
+            <UILanguageFallback>$locale</UILanguageFallback>
+            <UserLocale>$locale</UserLocale>
+        </component>
         <component name="Microsoft-Windows-Shell-Setup" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <OOBE>
-                <ProtectYourPC>3</ProtectYourPC>
                 <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>3</ProtectYourPC>
+#if $os_version not in ('2008', '2012', '7', '8')
+                <VMModeOptimizations>
+                    <SkipAdministratorProfileRemoval>false</SkipAdministratorProfileRemoval>
+                </VMModeOptimizations>
+                <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>
+#end if
+#if $os_version not in ('2008', '7')
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+#end if
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
             </OOBE>
-#if "user_accounts" in $autoinstall_meta
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=</Value>
-                    <PlainText>false</PlainText>
+                    <Value>User</Value>
+                    <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
-                            <PlainText>false</PlainText>
+                            <Value>User</Value>
+                            <PlainText>true</PlainText>
                         </Password>
                         <Name>User</Name>
                         <Group>Administrators</Group>
                     </LocalAccount>
                 </LocalAccounts>
-                <DomainAccounts>
-                    <DomainAccountList wcm:action="add">
-                        <Domain>WORKGROUP</Domain>
-                        <DomainAccount wcm:action="add">
-                            <Name>Domain Admins</Name>
-                            <Group>Administrators</Group>
-                        </DomainAccount>
-                        <DomainAccount wcm:action="add">
-                            <Name>User</Name>
-                            <Group>Administrators</Group>
-                        </DomainAccount>
-                    </DomainAccountList>
-                </DomainAccounts>
             </UserAccounts>
-#end if
             <TimeZone>UTC</TimeZone>
             <RegisteredOrganization>Some Organization</RegisteredOrganization>
             <RegisteredOwner>User</RegisteredOwner>
             <FirstLogonCommands>
-#if "user_accounts" in $autoinstall_meta
                 <SynchronousCommand wcm:action="add">
                     <RequiresUserInput>false</RequiresUserInput>
                     <Order>1</Order>
                     <CommandLine>cmd /C wmic useraccount where "name='User'" set PasswordExpires=FALSE</CommandLine>
                 </SynchronousCommand>
-#end if
                 <SynchronousCommand wcm:action="add">
                     <RequiresUserInput>false</RequiresUserInput>
                     <Order>2</Order>
                     <CommandLine>c:\post_install.cmd @@profile_name@@</CommandLine>
                 </SynchronousCommand>
             </FirstLogonCommands>
-#if "user_accounts" in $autoinstall_meta
             <AutoLogon>
                 <Password>
-                    <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
-                    <PlainText>false</PlainText>
+                    <Value>User</Value>
+                    <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
-                <Domain>WORKGROUP</Domain>
                 <Username>User</Username>
                 <LogonCount>10000</LogonCount>
             </AutoLogon>
-#end if
         </component>
     </settings>
 </unattend>
 #else
-#set $OriSrc = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $distro_name + '\\' + $win_arch
-#set $DevSrc = '\\Device\\LanmanRedirector\\' + $http_server + '\\' + $samba_distro_share + '\\' + $distro_name
+#set $OriSrc = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3] + '\\' + $win_arch
+#set $DevSrc = '\\Device\\LanmanRedirector\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3]
 [Data]
 floppyless = "1"
 msdosinitiated = "1"
@@ -278,9 +337,9 @@ AllowConnections=1
 
 [UserData]
 #if $os_version == '2003'
-ProductKey="XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+ProductKey="VD2BM-TP2KK-CBXDQ-7B7FQ-4M9V3"
 #else
-ProductKey="XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+ProductKey="CB9YB-Q73J8-RKPMH-M2WFT-P4WQJ"
 #end if
 ComputerName=*
 FullName="Admin"

--- a/templates/windows/answerfile.template
+++ b/templates/windows/answerfile.template
@@ -3,7 +3,7 @@
 #else if $arch == 'i386'
 	#set $win_arch = 'i386'
 #end if
-#if $os_version not in ('XP', '2003')
+#if $os_version not in ('xp', '2003')
 #set $procarch = 'processorArchitecture="' + $win_arch + '"'
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">

--- a/templates/windows/post_inst_cmd.template
+++ b/templates/windows/post_inst_cmd.template
@@ -1,15 +1,18 @@
 Echo on
 
-##%systemdrive%
-##CD %systemdrive%\TMP >nul 2>&1
-##$SNIPPET('my/win_wait_network_online')
-##wget.exe http://@@http_server@@/cblr/svc/op/autoinstall/profile/%1 -O install.cmd
-##todos.exe install.cmd
-##start /wait install.cmd
-##DEL /F /Q libeay32.dll >nul 2>&1
-##DEL /F /Q libiconv2.dll >nul 2>&1
-##DEL /F /Q libintl3.dll >nul 2>&1
-##DEL /F /Q libssl32.dll >nul 2>&1
-##DEL /F /Q wget.exe >nul 2>&1
-##DEL /F /Q %0 >nul 2>&1
+$SNIPPET('wait_network_online')
+#if $os_version not in ('xp', '2003')
+powershell -command "& {\$WebClient = New-Object System.Net.WebClient; \$WebClient.DownloadFile('http://@@http_server@@/cblr/svc/op/autoinstall/profile/%1','install.cmd')}"
+#else
+wget.exe http://@@http_server@@/cblr/svc/op/autoinstall/profile/%1 -O install.cmd
+todos.exe install.cmd
+DEL /F /Q libeay32.dll >nul 2>&1
+DEL /F /Q libiconv2.dll >nul 2>&1
+DEL /F /Q libintl3.dll >nul 2>&1
+DEL /F /Q libssl32.dll >nul 2>&1
+DEL /F /Q wget.exe >nul 2>&1
+#end if
+start /wait install.cmd
+DEL /F /Q install.cmd >nul 2>&1
+DEL /F /Q %0 >nul 2>&1
 

--- a/templates/windows/startnet.template
+++ b/templates/windows/startnet.template
@@ -1,8 +1,9 @@
 wpeinit
 
-ping 127.0.0.1 -n 10 >nul
-#set $distro_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3]
-net use z: $distro_dir
+$SNIPPET('wait_network_online')
+#set $distros_dir = '\\\\' + $http_server + '\\' + $samba_distro_share
+#set $distro_share = 'Z:\\links\\' + $distro_name
+net use z: $distros_dir
 set exit_code=%ERRORLEVEL%
 IF %exit_code% EQU 0 GOTO INSTALL
 echo "Can't mount network drive"
@@ -22,11 +23,11 @@ echo assign letter=C >>disk.scr
 diskpart.exe /s disk.scr
 bootsect.exe /nt52 c: /force /mbr
 #end if
-xcopy z:\\$OEM\$\\$1 c: /y /s /e
+xcopy $distro_share\\$OEM\$\\$1 c: /y /s /e
 #end if
 #set $unattended = ""
 #if "answerfile" in $autoinstall_meta
-#set $unattended = "/unattend:Z:\\" + $autoinstall_meta["answerfile"]
+#set $unattended = "/unattend:Z:\\images\\" + $distro_name + '\\' + $autoinstall_meta["answerfile"]
 #end if
 
 #if $os_version in ('xp', '2003' )
@@ -35,10 +36,10 @@ xcopy z:\\$OEM\$\\$1 c: /y /s /e
 #else if $arch == 'i386'
         #set $win_arch = 'i386'
 #end if
-#set $winnt = 'z:\\' + $win_arch + '\\winnt32.exe'
+#set $winnt = $distro_share + '\\' + $win_arch + '\\winnt32.exe'
 $winnt /syspart:c: /tempdrive:c: /makelocalsource $unattended
 #else
-z:\sources\setup.exe $unattended
+$distro_share\sources\setup.exe $unattended
 #end if
 :EXIT
 exit

--- a/templates/windows/startnet.template
+++ b/templates/windows/startnet.template
@@ -1,7 +1,7 @@
 wpeinit
 
 ping 127.0.0.1 -n 10 >nul
-#set $distro_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $distro_name
+#set $distro_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3]
 net use z: $distro_dir
 set exit_code=%ERRORLEVEL%
 IF %exit_code% EQU 0 GOTO INSTALL
@@ -10,7 +10,7 @@ pause
 goto EXIT
 
 :INSTALL
-#if $os_version in ('XP', '2003' )
+#if $os_version in ('xp', '2003' )
 #if "clean_disk" in $autoinstall_meta
 echo select disk 0 >disk.scr
 echo clean >>disk.scr
@@ -29,7 +29,7 @@ xcopy z:\\$OEM\$\\$1 c: /y /s /e
 #set $unattended = "/unattend:Z:\\" + $autoinstall_meta["answerfile"]
 #end if
 
-#if $os_version in ('XP', '2003' )
+#if $os_version in ('xp', '2003' )
 #if $arch == 'x86_64'
         #set $win_arch = 'amd64'
 #else if $arch == 'i386'

--- a/tests/utils/filesystem_helpers_test.py
+++ b/tests/utils/filesystem_helpers_test.py
@@ -196,7 +196,7 @@ def test_rmtree():
 def test_mkdir():
     # TODO: Check how already existing folder is handled.
     # Arrange
-    testfolder = "/dev/shm/testfoldercreation"
+    testfolder = "/dev/shm/testfoldercreation/testmkdir"
     testmode = 0o600
 
     try:


### PR DESCRIPTION
## Linked Items

Fixes #3473

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Fixes an issue with Windows UEFI + Docs + small fixes

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->
 - BCD: Windows Boot Application (13200003)
 - BCD: Timeout: 30

New: <!-- This is the new way Cobbler behaves -->
- BCD: Windows Boot Loader
- BCD: add Path: \windows\system32\winload.exe
 - description of the sync_post_wingen.py trigger is documented
 - BCD Tiimeout: 0
 - fix: os_version must be in lowercase
 - fix: non-standard distro directory in distro_mirror
 - fix: path for winpe.wim in case of using wimboot

## Category

This is related to a:

- [X] Bugfix
- [x] Feature
- [ ] Packaging
- [X] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
