### PR TITLE
Buildiso PPC64LE Enablement

### DIFF
--- a/changelog.d/3495.added
+++ b/changelog.d/3495.added
@@ -1,0 +1,1 @@
+Enable ppc64(le) buildiso artifacts

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -337,6 +337,7 @@ chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 %config(noreplace) %{_sysconfdir}/cobbler/import_rsync_whitelist
 %dir %{_sysconfdir}/cobbler/iso
 %config(noreplace) %{_sysconfdir}/cobbler/iso/buildiso.template
+%config(noreplace) %{_sysconfdir}/cobbler/iso/bootinfo.template
 %config(noreplace) %{_sysconfdir}/cobbler/iso/isolinux_menuentry.template
 %config(noreplace) %{_sysconfdir}/cobbler/iso/grub_menuentry.template
 %config(noreplace) %{_sysconfdir}/cobbler/logging_config.conf

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -49,19 +49,21 @@ def add_remaining_kopts(kopts: Dict[str, Union[str, List[str]]]) -> str:
     return " ".join(append_line)
 
 
-class BootFilesCopyset(NamedTuple):
+class BootFilesCopyset(NamedTuple):  # pylint: disable=missing-class-docstring
     src_kernel: str
     src_initrd: str
     new_filename: str
 
 
-class LoaderCfgsParts(NamedTuple):
+class LoaderCfgsParts(NamedTuple):  # pylint: disable=missing-class-docstring
     isolinux: List[str]
     grub: List[str]
     bootfiles_copysets: List[BootFilesCopyset]
 
 
-class BuildisoDirsX86_64(NamedTuple):
+class BuildisoDirsX86_64(
+    NamedTuple
+):  # noqa: N801 pylint: disable=invalid-name,missing-class-docstring
     root: pathlib.Path
     isolinux: pathlib.Path
     grub: pathlib.Path
@@ -69,17 +71,15 @@ class BuildisoDirsX86_64(NamedTuple):
     repo: pathlib.Path
 
 
-class BuildisoDirsPPC64LE(NamedTuple):
+class BuildisoDirsPPC64LE(NamedTuple):  # pylint: disable=missing-class-docstring
     root: pathlib.Path
     grub: pathlib.Path
     ppc: pathlib.Path
     autoinstall: pathlib.Path
     repo: pathlib.Path
 
-BuildisoDirs = Union[BuildisoDirsX86_64, BuildisoDirsPPC64LE]
 
-
-class Autoinstall(NamedTuple):
+class Autoinstall(NamedTuple):  # pylint: disable=missing-class-docstring
     config: str
     repos: List[str]
 
@@ -356,7 +356,7 @@ class BuildIso:
             self.bootinfo_template,
             out_path=None,
             search_table={"distro_name": distro_name},
-            template_type="jinja2"
+            template_type="jinja2",
         )
 
     def _copy_grub_into_esp(self, esp_image_location: str, arch: Archs):
@@ -552,8 +552,8 @@ class BuildIso:
         ppcdir = root / "ppc"
         autoinstalldir = root / "autoinstall"
         repodir = root / "repo_mirror"
