### PR TITLE
Add XML-RPC endpoint for generating a TFTP file dynamically

### DIFF
--- a/.prospector.yml
+++ b/.prospector.yml
@@ -26,9 +26,10 @@ pep257:
     - D400
     - D401
 
-pep8:
+pycodestyle:
   options:
     disable:
+      - E203 # https://github.com/PyCQA/pycodestyle/issues/373
       - E304
       - E265
       - E266

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -121,7 +121,7 @@ import threading
 from configparser import ConfigParser
 from pathlib import Path
 from types import ModuleType
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 
 from schema import SchemaError  # type: ignore
 
@@ -2723,3 +2723,16 @@ class CobblerAPI:
         .. seealso:: :func:`~cobbler.utils.input_converters.input_int`
         """
         return input_converters.input_int(value)
+
+    def get_tftp_file(self, path: str, offset: int, size: int) -> Tuple[bytes, int]:
+        """
+        Generate and return a file for a TFTP client.
+
+        :param path: Path to file
+        :param offset: Offset of the requested chunk in the file
+        :param size: Size of the requested chunk in the file
+        :return: The requested chunk and the length of the whole file
+        """
+        normalized_path = Path(os.path.normpath(os.path.join("/", path)))
+
+        return self.tftpgen.generate_tftp_file(normalized_path, offset, size)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -4350,6 +4350,22 @@ class CobblerXMLRPCInterface:
         """
         return self.api.input_int(value)
 
+    def get_tftp_file(
+        self, path: str, offset: int, size: int, token: str
+    ) -> Tuple[bytes, int]:
+        """
+        Generate and return a file for a TFTP client.
+
+        :param path: Path to file
+        :param token: The API-token obtained via the login() method
+        :param offset: Offset of the requested chunk in the file
+        :param size: Size of the requested chunk in the file
+        :return: The requested chunk and the length of the whole file
+        """
+        self._log("get_tftp_file", token=token)
+        self.check_access(token, "get_tftp_file")
+        return self.api.get_tftp_file(path, offset, size)
+
 
 # *********************************************************************************
 


### PR DESCRIPTION
## Linked Items

- Required by https://github.com/cobbler/cobbler-tftp/pull/24
- Fixes: #3555

## Description

Add a `get_tftp_file` endpoint that allows an XMLRPC client to get a TFTP boot file from the Cobbler server. The endpoint returns a chunk from a file, which is either generated dynamically or found in one of Cobbler's data directories (which are usually located in `/var/lib/cobbler`).

To implement this endpoint, add a few methods to TFTPGen that do the inverse of their static counterparts: instead of taking data and generating a file from it, they take a file path and generate the data it should contain.

## Behaviour changes

Old: Every change to Cobbler's data currently requires a `cobbler sync` to regenerate static files in the tftpboot directory. The TFTP server has to share a filesystem with Cobbler.

New: This pull request and https://github.com/cobbler/cobbler-tftp will allow boot configuration files to be generated on-the-fly and served to the TFTP server via XMLRPC. A static TFTP directory will not be required.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
