### PR TITLE
Fix `cobbler sync` with enabled DNS management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ system-test-env: ## Configures the environment for system tests
 
 build: ## Runs the Python Build.
 	@source distro_build_configs.sh; \
-	${PYTHON} setup.py build -f
+	${PYTHON} setup.py build -f --executable=${PYTHON}
 
 install: build ## Runs the build target and then installs via setup.py
 	# Debian/Ubuntu requires an additional parameter in setup.py

--- a/changelog.d/3126.fixed
+++ b/changelog.d/3126.fixed
@@ -1,0 +1,1 @@
+Fix "KeyError" on "cobbler sync" with enabled "manage_dns"

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -32,6 +32,10 @@ def register() -> str:
 
 
 class MetadataZoneHelper:
+    """
+    Helper class to hold data for template rendering of named config files.
+    """
+
     def __init__(
         self,
         forward_zones: List[str],

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
 from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler.modules.managers import DnsManagerModule
+from cobbler.utils import process_management
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
@@ -629,13 +630,8 @@ zone "{arpa}." {{
         This syncs the bind server with it's new config files.
         Basically this restarts the service to apply the changes.
         """
-        # TODO: Reuse the utils method for service restarts
         named_service_name = utils.named_service_name()
-        dns_restart_command = ["service", named_service_name, "restart"]
-        ret: int = utils.subprocess_call(dns_restart_command, shell=False)
-        if ret != 0:
-            self.logger.error("%s service failed", named_service_name)
-        return ret
+        return process_management.service_restart(named_service_name)
 
 
 def get_manager(api: "CobblerAPI") -> "_BindManager":

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -42,6 +42,7 @@ class MetadataZoneHelper:
         self.reverse_zones: List[Tuple[str, str]] = reverse_zones
         self.zone_include = zone_include
         self.bind_master = ""
+        self.bind_zonefiles = ""
 
 
 class _BindManager(DnsManagerModule):
@@ -276,6 +277,7 @@ class _BindManager(DnsManagerModule):
         # reverse_zones = self.settings.manage_reverse_zones
 
         metadata = MetadataZoneHelper(list(self.__forward_zones().keys()), [], "")
+        metadata.bind_zonefiles = self.settings.bind_zonefile_path
 
         for zone in metadata.forward_zones:
             txt = f"""
@@ -331,6 +333,7 @@ zone "{arpa}." {{
         # reverse_zones = self.settings.manage_reverse_zones
 
         metadata = MetadataZoneHelper(list(self.__forward_zones().keys()), [], "")
+        metadata.bind_zonefiles = self.settings.bind_zonefile_path
 
         for zone in metadata.forward_zones:
             txt = f"""

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -1,7 +1,65 @@
+"""
+Test to verify the functionallity of the isc bind module.
+"""
+
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from cobbler.api import CobblerAPI
 from cobbler.modules.managers import bind
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(scope="function")
+def named_template() -> str:
+    """
+    This provides a minmal test templated for named that is close to the real one.
+    """
+    return """options {
+          listen-on port 53 { 127.0.0.1; };
+          directory       "@@bind_zonefiles@@";
+          dump-file       "@@bind_zonefiles@@/data/cache_dump.db";
+          statistics-file "@@bind_zonefiles@@/data/named_stats.txt";
+          memstatistics-file "@@bind_zonefiles@@/data/named_mem_stats.txt";
+          allow-query     { localhost; };
+          recursion yes;
+};
+
+#for $zone in $forward_zones
+zone "${zone}." {
+    type master;
+    file "$zone";
+};
+
+#end for
+#for $zone, $arpa in $reverse_zones
+zone "${arpa}." {
+    type master;
+    file "$zone";
+};
+
+#end for
+"""
+
+
+@pytest.fixture(scope="function", autouse=True)
+def reset_singleton():
+    """
+    Helper fixture to reset the isc singleton before and after a test.
+    """
+    bind.MANAGER = None
+    yield
+    bind.MANAGER = None
 
 
 def test_register():
+    """
+    Test if the manager registers with the correct ID.
+    """
     # Arrange & Act
     result = bind.register()
 
@@ -10,13 +68,123 @@ def test_register():
 
 
 def test_manager_what():
+    """
+    Test if the manager identifies itself correctly.
+    """
+    # pylint: disable=protected-access
     # Arrange & Act & Assert
-    assert bind._BindManager.what() == "bind"
+    assert bind._BindManager.what() == "bind"  # type: ignore
 
 
-def test_get_manager(cobbler_api):
+def test_get_manager(cobbler_api: CobblerAPI):
+    """
+    Test if the singleton is correctly initialized.
+    """
+    # pylint: disable=protected-access
     # Arrange & Act
     result = bind.get_manager(cobbler_api)
 
     # Assert
-    isinstance(result, bind._BindManager)
+    isinstance(result, bind._BindManager)  # type: ignore
+
+
+def test_write_configs(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI, named_template: str
+):
+    """
+    Test if the manager is able to correctly write the configuration files.
+    """
+    # Arrange
+    open_mock = mocker.mock_open()
+    mock_named_template = mocker.mock_open(read_data=named_template)
+    mock_secondary_template = mocker.mock_open(read_data="garbage")
+    mock_zone_template = mocker.mock_open(read_data="garbage 2")
+    mock_bind_serial = mocker.mock_open()
+    mock_etc_named_conf = mocker.mock_open()
+    mock_etc_secondary_conf = mocker.mock_open()
+
+    def mock_open(*args: Any, **kwargs: Any):
+        if args[0] == "/etc/cobbler/named.template":
+            return mock_named_template(*args, **kwargs)
+        if args[0] == "/etc/cobbler/secondary.template":
+            return mock_secondary_template(*args, **kwargs)
+        if args[0] == "/etc/cobbler/zone.template":
+            return mock_zone_template(*args, **kwargs)
+        if args[0] == "/var/lib/cobbler/bind_serial":
+            return mock_bind_serial(*args, **kwargs)
+        if args[0] == "/etc/named.conf":
+            return mock_etc_named_conf(*args, **kwargs)
+        if args[0] == "/etc/secondary.conf":
+            return mock_etc_secondary_conf(*args, **kwargs)
+        return open_mock(*args, **kwargs)
+
+    mocker.patch("builtins.open", mock_open)
+    manager = bind.get_manager(cobbler_api)
+    # TODO Mock settings for manage_dns and forward/reverse zones
+
+    # Act
+    manager.write_configs()
+
+    # Assert
+    # TODO: Extend assertions
+    mock_bind_serial.assert_any_call(
+        "/var/lib/cobbler/bind_serial", "r", encoding="UTF-8"
+    )
+    mock_bind_serial_handle = mock_bind_serial()
+    mock_bind_serial_handle.write.assert_any_call(time.strftime("%Y%m%d00"))
+    open_mock.assert_not_called()
+
+
+@pytest.mark.skip("Advanced complicated test scenario for now.")
+def test_write_configs_zone_template(cobbler_api: CobblerAPI):
+    """
+    TODO
+    """
+    # Arrange
+    # TODO Mock zone specific template /etc/cobbler/zone_templates/{zone}
+    manager = bind.get_manager(cobbler_api)
+
+    # Act
+    manager.write_configs()
+
+    # Assert
+    # TODO: Mock that template was read
+    assert False
+
+
+@pytest.mark.skip("Advanced complicated test scenario for now.")
+def test_chrooted_named(cobbler_api: CobblerAPI):
+    """
+    TODO
+    """
+    # Arrange
+    manager = bind.get_manager(cobbler_api)
+
+    # Act
+    manager.write_configs()
+
+    # Assert
+    # TODO: Assert that correct paths are trying to be written
+    assert False
+
+
+def test_manager_restart_service(mocker: "MockerFixture", cobbler_api: CobblerAPI):
+    """
+    Test if the manager is able to correctly handle restarting the dhcpd server on different distros.
+    """
+    # Arrange
+    manager = bind.get_manager(cobbler_api)
+    mocked_restart = mocker.patch.object(
+        manager, "restart_service", autospec=True, return_value=0
+    )
+    mocked_service_name = mocker.patch(
+        "cobbler.utils.named_service_name", autospec=True, return_value="named"
+    )
+
+    # Act
+    result = manager.restart_service()
+
+    # Assert
+    assert mocked_service_name.call_count == 1
+    assert mocked_restart.call_count == 2
+    assert result == 0

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -170,15 +170,15 @@ def test_chrooted_named(cobbler_api: CobblerAPI):
 
 def test_manager_restart_service(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     """
-    Test if the manager is able to correctly handle restarting the dhcpd server on different distros.
+    Test if the manager is able to correctly handle restarting the named server on different distros.
     """
     # Arrange
     manager = bind.get_manager(cobbler_api)
-    mocked_restart = mocker.patch.object(
-        manager, "restart_service", autospec=True, return_value=0
-    )
     mocked_service_name = mocker.patch(
         "cobbler.utils.named_service_name", autospec=True, return_value="named"
+    )
+    mock_service_restart = mocker.patch(
+        "cobbler.utils.process_management.service_restart", return_value=0
     )
 
     # Act
@@ -186,5 +186,5 @@ def test_manager_restart_service(mocker: "MockerFixture", cobbler_api: CobblerAP
 
     # Assert
     assert mocked_service_name.call_count == 1
-    assert mocked_restart.call_count == 2
+    mock_service_restart.assert_called_with("named")
     assert result == 0


### PR DESCRIPTION
## Linked Items

Fixes #3126

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This PR fixes an error that causes `cobbler sync` to fail once `manage_dns` is set to `true`. It is caused by missing metadata in the template rendering context.

## Behaviour changes

Old: `cobbler sync` fails with `manage_dns: true`.

New: `cobbler sync` now succeeds.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
