### PR TITLE
Restart dhcpd for both IPv4 and IPv6

### DIFF
--- a/changelog.d/3484.fixed
+++ b/changelog.d/3484.fixed
@@ -1,0 +1,1 @@
+Fix isc manager to correctly test and restart both daemons (ipv6 and ipv4)

--- a/tests/modules/managers/isc_test.py
+++ b/tests/modules/managers/isc_test.py
@@ -1,4 +1,9 @@
+"""
+Test to verify the functionallity of the isc DHCP module.
+"""
+
 import time
+from typing import TYPE_CHECKING
 from unittest.mock import MagicMock
 
 import pytest
@@ -10,9 +15,15 @@ from cobbler.items.system import System
 from cobbler.modules.managers import isc
 from cobbler.settings import Settings
 
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
 
 @pytest.fixture
 def api_isc_mock():
+    """
+    Mock to prevent the full creation of a CobblerAPI and Settings object.
+    """
     settings_mock = MagicMock(name="isc_setting_mock", spec=Settings)
     settings_mock.server = "127.0.0.1"
     settings_mock.default_template_type = "cheetah"
@@ -37,30 +48,36 @@ def api_isc_mock():
     settings_mock.default_virt_disk_driver = "raw"
     settings_mock.cache_enabled = False
     api_mock = MagicMock(autospec=True, spec=CobblerAPI)
-    api_mock.settings.return_value = settings_mock
+    api_mock.settings.return_value = settings_mock  # type: ignore
     test_distro = Distro(api_mock)
     test_distro.name = "test"
-    api_mock.distros.return_value = [test_distro]
+    api_mock.distros.return_value = [test_distro]  # type: ignore
     test_profile = Profile(api_mock)
     test_profile.name = "test"
-    test_profile._parent = test_distro.name
-    api_mock.profiles.return_value = [test_profile]
+    test_profile._parent = test_distro.name  # type: ignore
+    api_mock.profiles.return_value = [test_profile]  # type: ignore
     test_system = System(api_mock)
     test_system.name = "test"
-    test_system._parent = test_profile.name
-    api_mock.systems.return_value = [test_system]
-    api_mock.repos.return_value = []
+    test_system._parent = test_profile.name  # type: ignore
+    api_mock.systems.return_value = [test_system]  # type: ignore
+    api_mock.repos.return_value = []  # type: ignore
     return api_mock
 
 
 @pytest.fixture(scope="function", autouse=True)
 def reset_singleton():
+    """
+    Helper fixture to reset the isc singleton before and after a test.
+    """
     isc.MANAGER = None
     yield
     isc.MANAGER = None
 
 
 def test_register():
+    """
+    Test if the manager registers with the correct ID.
+    """
     # Arrange & Act
     result = isc.register()
 
@@ -68,7 +85,10 @@ def test_register():
     assert result == "manage"
 
 
-def test_get_manager(api_isc_mock, reset_singleton):
+def test_get_manager(api_isc_mock: CobblerAPI):
+    """
+    Test if the singleton is correctly initialized.
+    """
     # Arrange
     isc.MANAGER = None
 
@@ -76,15 +96,21 @@ def test_get_manager(api_isc_mock, reset_singleton):
     result = isc.get_manager(api_isc_mock)
 
     # Assert
-    isinstance(result, isc._IscManager)
+    assert isinstance(result, isc._IscManager)  # type: ignore
 
 
 def test_manager_what():
+    """
+    Test if the manager identifies itself correctly.
+    """
     # Arrange & Act & Assert
