### PR TITLE
Do not preserve read-only permissions from mounted ISO image.

### DIFF
--- a/changelog.d/3506.fixed
+++ b/changelog.d/3506.fixed
@@ -1,0 +1,1 @@
+Fix cobbler import rsync failure with SELinux enabled

--- a/cobbler/actions/importer.py
+++ b/cobbler/actions/importer.py
@@ -106,7 +106,8 @@ class Importer:
         spacer = ""
         if not mirror_url.startswith("rsync://") and not mirror_url.startswith("/"):
             spacer = ' -e "ssh" '
-        rsync_cmd = ["rsync", "--archive"]
+        # --archive but without -p to avoid copying read-only ISO permissions and making sure we have write access
+        rsync_cmd = ["rsync", "-rltgoD", "--chmod=ug=rwX"]
         if spacer != "":
             rsync_cmd.append(spacer)
         rsync_cmd.append("--progress")


### PR DESCRIPTION
## Linked Items

Fixes #3506 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Do not preserve read-only permissions from mounted ISO image.

## Behaviour changes

Old: read-only permissions of a mounted ISO image would be preserved when copied to /var/www/cobbler/distro_mirror.  This would cause SELinux dac_override denials.

New: Files are given user/group write permissions according to the active umask, e.g.:
```
$ ls -la /var/www/cobbler/distro_mirror/centos-stream-9/
total 44
drwxr-xr-x. 7 root root   181 Oct 29 22:06 .
drwxr-xr-x. 5 root root    60 Nov  5 17:20 ..
drwxr-xr-x. 4 root root    38 Oct 29 22:06 AppStream
drwxr-xr-x. 4 root root    38 Oct 29 22:06 BaseOS
-rw-r--r--. 1 root root    45 Oct 29 22:06 .discinfo
drwxr-xr-x. 3 root root    18 Oct 29 21:53 EFI
-rw-r--r--. 1 root root   299 Oct 29 22:06 EULA
-rw-r--r--. 1 root root   745 Oct 29 22:06 extra_files.json
drwxr-xr-x. 3 root root    59 Oct 29 21:53 images
drwxr-xr-x. 2 root root  4096 Oct 29 21:53 isolinux
-rw-r--r--. 1 root root 18092 Oct 29 22:06 LICENSE
-rw-r--r--. 1 root root    88 Oct 29 22:06 media.repo
-rw-r--r--. 1 root root  1530 Oct 29 22:06 .treeinfo
```

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

Not sure if new tests are needed.