### PR TITLE
Docs: Make code-block directives coherent

### DIFF
--- a/changelog.d/3522.fixed
+++ b/changelog.d/3522.fixed
@@ -1,0 +1,1 @@
+Docs: Make code-block directives consistent across our whole documentation.

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -214,14 +214,14 @@ Email out a report when Cobbler finishes installing a system.
 
 defaults:
 
-.. code:: YAML
+.. code-block:: yaml
 
-    build_reporting_enabled: false
-    build_reporting_sender: ""
-    build_reporting_email: [ 'root@localhost' ]
-    build_reporting_smtp_server: "localhost"
-    build_reporting_subject: ""
-    build_reporting_ignorelist: [ "" ]
+   build_reporting_enabled: false
+   build_reporting_sender: ""
+   build_reporting_email: [ 'root@localhost' ]
+   build_reporting_smtp_server: "localhost"
+   build_reporting_subject: ""
+   build_reporting_ignorelist: [ "" ]
 
 buildisodir
 ###########
@@ -291,10 +291,10 @@ configurations you probably do **not** want to supply this.
 
 defaults:
 
-.. code:: YAML
+.. code-block:: yaml
 
-    default_name_servers: []
-    default_name_servers_search: []
+   default_name_servers: []
+   default_name_servers_search: []
 
 default_ownership
 #################
@@ -432,22 +432,22 @@ using LDAP for WebUI/XML-RPC authentication.
 
 defaults:
 
-.. code::
+.. code-block:: yaml
 
-    ldap_server: "ldap.example.com"
-    ldap_base_dn: "DC=example,DC=com"
-    ldap_port: 389
-    ldap_tls: true
-    ldap_anonymous_bind: true
-    ldap_search_bind_dn: ''
-    ldap_search_passwd: ''
-    ldap_search_prefix: 'uid='
-    ldap_tls_cacertdir: ''
-    ldap_tls_cacertfile: ''
-    ldap_tls_certfile: ''
-    ldap_tls_keyfile: ''
-    ldap_tls_reqcert: 'hard'
-    ldap_tls_cipher_suite: ''
+   ldap_server: "ldap.example.com"
+   ldap_base_dn: "DC=example,DC=com"
+   ldap_port: 389
+   ldap_tls: true
+   ldap_anonymous_bind: true
+   ldap_search_bind_dn: ''
+   ldap_search_passwd: ''
+   ldap_search_prefix: 'uid='
+   ldap_tls_cacertdir: ''
+   ldap_tls_cacertfile: ''
+   ldap_tls_certfile: ''
+   ldap_tls_keyfile: ''
+   ldap_tls_reqcert: 'hard'
+   ldap_tls_cipher_suite: ''
 
 bind_manage_ipmi
 ################
@@ -496,10 +496,10 @@ lists which zones are managed. See :ref:`dns-management` for more information.
 
 defaults:
 
-.. code::
+.. code-block:: yaml
 
-    manage_forward_zones: []
-    manage_reverse_zones: []
+   manage_forward_zones: []
+   manage_reverse_zones: []
 
 manage_genders
 ##############
@@ -533,9 +533,9 @@ parameters work in conjunction with ``--mgmt-classes`` and are described in furt
 
 .. code-block:: YAML
 
-    mgmt_classes: []
-    mgmt_parameters:
-        from_cobbler: true
+   mgmt_classes: []
+   mgmt_parameters:
+       from_cobbler: true
 
 next_server_v4
 ##############
@@ -633,7 +633,7 @@ External proxy which is used by the following commands: ``reposync``, ``signatur
 
 defaults:
 
-.. code::
+.. code-block:: text
 
   http: http://192.168.1.1:8080
   https: https://192.168.1.1:8443
@@ -792,10 +792,10 @@ need to change this.
 
 defaults:
 
-.. code:: YAML
+.. code-block:: YAML
 
-    restart_dns: true
-    restart_dhcp: true
+   restart_dns: true
+   restart_dhcp: true
 
 run_install_triggers
 ####################
@@ -816,12 +816,12 @@ purposes. Git and Mercurial are currently supported, but Git is the recommend SC
 
 default:
 
-.. code:: YAML
+.. code-block:: YAML
 
-    scm_track_enabled: false
-    scm_track_mode: "git"
-    scm_track_author: "cobbler <cobbler@localhost>"
-    scm_push_script: "/bin/true"
+   scm_track_enabled: false
+   scm_track_mode: "git"
+   scm_track_author: "cobbler <cobbler@localhost>"
+   scm_push_script: "/bin/true"
 
 serializer_pretty_json
 ######################