-        for d in [grubdir, ppcdir, autoinstalldir, repodir]:
-            d.mkdir(parents=True)
+        for _d in [grubdir, ppcdir, autoinstalldir, repodir]:
+            _d.mkdir(parents=True)
 
         return BuildisoDirsPPC64LE(
             root=root,
@@ -576,7 +576,7 @@ class BuildIso:
         :param iso: The name of the output iso.
         :param buildisodir: The directory in which we build the ISO.
         """
-        del esp_path # just accepted for polymorphism
+        del esp_path  # just accepted for polymorphism
 
         cmd = [
             "xorriso",
@@ -585,17 +585,19 @@ class BuildIso:
         ]
         if xorrisofs_opts != "":
             cmd.append(xorrisofs_opts)
-        cmd.extend([
-            "-chrp-boot",
-            "-hfs-bless-by",
-            "p",
-            "boot",
-            "-V",
-            "COBBLER_INSTALL",
-            "-o",
-            iso,
-            buildisodir,
-        ])
+        cmd.extend(
+            [
+                "-chrp-boot",
+                "-hfs-bless-by",
+                "p",
+                "boot",
+                "-V",
+                "COBBLER_INSTALL",
+                "-o",
+                iso,
+                buildisodir,
+            ]
+        )
 
         xorrisofs_return_code = utils.subprocess_call(cmd, shell=False)
         if xorrisofs_return_code != 0:

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -453,7 +453,6 @@ class BuildIso:
         with open(output_file, "w") as f:
             f.write(bootinfo_txt)
 
-
     def _create_esp_image_file(self, tmpdir: str) -> str:
         esp = pathlib.Path(tmpdir) / "efi"
         mkfs_cmd = ["mkfs.fat", "-C", str(esp), "3528"]

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -12,7 +12,6 @@ import os
 import pathlib
 import re
 import shutil
-import textwrap
 from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Union
 
 from cobbler import templar, utils
@@ -122,14 +121,10 @@ class BuildIso:
             .joinpath("grub_menuentry.template")
             .read_text(encoding="UTF-8")
         )
-        self.bootinfo_template = textwrap.dedent(
-            """\
-            <chrp-boot>
-            <description>COBBLER INSTALL</description>
-            <os-name>{{ distro_name }}</os-name>
-            <boot-script>boot &device;:1,\\boot\\grub.elf</boot-script>
-            </chrp-boot>
-            """
+        self.bootinfo_template = (
+            pathlib.Path(api.settings().iso_template_dir)
+            .joinpath("bootinfo.template")
+            .read_text(encoding="UTF-8")
         )
 
     def _find_distro_source(self, known_file: str, distro_mirror: str) -> str:

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -725,7 +725,7 @@ class NetbootBuildiso(buildiso.BuildIso):
             grub_bin = pathlib.Path(self.api.settings().bootloaders_dir) / "grub"/ "grub.ppc64le"
             bootinfo_txt = self._render_bootinfo_txt(distro_name)
             # fill temporary directory with arch-specific binaries
-            utils.copyfile(str(grub_bin), str(buildiso_dirs.grub / "grub.elf"))
+            filesystem_helpers.copyfile(str(grub_bin), str(buildiso_dirs.grub / "grub.elf"))
             esp_location = None
 
             self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -682,7 +682,6 @@ class NetbootBuildiso(buildiso.BuildIso):
         :param exclude_dns: Whether the repositories have to be locally available or the internet is reachable.
         """
         del kwargs  # just accepted for polymorphism
-
         distro_obj = self.parse_distro(distro_name)
         if distro_obj.arch not in (Archs.X86_64, Archs.PPC, Archs.PPC64, Archs.PPC64LE, Archs.PPC64EL):
             raise ValueError("cobbler buildiso does not work for arch={distro_obj.arch}")
@@ -692,7 +691,6 @@ class NetbootBuildiso(buildiso.BuildIso):
         loader_config_parts = self._generate_boot_loader_configs(
             profile_names, system_names, exclude_dns
         )
-
         buildisodir = self._prepare_buildisodir(buildisodir)
         distro_mirrordir = pathlib.Path(self.api.settings().webdir) / "distro_mirror"
 
@@ -728,6 +726,7 @@ class NetbootBuildiso(buildiso.BuildIso):
             bootinfo_txt = self._render_bootinfo_txt(distro_name)
             # fill temporary directory with arch-specific binaries
             utils.copyfile(str(grub_bin), str(buildiso_dirs.grub / "grub.elf"))
+            esp_location = None
 
             self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)
             self._write_bootinfo(bootinfo_txt, buildiso_dirs.ppc)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -149,20 +149,15 @@ class StandaloneBuildiso(buildiso.BuildIso):
             "distro": distro_obj,
             "append_line": append_line,
         }
+
         if descendant_obj.COLLECTION_TYPE == "profile":
             config_args.update({"menu_indent": 0})
-            profile_obj = cast("Profile", descendant_obj)
-            isolinux, grub, to_copy = self._generate_descendant_config(**config_args)
-            autoinstall = self.api.autoinstallgen.generate_autoinstall(
-                profile=profile_obj
-            )
+            autoinstall_args = {"profile": descendant_obj}
         else:  # system
             config_args.update({"menu_indent": 4})
-            system_obj = cast("System", descendant_obj)
-            isolinux, grub, to_copy = self._generate_descendant_config(**config_args)
-            autoinstall = self.api.autoinstallgen.generate_autoinstall(
-                system=system_obj
-            )
+            autoinstall_args = {"system": descendant_obj}
+        isolinux, grub, to_copy = self._generate_descendant_config(**config_args)
+        autoinstall = self.api.autoinstallgen.generate_autoinstall(**autoinstall_args)  # type: ignore
 
         if distro_obj.breed == "redhat":
             autoinstall = CDREGEX.sub("cdrom\n", autoinstall, count=1)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -14,6 +14,7 @@ from cobbler import utils
 from cobbler.enums import Archs
 from cobbler.actions import buildiso
 from cobbler.actions.buildiso import Autoinstall, BootFilesCopyset, LoaderCfgsParts
+from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:
     from cobbler.items.distro import Distro
@@ -313,7 +314,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
             grub_bin = pathlib.Path(self.api.settings().bootloaders_dir) / "grub"/ "grub.ppc64le"
             bootinfo_txt = self._render_bootinfo_txt(distro_name)
             # fill temporary directory with arch-specific binaries
