### PR TITLE
Add tree auto install meta back to imported distros

### DIFF
--- a/changelog.d/3417.fixed
+++ b/changelog.d/3417.fixed
@@ -1,0 +1,1 @@
+Re-Added "tree" variable to "autoinstall_meta"

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -237,9 +237,15 @@ class AppendLineBuilder:
             "rhel6",
             "fedora16",
         ]:
-            self.append_line += " ks=%s" % self.data["autoinstall"]
+            self.append_line += f" ks={self.data['autoinstall']}"
+            if self.data["autoinstall_meta"].get("tree"):
+                self.append_line += f" repo={self.data['autoinstall_meta']['tree']}"
         else:
-            self.append_line += " inst.ks=%s" % self.data["autoinstall"]
+            self.append_line += f" inst.ks={self.data['autoinstall']}"
+            if self.data["autoinstall_meta"].get("tree"):
+                self.append_line += (
+                    f" inst.repo={self.data['autoinstall_meta']['tree']}"
+                )
 
     def _generate_append_debian(self, system: "System") -> None:
         """
@@ -445,9 +451,15 @@ class AppendLineBuilder:
                     f" proxy={self.data['proxy']} http_proxy={self.data['proxy']}"
                 )
             if os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
-                self.append_line += " ks=%s" % self.data["autoinstall"]
+                self.append_line += f" ks={self.data['autoinstall']}"
+                if self.data["autoinstall_meta"].get("tree"):
+                    self.append_line += f" repo={self.data['autoinstall_meta']['tree']}"
             else:
-                self.append_line += " inst.ks=%s" % self.data["autoinstall"]
+                self.append_line += f" inst.ks={self.data['autoinstall']}"
+                if self.data["autoinstall_meta"].get("tree"):
+                    self.append_line += (
+                        f" inst.repo={self.data['autoinstall_meta']['tree']}"
+                    )
         elif distro_breed in ["ubuntu", "debian"]:
             self.append_line += (
                 f" auto-install/enable=true url={self.data['autoinstall']}"

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -38,9 +38,11 @@ def _generate_append_line_standalone(
     append_line = f"  APPEND initrd=/{os.path.basename(distro.initrd)}"
     if distro.breed == "redhat":
         if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
-            append_line += f" ks=cdrom:/autoinstall/{descendant.name}.cfg"
+            append_line += f" ks=cdrom:/autoinstall/{descendant.name}.cfg  repo=cdrom"
         else:
-            append_line += f" inst.ks=cdrom:/autoinstall/{descendant.name}.cfg"
+            append_line += (
+                f" inst.ks=cdrom:/autoinstall/{descendant.name}.cfg inst.repo=cdrom"
+            )
     elif distro.breed == "suse":
         append_line += (
             f" autoyast=file:///autoinstall/{descendant.name}.cfg install=cdrom:///"

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1239,6 +1239,7 @@ class CobblerAPI:
         ref: "ITEM_UNION",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add an abstract item to a collection of its specific items. This is not meant for external use. Please reefer
@@ -1248,10 +1249,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.log(f"add_item({what})", [ref.name])
         self.get_items(what).add(
-            ref, check_for_duplicate_names=check_for_duplicate_names, save=save  # type: ignore
+            ref,  # type: ignore
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
         )
 
     def add_distro(
@@ -1259,6 +1264,7 @@ class CobblerAPI:
         ref: "distro.Distro",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a distribution to Cobbler.
@@ -1266,12 +1272,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
             "distro",
             ref,
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
+            with_triggers=with_triggers,
         )
 
     def add_profile(
@@ -1279,6 +1287,7 @@ class CobblerAPI:
         ref: "profile_module.Profile",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a profile to Cobbler.
@@ -1286,12 +1295,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
             "profile",
             ref,
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
+            with_triggers=with_triggers,
         )
 
     def add_system(
@@ -1299,6 +1310,7 @@ class CobblerAPI:
         ref: "system_module.System",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a system to Cobbler.
@@ -1306,12 +1318,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
             "system",
             ref,
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
+            with_triggers=with_triggers,
         )
 
     def add_repo(
@@ -1319,6 +1333,7 @@ class CobblerAPI:
         ref: "repo.Repo",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a repository to Cobbler.
@@ -1326,9 +1341,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
-            "repo", ref, check_for_duplicate_names=check_for_duplicate_names, save=save
+            "repo",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
         )
 
     def add_image(
@@ -1336,6 +1356,7 @@ class CobblerAPI:
         ref: "image_module.Image",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add an image to Cobbler.
@@ -1343,9 +1364,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
-            "image", ref, check_for_duplicate_names=check_for_duplicate_names, save=save
+            "image",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
         )
 
     def add_mgmtclass(
@@ -1353,6 +1379,7 @@ class CobblerAPI:
         ref: "mgmtclass.Mgmtclass",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a management class to Cobbler.
@@ -1360,12 +1387,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
             "mgmtclass",
             ref,
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
+            with_triggers=with_triggers,
         )
 
     def add_package(
@@ -1373,6 +1402,7 @@ class CobblerAPI:
         ref: "package.Package",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a package to Cobbler.
@@ -1380,12 +1410,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
             "package",
             ref,
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
+            with_triggers=with_triggers,
         )
 
     def add_file(
@@ -1393,6 +1425,7 @@ class CobblerAPI:
         ref: "file.File",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a file to Cobbler.
@@ -1400,9 +1433,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
-            "file", ref, check_for_duplicate_names=check_for_duplicate_names, save=save
+            "file",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
         )
 
     def add_menu(
@@ -1410,6 +1448,7 @@ class CobblerAPI:
         ref: "menu.Menu",
         check_for_duplicate_names: bool = False,
         save: bool = True,
+        with_triggers: bool = True,
     ) -> None:
         """
         Add a submenu to Cobbler.