@@ -894,23 +894,23 @@ Directories that will not get wiped and recreated on a ``cobbler sync``.
 
 default:
 
-.. code::
+.. code-block:: yaml
 
-    webdir_whitelist:
-      - misc
-      - web
-      - webui
-      - localmirror
-      - repo_mirror
-      - distro_mirror
-      - images
-      - links
-      - pub
-      - repo_profile
-      - repo_system
-      - svc
-      - rendered
-      - .link_cache
+   webdir_whitelist:
+     - misc
+     - web
+     - webui
+     - localmirror
+     - repo_mirror
+     - distro_mirror
+     - images
+     - links
+     - pub
+     - repo_profile
+     - repo_system
+     - svc
+     - rendered
+     - .link_cache
 
 windows_enabled
 ###############

--- a/docs/cobbler.rst
+++ b/docs/cobbler.rst
@@ -478,7 +478,7 @@ Adds a Cobbler System to the configuration. Arguments are specified as per "prof
 |                     |                                                                                                |
 |                     | Example:                                                                                       |
 |                     |                                                                                                |
-|                     | .. code-block::                                                                                |
+|                     | .. code-block:: shell-session                                                                  |
 |                     |                                                                                                |
 |                     |     cobbler system edit --name=foo \                                                           |
 |                     |                         --interface=eth0 \                                                     |
@@ -507,7 +507,7 @@ Adds a Cobbler System to the configuration. Arguments are specified as per "prof
 |                     |                                                                                                |
 |                     | Example:                                                                                       |
 |                     |                                                                                                |
-|                     | .. code-block::                                                                                |
+|                     | .. code-block:: shell-session                                                                  |
 |                     |                                                                                                |
 |                     |     cobbler system report --name=foo                                                           |
 |                     |                                                                                                |

--- a/docs/quickstart-guide.rst
+++ b/docs/quickstart-guide.rst
@@ -42,16 +42,16 @@ Default encrypted password
 
 This setting controls the root password that is set for new systems during the handsoff installation.
 
-.. code::
+.. code-block:: yaml
 
-    default_password_crypted: "$1$bfI7WLZz$PxXetL97LkScqJFxnW7KS1"
+   default_password_crypted: "$1$bfI7WLZz$PxXetL97LkScqJFxnW7KS1"
 
 You should modify this by running the following command and inserting the output into the above string (be sure to save
 the quote marks):
 
-.. code-block:: shell
+.. code-block:: shell-session
 
-    $ openssl passwd -1
+   openssl passwd -1
 
 
 Server and next_server
@@ -61,16 +61,16 @@ The ``server`` option sets the IP that will be used for the address of the Cobbl
 is not the listening address. This should be set to the IP you want hosts that are being built to contact the Cobbler
 server on for such protocols as HTTP and TFTP.
 
-.. code::
+.. code-block:: yaml
 
-    server: 127.0.0.1
+   server: 127.0.0.1
 
 The ``next_server`` option is used for DHCP/PXE as the IP of the TFTP server from which network boot files are
 downloaded. Usually, this will be the same IP as the server setting.
 
-.. code::
+.. code-block:: yaml
 
-    next_server: 127.0.0.1
+   next_server: 127.0.0.1
 
 
 DHCP management and DHCP server template
@@ -79,9 +79,9 @@ DHCP management and DHCP server template
 In order to PXE boot, you need a DHCP server to hand out addresses and direct the booting system to the TFTP server
 where it can download the network boot files. Cobbler can manage this for you, via the ``manage_dhcp`` setting:
 
-.. code::
+.. code-block:: yaml
 
-    manage_dhcp: 0
+   manage_dhcp: 0
 
 Change that setting to 1 so Cobbler will generate the ``dhcpd.conf`` file based on the ``dhcp.template`` that is
 included with Cobbler. This template will most likely need to be modified as well, based on your network settings:
@@ -92,7 +92,7 @@ included with Cobbler. This template will most likely need to be modified as wel
 
 For most uses, you'll only need to modify this block:
 
