### PR TITLE
Do not open files for reading that we are only writing to.

### DIFF
--- a/changelog.d/3508.fixed
+++ b/changelog.d/3508.fixed
@@ -1,0 +1,1 @@
+Do not open files for reading if we are only writing to them

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -767,7 +767,7 @@ class RepoSync:
         self.logger.debug("creating: %s", fname)
         if not os.path.exists(dest_path):
             filesystem_helpers.mkdir(dest_path)
-        with open(fname, "w+", encoding="UTF-8") as config_file:
+        with open(fname, "w", encoding="UTF-8") as config_file:
             if not output:
                 config_file.write("[main]\nreposdir=/dev/null\n")
             config_file.write(f"[{repo.name}]\n")

--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -136,7 +136,7 @@ class AutoInstallationManager:
                 f"unable to create directory for automatic OS installation template at {file_path}"
             )
 
-        with open(file_full_path, "w+", encoding="UTF-8") as fileh:
+        with open(file_full_path, "w", encoding="UTF-8") as fileh:
             fileh.write(data)
 
         return True
@@ -243,7 +243,7 @@ class AutoInstallationManager:
                 f"unable to create directory for automatic OS installation snippet at {file_path}"
             )
 
-        with open(file_full_path, "w+", encoding="UTF-8") as fileh:
+        with open(file_full_path, "w", encoding="UTF-8") as fileh:
             fileh.write(data)
 
     def remove_autoinstall_snippet(self, file_path: str) -> bool:

--- a/cobbler/modules/installation/post_log.py
+++ b/cobbler/modules/installation/post_log.py
@@ -56,7 +56,7 @@ def run(api: "CobblerAPI", args: List[str]) -> int:
 
     # FIXME: use the logger
 
-    with open("/var/log/cobbler/install.log", "a+", encoding="UTF-8") as install_log_fd:
+    with open("/var/log/cobbler/install.log", "a", encoding="UTF-8") as install_log_fd:
         install_log_fd.write(f"{objtype}\t{name}\t{ip_address}\tstop\t{time.time()}\n")
 
     return 0

--- a/cobbler/modules/installation/pre_log.py
+++ b/cobbler/modules/installation/pre_log.py
@@ -53,7 +53,7 @@ def run(api: "CobblerAPI", args: List[str]) -> int:
 
     # FIXME: use the logger
 
-    with open("/var/log/cobbler/install.log", "a+", encoding="UTF-8") as install_log_fd:
+    with open("/var/log/cobbler/install.log", "a", encoding="UTF-8") as install_log_fd:
         install_log_fd.write(f"{objtype}\t{name}\t{ip_address}\tstart\t{time.time()}\n")
 
     return 0

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -145,7 +145,7 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
         """
         # dnsmasq knows how to read this database of MACs -> IPs, so we'll keep it up to date every time we add a
         # system.
-        with open("/etc/ethers", "w+", encoding="UTF-8") as ethers_fh:
+        with open("/etc/ethers", "w", encoding="UTF-8") as ethers_fh:
             for system in self.systems:
                 if not system.is_management_supported(cidr_ok=False):
                     continue
@@ -164,7 +164,7 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
         """
         # dnsmasq knows how to read this database for host info (other things may also make use of this later)
         with open(
-            "/var/lib/cobbler/cobbler_hosts", "w+", encoding="UTF-8"
+            "/var/lib/cobbler/cobbler_hosts", "w", encoding="UTF-8"
         ) as regen_hosts_fd:
             for system in self.systems:
                 if not system.is_management_supported(cidr_ok=False):

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -900,7 +900,7 @@ class _ImportSignatureManager(ManagerModule):
             # the @@http_server@@ left as templating magic.
             # repo_url2 is actually no longer used. (?)
 
-            with open(fname, "w+", encoding="UTF-8") as config_file:
+            with open(fname, "w", encoding="UTF-8") as config_file:
                 config_file.write(f"[core-{counter}]\n")
                 config_file.write(f"name=core-{counter}\n")
                 config_file.write(

--- a/cobbler/modules/nsupdate_add_system_post.py
+++ b/cobbler/modules/nsupdate_add_system_post.py
@@ -75,7 +75,7 @@ def run(api: "CobblerAPI", args: List[Any]):
 
     # read our settings
     if str(settings.nsupdate_log) is not None:
-        LOGF = open(str(settings.nsupdate_log), "a+", encoding="UTF-8")  # type: ignore
+        LOGF = open(str(settings.nsupdate_log), "a", encoding="UTF-8")  # type: ignore
         nslog(f">> starting {__name__} {args}\n")
 
     if str(settings.nsupdate_tsig_key) is not None:

--- a/cobbler/modules/nsupdate_delete_system_pre.py
+++ b/cobbler/modules/nsupdate_delete_system_pre.py
@@ -75,7 +75,7 @@ def run(api: "CobblerAPI", args: List[Any]):
 
     # Read our settings
     if str(settings.nsupdate_log) is not None:
-        LOGF = open(str(settings.nsupdate_log), "a+", encoding="UTF-8")  # type: ignore
+        LOGF = open(str(settings.nsupdate_log), "a", encoding="UTF-8")  # type: ignore
         nslog(f">> starting {__name__} {args}\n")
 
     if str(settings.nsupdate_tsig_key) is not None:

--- a/cobbler/modules/serializers/file.py
+++ b/cobbler/modules/serializers/file.py
@@ -80,7 +80,7 @@ class FileSerializer(StorageBase):
             indent = None
 
         _dict = item.serialize()
-        with open(filename, "w+", encoding="UTF-8") as file_descriptor:
+        with open(filename, "w", encoding="UTF-8") as file_descriptor:
             data = json.dumps(_dict, sort_keys=sort_keys, indent=indent)
             file_descriptor.write(data)
 

--- a/cobbler/modules/sync_post_wingen.py
+++ b/cobbler/modules/sync_post_wingen.py
@@ -338,14 +338,14 @@ def run(api: "CobblerAPI", args: Any):
                 post_install_dir, meta["post_install_script"]
             )
             logger.info("Build post install script: %s", post_install_script)