-            utils.copyfile(str(grub_bin), str(buildiso_dirs.grub / "grub.elf"))
+            filesystem_helpers.copyfile(str(grub_bin), str(buildiso_dirs.grub / "grub.elf"))
 
             self._write_bootinfo(bootinfo_txt, buildiso_dirs.ppc)
             self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -11,6 +11,7 @@ import re
 from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from cobbler import utils
+from cobbler.enums import Archs
 from cobbler.actions import buildiso
 from cobbler.actions.buildiso import Autoinstall, BootFilesCopyset, LoaderCfgsParts
 
@@ -259,12 +260,14 @@ class StandaloneBuildiso(buildiso.BuildIso):
         del kwargs  # just accepted for polymorphism
 
         distro_obj = self.parse_distro(distro_name)
+        if distro_obj.arch not in (Archs.X86_64, Archs.PPC, Archs.PPC64, Archs.PPC64LE, Archs.PPC64EL):
+            raise ValueError("cobbler buildiso does not work for arch={distro_obj.arch}")
+
         profile_objs = self.parse_profiles(profiles, distro_obj)
         filesource = source
         loader_config_parts = LoaderCfgsParts([self.iso_template], [], [])
         autoinstall_data: Dict[str, Autoinstall] = {}
         buildisodir = self._prepare_buildisodir(buildisodir)
-        buildiso_dirs = self.create_buildiso_dirs(buildisodir)
         repo_mirrordir = pathlib.Path(self.api.settings().webdir) / "repo_mirror"
         distro_mirrordir = pathlib.Path(self.api.settings().webdir) / "distro_mirror"
 
@@ -288,9 +291,40 @@ class StandaloneBuildiso(buildiso.BuildIso):
                     repo_mirrordir=repo_mirrordir,
                     autoinstall_data=autoinstall_data,
                 )
+        if distro_obj.arch == Archs.X86_64:
+            xorriso_func = self._xorriso_x86_64
+            buildiso_dirs = self.create_buildiso_dirs_x86_64(buildisodir)
 
-        # copy isolinux, kernels, initrds, and distro files (e.g. installer)
-        self._copy_isolinux_files()
+            # fill temporary directory with arch-specific binaries
+            self._copy_isolinux_files()
+            # create EFI system partition (ESP) if needed, uses the ESP from the
+            # distro if it was copied
+            esp_location = self._find_esp(buildiso_dirs.root)
+            if esp_location is None:
+                esp_location = self._create_esp_image_file(buildisodir)
+                self._copy_grub_into_esp(esp_location, distro_obj.arch)
+
+            self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)
+            self._write_isolinux_cfg(loader_config_parts.isolinux, buildiso_dirs.isolinux)
+
+        elif distro_obj.arch in (Archs.PPC, Archs.PPC64, Archs.PPC64LE, Archs.PPC64EL):
+            xorriso_func = self._xorriso_ppc64le
+            buildiso_dirs = self.create_buildiso_dirs_ppc64le(buildisodir)
+            grub_bin = pathlib.Path(self.api.settings().bootloaders_dir) / "grub"/ "grub.ppc64le"
+            bootinfo_txt = self._render_bootinfo_txt(distro_name)
+            # fill temporary directory with arch-specific binaries
+            utils.copyfile(str(grub_bin), str(buildiso_dirs.grub / "grub.elf"))
+
+            self._write_bootinfo(bootinfo_txt, buildiso_dirs.ppc)
+            self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)
+
+
+        if not filesource:
+            filesource = self._find_distro_source(
+                distro_obj.kernel, str(distro_mirrordir)
+            )
+        # copy kernels, initrds, and distro files (e.g. installer)
+        self._copy_distro_files(filesource, str(buildiso_dirs.root))
         for copyset in loader_config_parts.bootfiles_copysets:
             self._copy_boot_files(
                 copyset.src_kernel,
@@ -298,18 +332,6 @@ class StandaloneBuildiso(buildiso.BuildIso):
                 str(buildiso_dirs.root),
                 copyset.new_filename,
             )
-        if not filesource:
-            filesource = self._find_distro_source(
-                distro_obj.kernel, str(distro_mirrordir)
-            )
-        self._copy_distro_files(filesource, str(buildiso_dirs.root))
-
-        # create EFI system partition (ESP) if needed, uses the ESP from the
-        # distro if it was copied
-        esp_location = self._find_esp(buildiso_dirs.root)
-        if esp_location is None:
-            esp_location = self._create_esp_image_file(buildisodir)
-            self._copy_grub_into_esp(esp_location, distro_obj.arch)
 
         # sync repos
         if airgapped:
@@ -317,7 +339,6 @@ class StandaloneBuildiso(buildiso.BuildIso):
             self._copy_repos(
                 autoinstall_data.values(), repo_mirrordir, buildiso_dirs.repo
             )
