### PR TITLE
Add EFI chainloader for Ubuntu to menu local

### DIFF
--- a/changelog.d/3525.fixed
+++ b/changelog.d/3525.fixed
@@ -1,0 +1,1 @@
+Add EFI chainloader for Ubuntu to menu local

--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -23,6 +23,8 @@ menuentry "local" --class gnu-linux --class gnu --class os {
       chainloader (${root})/efi/sles/grub.efi
     elif [ -f (${root})/efi/grub/grub.efi ] ; then
       chainloader (${root})/efi/grub/grub.efi
+    elif [ -f (${root})/efi/ubuntu/grubx64.efi ] ; then
+      chainloader (${root})/efi/ubuntu/grubx64.efi
     else
       chainloader (${root})/efi/boot/bootx64.efi
     fi


### PR DESCRIPTION
## Linked Items

Fixes #3524

## Description

Add support of Ubuntu to the local_efi chainload file

## Behaviour changes

Old: a node booting PXE with Ubuntu 22.04 was unable to boot correctly

New: a node booting PXE with Ubuntu 22.04 can boot correctly

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