-            with open(post_install_script, "w+", encoding="UTF-8") as pi_file:
+            with open(post_install_script, "w", encoding="UTF-8") as pi_file:
                 pi_file.write(data)
 
         if "answerfile" in meta:
             data = templ.render(tmpl_data, meta, None)
             answerfile_name = os.path.join(distro_dir, meta["answerfile"])
             logger.info("Build answer file: %s", answerfile_name)
-            with open(answerfile_name, "w+", encoding="UTF-8") as answerfile:
+            with open(answerfile_name, "w", encoding="UTF-8") as answerfile:
                 answerfile.write(data)
             tgen.copy_single_distro_file(answerfile_name, distro_path, False)
             tgen.copy_single_distro_file(answerfile_name, web_dir, True)

--- a/cobbler/templar.py
+++ b/cobbler/templar.py
@@ -147,7 +147,7 @@ class Templar:
         # if requested, write the data out to a file
         if out_path is not None:
             filesystem_helpers.mkdir(os.path.dirname(out_path))
-            with open(out_path, "w+", encoding="UTF-8") as file_descriptor:
+            with open(out_path, "w", encoding="UTF-8") as file_descriptor:
                 file_descriptor.write(data_out)
 
         return data_out

--- a/setup.py
+++ b/setup.py
@@ -114,7 +114,7 @@ def gen_build_version():
             gitstamp, gitdate = data.decode("utf8").split("\n")
 
     with open(
-        os.path.join(OUTPUT_DIR, "version"), "w+", encoding="UTF-8"
+        os.path.join(OUTPUT_DIR, "version"), "w", encoding="UTF-8"
     ) as version_file:
         config = ConfigParser()
         config.add_section("cobbler")

--- a/tests/actions/reposync_test.py
+++ b/tests/actions/reposync_test.py
@@ -538,7 +538,7 @@ def test_create_local_file(mocker, reposync_object, repo):
     # Assert
     # TODO: Extend checks
     assert mock_open.call_count == 1
-    assert mock_open.mock_calls[0] == mocker.call("config.repo", "w+", encoding="UTF-8")
+    assert mock_open.mock_calls[0] == mocker.call("config.repo", "w", encoding="UTF-8")
     mock_open_handle = mock_open()
     assert mock_open_handle.write.mock_calls[0] == mocker.call("[testrepo0]\n")
     assert mock_open_handle.write.mock_calls[1] == mocker.call("name=testrepo0\n")

--- a/tests/modules/managers/dnsmasq_test.py
+++ b/tests/modules/managers/dnsmasq_test.py
@@ -88,7 +88,7 @@ def test_manager_regen_ethers(mocker, cobbler_api):
     test_manager.regen_ethers()
 
     # Assert
-    mock_builtins_open.assert_called_once_with("/etc/ethers", "w+", encoding="UTF-8")
+    mock_builtins_open.assert_called_once_with("/etc/ethers", "w", encoding="UTF-8")
     write_handle = mock_builtins_open()
     write_handle.write.assert_called_once_with("AA:BB:CC:DD:EE:FF\t192.168.1.2\n")
 
@@ -112,7 +112,7 @@ def test_manager_regen_hosts(mocker, cobbler_api):
 
     # Assert
     mock_builtins_open.assert_called_once_with(
-        "/var/lib/cobbler/cobbler_hosts", "w+", encoding="UTF-8"
+        "/var/lib/cobbler/cobbler_hosts", "w", encoding="UTF-8"
     )
     write_handle = mock_builtins_open()
     write_handle.write.assert_called_once_with("::1\thost.example.org\n")


### PR DESCRIPTION
## Linked Items

Fixes #3508 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Currently cobbler opens a lot of files with `"w+"` or `"a+"` that are only being written to.  There is no need for the `+` which add read capability.  This improves compatibility with a restrictive SELinux policy for cobbler.

## Behaviour changes

Old: Files being written to were opened with O_RDWR, which was more permissions than needed.

New: Files being written to are opened with O_WR.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

I'm not sure if any more tests are needed for this.