-.. code::
+.. code-block:: text
 
     subnet 192.168.1.0 netmask 255.255.255.0 {
         option routers             192.168.1.1;
@@ -108,7 +108,7 @@ No matter what, make sure you do not modify the ``next-server $next_server_v4;``
 setting is pulled into the configuration. This file is a cheetah template, so be sure not to modify anything starting
 after this line:
 
-.. code::
+.. code-block:: cheetah
 
     #for dhcp_tag in $dhcp_tags.keys():
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -102,7 +102,8 @@ PXE Menus
 Cobbler will automatically generate PXE menus for all profiles that have the ``enable_menu`` property set. You can
 enable this with:
 
-.. code-block:: shell
+.. code-block:: shell-session
+
    cobbler profile edit --name=PROFILE --enable-menu=yes
 
 Running ``cobbler sync`` is required to generate and update these menus.

--- a/docs/user-guide/advanced-networking.rst
+++ b/docs/user-guide/advanced-networking.rst
@@ -22,10 +22,10 @@ Arbitrary NIC naming
 
 You can give your network interface (almost) any name you like.
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name=foo1.bar.local --interface=mgmt --mac=AA:BB:CC:DD:EE:F0]
-    cobbler system edit --name=foo1.bar.local --interface=dmz --mac=AA:BB:CC:DD:EE:F1
+   cobbler system edit --name=foo1.bar.local --interface=mgmt --mac=AA:BB:CC:DD:EE:F0]
+   cobbler system edit --name=foo1.bar.local --interface=dmz --mac=AA:BB:CC:DD:EE:F1
 
 The default interface is named ``default``, but you don't have to call it that.
 
@@ -38,9 +38,9 @@ Name Servers
 For static systems, the ``--name-servers`` parameter can be used to
 specify a list of name servers to assign to the systems.
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name=foo --interface=eth0 --mac=AA:BB:CC::DD:EE:FF --static=1 --name-servers="<ip1> <ip2>"
+   cobbler system edit --name=foo --interface=eth0 --mac=AA:BB:CC::DD:EE:FF --static=1 --name-servers="<ip1> <ip2>"
 
 DNS and DHCP Management
 -----------------------
@@ -56,11 +56,11 @@ physical interfaces to one logical interface, for redundancy and/or performance.
 You can set up a bond, to join interfaces eth0 and ``eth1`` to a failover (active-backup) interface ``bond0`` as
 follows:
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name=foo2.bar.local --interface=eth0 --mac=AA:BB:CC:DD:EE:F0 --bonding=slave --bonding-master=bond0
-    cobbler system edit --name=foo2.bar.local --interface=eth1 --mac=AA:BB:CC:DD:EE:F1 --bonding=slave --bonding-master=bond0
-    cobbler system edit --name=foo2.bar.local --interface=bond0 --bonding=master --bonding-opts="miimon=100 mode=1"
+   cobbler system edit --name=foo2.bar.local --interface=eth0 --mac=AA:BB:CC:DD:EE:F0 --bonding=slave --bonding-master=bond0
+   cobbler system edit --name=foo2.bar.local --interface=eth1 --mac=AA:BB:CC:DD:EE:F1 --bonding=slave --bonding-master=bond0
+   cobbler system edit --name=foo2.bar.local --interface=bond0 --bonding=master --bonding-opts="miimon=100 mode=1"
 
 Static routes
 =============
@@ -71,9 +71,9 @@ The format of a static route is: ``network/CIDR:gateway``
 
 So, for example to route the ``192.168.1.0/24`` network through ``192.168.1.254``:
 
-.. code-block::
+.. code-block:: shell
 
-    $ cobbler system edit --name=foo --interface=eth0 --static-routes="192.168.1.0/24:192.168.1.254"
+   cobbler system edit --name=foo --interface=eth0 --static-routes="192.168.1.0/24:192.168.1.254"
 
 As with all lists in cobbler, the ``--static-routes`` list is space-separated so you can specify multiple static routes
 if needed.
@@ -84,11 +84,11 @@ VLANs
 You can now add VLAN tags to interfaces from Cobbler. In this case we have two VLANs on ``eth0``: 10 and 20. The default
 VLAN (untagged traffic) is not used:
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name=foo3.bar.local --interface=eth0 --mac=AA:BB:CC:DD:EE:F0 --static=1
-    cobbler system edit --name=foo3.bar.local --interface=eth0.10 --static=1 --ip=10.0.10.5 --subnet=255.255.255.0
-    cobbler system edit --name=foo3.bar.local --interface=eth0.20 --static=1 --ip=10.0.20.5 --subnet=255.255.255.0
+   cobbler system edit --name=foo3.bar.local --interface=eth0 --mac=AA:BB:CC:DD:EE:F0 --static=1
+   cobbler system edit --name=foo3.bar.local --interface=eth0.10 --static=1 --ip=10.0.10.5 --subnet=255.255.255.0
+   cobbler system edit --name=foo3.bar.local --interface=eth0.20 --static=1 --ip=10.0.20.5 --subnet=255.255.255.0
 
 You have to install the vconfig package for this to work.
 

