### PR TITLE
SafeConfigParser was removed in 3.12

### DIFF
--- a/changelog.d/3552.fixed
+++ b/changelog.d/3552.fixed
@@ -1,0 +1,1 @@
+Removed from Python 3.12 SafeConfigParser replaced with ConfigParser

--- a/cobbler/modules/authorization/configfile.py
+++ b/cobbler/modules/authorization/configfile.py
@@ -10,7 +10,7 @@ not authz_allowall, which will most likely NOT do what you want.
 
 
 import os
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 from typing import TYPE_CHECKING, Any, Dict
 
 if TYPE_CHECKING:
@@ -37,7 +37,7 @@ def __parse_config() -> Dict[str, Dict[Any, Any]]:
     """
     if not os.path.exists(CONFIG_FILE):
         return {}
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(CONFIG_FILE)
     alldata: Dict[str, Dict[str, Any]] = {}
     groups = config.sections()


### PR DESCRIPTION
## Linked Items

Fixes #3551

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

SafeConfigParser replaced with ConfigParser

## Behaviour changes

Old: Cobbler can't start

New: Cobbler starts successfully

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [X] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
