### PR TITLE
snippets: Use mac instead of ifname in netconfig

### DIFF
--- a/autoinstall_snippets/pre_install_network_config
+++ b/autoinstall_snippets/pre_install_network_config
@@ -154,7 +154,7 @@ touch /tmp/pre_install_network_config
 if mac_exists $mac
 then
   get_ifname $mac
-  echo "network --device=\$IFNAME $netinfo" >> /tmp/pre_install_network_config
+  echo "network --device=$mac $netinfo" >> /tmp/pre_install_network_config
             #for $route in $static_routes
                 #if $routepattern.match($route)
                     #set $routebits = $route.split(":")

--- a/changelog.d/3530.changed
+++ b/changelog.d/3530.changed
@@ -1,0 +1,1 @@
+Change --device flag to mac instead of interface name for pre_install_network_config


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->
none reported yet
<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->

## Behaviour changes
We should use --device=$mac instead of $ifname since ifname can change and this will result in wrong interface being configured

Old: <!-- This is the old way Cobbler behaved -->
Cobbler uses ifname to inform dracut what interface to configure
New: <!-- This is the new way Cobbler behaves -->
Cobbler uses MAC to inform dracut what interface to configure
## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
