### PR TITLE
isc_manager: Handle ipv6 systemd/service correctly

### DIFF
--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -404,7 +404,7 @@ class _IscManager(DhcpManagerModule):
         self.logger.info("generating %s", self.settings_file_v6)
         self.templar.render(template_data, metadata, self.settings_file_v6)
 
-    def restart_dhcp(self, service_name: str) -> int:
+    def restart_dhcp(self, service_name: str, version: int) -> int:
         """
         This syncs the dhcp server with it's new config files.
         Basically this restarts the service to apply the changes.
@@ -416,11 +416,14 @@ class _IscManager(DhcpManagerModule):
             self.logger.error("%s path could not be found", service_name)
             return -1
         return_code_service_restart = utils.subprocess_call(
-            [dhcpd_path, "-t", "-q"], shell=False
+            [dhcpd_path, f"-{version}", "-t", "-q"], shell=False
         )
         if return_code_service_restart != 0:
             self.logger.error("Testing config - %s -t failed", service_name)
-        return_code_service_restart = process_management.service_restart(service_name)
+        if version == 4:
+            return_code_service_restart = process_management.service_restart(service_name)
+        else:
+            return_code_service_restart = process_management.service_restart(f"{service_name}{version}")
         if return_code_service_restart != 0:
             self.logger.error("%s service failed", service_name)
         return return_code_service_restart
@@ -437,12 +440,11 @@ class _IscManager(DhcpManagerModule):
 
         # Even if one fails, try both and return an error
         ret = 0
+        service = utils.dhcp_service_name()
         if self.settings.manage_dhcp_v4:
-            service_v4 = utils.dhcp_service_name()
-            ret |= self.restart_dhcp(service_v4)
+            ret |= self.restart_dhcp(service, 4)
         if self.settings.manage_dhcp_v6:
-            # TODO: Fix hard coded string
-            ret |= self.restart_dhcp("dhcpd6")
+            ret |= self.restart_dhcp(service, 6)
         return ret
 
 


### PR DESCRIPTION
## Linked Items

Probably there is no issue create, yet it is still bugfix

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Makes cobbler able to restart/test both, ipv6 and ipv4 DHCP daemons.

## Behaviour changes

Old:
Old method was on hope that there is 2 binaries, `dhcpd` and `dhcpd6` which is false, it is same binary, just with separate arguments.

New:
Now it handles systemd (calling `dhcpd` and `dhcpd6` ) but also calls correct binary (`dhcp -4` or `dhcp -6`)

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
