### PR TITLE
Update distro_signatures.json

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -127,7 +127,8 @@
       },
       "rhel8": {
         "signatures": [
-          "BaseOS"
+          "BaseOS",
+          "Minimal"
         ],
         "version_file": "(redhat|sl|slf|almalinux|anolis|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
@@ -154,7 +155,8 @@
       },
       "rhel9": {
         "signatures": [
-          "BaseOS"
+          "BaseOS",
+          "Minimal"
         ],
         "version_file": "(redhat|sl|slf|almalinux|anolis|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*9[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,


### PR DESCRIPTION
added AlmaLinux 8/9 Minimal ISO Support

## Linked Items

Fixes #3531 

## Description

Adds support for Minimal AlmaLinux 8/9 ISOs

## Behaviour changes

Old: see #3531 

New: AlmaLinux 9.3 Minimal ISO could be imported

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