--- a/docs/user-guide/building-isos.rst
+++ b/docs/user-guide/building-isos.rst
@@ -24,7 +24,7 @@ Thus we don't execute "mkisofs" anymore. Please be aware of this when adding CLI
 
 On the Python side we are executing the following command:
 
-.. code::
+.. code-block:: shell
 
    xorriso -as mkisofs $XORRISOFS_OPTS -isohybrid-mbr $ISOHDPFX_location -c isolinux/boot.cat \
      -b isolinux/isolinux.bin -no-emul-boot -boot-load-size 4 -boot-info-table -eltorito-alt-boot \
@@ -33,7 +33,7 @@ On the Python side we are executing the following command:
 
 Explanation what this command is doing:
 
-.. code::
+.. code-block:: shell
 
    xorriso -as mkisofs \
      -isohybrid-mbr /usr/share/syslinux/isohdpfx.bin \  # --> Makes the image MBR bootable and specifies the MBR File

--- a/docs/user-guide/configuration-management-integrations.rst
+++ b/docs/user-guide/configuration-management-integrations.rst
@@ -94,7 +94,7 @@ Set up Cobbler to include a package repository that contains your chosen CMS:
 
 Then (illustrating a Red Hat/Puppet combination) set up the kickstart file to say something like:
 
-.. code::
+.. code-block:: text
 
     %packages
     puppet
@@ -273,23 +273,23 @@ For more documentation on Puppet's external nodes feature, see https://docs.pupp
 
 Cobbler provides one, so configure puppet to use ``/usr/bin/cobbler-ext-nodes``:
 
-.. code::
+.. code-block:: ini
 
-    [main]
-    external_nodes = /usr/bin/cobbler-ext-nodes
+   [main]
+   external_nodes = /usr/bin/cobbler-ext-nodes
 
 Note: if you are using puppet 0.24 or later then you will want to also add the following to your configuration file.
 
-.. code::
+.. code-block:: ini
 
-    node_terminus = exec
+   ode_terminus = exec
 
 You may wonder what this does. This is just a very simple script that grabs the data at the following URL, which is a
 URL that always returns a YAML document in the way that Puppet expects it to be returned. This file contains all the
 parameters and classes that are to be assigned to the node in question. The magic URL being visited is powered by
 Cobbler.
 
-.. code::
+.. code-block:: text
 
     http://cobbler/cblr/svc/op/puppet/hostname/foo
 
@@ -297,16 +297,16 @@ Cobbler.
 
 And this will return data such as:
 
-.. code::
+.. code-block:: yaml
 
-    ---
-    classes:
-        - distro1
-        - webserver
-        - likes_llamas
-        - orange
-    parameters:
-        tree: 'http://.../x86_64/tree'
+   ---
+   classes:
+       - distro1
+       - webserver
+       - likes_llamas
+       - orange
+   parameters:
+       tree: 'http://.../x86_64/tree'
 
 Where do the parameters come from? Everything that cobbler tracks in ``--ks-meta`` is also a parameter. This way you can
 easily add parameters as easily as you can add classes, and keep things all organized in one place.
@@ -314,16 +314,16 @@ easily add parameters as easily as you can add classes, and keep things all orga
 What if you have global parameters or classes to add? No problem. You can also add more classes by editing the following
 fields in ``/etc/cobbler/settings.yaml``:
 
-.. code::
+.. code-block:: yaml
 
-    # cobbler has a feature that allows for integration with config management
-    # systems such as Puppet.  The following parameters work in conjunction with
+   # cobbler has a feature that allows for integration with config management
+   # systems such as Puppet.  The following parameters work in conjunction with
 
-    # --mgmt-classes  and are described in furhter detail at:
-    # https://fedorahosted.org/cobbler/wiki/UsingCobblerWithConfigManagementSystem
-    mgmt_classes: []
-    mgmt_parameters:
-       from_cobbler: 1
+   # --mgmt-classes  and are described in furhter detail at:
+   # https://fedorahosted.org/cobbler/wiki/UsingCobblerWithConfigManagementSystem
+   mgmt_classes: []
+   mgmt_parameters:
+      from_cobbler: 1
 
 Alternate External Nodes Script
 ===============================
@@ -333,14 +333,14 @@ repository (at ``/etc/puppet/manifests/``) and networking information from cobbl
 the puppet side, and then looks for ``/etc/puppet/external_node.yaml`` for cobbler side configuration.
 The configuration is as follows.
 
