### PR TITLE
Feature: Add SQLite backend support

### DIFF
--- a/changelog.d/3554.added
+++ b/changelog.d/3554.added
@@ -1,0 +1,1 @@
+Added SQLite backend support

--- a/cobbler/modules/serializers/__init__.py
+++ b/cobbler/modules/serializers/__init__.py
@@ -2,7 +2,7 @@
 This module contains code to persist the in memory state of Cobbler on a target. The name of the target should be the
 name of the Python file. Cobbler is currently only tested against the file serializer.
 """
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
@@ -19,10 +19,10 @@ class StorageBase:
 
     def serialize_item(self, collection: "Collection[ITEM]", item: "ITEM") -> None:
         """
-        Save a collection item to database.
+        Save a collection item to disk
 
-        :param collection: collection
-        :param item: collection item
+        :param collection: The Cobbler collection to know the type of the item.
+        :param item: The collection item to serialize.
         """
         raise NotImplementedError(
             "The implementation for the configured serializer is missing!"
@@ -30,7 +30,7 @@ class StorageBase:
 
     def serialize_delete(self, collection: "Collection[ITEM]", item: "ITEM") -> None:
         """
-        Delete a collection item from database.
+        Delete a collection item from disk.
 
         :param collection: collection
         :param item: collection item
@@ -41,20 +41,22 @@ class StorageBase:
 
     def serialize(self, collection: "Collection[ITEM]") -> None:
         """
-        Save a collection to database
+        Save a collection to disk
 
-        :param collection: collection
+        :param collection: The collection to serialize.
         """
         raise NotImplementedError(
             "The implementation for the configured serializer is missing!"
         )
 
