### PR TITLE
Add missing managers. for dnsmasq

### DIFF
--- a/changelog.d/3514.fixed
+++ b/changelog.d/3514.fixed
@@ -1,0 +1,2 @@
+Add missing `managers.` prefix for dnsmasq in DHCP Management documentation
+Add note about needing to set enable-menu for profiles to appear in PXE menu

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -99,8 +99,13 @@ Network Topics
 PXE Menus
 =========
 
-Cobbler will automatically generate PXE menus for all profiles it has defined. Running ``cobbler sync`` is required to
-generate and update these menus.
+Cobbler will automatically generate PXE menus for all profiles that have the ``enable_menu`` property set. You can
+enable this with:
+
+.. code-block:: shell
+   cobbler profile edit --name=PROFILE --enable-menu=yes
+
+Running ``cobbler sync`` is required to generate and update these menus.
 
 To access the menus, type ``menu`` at the ``boot:`` prompt while a system is PXE booting. If nothing is typed, the
 network boot will default to a local boot. If "menu" is typed, the user can then choose and provision any Cobbler

--- a/docs/user-guide/boot-cd.rst
+++ b/docs/user-guide/boot-cd.rst
@@ -12,7 +12,7 @@ DHCP Management
 
 Cobbler can optionally help you manage DHCP server. This feature is off by default.
 
-Choose either ``modules.dhcp.module: "managers.isc"`` or ``modules.dhcp.module: "dnsmasq"`` in the settings. For this
+Choose either ``modules.dhcp.module: "managers.isc"`` or ``modules.dhcp.module: "managers.dnsmasq"`` in the settings. For this
 setting to take effect ``manage_dhcp: true`` and at least one of ``manage_dhcp_v4`` or ``manage_dhcp_v6`` must be also
 set to ``true``.
 


### PR DESCRIPTION
## Description

Adds a missing `managers.` in front of dnsmasq.


## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [X] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [X] No tests required 
