### PR TITLE
 Backport windows UEFI fix from PR cobbler#3476 for 3.3

### DIFF
--- a/autoinstall_snippets/Windows/wait_network_online
+++ b/autoinstall_snippets/Windows/wait_network_online
@@ -1,0 +1,15 @@
+:wno10
+set n=0
+
+:wno20
+ping @@http_server@@ -n 3
+set exit_code=%ERRORLEVEL%
+
+IF %exit_code% EQU 0 GOTO wno_exit
+set /a n=n+1
+IF %n% lss 30 goto wno20
+pause
+goto wno10
+
+:wno_exit
+

--- a/autoinstall_templates/win.ks
+++ b/autoinstall_templates/win.ks
@@ -1,1 +1,4 @@
 REM Sample kickstart file for Windows distributions.
+Echo on
+$SNIPPET('wait_network_online')
+exit

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -146,6 +146,21 @@ class MkLoaders:
             self.bootloaders_dir.joinpath("pxelinux.0"),
             skip_existing=True
         )
+        # Make linux.c32 for syslinux + wimboot
+        libcom32_c32_path = self.syslinux_folder.joinpath("libcom32.c32")
+        if syslinux_version > 4 and libcom32_c32_path.exists():
+            symlink(
+                self.syslinux_pxelinux_folder.joinpath("linux.c32"),
+                self.bootloaders_dir.joinpath("linux.c32"),
+                skip_existing=True,
+            )
+            # Make libcom32.c32
+            # 'linux.c32' depends on 'libcom32.c32'
+            symlink(
+                self.syslinux_pxelinux_folder.joinpath("libcom32.c32"),
+                self.bootloaders_dir.joinpath("libcom32.c32"),
+                skip_existing=True,
+            )
 
     def make_grub(self):
         """

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -34,7 +34,7 @@ import magic
 HAS_HIVEX = True
 try:
     import hivex
-    from hivex.hive_types import REG_SZ
+    from hivex.hive_types import REG_SZ, REG_EXPAND_SZ
 except Exception:
     HAS_HIVEX = False
 
@@ -227,30 +227,34 @@ class _ImportSignatureManager(ManagerModule):
                                 software = os.path.join(dest_path, os.path.basename(config_path))
                                 h = hivex.Hivex(software, write=True)
                                 root = h.root()
-                                node = h.node_get_child(root, "Microsoft")
-                                node = h.node_get_child(node, "Windows NT")
-                                node = h.node_get_child(node, "CurrentVersion")
-                                h.node_set_value(node, {"key": "SystemRoot", "t": REG_SZ,
-                                                        "value": "x:\\Windows\0".encode(encoding="utf-16le")})
-                                node = h.node_get_child(node, "WinPE")
+                                nodes: List[Any] = [root]
+                                pat = "X:\\$windows.~bt"
 
-                                # remove the key InstRoot from the registry
-                                values = h.node_values(node)
-                                new_values = []
+                                while len(nodes) > 0:
+                                    n = nodes.pop()
+                                    nodes.extend(h.node_children(n))
 
-                                for value in values:
-                                    keyname = h.value_key(value)
+                                    new_values = []
+                                    update_flag = False
+                                    key_vals = h.node_values(n)
+                                    for key_val in key_vals:
+                                        key = h.value_key(key_val)
+                                        val = h.node_get_value(n, key)
+                                        val_type, val_value = h.value_value(val)
+                                        if pat in key:
+                                            key = key.replace(pat, "X:")
+                                            update_flag = True
+                                        if val_type in (REG_SZ, REG_EXPAND_SZ):
+                                            val_string = h.value_string(val)
+                                            if pat in val_string:
+                                                val_string = val_string.replace(pat, "X:")
+                                                val_value = (val_string + "\0").encode(encoding="utf-16le")
+                                                update_flag = True
+                                        new_val = { "key": key, "t": val_type, "value": val_value, }
+                                        new_values.append(new_val)
 
-                                    if keyname == "InstRoot":
-                                        continue
-
-                                    val = h.node_get_value(node, keyname)
-                                    valtype = h.value_type(val)[0]
-                                    value2 = h.value_value(val)[1]
-                                    valobject = {"key": keyname, "t": int(valtype), "value": value2}
-                                    new_values.append(valobject)
-
-                                h.node_set_values(node, new_values)
+                                    if update_flag:
+                                        h.node_set_values(n, new_values)
                                 h.commit(software)
 
                                 cmd_path = "/usr/bin/wimupdate"
@@ -506,7 +510,7 @@ class _ImportSignatureManager(ManagerModule):
                 bcd_path = os.path.join(dest_path, "bcd")
                 winpe_path = os.path.join(dest_path, "winpe.wim")
                 if os.path.exists(bootmgr_path) and os.path.exists(bcd_path) and os.path.exists(winpe_path):
-                    new_profile.autoinstall_meta = {"kernel": os.path.basename(kernel),
+                    new_profile.autoinstall_meta = {"kernel": "pxeboot.0",
                                                     "bootmgr": "bootmgr.exe",
                                                     "bcd": "bcd",
                                                     "winpe": "winpe.wim",

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -138,8 +138,8 @@ class _ImportSignatureManager(ManagerModule):
                 return f.readlines()
         else:
             self.logger.info(
-                'Could not detect the filetype and read the content of file "%s". Returning nothing.',
-                filename,
+                'Could not detect the filetype "%s" and read the content of file "%s". Returning nothing.',
+                ftype.mime_type, filename,
             )
         return []
 
@@ -250,7 +250,7 @@ class _ImportSignatureManager(ManagerModule):
                                                 val_string = val_string.replace(pat, "X:")
                                                 val_value = (val_string + "\0").encode(encoding="utf-16le")
                                                 update_flag = True
-                                        new_val = { "key": key, "t": val_type, "value": val_value, }
+                                        new_val = {"key": key, "t": val_type, "value": val_value,}
                                         new_values.append(new_val)
 
                                     if update_flag:
@@ -506,15 +506,19 @@ class _ImportSignatureManager(ManagerModule):
 
             if self.breed == "windows":
                 dest_path = os.path.join(self.path, "boot")
+                kernel_path = f"http://@@http_server@@/images/{name}/wimboot"
+                if new_distro.os_version in ("xp", "2003"):
+                    kernel_path = "pxeboot.0"
                 bootmgr_path = os.path.join(dest_path, "bootmgr.exe")
                 bcd_path = os.path.join(dest_path, "bcd")
                 winpe_path = os.path.join(dest_path, "winpe.wim")
                 if os.path.exists(bootmgr_path) and os.path.exists(bcd_path) and os.path.exists(winpe_path):
-                    new_profile.autoinstall_meta = {"kernel": "pxeboot.0",
+                    new_profile.autoinstall_meta = {"kernel": kernel_path,
                                                     "bootmgr": "bootmgr.exe",
                                                     "bcd": "bcd",
                                                     "winpe": "winpe.wim",
-                                                    "answerfile": "autounattended.xml"}
+                                                    "answerfile": "autounattended.xml",
+                                                    "post_install_script": "post_install.cmd"}
 
             self.profiles.add(new_profile, save=True)
 

--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -80,8 +80,10 @@ def bcdedit(orig_bcd, new_bcd, wim, sdi, startoptions=None):
 
     b = h.node_add_child(objs, "{65c31250-afa2-11df-8045-000c29f37d88}")
     d = h.node_add_child(b, "Description")
-    h.node_set_value(d, {"key": "Type", "t": REG_DWORD, "value": b"\x03\x00\x20\x13"})
+    h.node_set_value(d, {"key": "Type", "t": REG_DWORD, "value": b"\x03\x00\x20\x10"})
     e = h.node_add_child(b, "Elements")
+    e1 = h.node_add_child(e, "12000002")
+    h.node_set_value(e1, {"key": "Element", "t": REG_SZ, "value": "\\windows\\system32\\winload.exe\0".encode(encoding="utf-16le"), }, )
     e1 = h.node_add_child(e, "12000004")
     h.node_set_value(e1, {"key": "Element", "t": REG_SZ, "value": "Windows PE\0".encode(encoding="utf-16le")})
     e1 = h.node_add_child(e, "22000002")
@@ -172,9 +174,6 @@ def run(api, args):
         is_wimboot = "wimboot" in kernel_name
 
         if is_wimboot:
-            distro_path = os.path.join(settings.webdir, "distro_mirror", distro.name)
-            kernel_path = os.path.join(distro_path, "boot")
-
             if "kernel" in meta and "wimboot" not in distro.kernel:
                 tgen.copy_single_distro_file(os.path.join(settings.tftpboot_location, kernel_name), distro_dir, False)
                 tgen.copy_single_distro_file(os.path.join(distro_dir, kernel_name), web_dir, True)
@@ -296,7 +295,7 @@ def run(api, args):
                 wim_file_name = meta["winpe"]
 
             if is_wimboot:
-                wim_file_name = '\\Boot\\' + wim_file_name
+                wim_file_name = '\\Boot\\' + "winpe.wim"
                 sdi_file_name = '\\Boot\\' + 'boot.sdi'
             else:
                 wim_file_name = os.path.join("/images", distro.name, wim_file_name)

--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -69,7 +69,7 @@ def bcdedit(orig_bcd, new_bcd, wim, sdi, startoptions=None):
     h.node_set_value(d, {"key": "Type", "t": REG_DWORD, "value": b"\x02\x00\x10\x10"})
     e = h.node_add_child(b, "Elements")
     e1 = h.node_add_child(e, "25000004")
-    h.node_set_value(e1, {"key": "Element", "t": REG_BINARY, "value": b"\x1e\x00\x00\x00\x00\x00\x00\x00"})
+    h.node_set_value(e1, {"key": "Element", "t": REG_BINARY, "value": b"\x00\x00\x00\x00\x00\x00\x00\x00"})
     e1 = h.node_add_child(e, "12000004")
     h.node_set_value(e1, {"key": "Element", "t": REG_SZ, "value": "Windows Boot Manager\0".encode(encoding="utf-16le")})
     e1 = h.node_add_child(e, "24000001")
@@ -83,7 +83,14 @@ def bcdedit(orig_bcd, new_bcd, wim, sdi, startoptions=None):
     h.node_set_value(d, {"key": "Type", "t": REG_DWORD, "value": b"\x03\x00\x20\x10"})
     e = h.node_add_child(b, "Elements")
     e1 = h.node_add_child(e, "12000002")
-    h.node_set_value(e1, {"key": "Element", "t": REG_SZ, "value": "\\windows\\system32\\winload.exe\0".encode(encoding="utf-16le"), }, )
+    h.node_set_value(
+        e1,
+        {
+            "key": "Element",
+            "t": REG_SZ,
+            "value": "\\windows\\system32\\winload.exe\0".encode(encoding="utf-16le"),
+        },
+    )
     e1 = h.node_add_child(e, "12000004")
     h.node_set_value(e1, {"key": "Element", "t": REG_SZ, "value": "Windows PE\0".encode(encoding="utf-16le")})
     e1 = h.node_add_child(e, "22000002")
@@ -173,15 +180,14 @@ def run(api, args):
         kernel_name = os.path.basename(kernel_name)
         is_wimboot = "wimboot" in kernel_name
 
-        if is_wimboot:
-            if "kernel" in meta and "wimboot" not in distro.kernel:
-                tgen.copy_single_distro_file(os.path.join(settings.tftpboot_location, kernel_name), distro_dir, False)
-                tgen.copy_single_distro_file(os.path.join(distro_dir, kernel_name), web_dir, True)
+        if is_wimboot and "kernel" in meta and "wimboot" not in distro.kernel:
+            tgen.copy_single_distro_file(os.path.join(settings.tftpboot_location, kernel_name), distro_dir, False)
+            tgen.copy_single_distro_file(os.path.join(distro_dir, kernel_name), web_dir, True)
 
         if "post_install_script" in meta:
             post_install_dir = distro_path
 
-            if distro.os_version not in ("XP", "2003"):
+            if distro.os_version not in ("xp", "2003"):
                 post_install_dir = os.path.join(post_install_dir, "sources")
 
             post_install_dir = os.path.join(post_install_dir, "$OEM$", "$1")
@@ -201,15 +207,14 @@ def run(api, args):
             logger.info("Build answer file: %s", answerfile_name)
             with open(answerfile_name, "w+") as answerfile:
                 answerfile.write(data)
-            tgen.copy_single_distro_file(answerfile_name, distro_path, False)
-            tgen.copy_single_distro_file(answerfile_name, web_dir, True)
+            tgen.copy_single_distro_file(answerfile_name, web_dir, False)
 
         if "kernel" in meta and "bootmgr" in meta:
             wk_file_name = os.path.join(distro_dir, kernel_name)
             wl_file_name = os.path.join(distro_dir, meta["bootmgr"])
             tl_file_name = os.path.join(kernel_path, "bootmgr.exe")
 
-            if distro.os_version in ("XP", "2003") and not is_winpe:
+            if distro.os_version in ("xp", "2003") and not is_winpe:
                 tl_file_name = os.path.join(kernel_path, "setupldr.exe")
 
                 if len(meta["bootmgr"]) != 5:
@@ -265,7 +270,7 @@ def run(api, args):
                 tgen.copy_single_distro_file(wl_file_name, web_dir, True)
 
             if not is_wimboot:
-                if distro.os_version not in ("XP", "2003") or is_winpe:
+                if distro.os_version not in ("xp", "2003") or is_winpe:
                     pe = pefile.PE(wl_file_name, fast_load=True)
                     pe.OPTIONAL_HEADER.CheckSum = pe.generate_checksum()
                     pe.write(filename=wl_file_name)
@@ -294,12 +299,11 @@ def run(api, args):
             if is_winpe:
                 wim_file_name = meta["winpe"]
 
+            tftp_image = os.path.join("/images", distro.name)
             if is_wimboot:
-                wim_file_name = '\\Boot\\' + "winpe.wim"
-                sdi_file_name = '\\Boot\\' + 'boot.sdi'
-            else:
-                wim_file_name = os.path.join("/images", distro.name, wim_file_name)
-                sdi_file_name = os.path.join("/images", distro.name, os.path.basename(distro.initrd))
+                tftp_image = "/Boot"
+            wim_file_name = os.path.join(tftp_image, wim_file_name)
+            sdi_file_name = os.path.join(tftp_image, os.path.basename(distro.initrd))
 
             logger.info(
                 "Build BCD: %s from %s for %s",
@@ -316,7 +320,6 @@ def run(api, args):
 
             cmd = ["/usr/bin/cp", "--reflink=auto", wim_pl_name, ps_file_name]
             utils.subprocess_call(cmd, shell=False)
-            tgen.copy_single_distro_file(ps_file_name, web_dir, True)
 
             if os.path.exists(wimupdate):
                 data = templ.render(tmplstart_data, meta, None)
@@ -328,11 +331,15 @@ def run(api, args):
                 cmd = [wimupdate, ps_file_name, "--command=add %s %s" % (pi_file.name, startnet_path)]
                 utils.subprocess_call(cmd, shell=False)
                 pi_file.close()
+            tgen.copy_single_distro_file(ps_file_name, web_dir, True)
 
     for profile in profiles:
         distro = profile.get_conceptual_parent()
 
-        if distro and distro.breed == "windows":
+        if distro is None:
+            raise ValueError("Distro not found!")
+
+        if distro.breed == "windows":
             logger.info("Profile: %s", profile.name)
             meta = utils.blender(api, False, profile)
             autoinstall_meta = meta.get("autoinstall_meta", {})

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1251,7 +1251,7 @@ class TFTPGen:
         initrd_line = custom_loader_name
 
         if format == "ipxe":
-            initrd_line = f"--name {loader_name}  {custom_loader_name}"
+            initrd_line = f"--name {loader_name} {custom_loader_name} {loader_name}"
         elif format == "pxe":
             initrd_line = f"{custom_loader_name}@{loader_name}"
         elif format == "grub":

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -3115,7 +3115,18 @@
         "kernel_arch": "(i386|amd64)",
         "kernel_arch_regex": null,
         "supported_arches":["i386","amd64"],
-        "boot_loaders":{"i386":["pxe","ipxe"], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "i386":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3137,7 +3148,18 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["x86","x86_64"],
-        "boot_loaders":{"i386":["pxe","ipxe"], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "i386":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3156,7 +3178,13 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86_64)$",
         "supported_arches":["x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3175,7 +3203,13 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86_64)$",
         "supported_arches":["x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3194,7 +3228,13 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86_64)$",
         "supported_arches":["x86_64"],
-        "boot_loaders":{"x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3203,7 +3243,32 @@
         "kernel_options_post": "",
         "boot_files": []
       },
-      "XP": {
+      "2022": {
+        "signatures": [
+          "sources",
+          "autorun.inf"
+        ],
+        "version_file": "install\\.wim",
+        "version_file_regex": "^Name:.*Windows Server 2022.*$",
+        "kernel_arch": "install\\.wim",
+        "kernel_arch_regex": "^Architecture:.*(x86_64)$",
+        "supported_arches":["x86_64"],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "pxeboot\\.n12",
+        "initrd_file": "boot\\.sdi",
+        "default_autoinstall": "win.ks",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
+      "xp": {
         "signatures": [
           "amd64",
           "i386",
@@ -3214,7 +3279,18 @@
         "kernel_arch": "(i386|amd64)",
         "kernel_arch_regex": null,
         "supported_arches":["i386","amd64"],
-        "boot_loaders":{"i386":["pxe","ipxe"], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "i386":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3236,7 +3312,18 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["x86","x86_64"],
-        "boot_loaders":{"i386":["pxe","ipxe"], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "i386":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3255,7 +3342,18 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["x86","x86_64"],
-        "boot_loaders":{"i386":["pxe","ipxe"], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "i386":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3274,7 +3372,18 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(x86|x86_64)$",
         "supported_arches":["x86","x86_64"],
-        "boot_loaders":{"i386":["pxe","ipxe"], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "i386":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",
@@ -3293,7 +3402,14 @@
         "kernel_arch": "install\\.wim",
         "kernel_arch_regex": "^Architecture:.*(ARM64|x86_64)$",
         "supported_arches":["ARM64","x86_64"],
-        "boot_loaders":{"aarch64":[], "x86_64":["pxe","ipxe"]},
+        "boot_loaders":{
+          "aarch64":[],
+          "x86_64":[
+            "pxe",
+            "ipxe",
+            "grub"
+          ]
+        },
         "supported_repo_breeds": [],
         "kernel_file": "pxeboot\\.n12",
         "initrd_file": "boot\\.sdi",

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -6,7 +6,7 @@ User Guide
    :maxdepth: 2
 
    Configuration Management Integrations <user-guide/configuration-management-integrations>
-   Automatic Windows installation with Cobbler <user-guide/wingen>
+   Windows installation with Cobbler <user-guide/wingen>
    Extending Cobbler <user-guide/extending-cobbler>
    Terraform Provider for Cobbler <user-guide/terraform-provider>
    Building ISOs <user-guide/building-isos>

--- a/docs/user-guide/wingen.rst
+++ b/docs/user-guide/wingen.rst
@@ -344,7 +344,7 @@ Legacy Windows XP and Windows 2003 Server
     --initrd=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/boot.sdi \
     --remote-boot-kernel=http://@@http_server@@/cobbler/images/@@distro_name@@/wimboot \
     --remote-boot-initrd=http://@@http_server@@/cobbler/images/@@distro_name@@/boot.sdi \
-    --arch=i386 --breed=windows --os-version=XP \
+    --arch=i386 --breed=windows --os-version=xp \
     --boot-loaders=ipxe --autoinstall-meta='clean_disk'
 
     cobbler distro add --name=Win2k3-Server_EN-x64 \
@@ -370,7 +370,7 @@ Legacy Windows XP and Windows 2003 Server
     cobbler distro add --name=WinXp_EN-i386 \
     --kernel=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/pxeboot.n12 \
     --initrd=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/boot.sdi \
-    --arch=i386 --breed=windows --os-version=XP \
+    --arch=i386 --breed=windows --os-version=xp \
     --autoinstall-meta='clean_disk'
 
     cobbler distro add --name=Win2k3-Server_EN-x64 \
@@ -462,7 +462,7 @@ Copy the required drivers to the ``i386``
     --kernel=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/pxeboot.n12 \
     --initrd=/var/www/cobbler/distro_mirror/WinXp_EN-i386/boot/boot.sdi \
     --boot-files='@@local_img_path@@/i386/=@@web_img_path@@/i386/*.*' \
-    --arch=i386 --breed=windows –os-version=XP
+    --arch=i386 --breed=windows –os-version=xp
 
     cobbler distro add --name=Win2k3-Server_EN-x64 \
     --kernel=/var/www/cobbler/distro_mirror/Win2k3-Server_EN-x64/boot/pxeboot.n12 \

--- a/templates/boot_loader_conf/grub.template
+++ b/templates/boot_loader_conf/grub.template
@@ -10,7 +10,15 @@ set default='local'
 menuentry '$menu_name' --class gnu-linux --class gnu --class os {
   echo 'Loading kernel ...'
   clinux $kernel_path $kernel_options
+#if "wimboot" in $kernel_path
+#set $initrd_path = ""
+#for $init in $initrd
+#set $initrd_path += " " + $init
+#end for
+#end if
+#if $breed != "windows" or "wimboot" in $kernel_path
   echo 'Loading initial ramdisk ...'
   cinitrd $initrd_path
+#end if
   echo '...done'
 }

--- a/templates/boot_loader_conf/pxe.template
+++ b/templates/boot_loader_conf/pxe.template
@@ -22,8 +22,19 @@ LABEL $menu_name
 #if $system_local
 	localboot -1
 #else
+#if $breed == "windows"
+#if "wimboot" in $kernel_path
+	kernel linux.c32
+#set $append_line = "append " + $kernel_path
+#for $init in $initrd
+#set $append_line += " initrdfile=" + $init
+#end for
+	$append_line
+#else
 	kernel $kernel_path
-#if $breed != "windows"
+#end if
+#else
+	kernel $kernel_path
 	$append_line
 	ipappend 2
 #end if

--- a/templates/windows/answerfile.template
+++ b/templates/windows/answerfile.template
@@ -3,46 +3,64 @@
 #else if $arch == 'i386'
 	#set $win_arch = 'i386'
 #end if
-#if $os_version not in ('XP', '2003')
+#if $os_version not in ('xp', '2003')
 #set $procarch = 'processorArchitecture="' + $win_arch + '"'
 <?xml version="1.0" encoding="utf-8"?>
 <unattend xmlns="urn:schemas-microsoft-com:unattend">
     <settings pass="windowsPE">
         <component name="Microsoft-Windows-International-Core-WinPE" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-#if "locale_num" in $autoinstall_meta
-            <InputLocale>@@locale_num@@</InputLocale>
-#else
-            <InputLocale>0409:00000409</InputLocale>
-#end if
-#if "locale" in $autoinstall_meta
-            <SystemLocale>@@locale@@</SystemLocale>
-            <UILanguage>@@locale@@</UILanguage>
-            <UILanguageFallback>@@locale@@</UILanguageFallback>
-            <UserLocale>@@locale@@</UserLocale>
-#else
-            <SystemLocale>en-US</SystemLocale>
-            <UILanguage>en-US</UILanguage>
-            <UILanguageFallback>en-US</UILanguageFallback>
-            <UserLocale>en-US</UserLocale>
-#end if
+            <SetupUILanguage>
+#set $locale = $getVar('locale', 'en-US')
+                <UILanguage>$locale</UILanguage>
+            </SetupUILanguage>
+            <InputLocale>$locale</InputLocale>
+            <SystemLocale>$locale</SystemLocale>
+            <UILanguage>$locale</UILanguage>
+            <UILanguageFallback>$locale</UILanguageFallback>
+            <UserLocale>$locale</UserLocale>
         </component>
         <component name="Microsoft-Windows-Setup" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
-#if "clean_disk"  in $autoinstall_meta
             <DiskConfiguration>
                 <WillShowUI>OnError</WillShowUI>
                 <Disk wcm:action="add">
                     <DiskID>0</DiskID>
                     <WillWipeDisk>true</WillWipeDisk>
+#set $uefi = 'True'
+#if $os_version in ('7', '2008')
+#set $uefi = 'False'
+#end if
+#set $uefi = $getVar('uefi', $uefi)
+#set $part_num = 0
                     <CreatePartitions>
+#if $uefi == 'True'
                         <CreatePartition wcm:action="add">
-                            <Order>1</Order>
+#set $part_num += 1
+                            <Order>$part_num</Order>
+                            <Type>Primary</Type>
+                            <Size>300</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+#set $part_num += 1
+                            <Order>$part_num</Order>
+                            <Type>EFI</Type>
+                            <Size>100</Size>
+                        </CreatePartition>
+                        <CreatePartition wcm:action="add">
+#set $part_num += 1
+                            <Order>$part_num</Order>
+                            <Type>MSR</Type>
+                            <Size>128</Size>
+                        </CreatePartition>
+#end if
+                        <CreatePartition wcm:action="add">
+#set $part_num += 1
+                            <Order>$part_num</Order>
                             <Extend>true</Extend>
                             <Type>Primary</Type>
                         </CreatePartition>
                     </CreatePartitions>
                 </Disk>
             </DiskConfiguration>
-#end if
             <ImageInstall>
                 <OSImage>
                     <InstallFrom>
@@ -50,18 +68,55 @@
                             <Domain></Domain>
                         </Credentials>
                         <MetaData wcm:action="add">
-                            <Key>/IMAGE/INDEX</Key>
-                            <Value>1</Value>
+                            <Key>/IMAGE/NAME</Key>
+#if $os_version == '7'
+                            <Value>Windows 7 PROFESSIONAL</Value>
+#else if $os_version == '8'
+                            <Value>Windows 8.1 Pro</Value>
+#else if $os_version == '10'
+                            <Value>Windows 10 Pro</Value>
+#else if $os_version == '11'
+                            <Value>Windows 11 Pro</Value>
+#else if $os_version == '2008'
+                            <Value>Windows Server 2008 R2 SERVERENTERPRISE</Value>
+#else if $os_version == '2012'
+                            <Value>Windows Server 2012 R2 SERVERSTANDARD</Value>
+#else if $os_version == '2016'
+                            <Value>Windows Server 2016 SERVERSTANDARD</Value>
+#else if $os_version == '2019'
+                            <Value>Windows Server 2019 SERVERSTANDARD</Value>
+#else if $os_version == '2022'
+                            <Value>Windows Server 2022 SERVERSTANDARD</Value>
+#end if
                         </MetaData>
                     </InstallFrom>
                     <InstallTo>
                         <DiskID>0</DiskID>
-                        <PartitionID>1</PartitionID>
+                        <PartitionID>$part_num</PartitionID>
                     </InstallTo>
                 </OSImage>
             </ImageInstall>
             <UserData>
                 <ProductKey>
+#if $os_version == '7'
+                    <Key>FJ82H-XT6CR-J8D7P-XQJJ2-GPDD4</Key>
+#else if $os_version == '8'
+                    <Key>GCRJD-8NW9H-F2CDX-CCM8D-9D6T9</Key>
+#else if $os_version == '10'
+                    <Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>
+#else if $os_version == '11'
+                    <Key>W269N-WFGWX-YVC9B-4J6C9-T83GX</Key>
+#else if $os_version == '2008'
+                    <Key>489J6-VHDMP-X63PK-3K798-CPX3Y</Key>
+#else if $os_version == '2012'
+                    <Key>D2N9P-3P6X9-2R39C-7RTCD-MDVJX</Key>
+#else if $os_version == '2016'
+                    <Key>WC2BQ-8NRM3-FDDYY-2BFGV-KHKQY</Key>
+#else if $os_version == '2019'
+                    <Key>N69G4-B89J2-4G8F4-WWYCC-J464C</Key>
+#else if $os_version == '2022'
+                    <Key>VDYBN-27WPP-V4HQT-9VMD4-VMK7H</Key>
+#end if
                     <WillShowUI>Never</WillShowUI>
                 </ProductKey>
                 <AcceptEula>true</AcceptEula>
@@ -73,7 +128,8 @@
         <component name="Microsoft-Windows-PnpCustomizationsWinPE" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <DriverPaths>
                 <PathAndCredentials wcm:action="add" wcm:keyValue="6">
-                    <Path>\\@@http_server@@\@@samba_distro_share@@\@@distro_name@@\Drivers\@@os_version@@</Path>
+#set $drivers_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\links\\' + $distro_name + '\\Drivers'
+                    <Path>$drivers_dir</Path>
                 </PathAndCredentials>
             </DriverPaths>
         </component>
@@ -88,6 +144,7 @@
             <ComputerName>*</ComputerName>
             <RegisteredOrganization>Some Organization</RegisteredOrganization>
             <RegisteredOwner>User</RegisteredOwner>
+            <TimeZone>UTC</TimeZone>
         </component>
         <component name="Microsoft-Windows-UnattendedJoin" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <Identification>
@@ -111,77 +168,87 @@
         </component>
     </settings>
     <settings pass="oobeSystem">
+        <component name="Microsoft-Windows-International-Core" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+#if "locale" in $autoinstall_meta
+            <InputLocale>@@locale@@</InputLocale>
+            <SystemLocale>@@locale@@</SystemLocale>
+            <UILanguage>@@locale@@</UILanguage>
+            <UILanguageFallback>@@locale@@</UILanguageFallback>
+            <UserLocale>@@locale@@</UserLocale>
+#else
+            <InputLocale>en-US</InputLocale>
+            <SystemLocale>en-US</SystemLocale>
+            <UILanguage>en-US</UILanguage>
+            <UILanguageFallback>en-US</UILanguageFallback>
+            <UserLocale>en-US</UserLocale>
+#end if
+        </component>
         <component name="Microsoft-Windows-Shell-Setup" $procarch publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS" xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
             <OOBE>
-                <ProtectYourPC>3</ProtectYourPC>
                 <NetworkLocation>Work</NetworkLocation>
+                <ProtectYourPC>3</ProtectYourPC>
+#if $os_version not in ('2008', '2012', '7', '8')
+                <VMModeOptimizations>
+                    <SkipAdministratorProfileRemoval>false</SkipAdministratorProfileRemoval>
+                </VMModeOptimizations>
+                <UnattendEnableRetailDemo>false</UnattendEnableRetailDemo>
+#end if
+#if $os_version not in ('2008', '7')
+                <HideLocalAccountScreen>true</HideLocalAccountScreen>
+                <HideOEMRegistrationScreen>true</HideOEMRegistrationScreen>
+                <HideOnlineAccountScreens>true</HideOnlineAccountScreens>
+#end if
+                <HideEULAPage>true</HideEULAPage>
+                <HideWirelessSetupInOOBE>true</HideWirelessSetupInOOBE>
+                <SkipMachineOOBE>true</SkipMachineOOBE>
+                <SkipUserOOBE>true</SkipUserOOBE>
             </OOBE>
-#if "user_accounts" in $autoinstall_meta
             <UserAccounts>
                 <AdministratorPassword>
-                    <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=</Value>
-                    <PlainText>false</PlainText>
+                    <Value>User</Value>
+                    <PlainText>true</PlainText>
                 </AdministratorPassword>
                 <LocalAccounts>
                     <LocalAccount wcm:action="add">
                         <Password>
-                            <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
-                            <PlainText>false</PlainText>
+                            <Value>User</Value>
+                            <PlainText>true</PlainText>
                         </Password>
                         <Name>User</Name>
                         <Group>Administrators</Group>
                     </LocalAccount>
                 </LocalAccounts>
-                <DomainAccounts>
-                    <DomainAccountList wcm:action="add">
-                        <Domain>WORKGROUP</Domain>
-                        <DomainAccount wcm:action="add">
-                            <Name>Domain Admins</Name>
-                            <Group>Administrators</Group>
-                        </DomainAccount>
-                        <DomainAccount wcm:action="add">
-                            <Name>User</Name>
-                            <Group>Administrators</Group>
-                        </DomainAccount>
-                    </DomainAccountList>
-                </DomainAccounts>
             </UserAccounts>
-#end if
             <TimeZone>UTC</TimeZone>
             <RegisteredOrganization>Some Organization</RegisteredOrganization>
             <RegisteredOwner>User</RegisteredOwner>
             <FirstLogonCommands>
-#if "user_accounts" in $autoinstall_meta
                 <SynchronousCommand wcm:action="add">
                     <RequiresUserInput>false</RequiresUserInput>
                     <Order>1</Order>
                     <CommandLine>cmd /C wmic useraccount where "name='User'" set PasswordExpires=FALSE</CommandLine>
                 </SynchronousCommand>
-#end if
                 <SynchronousCommand wcm:action="add">
                     <RequiresUserInput>false</RequiresUserInput>
                     <Order>2</Order>
                     <CommandLine>c:\post_install.cmd @@profile_name@@</CommandLine>
                 </SynchronousCommand>
             </FirstLogonCommands>
-#if "user_accounts" in $autoinstall_meta
             <AutoLogon>
                 <Password>
-                    <Value>xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</Value>
-                    <PlainText>false</PlainText>
+                    <Value>User</Value>
+                    <PlainText>true</PlainText>
                 </Password>
                 <Enabled>true</Enabled>
-                <Domain>WORKGROUP</Domain>
                 <Username>User</Username>
                 <LogonCount>10000</LogonCount>
             </AutoLogon>
-#end if
         </component>
     </settings>
 </unattend>
 #else
-#set $OriSrc = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $distro_name + '\\' + $win_arch
-#set $DevSrc = '\\Device\\LanmanRedirector\\' + $http_server + '\\' + $samba_distro_share + '\\' + $distro_name
+#set $OriSrc = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3] + '\\' + $win_arch
+#set $DevSrc = '\\Device\\LanmanRedirector\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3]
 [Data]
 floppyless = "1"
 msdosinitiated = "1"
@@ -278,9 +345,9 @@ AllowConnections=1
 
 [UserData]
 #if $os_version == '2003'
-ProductKey="XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+ProductKey="VD2BM-TP2KK-CBXDQ-7B7FQ-4M9V3"
 #else
-ProductKey="XXXXX-XXXXX-XXXXX-XXXXX-XXXXX"
+ProductKey="CB9YB-Q73J8-RKPMH-M2WFT-P4WQJ"
 #end if
 ComputerName=*
 FullName="Admin"

--- a/templates/windows/post_inst_cmd.template
+++ b/templates/windows/post_inst_cmd.template
@@ -1,15 +1,18 @@
 Echo on
 
-##%systemdrive%
-##CD %systemdrive%\TMP >nul 2>&1
-##$SNIPPET('my/win_wait_network_online')
-##wget.exe http://@@http_server@@/cblr/svc/op/autoinstall/profile/%1 -O install.cmd
-##todos.exe install.cmd
-##start /wait install.cmd
-##DEL /F /Q libeay32.dll >nul 2>&1
-##DEL /F /Q libiconv2.dll >nul 2>&1
-##DEL /F /Q libintl3.dll >nul 2>&1
-##DEL /F /Q libssl32.dll >nul 2>&1
-##DEL /F /Q wget.exe >nul 2>&1
-##DEL /F /Q %0 >nul 2>&1
+$SNIPPET('wait_network_online')
+#if $os_version not in ('xp', '2003')
+powershell -command "& {\$WebClient = New-Object System.Net.WebClient; \$WebClient.DownloadFile('http://@@http_server@@/cblr/svc/op/autoinstall/profile/%1','install.cmd')}"
+#else
+wget.exe http://@@http_server@@/cblr/svc/op/autoinstall/profile/%1 -O install.cmd
+todos.exe install.cmd
+DEL /F /Q libeay32.dll >nul 2>&1
+DEL /F /Q libiconv2.dll >nul 2>&1
+DEL /F /Q libintl3.dll >nul 2>&1
+DEL /F /Q libssl32.dll >nul 2>&1
+DEL /F /Q wget.exe >nul 2>&1
+#end if
+start /wait install.cmd
+DEL /F /Q install.cmd >nul 2>&1
+DEL /F /Q %0 >nul 2>&1
 

--- a/templates/windows/startnet.template
+++ b/templates/windows/startnet.template
@@ -1,8 +1,9 @@
 wpeinit
 
-ping 127.0.0.1 -n 10 >nul
-#set $distro_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3]
-net use z: $distro_dir
+$SNIPPET('wait_network_online')
+#set $distros_dir = '\\\\' + $http_server + '\\' + $samba_distro_share
+#set $distro_share = 'Z:\\links\\' + $distro_name
+net use z: $distros_dir
 set exit_code=%ERRORLEVEL%
 IF %exit_code% EQU 0 GOTO INSTALL
 echo "Can't mount network drive"
@@ -10,7 +11,7 @@ pause
 goto EXIT
 
 :INSTALL
-#if $os_version in ('XP', '2003' )
+#if $os_version in ('xp', '2003' )
 #if "clean_disk" in $autoinstall_meta
 echo select disk 0 >disk.scr
 echo clean >>disk.scr
@@ -22,23 +23,23 @@ echo assign letter=C >>disk.scr
 diskpart.exe /s disk.scr
 bootsect.exe /nt52 c: /force /mbr
 #end if
-xcopy z:\\$OEM\$\\$1 c: /y /s /e
+xcopy $distro_share\\$OEM\$\\$1 c: /y /s /e
 #end if
 #set $unattended = ""
 #if "answerfile" in $autoinstall_meta
-#set $unattended = "/unattend:Z:\\" + $autoinstall_meta["answerfile"]
+#set $unattended = "/unattend:Z:\\images\\" + $distro_name + '\\' + $autoinstall_meta["answerfile"]
 #end if
 
-#if $os_version in ('XP', '2003' )
+#if $os_version in ('xp', '2003' )
 #if $arch == 'x86_64'
         #set $win_arch = 'amd64'
 #else if $arch == 'i386'
         #set $win_arch = 'i386'
 #end if
-#set $winnt = 'z:\\' + $win_arch + '\\winnt32.exe'
+#set $winnt = $distro_share + '\\' + $win_arch + '\\winnt32.exe'
 $winnt /syspart:c: /tempdrive:c: /makelocalsource $unattended
 #else
-z:\sources\setup.exe $unattended
+$distro_share\sources\setup.exe $unattended
 #end if
 :EXIT
 exit

--- a/templates/windows/startnet.template
+++ b/templates/windows/startnet.template
@@ -1,7 +1,7 @@
 wpeinit
 
 ping 127.0.0.1 -n 10 >nul
-#set $distro_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $distro_name
+#set $distro_dir = '\\\\' + $http_server + '\\' + $samba_distro_share + '\\' + $initrd.split('/')[-3]
 net use z: $distro_dir
 set exit_code=%ERRORLEVEL%
 IF %exit_code% EQU 0 GOTO INSTALL


### PR DESCRIPTION
## Linked Items

Fixes #3473

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Windows UEFI fix

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->
 - BCD: Windows Boot Application (13200003)

New: <!-- This is the new way Cobbler behaves -->
 - BCD:  Windows Boot Loader
 - BCD add Path: \windows\system32\winload.exe
 - fix:	non-standard distro directory in distro_mirror
 - fix:	path for winpe.wim in case of using wimboot

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