-    def deserialize_raw(self, collection_type: str) -> List[Dict[str, Any]]:
+    def deserialize_raw(
+        self, collection_type: str
+    ) -> Union[List[Optional[Dict[str, Any]]], Dict[str, Any]]:
         """
-        Get a collection from mongodb and parse it into an object.
+        Read the collection from the disk or read the settings file.
 
-        :param collection_type: The collection type to fetch.
-        :return: The first element of the collection requested.
+        :param collection_type: The collection type to read.
+        :return: The list of collection dicts or settings dict.
         """
         raise NotImplementedError(
             "The implementation for the configured serializer is missing!"
@@ -64,10 +66,12 @@ class StorageBase:
         self, collection: "Collection[ITEM]", topological: bool = True
     ) -> None:
         """
-        Load a collection from the database.
+        Load a collection from disk.
 
-        :param collection: The collection to deserialize.
-        :param topological: If the collection list should be sorted by the collection dict depth value or not.
+        :param collection: The Cobbler collection to know the type of the item.
+        :param topological: Sort collection based on each items' depth attribute in the list of collection items. This
+                            ensures properly ordered object loading from disk with objects having parent/child
+                            relationships, i.e. profiles/subprofiles.  See cobbler/items/item.py
         """
         raise NotImplementedError(
             "The implementation for the configured serializer is missing!"
@@ -75,12 +79,11 @@ class StorageBase:
 
     def deserialize_item(self, collection_type: str, name: str) -> Dict[str, Any]:
         """
-        Get a collection item from database and parse it into an object.
+        Get a collection item from disk and parse it into an object.
 
-        :param collection_type: The collection type to fetch.
-        :param item: collection item
-        :param topological: If the collection list should be sorted by the collection dict depth value or not.
-        :return: The first element of the collection requested.
+        :param collection_type: The collection type to deserialize.
+        :param item_name: The collection item name to deserialize.
+        :return: Dictionary of the collection item.
         """
         raise NotImplementedError(
             "The implementation for the configured serializer is missing!"

--- a/cobbler/modules/serializers/sqlite.py
+++ b/cobbler/modules/serializers/sqlite.py
@@ -1,0 +1,313 @@
+"""
+Cobbler's SQLite database based object serializer.
+"""
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: Copyright 2024 Yuriy Chelpanov <yuriy.chelpanov@gmail.com>
+
+import json
+import logging
+import os
+import sqlite3
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from cobbler import settings
+from cobbler.cexceptions import CX
+from cobbler.modules.serializers import StorageBase
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+    from cobbler.cobbler_collections.collection import ITEM, Collection
+
+
+def register() -> str:
+    """
+    The mandatory Cobbler module registration hook.
+    """
+    return "serializer"
+
+
+def what() -> str:
+    """
+    Module identification function
+    """
+    return "serializer/sqlite"
+
+
+class SQLiteSerializer(StorageBase):
+    """
+    Each collection is stored in a separate table named distros, profiles, etc.
+    Tables are created on demand, when the first object of this type is written.
+
+    TABLE name // name from collection.collection_types()
+    (
+        name TEXT PRIMARY KEY,    // name from item.name
+        item TEXT                 // JSON representation of an object
+    )
+    """
+
+    def __init__(self, api: "CobblerAPI"):
+        super().__init__(api)
+        self.logger = logging.getLogger()
+        self.connection: Optional[sqlite3.Connection] = None
+        self.arraysize = 1000
+        self.database_file = "/var/lib/cobbler/collections/collections.db"
+
+    def __connect(self) -> None:
+        """
+        Connect to the sqlite.
+        """
+        if self.connection is not None:
+            return
+        is_new_database = not os.path.isfile(self.database_file)
+        conn = sqlite3.connect(":memory:")
+        threadsafety_option = conn.execute(
+            """
+            select * from pragma_compile_options
+            where compile_options like 'THREADSAFE=%'
+            """
+        ).fetchone()[0]
+        conn.close()
+
+        threadsafety = int(threadsafety_option.split("=")[1])
+        if threadsafety != 1:
+            raise CX(
+                f"You cannot use SQLite compiled with SQLITE_THREADSAFE={threadsafety} with Cobbler.\n"
+                "Please compile the code with the option SQLITE_THREADSAFE=1"
+            )
+
+        try:
+            self.connection = sqlite3.connect(
+                self.database_file,
+                detect_types=sqlite3.PARSE_DECLTYPES,
+                check_same_thread=False,
+            )
+        except sqlite3.DatabaseError as error:
+            raise CX(
+                f'Unable to connect to SQLite database "{self.database_file}": {error}'
+            ) from error
+
+        if is_new_database:
+            self.logger.info(
+                'Database with name "{%s}" was not found and will be created.',
+                self.database_file,
+            )
+
+    def __create_table(self, table_name: str) -> None:
+        """
+        Creates a new SQLite table.
+
+        :param table_name: The table name.
+        """
+        try:
+            self.connection.execute(f"CREATE TABLE {table_name}(name text primary key, item text)")  # type: ignore
+        except sqlite3.DatabaseError as error:
+            raise CX(f'Unable to create table "{table_name}": {error}') from error
+
+    def __is_table_exists(self, table_name: str) -> bool:
+        """
+        Return True if the table exists.
+
+        :param table_name: The table name.
+        :return: True if the table exists. Otherwise false.
+        """
+        cursor = self.connection.execute(  # type: ignore
+            "SELECT name FROM sqlite_master WHERE name=:name", {"name": table_name}
+        )
+        if cursor.fetchone() is None:
+            return False
+        return True
+
+    def __upsert_items(
+        self, table_name: str, bind_vars: List[Optional[Dict[str, str]]]
+    ) -> None:
+        """
+        Insert/Update values into the table.
+
+        :param table_name: The table name.
+        :param bind_vars: The list of bind variables for SQL statement.
+        """
+        if len(bind_vars) == 0:
+            return
+
+        self.__connect()
+        if not self.__is_table_exists(table_name):
+            self.__create_table(table_name)
+        try:
+            self.connection.executemany(  # type: ignore
+                f"INSERT INTO {table_name}(name, item) "  # nosec
+                "VALUES(:name, :item) "
+                "ON CONFLICT(name) DO UPDATE SET item=excluded.item",
+                bind_vars,  # type: ignore
+            )
+            self.connection.commit()  # type: ignore
+        except sqlite3.DatabaseError as error:
+            raise CX(f'Unable to upsert into table "{table_name}": {error}') from error
+
+    def __build_bind_vars(self, item: "ITEM") -> Dict[str, str]:
+        """
+        Build the bind variables for Insert/Update.
+
+        :param item: The object for Insert/Update.
+        :return: The bind variables dict.
+        """
+        if self.api.settings().serializer_pretty_json:
+            sort_keys = True
+            indent = 4
+        else:
+            sort_keys = False
+            indent = None
+
+        _dict = item.serialize()
+        data = json.dumps(_dict, sort_keys=sort_keys, indent=indent)
+        return {"name": item.name, "item": data}
+
+    def serialize_item(self, collection: "Collection[ITEM]", item: "ITEM") -> None:
+        """
+        Save a collection item to table
+
+        :param collection: The Cobbler collection to know the type of the item.
+        :param item: The collection item to serialize.
+        """
+        if not item.name:
+            raise CX("name unset for item!")
+
+        self.__connect()
+        self.__upsert_items(
+            collection.collection_types(), [self.__build_bind_vars(item)]
+        )
+
+    def serialize(self, collection: "Collection[ITEM]") -> None:
+        """
+        Save a collection to disk
+
+        :param collection: The collection to serialize.
+        """
+        self.__connect()
+        ctype = collection.collection_types()
+        if ctype != "settings":
+            bind_vars: List[Optional[Dict[str, str]]] = []
+            for item in collection:
+                bind_vars.append(self.__build_bind_vars(item))
+            self.__upsert_items(ctype, bind_vars)
+
+    def serialize_delete(self, collection: "Collection[ITEM]", item: "ITEM") -> None:
+        """
+        Delete a collection item from table
+
+        :param collection: The Cobbler collection to know the type of the item.
+        :param item: The collection item to delete.
+        """
+        self.__connect()
+        table_name = collection.collection_types()
+        try:
+            self.connection.execute(  # type: ignore
+                f"DELETE FROM {table_name} WHERE name=:name",  # nosec
+                {"name": item.name},
+            )
+            self.connection.commit()  # type: ignore
+        except sqlite3.DatabaseError as error:
+            raise CX(
+                f'Unable to delete from table "{table_name}": {error}'  # nosec
+            ) from error
+
+    def deserialize_raw(
+        self, collection_type: str
+    ) -> Union[List[Optional[Dict[str, Any]]], Dict[str, Any]]:
+        """
+        Read the collection from the table or read the settings file.
+
+        :param collection_type: The collection type to read.
+        :return: The list of collection dicts or settings dict.
+        """
+        if collection_type == "settings":
+            return settings.read_settings_file()
+
+        self.__connect()
+        results: List[Optional[Dict[str, Any]]] = []
+        if not self.__is_table_exists(collection_type):
+            return results
+
+        projection = "item"
+        lazy_start = self.api.settings().lazy_start
+        if lazy_start:
+            projection = "name"
+
+        try:
+            cursor = self.connection.execute(  # type: ignore
+                f"SELECT {projection} FROM {collection_type}"  # nosec
+            )
+        except sqlite3.DatabaseError as error:
+            raise CX(
+                f'Unable to SELECT from table "{collection_type}": {error}'  # nosec
+            ) from error
+        cursor.arraysize = self.arraysize
+        for result in cursor.fetchall():
+            _dict = json.loads(result[0])
+            _dict["inmemory"] = not lazy_start
+            results.append(_dict)
+        return results
+
+    def deserialize(
+        self, collection: "Collection[ITEM]", topological: bool = True
+    ) -> None:
+        """
+        Load a collection from disk.
+
+        :param collection: The Cobbler collection to know the type of the item.
+        :param topological: Sort collection based on each items' depth attribute in the list of collection items. This
+                            ensures properly ordered object loading from disk with objects having parent/child
+                            relationships, i.e. profiles/subprofiles.  See cobbler/items/item.py
+        """
+        self.__connect()
+        datastruct = self.deserialize_raw(collection.collection_types())
+        if topological and isinstance(datastruct, list):  # type: ignore
+            datastruct.sort(key=lambda x: x.get("depth", 1))  # type: ignore
+        if isinstance(datastruct, dict):
+            # This is currently the corner case for the settings type.
+            collection.from_dict(datastruct)  # type: ignore
+        elif isinstance(datastruct, list):  # type: ignore
+            collection.from_list(datastruct)  # type: ignore
+
+    def deserialize_item(self, collection_type: str, name: str) -> Dict[str, Any]:
+        """
+        Get a collection item from disk and parse it into an object.
+
+        :param collection_type: The collection type to deserialize.
+        :param item_name: The collection item name to deserialize.
+        :return: Dictionary of the collection item.
+        """
+        self.__connect()
+        if not self.__is_table_exists(collection_type):
+            raise CX(
+                f"Item {name} of collection {collection_type} was not found in SQLite database {self.database_file}!"
+            )
+
+        try:
+            cursor = self.connection.execute(  # type: ignore
+                f"SELECT item from {collection_type} WHERE name=:name",  # nosec
+                {"name": name},
+            )
+        except sqlite3.DatabaseError as error:
+            raise CX(
+                f'Unable to SELECT from table "{collection_type}": {error}'  # nosec
+            ) from error
+        result = cursor.fetchone()
+        if result is None:
+            raise CX(
+                f"Item {name} of collection {collection_type} was not found in SQLite database {self.database_file}!"
+            )
+        _dict = json.loads(result[0])
+        if _dict["name"] != name:
+            raise CX(
+                f"The file name {name} does not match the {_dict['name']} {collection_type}!"
+            )
+        _dict["inmemory"] = True
+        return _dict
+
+
+def storage_factory(api: "CobblerAPI") -> SQLiteSerializer:
+    """
+    TODO
+    """
+    return SQLiteSerializer(api)

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -1109,6 +1109,7 @@ Choices:
 
 * serializers.file
 * serializers.mongodb
+* serializers.sqlite
 
 default: ``serializers.file``
 

--- a/docs/code-autodoc/cobbler.modules.serializers.rst
+++ b/docs/code-autodoc/cobbler.modules.serializers.rst
@@ -20,6 +20,14 @@ cobbler.modules.serializers.mongodb module
    :undoc-members:
    :show-inheritance:
 
+cobbler.modules.serializers.sqlite module
+------------------------------------------
+
+.. automodule:: cobbler.modules.serializers.sqlite
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/tests/module_loader_test.py
+++ b/tests/module_loader_test.py
@@ -174,7 +174,11 @@ def test_get_module_from_file(
         ("manage/import", ["cobbler.modules.managers.import_signatures"]),
         (
             "serializer",
-            ["cobbler.modules.serializers.file", "cobbler.modules.serializers.mongodb"],
+            [
+                "cobbler.modules.serializers.file",
+                "cobbler.modules.serializers.mongodb",
+                "cobbler.modules.serializers.sqlite",
+            ],
         ),
         (
             "authz",

--- a/tests/modules/serializer/sqlite_test.py
+++ b/tests/modules/serializer/sqlite_test.py
@@ -1,0 +1,396 @@
+import json
+import os
+import pathlib
+from typing import Any, Dict, List, Union
+from unittest.mock import MagicMock
+
+import pytest
+from pytest_mock import MockerFixture
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections.collection import Collection
+from cobbler.items.item import Item
+from cobbler.modules.serializers import sqlite
+from cobbler.settings import Settings
+
+from tests.conftest import does_not_raise
+
+
+class MockItem(Item):
+    """
+    Test Item for the serializer tests.
+    """
+
+    def make_clone(self) -> "MockItem":
+        return MockItem(self.api)
+
+
+class MockCollection(Collection[MockItem]):
+    """
+    Test Collection that is used for the serializer tests.
+    """
+
+    @staticmethod
+    def collection_type() -> str:
+        return "test"
+
+    @staticmethod
+    def collection_types() -> str:
+        return "tests"
+
+    def factory_produce(self, api: "CobblerAPI", seed_data: Dict[Any, Any]) -> MockItem:
+        new_test = MockItem(api)
+        return new_test
+
+    def remove(
+        self,
+        name: str,
+        with_delete: bool = True,
+        with_sync: bool = True,
+        with_triggers: bool = True,
+        recursive: bool = False,
+    ) -> None:
+        del self.listing[name]
+
+
+@pytest.fixture()
+def serializer_obj(cobbler_api: CobblerAPI, tmpdir: pathlib.Path):
+    """
+    Generates an empty serializer object that is ready to be used.
+    """
+    sqlite_obj = sqlite.storage_factory(cobbler_api)
+    sqlite_obj.database_file = os.path.join(tmpdir, "tests.db")
+
+    try:
+        sqlite_obj.deserialize_item("tests", "test")
+    except CX:
+        pass
+
+    sqlite_obj.connection.execute(  # type: ignore
+        f"CREATE table if not exists tests(name text primary key, item text)"
+    )
+    sqlite_obj.connection.commit()  # type: ignore
+    return sqlite_obj
+
+
+def test_register():
+    """
+    Test that will assert if the return value of the register method is correct.
+    """
+    # Arrange
+    # Act
+    result = sqlite.register()
+
+    # Assert
+    assert isinstance(result, str)
+    assert result == "serializer"
+
+
+def test_what():
+    """
+    Test that will assert if the return value of the identity hook of the module is correct.
+    """
+    # Arrange
+    # Act
+    result = sqlite.what()
+
+    # Assert
+    assert isinstance(result, str)
+    assert result == "serializer/sqlite"
+
+
+def test_storage_factory(cobbler_api: CobblerAPI):
+    """
+    Test that will assert if the factory can successfully generate a SQLiteSerializer object.
+    """
+    # Arrange
+
+    # Act
+    result = sqlite.storage_factory(cobbler_api)
+
+    # Assert
+    assert isinstance(result, sqlite.SQLiteSerializer)
+
+
+def test_serialize_item_raise(
+    mocker: MockerFixture, serializer_obj: sqlite.SQLiteSerializer
+):
+    # Arrange
+    mitem = mocker.Mock()
+    mcollection = mocker.Mock()
+    mitem.name = ""
+
+    # Act and assert
+    with pytest.raises(CX):
+        serializer_obj.serialize_item(mcollection, mitem)
+
+    # Cleanup
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.connection.commit()  # type: ignore
+    serializer_obj.connection.close()  # type: ignore
+
+
+def test_serialize_item(
+    serializer_obj: sqlite.SQLiteSerializer, cobbler_api: CobblerAPI
+):
+    """
+    Test that will assert if a given item can be written to table successfully.
+    """
+    # Arrange
+    mitem = MockItem(cobbler_api)
+    mitem.name = "test_serializer_item"
+    mcollection = MockCollection(cobbler_api._collection_mgr)  # type: ignore
+
+    # Act
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.serialize_item(mcollection, mitem)
+    cursor = serializer_obj.connection.execute(  # type: ignore
+        "SELECT name FROM sqlite_master WHERE name=:name", {"name": "tests"}
+    )
+    table_exists = cursor.fetchone() is not None
+    cursor = serializer_obj.connection.execute(  # type: ignore
+        "SELECT name FROM tests WHERE name=:name", {"name": mitem.name}
+    )
+    row_exists = cursor.fetchone() is not None
+
+    # Cleanup
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.connection.commit()  # type: ignore
+    serializer_obj.connection.close()  # type: ignore
+
+    # Assert
+    assert os.path.exists(serializer_obj.database_file)
+    assert table_exists
+    assert row_exists
+
+
+def test_serialize_delete(
+    serializer_obj: sqlite.SQLiteSerializer, cobbler_api: CobblerAPI
+):
+    """
+    Test that will assert if a given item can be deleted.
+    """
+    # Arrange
+    mitem = MockItem(cobbler_api)
+    mitem.name = "test_serializer_del"
+    mcollection = MockCollection(cobbler_api._collection_mgr)  # type: ignore
+    serializer_obj.serialize_item(mcollection, mitem)
+
+    # Act
+    serializer_obj.serialize_delete(mcollection, mitem)
+    cursor = serializer_obj.connection.execute(  # type: ignore
+        "SELECT name FROM tests WHERE name=:name", {"name": mitem.name}
+    )
+    row_exists = cursor.fetchone() is not None
+
+    # Cleanup
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.connection.commit()  # type: ignore
+    serializer_obj.connection.close()  # type: ignore
+
+    # Assert
+    assert not row_exists
+
+
+@pytest.mark.parametrize(
+    "input_collection_type,input_collection",
+    [("settings", {}), ("tests", MagicMock())],
+)
+def test_serialize(
+    #    mocker: MockerFixture,
+    input_collection_type: str,
+    input_collection: Union[Dict[Any, Any], MagicMock],
+    serializer_obj: sqlite.SQLiteSerializer,
+    cobbler_api: CobblerAPI,
+):
+    # Arrange
+    if input_collection_type == "settings":
+        mcollection = Settings()
+    else:
+        mitem = MockItem(cobbler_api)
+        mitem.name = "test_serialize"
+        mcollection = MockCollection(cobbler_api._collection_mgr)  # type: ignore
+        mcollection.listing[mitem.name] = mitem
+
+    # Act
+    serializer_obj.serialize(mcollection)  # type: ignore
+    if input_collection_type != "settings":
+        cursor = serializer_obj.connection.execute(  # type: ignore
+            "SELECT name FROM sqlite_master WHERE name=:name",
+            {"name": input_collection_type},
+        )
+        table_exists = cursor.fetchone() is not None
+        cursor = serializer_obj.connection.execute(  # type: ignore
+            f"SELECT name FROM {input_collection_type} WHERE name=:name",
+            {"name": mitem.name},  # type: ignore
+        )
+        row_exists = cursor.fetchone() is not None
+
+        # Cleanup
+        serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+        serializer_obj.connection.commit()  # type: ignore
+        serializer_obj.connection.close()  # type: ignore
+
+    # Assert
+    if input_collection_type == "settings":
+        assert mcollection.collection_types() == "settings"
+    else:
+        assert os.path.exists(serializer_obj.database_file)
+        assert table_exists  # type: ignore[reportUnboundVariable]
+        assert row_exists  # type: ignore[reportUnboundVariable]
+
+
+@pytest.mark.parametrize(
+    "input_collection_type,expected_result,settings_read",
+    [
+        ("settings", {}, True),
+        ("distros", [], False),
+    ],
+)
+def test_deserialize_raw(
+    mocker: MockerFixture,
+    input_collection_type: str,
+    expected_result: Union[List[Any], Dict[Any, Any]],
+    settings_read: bool,
+    serializer_obj: sqlite.SQLiteSerializer,
+):
+    """
+    Test that will assert if a given item can be deserilized in raw.
+    """
+    # Arrange
+    mocker.patch("cobbler.settings.read_settings_file", return_value=expected_result)
+
+    # Act
+    result = serializer_obj.deserialize_raw(input_collection_type)
+
+    # Cleanup
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.connection.commit()  # type: ignore
+    serializer_obj.connection.close()  # type: ignore
+
+    # Assert
+    assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_collection_type,input_collection,input_topological,expected_result",
+    [
+        ("settings", {}, True, {}),
+        ("settings", {}, False, {}),
+        (
+            "distros",
+            [{"depth": 2, "name": False}, {"depth": 1, "name": True}],
+            True,
+            [{"depth": 1, "name": True}, {"depth": 2, "name": False}],
+        ),
+        (
+            "distros",
+            [{"depth": 2, "name": False}, {"depth": 1, "name": True}],
+            False,
+            [{"depth": 2, "name": False}, {"depth": 1, "name": True}],
+        ),
+        (
+            "distros",
+            [{"name": False}, {"name": True}],
+            True,
+            [{"name": False}, {"name": True}],
+        ),
+        (
+            "distros",
+            [{"name": False}, {"name": True}],
+            False,
+            [{"name": False}, {"name": True}],
+        ),
+    ],
+)
+def test_deserialize(
+    mocker: MockerFixture,
+    input_collection_type: str,
+    input_collection: Union[Dict[Any, Any], List[Dict[Any, Any]]],
+    input_topological: bool,
+    expected_result: Union[Dict[Any, Any], List[Dict[Any, Any]]],
+    serializer_obj: sqlite.SQLiteSerializer,
+):
+    """
+    Test that will assert if a given item can be successfully deserialized.
+    """
+    # Arrange
+    mocker.patch.object(
+        serializer_obj,
+        "deserialize_raw",
+        return_value=input_collection,
+    )
+    if input_collection_type == "settings":
+        stub_from = mocker.stub(name="from_dict_stub")
+        mock = Settings()
+        mocker.patch.object(mock, "from_dict", new=stub_from)
+    else:
+        stub_from = mocker.stub(name="from_list_stub")
+        mock = MockCollection(mocker.MagicMock())
+        mocker.patch.object(mock, "from_list", new=stub_from)
+        mocker.patch.object(
+            mock, "collection_types", return_value=input_collection_type
+        )
+
+    # Act
+    serializer_obj.deserialize(mock, input_topological)  # type: ignore
+
+    # Cleanup
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.connection.commit()  # type: ignore
+    serializer_obj.connection.close()  # type: ignore
+
+    # Assert
+    assert stub_from.called
+    stub_from.assert_called_with(expected_result)
+
+
+@pytest.mark.parametrize(
+    "input_collection_type,input_item,expected_result,expected_exception",
+    [
+        (
+            "tests",
+            {"name": "test1"},
+            {"name": "test1", "inmemory": True},
+            does_not_raise(),
+        ),
+        (
+            "tests",
+            {"name": "test2"},
+            {"name": "fake", "inmemory": True},
+            pytest.raises(CX),
+        ),
+    ],
+)
+def test_deserialize_item(
+    mocker: MockerFixture,
+    input_collection_type: str,
+    input_item: Dict[str, str],
+    expected_result: Dict[str, Union[str, bool]],
+    expected_exception: Any,
+    serializer_obj: sqlite.SQLiteSerializer,
+):
+    """
+    TODO
+    """
+    # Arrange
+    serializer_obj.connection.execute(  # type: ignore
+        f"INSERT INTO {input_collection_type}(name, item) VALUES(:name,:item)",
+        {"name": input_item["name"], "item": json.dumps(input_item)},
+    )
+    serializer_obj.connection.commit()  # type: ignore
+
+    # Act
+    with expected_exception:
+        result = serializer_obj.deserialize_item(
+            input_collection_type, expected_result["name"]  # type: ignore[reportGeneralTypeIssues]
+        )
+
+        # Assert
+        assert result == expected_result
+
+    # Cleanup
+    serializer_obj.connection.execute("DROP table if exists tests")  # type: ignore
+    serializer_obj.connection.commit()  # type: ignore
+    serializer_obj.connection.close()  # type: ignore


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Adds support for SQLite database backend.

Similarities and differences from existing serializes:
- just like `file`, `sqlite` stores items in JSON format
- unlike `file`, `sqlite`  stores items not in separate files, but in one database file
- just like `mongodb`, `sqlite` can speed up the start of `Cobbler` in the case of a large number of items due to fewer necessary operations with the filesystem (opening/closing files)
- unlike `mongodb`, `sqlite` does not require a separate infrastructure

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [X] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