@@ -1417,9 +1456,14 @@ class CobblerAPI:
         :param ref: The identifier for the object to add to a collection.
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
         """
         self.add_item(
-            "menu", ref, check_for_duplicate_names=check_for_duplicate_names, save=save
+            "menu",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
         )
 
     # ==========================================================================

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1144,7 +1144,7 @@ class CobblerAPI:
         :return: An empty Profile object.
         """
         self.log("new_profile", kwargs)
-        return profile_module.Profile(self, is_subobject, kwargs)
+        return profile_module.Profile(self, is_subobject, **kwargs)
 
     def new_system(
         self, is_subobject: bool = False, **kwargs: Any
@@ -1157,7 +1157,7 @@ class CobblerAPI:
         :return: An empty System object.
         """
         self.log("new_system", kwargs)
-        return system_module.System(self, is_subobject, kwargs)
+        return system_module.System(self, is_subobject, **kwargs)
 
     def new_repo(self, is_subobject: bool = False, **kwargs: Any) -> "repo.Repo":
         """
@@ -1181,7 +1181,7 @@ class CobblerAPI:
         :return: An empty image object.
         """
         self.log("new_image", kwargs)
-        return image_module.Image(self, is_subobject, kwargs)
+        return image_module.Image(self, is_subobject, **kwargs)
 
     def new_mgmtclass(
         self, is_subobject: bool = False, **kwargs: Any
@@ -1194,7 +1194,7 @@ class CobblerAPI:
         :return: An empty mgmtclass object.
         """
         self.log("new_mgmtclass", kwargs)
-        return mgmtclass.Mgmtclass(self, is_subobject, kwargs)
+        return mgmtclass.Mgmtclass(self, is_subobject, **kwargs)
 
     def new_package(
         self, is_subobject: bool = False, **kwargs: Any
@@ -1207,7 +1207,7 @@ class CobblerAPI:
         :return: An empty Package object.
         """
         self.log("new_package", kwargs)
-        return package.Package(self, is_subobject, kwargs)
+        return package.Package(self, is_subobject, **kwargs)
 
     def new_file(self, is_subobject: bool = False, **kwargs: Any) -> "file.File":
         """
@@ -1218,7 +1218,7 @@ class CobblerAPI:
         :return: An empty File object.
         """
         self.log("new_file", kwargs)
-        return file.File(self, is_subobject, kwargs)
+        return file.File(self, is_subobject, **kwargs)
 
     def new_menu(self, is_subobject: bool = False, **kwargs: Any) -> "menu.Menu":
         """
@@ -1229,7 +1229,7 @@ class CobblerAPI:
         :return: An empty File object.
         """
         self.log("new_menu", kwargs)
-        return menu.Menu(self, is_subobject, kwargs)
+        return menu.Menu(self, is_subobject, **kwargs)
 
     # ==========================================================================
 

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -404,7 +404,7 @@ class Collection(Generic[ITEM]):
                           deserialization, in which case extra semantics around the add don't really apply. So, in that
                           case, don't run any triggers and don't deal with any actual files.
         :param with_sync: If a sync should be triggered when the object is renamed.
-        :param with_triggers: If triggers should be run when the object is renamed.
+        :param with_triggers: If triggers should be run when the object is added.
         :param quick_pxe_update: This decides if there should be run a quick or full update after the add was done.
         :param check_for_duplicate_names: If the name of an object should be unique or not.
         :raises TypError: Raised in case ``ref`` is None.

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -501,23 +501,22 @@ class _ImportSignatureManager(ManagerModule):
                     "skipping import, as distro name already exists: %s", name
                 )
                 continue
-            new_distro = self.api.new_distro()
 
             if name.find("-autoboot") != -1:
                 # this is an artifact of some EL-3 imports
                 continue
 
-            new_distro.name = name
-            new_distro.kernel = kernel
-            new_distro.initrd = initrd
-            new_distro.arch = pxe_arch
-            new_distro.breed = self.breed  # type: ignore
-            new_distro.os_version = self.os_version  # type: ignore
-            new_distro.kernel_options = self.signature.get("kernel_options", "")
-            new_distro.kernel_options_post = self.signature.get(
-                "kernel_options_post", ""
+            new_distro = self.api.new_distro(
+                name=name,
+                kernel=kernel,
+                initrd=initrd,
+                arch=pxe_arch,
+                breed=self.breed,  # type: ignore
+                os_version=self.os_version,  # type: ignore
+                kernel_options=self.signature.get("kernel_options", {}),
+                kernel_options_post=self.signature.get("kernel_options_post", {}),
+                template_files=self.signature.get("template_files", {}),
             )
-            new_distro.template_files = self.signature.get("template_files", "")
 
             boot_files: Dict[str, str] = {}
             for boot_file in self.signature["boot_files"]:
@@ -535,16 +534,16 @@ class _ImportSignatureManager(ManagerModule):
             existing_profile = self.profiles.find(name=name)
 
             if existing_profile is None:
-                new_profile = self.api.new_profile()
+                new_profile = self.api.new_profile(
+                    name=name,
+                    distro=name,
+                    autoinstall=self.autoinstall_file,  # type: ignore
+                )
             else:
                 self.logger.info(
                     "skipping existing profile, name already exists: %s", name
                 )
                 continue
-
-            new_profile.name = name
-            new_profile.distro = name
-            new_profile.autoinstall = self.autoinstall_file  # type: ignore
 
             # depending on the name of the profile we can
             # define a good virt-type for usage with koan

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -526,7 +526,7 @@ class _ImportSignatureManager(ManagerModule):
 
             self.configure_tree_location(new_distro)
 
-            self.distros.add(new_distro, save=True)
+            self.api.add_distro(new_distro, save=True)
             distros_added.append(new_distro)
 
             # see if the profile name is already used, if so, skip it and
@@ -573,7 +573,7 @@ class _ImportSignatureManager(ManagerModule):
                         "answerfile": "autounattended.xml",
                     }
 
-            self.profiles.add(new_profile, save=True)
+            self.api.add_profile(new_profile, save=True)
 
         return distros_added
 
@@ -752,8 +752,8 @@ class _ImportSignatureManager(ManagerModule):
         :param distribution: The distribution object for which the install tree should be set.
         :param url: The url for the tree.
         """
-        # mypy cannot handle subclassed setters
-        distribution.autoinstall_meta = {"tree": url}  # type: ignore
+        self.logger.debug('Setting "tree" for distro "%s"', distribution.name)
+        distribution.autoinstall_meta = {"tree": url}
 
     # ==========================================================================
     # Repo Functions
@@ -785,7 +785,7 @@ class _ImportSignatureManager(ManagerModule):
             for current_distro_added in distros_added:
                 if current_distro_added.kernel.find("distro_mirror") != -1:
                     repo_adder(current_distro_added)
-                    self.distros.add(
+                    self.api.add_distro(
                         current_distro_added, save=True, with_triggers=False
                     )
                 else:

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -528,25 +528,21 @@ class _ImportSignatureManager(ManagerModule):
             self.api.add_distro(new_distro, save=True)
             distros_added.append(new_distro)
 
-            # see if the profile name is already used, if so, skip it and
-            # do not modify the existing profile
-
+            # see if the profile name is already used, if so, skip it and do not modify the existing profile
             existing_profile = self.profiles.find(name=name)
-
-            if existing_profile is None:
-                new_profile = self.api.new_profile(
-                    name=name,
-                    distro=name,
-                    autoinstall=self.autoinstall_file,  # type: ignore
-                )
-            else:
+            if existing_profile is not None:
                 self.logger.info(
                     "skipping existing profile, name already exists: %s", name
                 )
                 continue
 
-            # depending on the name of the profile we can
-            # define a good virt-type for usage with koan
+            new_profile = self.api.new_profile(
+                name=name,
+                distro=name,
+                autoinstall=self.autoinstall_file,  # type: ignore
+            )
+
+            # depending on the name of the profile we can define a good virt-type for usage with koan
             if name.find("-xen") != -1:
                 new_profile.virt_type = enums.VirtType.XENPV
             elif name.find("vmware") != -1:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1225,8 +1225,14 @@ class TFTPGen:
 
                 if distro.os_version in ["rhel4", "rhel5", "rhel6", "fedora16"]:
                     append_line += f" kssendmac ks={autoinstall_path}"
+                    if blended["autoinstall_meta"].get("tree"):
+                        append_line += f" repo={blended['autoinstall_meta']['tree']}"
                 else:
                     append_line += f" inst.ks.sendmac inst.ks={autoinstall_path}"
+                    if blended["autoinstall_meta"].get("tree"):
+                        append_line += (
+                            f" inst.repo={blended['autoinstall_meta']['tree']}"
+                        )
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace(


### PR DESCRIPTION
## Linked Items

Fixes #3417

## Description

This Pull Request fixes a bug that causes the `autoinstall_meta` dict to miss the value `tree`.

## Behaviour changes

Old: Autoinstallation stops with error "invalid value for `inst.rep`.

New: Autoinstallation works without supervision.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
