### PR TITLE
Make SLE-Micro 5.4 boot via "local network boot"

### DIFF
--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -4,6 +4,8 @@ menuentry "local" --class gnu-linux --class gnu --class os {
       chainloader /efi/opensuse/grub.efi
     elif [ -f /efi/sles/shim.efi ] ; then
       chainloader /efi/sles/grub.efi
+    elif [ -f (${root})/efi/sle/grub.efi ] ; then
+      chainloader (${root})/efi/sle/grub.efi
     elif [ -f /efi/redhat/grub.efi ]; then
       chainloader /efi/redhat/grub.efi
     elif [ -f /efi/redhat/grubx64.efi ]; then


### PR DESCRIPTION
This is a quick fix, a re-work of how OSes are booted from local disks to have a more general fitting code would be great. This would need some input from grub people and is a bigger change to be kept in mind for the future.
l

## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