-        self._write_isolinux_cfg(loader_config_parts.isolinux, buildiso_dirs.isolinux)
-        self._write_grub_cfg(loader_config_parts.grub, buildiso_dirs.grub)
+
         self._write_autoinstall_cfg(autoinstall_data, buildiso_dirs.autoinstall)
-        self._generate_iso(xorrisofs_opts, iso, buildisodir, esp_location)
+        xorriso_func(xorrisofs_opts, iso, buildisodir, esp_location)

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -8,17 +8,7 @@ import itertools
 import os
 import pathlib
 import re
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Tuple, Union
 
 from cobbler import utils
 from cobbler.actions import buildiso
@@ -162,7 +152,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         if distro_obj.breed == "redhat":
             autoinstall = CDREGEX.sub("cdrom\n", autoinstall, count=1)
 
-        repos = []
+        repos: List[str] = []
         if airgapped:
             repos = data.get("repos", [])
             if repos:
@@ -177,7 +167,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         cfg_parts.isolinux.append(isolinux)
         cfg_parts.grub.append(grub)
         cfg_parts.bootfiles_copysets.append(to_copy)
-        autoinstall_data[name] = Autoinstall(autoinstall, cast(List[str], repos))
+        autoinstall_data[name] = Autoinstall(autoinstall, repos)
 
     def _update_repos_in_autoinstall_data(
         self, autoinstall_data: str, repos_names: List[str]

--- a/docs/user-guide/building-isos.rst
+++ b/docs/user-guide/building-isos.rst
@@ -14,6 +14,8 @@ Per default this builds an ISO for all available systems and profiles.
 
 If you want to generate multiple ISOs you need to execute this command multiple times (with different ``--iso`` names).
 
+NOTE: This feature is currently only supported for the following architectures: x86_64, ppc, ppc64, ppc64le and ppc64el.
+
 Under the hood
 ##############
 

--- a/system-tests/tests/buildiso-ppc64le
+++ b/system-tests/tests/buildiso-ppc64le
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Check that Cobbler is able to build a customized ISO based for PPC64LE
+
+source ${SYSTESTS_PRELUDE} && prepare
+
+build_iso_test=${TEST_NAME#buildiso-}
+
+trap cleanup EXIT
+
+cleanup() {
+        mountpoint -q ${mp} && umount ${mp}
+        rmdir ${mp}
+}
+
+set -x -e -o pipefail
+
+wget -nv -P "${tmp}/" https://download.opensuse.org/distribution/leap/15.3/iso/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso
+mp=$(mktemp -dt leap-mp-XXX)
+mount -o loop,ro "${tmp}/openSUSE-Leap-15.3-DVD-ppc64le-Current.iso" "${mp}"
+cobbler import --name leap --path "${mp}"
+
+# Install grub2-ppc64le and run cobbler mkloaders
+zypper ar https://download.opensuse.org/ports/ppc/tumbleweed/repo/oss/ tumbleweed_os_ppc64le
+zypper ref
+zypper in -y grub2-powerpc-ieee1275
+cobbler mkloaders
+
+# Preparations
+cobbler system add --name testbed --profile leap-ppc64le
+
+# Tmp: Create "/var/cache/cobbler" because it does not exist per default
+mkdir -p /var/cache/cobbler/buildiso
+
+# Real test
+cobbler buildiso --profile="leap-ppc64le" --distro="leap-ppc64le" \
+                 --source="${mp}" --tempdir="/var/cache/cobbler/buildiso" --iso="${tmp}/autoinst.iso"
+
+# Check ISO exists & is bootable
+cat >${tmp}/a <<-EOF
+MBR CHRP cyl-align-off
+EOF
+xorriso -indev ${tmp}/autoinst.iso -toc 2>/dev/null | sed -En 's/^Boot record.* \(system area only\) , (.*)$/\1/p' >>${tmp}/b
+
+diff ${tmp}/{a,b}

--- a/templates/iso/bootinfo.template
+++ b/templates/iso/bootinfo.template
@@ -1,0 +1,5 @@
+<chrp-boot>
+<description>COBBLER INSTALL</description>
+<os-name>{{ distro_name }}</os-name>
+<boot-script>boot &device;:1,\\boot\\grub.elf</boot-script>
+</chrp-boot>


### PR DESCRIPTION
## Description

Enable ppc64(le) buildiso artifacts. The approach is to use grub, built by ``cobbler mkloaders``, to run the installation.

The buildiso directory is prepared with a `ppc/bootinfo.txt` that boots `/boot/grub.elf`, the location grub is copied too.

Additionally this fixes a problem detected after `utils.copyfile` was moved to `filesystem_helpers.copyfile`.

Tracks: https://github.com/SUSE/spacewalk/issues/22256

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [x] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
