### PR TITLE
Use get_conceptual_parent() for resolving attrs

### DIFF
--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -453,47 +453,19 @@ class Item:
             settings_name = "default_ownership"
         attribute = "_" + property_name
 
-        if not hasattr(self, attribute):
-            raise AttributeError(
-                f'{type(self)} "{self.name}" does not have property "{property_name}"'
-            )
-
         return getattr(self, attribute), settings_name
 
     def __resolve_get_parent_or_settings(self, property_name: str, settings_name: str):
         settings = self.api.settings()
-        if self.parent is not None and hasattr(self.parent, property_name):
+        conceptual_parent = self.get_conceptual_parent()
+
+        if hasattr(self.parent, property_name):
             return getattr(self.parent, property_name)
-        if (
-            hasattr(self, "distro")
-            and getattr(self, "distro") is not None
-            and hasattr(getattr(self, "distro"), property_name)
-        ):
-            # This is only valid for profiles and is a workaround.
-            return getattr(getattr(self, "distro"), property_name)
-        if (
-            hasattr(self, "profile")
-            and getattr(self, "profile") != ""
-            and hasattr(
-                self.api.find_profile(name=getattr(self, "profile")), property_name
-            )
-        ):
-            # This is only valid for systems and is a workaround.
-            return getattr(
-                self.api.find_profile(name=getattr(self, "profile")), property_name
-            )
-        if (
-            hasattr(self, "image")
-            and getattr(self, "image") != ""
-            and hasattr(self.api.find_image(name=getattr(self, "image")), property_name)
-        ):
-            # This is only valid for systems and is a workaround.
-            return getattr(
-                self.api.find_image(name=getattr(self, "image")), property_name
-            )
-        if hasattr(settings, settings_name):
+        elif hasattr(conceptual_parent, property_name):
+            return getattr(conceptual_parent, property_name)
+        elif hasattr(settings, settings_name):
             return getattr(settings, settings_name)
-        if hasattr(settings, f"default_{settings_name}"):
+        elif hasattr(settings, f"default_{settings_name}"):
             return getattr(settings, f"default_{settings_name}")
         return None
 
@@ -523,6 +495,7 @@ class Item:
 
         return attribute_value
 
+
     def _resolve_enum(
         self, property_name: str, enum_type: Type[enums.ConvertableEnum]
     ) -> Any:
@@ -530,22 +503,14 @@ class Item:
         See :meth:`~cobbler.items.item.Item._resolve`
         """
         attribute_value, settings_name = self.__common_resolve(property_name)
-        settings = self.api.settings()
-
-        if (
-            isinstance(attribute_value, enums.ConvertableEnum)
-            and attribute_value.value == enums.VALUE_INHERITED
-        ):
-            logical_parent = self.logical_parent
-            if logical_parent is not None and hasattr(logical_parent, property_name):
-                return getattr(logical_parent, property_name)
-            if hasattr(settings, settings_name):
-                return enum_type.to_enum(getattr(settings, settings_name))
-            if hasattr(settings, f"default_{settings_name}"):
-                return enum_type.to_enum(getattr(settings, f"default_{settings_name}"))
+        unwrapped_value = getattr(attribute_value, "value", "")
+        if unwrapped_value  == enums.VALUE_INHERITED:
+            possible_return = self.__resolve_get_parent_or_settings(unwrapped_value, settings_name)
+            if possible_return is not None:
+                return enum_type(possible_return)
             raise AttributeError(
                 f'{type(self)} "{self.name}" inherits property "{property_name}", but neither its parent nor'
-                "settings have it"
+                f" settings have it"
             )
 
         return attribute_value
@@ -561,19 +526,14 @@ class Item:
         """
         attribute = "_" + property_name
 
-        if not hasattr(self, attribute):
-            raise AttributeError(
-                f'{type(self)} "{self.name}" does not have property "{property_name}"'
-            )
-
         attribute_value = getattr(self, attribute)
         settings = self.api.settings()
 
         merged_dict: Dict[str, Any] = {}
 
-        logical_parent = self.logical_parent
-        if logical_parent is not None and hasattr(logical_parent, property_name):
-            merged_dict.update(getattr(logical_parent, property_name))
+        conceptual_parent = self.get_conceptual_parent()
+        if hasattr(conceptual_parent, property_name):
+            merged_dict.update(getattr(conceptual_parent, property_name))
         elif hasattr(settings, property_name):
             merged_dict.update(getattr(settings, property_name))
 
@@ -594,39 +554,18 @@ class Item:
         :param value: The value that should be deduplicated.
         :returns: The deduplicated dictionary
         """
+        _, settings_name = self.__common_resolve(property_name)
         settings = self.api.settings()
+        conceptual_parent = self.get_conceptual_parent()
 
-        if self.parent is not None and hasattr(self.parent, property_name):
+        if hasattr(self.parent, property_name):
             parent_value = getattr(self.parent, property_name)
-        elif (
-            hasattr(self, "distro")
-            and getattr(self, "distro") is not None
-            and hasattr(getattr(self, "distro"), property_name)
-        ):
-            # This is only valid for profiles and is a workaround.
-            parent_value = getattr(getattr(self, "distro"), property_name)
-        elif (
-            hasattr(self, "profile")
-            and getattr(self, "profile") != ""
-            and hasattr(
-                self.api.find_profile(name=getattr(self, "profile")), property_name
-            )
-        ):
-            # This is only valid for systems and is a workaround.
-            parent_value = getattr(
-                self.api.find_profile(name=getattr(self, "profile")), property_name
-            )
-        elif (
-            hasattr(self, "image")
-            and getattr(self, "image") != ""
-            and hasattr(self.api.find_image(name=getattr(self, "image")), property_name)
-        ):
-            # This is only valid for systems and is a workaround.
-            parent_value = getattr(
-                self.api.find_image(name=getattr(self, "image")), property_name
-            )
-        elif hasattr(settings, property_name):
-            parent_value = getattr(settings, property_name)
+        elif hasattr(conceptual_parent, property_name):
+            parent_value = getattr(conceptual_parent, property_name)
+        elif hasattr(settings, settings_name):
+            parent_value = getattr(settings, settings_name)
+        elif hasattr(settings, f"default_{settings_name}"):
+            parent_value = getattr(settings, f"default_{settings_name}")
         else:
             parent_value = {}
 


### PR DESCRIPTION
`get_conceptual_parent()` contains the logic required to traverse the inheritance chain. For resolving an inherited  attribute, this method can be re-used.

Additionally, redundant `hasattr()` checks are removed. These were only used to raise an exception, that will now be  saised in the succeeding lines by calling `getattr()` without a default argument.