### PR TITLE
Fixes problem with grub netboot - systemspecific config was not used

### DIFF
--- a/cobbler/data/config/grub/grub/grub.cfg
+++ b/cobbler/data/config/grub/grub/grub.cfg
@@ -43,19 +43,6 @@ fi
 echo "Running on $arch CPU architecture"
 
 #-------------------------------------------------------------------------------
-# MAC address
-#-------------------------------------------------------------------------------
-set mac=${net_default_mac}
-export mac
-
-if [ -s "$prefix/system/$mac" ]; then
-  source "$prefix/system/$mac"
-  echo "Machine specific grub config file $prefix/system/$mac for $system loaded"
-else
-  echo "Could not find machine specific grub config file $prefix/system/$mac"
-fi
-
-#-------------------------------------------------------------------------------
 # Serial console
 #-------------------------------------------------------------------------------
 if [ $serial_console == true -a "$grub_platform" != "efi" ]; then
@@ -120,6 +107,19 @@ if [ !"{$arch}" == "unknown" ]; then
   echo "Warning: architecture is unknown, skipping menu items";
   else
   source "$prefix/${arch}_menu_items.cfg"
+fi
+
+#-------------------------------------------------------------------------------
+# MAC address
+#-------------------------------------------------------------------------------
+set mac=${net_default_mac}
+export mac
+
+if [ -s "$prefix/system/$mac" ]; then
+  source "$prefix/system/$mac"
+  echo "Machine specific grub config file $prefix/system/$mac for $system loaded"
+else
+  echo "Could not find machine specific grub config file $prefix/system/$mac"
 fi
 
 # Trigger local boot setting (may alter grub.cfg) at the very end to avoid races


### PR DESCRIPTION
Had problems with netbooting efi systems with grub. The last entry from the $arch_menu.cfg was booted, even if a system entry with MAC existed.
Added a efi-system with cobbler command to reinstall using netboot and the configuration below `grub/system/$MAC` was created. During boot I could see the loading of the file in the tftp's log.
But the last entry in the menu was loaded and not the specific one.

Changing the order of loading the files made the system specific entry the last one in the list and it was booted. The system was installed with the correct profile.

Did also the test without a systemspecific configuration: the menu was shown and an entry could be chosen.