-    assert isc._IscManager.what() == "isc"
+    assert isc._IscManager.what() == "isc"  # type: ignore
 
 
-def test_manager_write_v4_config(mocker, api_isc_mock, reset_singleton):
+def test_manager_write_v4_config(mocker: "MockerFixture", api_isc_mock: CobblerAPI):
+    """
+    Test if the manager is able to correctly generate the IPv4 isc dhcpd conf file.
+    """
     # Arrange
     mocker.patch("builtins.open", mocker.mock_open(read_data="test"))
     mocker.patch(
@@ -99,8 +125,8 @@ def test_manager_write_v4_config(mocker, api_isc_mock, reset_singleton):
     manager.write_v4_config()
 
     # Assert
-    assert mocked_templar.render.call_count == 1
-    mocked_templar.render.assert_called_with(
+    assert mocked_templar.render.call_count == 1  # type: ignore
+    mocked_templar.render.assert_called_with(  # type: ignore
         "test",
         {
             "cobbler_server": "127.0.0.1:80",
@@ -112,7 +138,10 @@ def test_manager_write_v4_config(mocker, api_isc_mock, reset_singleton):
     )
 
 
-def test_manager_write_v6_config(mocker, api_isc_mock, reset_singleton):
+def test_manager_write_v6_config(mocker: "MockerFixture", api_isc_mock: CobblerAPI):
+    """
+    Test if the manager is able to correctly generate the IPv6 isc dhcpd conf file.
+    """
     # Arrange
     mocker.patch("builtins.open", mocker.mock_open(read_data="test"))
     mocker.patch(
@@ -127,8 +156,8 @@ def test_manager_write_v6_config(mocker, api_isc_mock, reset_singleton):
     manager.write_v6_config()
 
     # Assert
-    assert mocked_templar.render.call_count == 1
-    mocked_templar.render.assert_called_with(
+    assert mocked_templar.render.call_count == 1  # type: ignore
+    mocked_templar.render.assert_called_with(  # type: ignore
         "test",
         {
             "date": "Mon Jan  1 00:00:00 2000",
@@ -139,7 +168,10 @@ def test_manager_write_v6_config(mocker, api_isc_mock, reset_singleton):
     )
 
 
-def test_manager_restart_dhcp(mocker, api_isc_mock, reset_singleton):
+def test_manager_restart_dhcp(mocker: "MockerFixture", api_isc_mock: CobblerAPI):
+    """
+    Test if the manager correctly restart the daemon.
+    """
     # Arrange
     isc.MANAGER = None
     mocked_subprocess = mocker.patch(
@@ -153,17 +185,22 @@ def test_manager_restart_dhcp(mocker, api_isc_mock, reset_singleton):
     manager = isc.get_manager(api_isc_mock)
 
     # Act
-    result = manager.restart_dhcp("dhcpd")
+    result = manager.restart_dhcp("dhcpd", 4)
 
     # Assert
     assert mocked_subprocess.call_count == 1
-    mocked_subprocess.assert_called_with(["/usr/sbin/dhcpd", "-t", "-q"], shell=False)
+    mocked_subprocess.assert_called_with(
+        ["/usr/sbin/dhcpd", "-4", "-t", "-q"], shell=False
+    )
     assert mocked_service_restart.call_count == 1
     mocked_service_restart.assert_called_with("dhcpd")
     assert result == 0
 
 
-def test_manager_write_configs(mocker, api_isc_mock, reset_singleton):
+def test_manager_write_configs(mocker: "MockerFixture", api_isc_mock: CobblerAPI):
+    """
+    Test if the manager is able to correctly kick of generation of the v4 and v6 configs.
+    """
     # Arrange
     isc.MANAGER = None
     manager = isc.get_manager(api_isc_mock)
@@ -178,7 +215,10 @@ def test_manager_write_configs(mocker, api_isc_mock, reset_singleton):
     assert mocked_v6.call_count == 1
 
 
-def test_manager_restart_service(mocker, api_isc_mock, reset_singleton):
+def test_manager_restart_service(mocker: "MockerFixture", api_isc_mock: CobblerAPI):
+    """
+    Test if the manager is able to correctly handle restarting the dhcpd server on different distros.
+    """
     # Arrange
     isc.MANAGER = None
     manager = isc.get_manager(api_isc_mock)


### PR DESCRIPTION
## Linked Items

Probably there is no issue create, yet it is still bugfix

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Makes cobbler able to restart/test both, ipv6 and ipv4 DHCP daemons.

## Behaviour changes

Old:
Old method was on hope that there is 2 binaries, `dhcpd` and `dhcpd6` which is false, it is same binary, just with separate arguments.

New:
Now it handles systemd (calling `dhcpd` and `dhcpd6` ) but also calls correct binary (`dhcp -4` or `dhcp -6`)

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