-.. code::
+.. code-block:: yaml
 
-    base: /etc/puppet/manifests/nodes
-    cobbler: <%= cobbler_host %>
-    no_yaml: puppet::noyaml
-    no_cobbler: network::nocobbler
-    bad_yaml: puppet::badyaml
-    unmanaged: network::unmanaged
+   base: /etc/puppet/manifests/nodes
+   cobbler: <%= cobbler_host %>
+   no_yaml: puppet::noyaml
+   no_cobbler: network::nocobbler
+   bad_yaml: puppet::badyaml
+   unmanaged: network::unmanaged
 
 The output for network information will be in the form of a pseudo data structure that allows puppet to split it apart
 and create the network interfaces on the node being managed.

--- a/docs/user-guide/esxi.rst
+++ b/docs/user-guide/esxi.rst
@@ -74,7 +74,7 @@ Now add a system with the previously created profile
 
 Entries in the ``/etc/dhcp/dhcpd.conf`` file should have been generated for system ``some-esxi-host``.
 
- .. code-block::
+ .. code-block:: text
 
     # group for Cobbler DHCP tag: default
     group {
@@ -267,7 +267,7 @@ iPXE boot can be enabled on a profile or system basis.
 
 After enabling iPXE, you shoud see a different DHCP configuration for the host.
 
-.. code-block::
+.. code-block:: text
 
     ...
     # group for Cobbler DHCP tag: default

--- a/docs/user-guide/http-api.rst
+++ b/docs/user-guide/http-api.rst
@@ -31,7 +31,7 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: text
 
     #{
         "allow_duplicate_hostnames": false,
@@ -61,10 +61,10 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    # this file intentionally left blank
-    # admins:  edit it as you like, or leave it blank for non-interactive install
+   # this file intentionally left blank
+   # admins:  edit it as you like, or leave it blank for non-interactive install
 
 System
 ------
@@ -73,14 +73,14 @@ Example Call:
 
 .. code-block:: console
 
-    curl http://localhost/cblr/svc/op/autoinstall/system/example_system
+   curl http://localhost/cblr/svc/op/autoinstall/system/example_system
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    # this file intentionally left blank
-    # admins:  edit it as you like, or leave it blank for non-interactive install
+   # this file intentionally left blank
+   # admins:  edit it as you like, or leave it blank for non-interactive install
 
 ks
 ==
@@ -95,14 +95,14 @@ Example Call:
 
 .. code-block:: console
 
-    curl http://localhost/cblr/svc/op/ks/profile/example_profile
+   curl http://localhost/cblr/svc/op/ks/profile/example_profile
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    # this file intentionally left blank
-    # admins:  edit it as you like, or leave it blank for non-interactive install
+   # this file intentionally left blank
+   # admins:  edit it as you like, or leave it blank for non-interactive install
 
 System
 ------
@@ -115,10 +115,10 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    # this file intentionally left blank
-    # admins:  edit it as you like, or leave it blank for non-interactive install
+   # this file intentionally left blank
+   # admins:  edit it as you like, or leave it blank for non-interactive install
 
 iPXE
 ====
@@ -136,7 +136,7 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: text
 
     :example_profile
     kernel /images/example_distro/vmlinuz   initrd=initrd.magic
@@ -170,7 +170,7 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: text
 
     #!ipxe
     iseq ${smbios/manufacturer} HP && exit ||
@@ -195,7 +195,7 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: text
 
     bootstate=0
     title=Loading ESXi installer
@@ -217,7 +217,7 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: text
 
     bootstate=0
     title=Loading ESXi installer
@@ -272,9 +272,9 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    []
+   []
 
 .. warning:: If the specified user doesn't exist there is currently no output.
 
@@ -353,9 +353,9 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    False
+   False
 
 Profile
 -------
@@ -368,9 +368,9 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    False
+   False
 
 System
 ------
@@ -383,9 +383,9 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    False
+   False
 
 noPXE
 =====
@@ -400,9 +400,9 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: yaml
 
-    True
+   True
 
 list
 ====
@@ -421,7 +421,7 @@ Example Call:
 
 Example Output:
 
-.. code-block::
+.. code-block:: text
 
     example_profile
     example_profile2

--- a/docs/user-guide/httpboot.rst
+++ b/docs/user-guide/httpboot.rst
@@ -11,7 +11,7 @@ HTTP configuration
 On the Cobbler server create the following files in ``/etc/apache2/conf.d/http-tftpboot.conf`` with the following
 content:
 
-.. code-block::
+.. code-block:: text
 
     # allow http access to /srv/tftpboot/grub
     Alias "/httpboot" "/srv/tftpboot"
@@ -30,9 +30,9 @@ content:
 
 After the changes have been made issue the following command:
 
-.. code-block::
+.. code-block:: shell
 
-    systemctl restart apache2.service
+   systemctl restart apache2.service
 
 
 DHCP configuration
@@ -40,31 +40,29 @@ DHCP configuration
 
 To use HTTP-boot the following 2 entries need to be added:
 
-.. code-block::
+.. code-block:: text
 
-      option vendor-class-identifier "HTTPClient";
-      filename "http://<ip address SUSE Manager Server>/httpboot/grub/shim.efi";
+   option vendor-class-identifier "HTTPClient";
+   filename "http://<ip address SUSE Manager Server>/httpboot/grub/shim.efi";
 
 The following example can be used if both traditional and HTTP boot are needed. It is recommended to use ``class``-ses
 for this.
 
 Example Configuration:
 
-.. code-block::
+.. code-block:: text
 
-    class "pxeclients" {
-      match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
-      next-server <ip address SUSE Manager Server>;
-      filename "pxelinux.0";
-    }
+   class "pxeclients" {
+     match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
+     next-server <ip address SUSE Manager Server>;
+     filename "pxelinux.0";
+   }
 
-    class "httpclients" {
-      match if substring (option vendor-class-identifier, 0, 10) = "HTTPClient";
-      option vendor-class-identifier "HTTPClient";
-      filename "http://<ip address SUSE Manager Server>/httpboot/grub/shim.efi";
-    }
-
-
+   class "httpclients" {
+     match if substring (option vendor-class-identifier, 0, 10) = "HTTPClient";
+     option vendor-class-identifier "HTTPClient";
+     filename "http://<ip address SUSE Manager Server>/httpboot/grub/shim.efi";
+   }
 
 Author
 ======

--- a/docs/user-guide/power-management.rst
+++ b/docs/user-guide/power-management.rst
@@ -34,27 +34,27 @@ Example of Set Up
 
 You have a WTI powerbar. Define that system foo is a part of that powerbar on plug 7
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name foo --power-type=wti --power-address=foo-mgmt.example.org --power-user Administrator --power-pass PASSWORD --power-id 7
+   cobbler system edit --name foo --power-type=wti --power-address=foo-mgmt.example.org --power-user Administrator --power-pass PASSWORD --power-id 7
 
 You have a DRAC based blade:
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name blade7 --power-type=drac --power-address=blade-mgmt.example.org --power-user Administrator --power-pass=PASSWORD --power-id blade7
+   cobbler system edit --name blade7 --power-type=drac --power-address=blade-mgmt.example.org --power-user Administrator --power-pass=PASSWORD --power-id blade7
 
 You have an IPMI based system:
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name foo --power-type=ipmi --power-address=foo-mgmt.example.org --power-user Administrator --power-pass=PASSWORD
+   cobbler system edit --name foo --power-type=ipmi --power-address=foo-mgmt.example.org --power-user Administrator --power-pass=PASSWORD
 
 You have a IBM HMC managed system:
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name 9115-505 --power-type=lpar --power-address=ibm-hmc.example.org --power-user hscroot --power-pass=PASSWORD --power-id system:partition
+   cobbler system edit --name 9115-505 --power-type=lpar --power-address=ibm-hmc.example.org --power-user hscroot --power-pass=PASSWORD --power-id system:partition
 
 .. note:: The *--power-id* option is used to indicate **both** the managed system name and a logical partition name.
           Since an IBM HMC is responsible for managing more than one system, you must supply the managed system name
@@ -62,9 +62,9 @@ You have a IBM HMC managed system:
 
 You have an IBM Bladecenter:
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name blade-06 --power-type=bladecenter --power-address=blademm.example.org --power-user USERID --power-pass=PASSW0RD --power-id 6
+   cobbler system edit --name blade-06 --power-type=bladecenter --power-address=blademm.example.org --power-user USERID --power-pass=PASSW0RD --power-id 6
 
 .. note:: The ``*--power-id*`` option is used to specify what slot your blade is connected.
 
@@ -88,28 +88,28 @@ Using the Power Management Features
 
 Assigning A System To Be Installed To A New Profile
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system edit --name=foo --netboot-enabled=1 --profile=install-this-profile-name-instead
+   obbler system edit --name=foo --netboot-enabled=1 --profile=install-this-profile-name-instead
 
 Powering Off A System
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system poweroff --name=foo
+   cobbler system poweroff --name=foo
 
 Powering On A System
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system poweron --name=foo
+   cobbler system poweron --name=foo
 
 Rebooting A System (if netboot-enabled is turned on, it will now
 reinstall to the new profile -- assuming PXE is working)
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system reboot --name=foo
+   cobbler system reboot --name=foo
 
 Since not all power management systems support reboot, this is a "power off, sleep for 1 second, and power on"
 operation.
@@ -140,9 +140,9 @@ This may also be too insecure for some, so in this case, don't set these, and su
 ``--power-pass`` when running commands like ``cobbler system poweron`` and ``cobbler system poweroff``. The values used
 on the command line are always used, regardless of the value stored in Cobbler or the environment, if so provided.
 
-.. code-block::
+.. code-block:: shell
 
-    cobbler system poweron --name=foo --power-user=X --power-pass=Y
+   cobbler system poweron --name=foo --power-user=X --power-pass=Y
 
 Be advised of current limitations in storing passwords, make your choices accordingly and in relation to the
 ease-of-use that you need, and secure your networks appropriately.

--- a/docs/user-guide/terraform-provider.rst
+++ b/docs/user-guide/terraform-provider.rst
@@ -47,7 +47,7 @@ Unpack the ZIP-file and move the binary-file into ``/usr/local/bin``.
 Make sure you’re using at least **Terraform v0.14 or higher**.
 Check with ``terraform version``:
 
-.. code::
+.. code-block:: text
 
   $ terraform version
   Terraform v0.14.5
@@ -62,7 +62,7 @@ After setting up a Cobbler Terraform repository for the first time, run
 ``terraform init`` in the **basedir**, so the Cobbler provider
 gets installed automatically in ``tf_cobbler/.terraform/providers``.
 
-.. code::
+.. code-block:: text
 
     $ terraform init
 
@@ -117,7 +117,7 @@ of software testing and deployment in the `DTAP <https://en.wikipedia.org/wiki/D
 
 The directory-tree would look something like this:
 
-.. code::
+.. code-block:: text
 
    ├── .gitignore
    ├── .terraform
@@ -161,7 +161,7 @@ one **symlinked** directory ``.terraform`` and files **symlinked**
 from the root: ``versions.tf``, ``variables.tf``. ``.terraform.lock.hcl``
 and ``terraform.tfvars``:
 
-.. code::
+.. code-block:: text
 
    tf_cobbler/production/webserver
    .
@@ -182,7 +182,7 @@ File ``versions.tf``
 
 The block in this file specifies the required provider version and required Terraform version for the configuration.
 
-.. code::
+.. code-block:: terraform
 
   terraform {
     required_version = ">= 0.14"
@@ -204,7 +204,7 @@ in the basedir of your repo.
 File ``terraform.tfvars``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code::
+.. code-block:: terraform
 
    cobbler_username = "cobbler"
    cobbler_password = "<the Cobbler-password>"
@@ -227,7 +227,7 @@ File ``variables.tf``
 
    Excerpt from: James Turnbull, "The Terraform Book."
 
-.. code::
+.. code-block:: terraform
 
    variable "cobbler_username" {
      description = "Cobbler admin user"
@@ -262,7 +262,7 @@ It has been cleaned up with the
 .. important::
    Make sure there is only **ONE** gateway defined on **ONE** interface!
 
-.. code::
+.. code-block:: terraform
 
    resource "cobbler_system" "webserver" {
      count            = "1"
@@ -309,7 +309,7 @@ Example configuration - snippet
 
 This is the ``main.tf`` for a snippet:
 
-.. code::
+.. code-block:: terraform
 
   resource "cobbler_snippet" "partitioning-VMware" {
     name = "partitioning-VMware"
@@ -322,7 +322,7 @@ snippet.
 Example configuration - repo
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code::
+.. code-block:: terraform
 
   resource "cobbler_repo" "debian10-x86_64" {
     name           = "debian10-x86_64"
@@ -336,7 +336,7 @@ Example configuration - repo
 Example configuration - distro
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code::
+.. code-block:: terraform
 
   resource "cobbler_distro" "debian10-x86_64" {
     name            = "debian10-x86_64"
@@ -350,7 +350,7 @@ Example configuration - distro
 Example configuration - profile
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. code::
+.. code-block:: terraform
 
   resource "cobbler_profile" "debian10-x86_64" {
     name                = "debian10-x86_64"
@@ -369,7 +369,7 @@ Example configuration - combined
 It is also possible to combine multiple resources into one file.
 For example, this will combine an Ubuntu Bionic distro, a profile and a system:
 
-.. code::
+.. code-block:: terraform
 
   resource "cobbler_distro" "foo" {
       name = "foo"
@@ -413,7 +413,7 @@ File ``set_links.sh``
 The file ``set_links.sh`` is used to symlink to the default variables.
 We need these in every subdirectory.
 
-.. code:: shell
+.. code-block:: shell
 
   #!/bin/sh
 
@@ -426,7 +426,7 @@ We need these in every subdirectory.
 Adding a new system
 ~~~~~~~~~~~~~~~~~~~
 
-.. code::
+.. code-block:: text
 
    git pull --rebase <-- Refresh the repository
 

--- a/docs/user-guide/wingen.rst
+++ b/docs/user-guide/wingen.rst
@@ -34,7 +34,7 @@ A logically automatic network installation of Windows 7 and newer can be represe
 
 PXE + Legacy BIOS Boot
 
-.. code::
+.. code-block:: text
 
     Original files: pxeboot.n12 → bootmgr.exe → BCD → winpe.wim → startnet.cmd → autounattended.xml
     Cobbler profile 1: pxeboot.001 → boot001.exe → 001 → wi001.wim → startnet.cmd → autounatten001.xml → post_install.cmd profile_name
@@ -42,7 +42,7 @@ PXE + Legacy BIOS Boot
 
 iPXE + UEFI Boot
 
-.. code::
+.. code-block:: text
 
     Original files: ipxe-x86_64.efi → wimboot → bootmgr.exe → BCD → winpe.wim → startnet.cmd → autounattended.xml
     Cobbler profile 1: ipxe-x86_64.efi → wimboot → bootmgr.exe → 001 → wi001.wim → startnet.cmd → autounatten001.xml → post_install.cmd profile_name
@@ -50,7 +50,7 @@ iPXE + UEFI Boot
 
 For older versions (Windows XP, 2003) + RIS:
 
-.. code::
+.. code-block:: text
 
     Original files: pxeboot.n12 → setupldr.exe → winnt.sif → post_install.cmd profile_name
     Cobbler profile <xxx>: pxeboot.<xxx> → setup<xxx>.exe → wi<xxx>.sif → post_install.cmd profile_name
@@ -142,16 +142,16 @@ Preparing for an unattended network installation of Windows
 * ``dnf install python3-pefile python3-hivex wimlib-utils``
 * enable Windows support in settings ``/etc/cobbler/settings.yaml``:
 
-    .. code::
+    .. code-block:: yaml
 
-        windows_enabled: true
+       windows_enabled: true
 
 * If you have ``file 5.37`` or newer installed (openSUSE Tumbleweed, Debian 11, RHEL/Rocky Linux 9, Fedora 37)
   you can easily import the Wibdows distro:
 
-    .. code::
+    .. code-block:: shell
 
-        cobbler import --name=Win10_EN-x64 --path=/mnt
+       cobbler import --name="Win10_EN-x64" --path="/mnt"
 
     This command will determine the version and architecture of the Windows distribution, will extract the necessary boot
     files from the distribution and create a distro and profile named ``Win10_EN-x64``.
@@ -163,7 +163,7 @@ Preparing for an unattended network installation of Windows
 
   * ADK for Windows 10 / 8.1
 
-.. code::
+.. code-block:: text
 
     Start -> Apps -> Windows Kits -> Deployment and Imaging Tools Environment
 
@@ -171,13 +171,13 @@ or
 
   * WAIK for Windows 7
 
-.. code::
+.. code-block:: text
 
     Start -> All Programs -> Microsoft Windows AIK -> Deployment Tools Command Prompt
 
-.. code::
+.. code-block:: text
 
-    copype.cmd <amd64|x86|arm> c:\winpe
+   copype.cmd <amd64|x86|arm> c:\winpe
 
 After executing the command, the WinPE image will be located in ``.\winpe.wim`` for WAIK and in
 ``media\sources\boot.wim`` for ADK. You can use either it or replace it with the one that has been obtained as a result
@@ -218,7 +218,7 @@ Example:
 
 Replace the line in the ``/etc/systemd/system/tftp.service``
 
-.. code::
+.. code-block:: text
 
     ExecStart=/usr/sbin/in.tftpd -s /var/lib/tftpboot
         to:


### PR DESCRIPTION
## Linked Items

Fixes #3522

## Description

rstcheck was complaining about AttributeErrors in our documentation. As such the linter failed.

## Behaviour changes

Old: rstcheck failed due to errors and warnings

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [x] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
