### PR TITLE
Fix: Inheriting some non-string properties

### DIFF
--- a/changelog.d/3558.fixed
+++ b/changelog.d/3558.fixed
@@ -1,0 +1,1 @@
+Fix inheriting some non-string properties

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -170,7 +170,7 @@ class Image(item.Item):
         self._display_name = ""
         self._virt_auto_boot: Union[str, bool] = enums.VALUE_INHERITED
         self._virt_bridge = enums.VALUE_INHERITED
-        self._virt_cpus = 0
+        self._virt_cpus = 1
         self._virt_disk_driver: enums.VirtDiskDrivers = enums.VirtDiskDrivers.INHERITED
         self._virt_file_size: Union[str, float] = enums.VALUE_INHERITED
         self._virt_path = ""
@@ -460,7 +460,7 @@ class Image(item.Item):
         return self._resolve("virt_auto_boot")
 
     @virt_auto_boot.setter
-    def virt_auto_boot(self, num: bool):
+    def virt_auto_boot(self, num: Union[str, bool]):
         """
         Setter for the virtual automatic boot option.
 

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -198,8 +198,8 @@ class Profile(item.Item):
         self._boot_loaders: Union[List[str], str] = enums.VALUE_INHERITED
         self._dhcp_tag = ""
         self._distro = ""
-        self._enable_ipxe = enums.VALUE_INHERITED
-        self._enable_menu = enums.VALUE_INHERITED
+        self._enable_ipxe: Union[str, bool] = enums.VALUE_INHERITED
+        self._enable_menu: Union[str, bool] = enums.VALUE_INHERITED
         self._name_servers = enums.VALUE_INHERITED
         self._name_servers_search = enums.VALUE_INHERITED
         self._next_server_v4 = enums.VALUE_INHERITED
@@ -211,23 +211,23 @@ class Profile(item.Item):
         self._server = enums.VALUE_INHERITED
         self._menu = ""
         self._display_name = ""
-        self._virt_auto_boot = enums.VALUE_INHERITED
+        self._virt_auto_boot: Union[str, bool] = enums.VALUE_INHERITED
         self._virt_bridge = enums.VALUE_INHERITED
-        self._virt_cpus: Union[int, str] = 1
+        self._virt_cpus: int = 1
         self._virt_disk_driver: enums.VirtDiskDrivers = enums.VirtDiskDrivers.INHERITED
-        self._virt_file_size = enums.VALUE_INHERITED
+        self._virt_file_size: Union[str, float] = enums.VALUE_INHERITED
         self._virt_path = ""
-        self._virt_ram = enums.VALUE_INHERITED
-        self._virt_type: enums.VirtType = enums.VirtType.AUTO
+        self._virt_ram: Union[str, int] = enums.VALUE_INHERITED
+        self._virt_type: Union[str, enums.VirtType] = enums.VirtType.INHERITED
 
         # Overwrite defaults from item.py
-        self._boot_files = enums.VALUE_INHERITED
-        self._fetchable_files = enums.VALUE_INHERITED
-        self._autoinstall_meta = enums.VALUE_INHERITED
-        self._kernel_options = enums.VALUE_INHERITED
-        self._kernel_options_post = enums.VALUE_INHERITED
-        self._mgmt_classes = enums.VALUE_INHERITED
-        self._mgmt_parameters = enums.VALUE_INHERITED
+        self._boot_files: Union[Dict[Any, Any], str] = enums.VALUE_INHERITED
+        self._fetchable_files: Union[Dict[Any, Any], str] = enums.VALUE_INHERITED
+        self._autoinstall_meta: Union[Dict[Any, Any], str] = enums.VALUE_INHERITED
+        self._kernel_options: Union[Dict[Any, Any], str] = enums.VALUE_INHERITED
+        self._kernel_options_post: Union[Dict[Any, Any], str] = enums.VALUE_INHERITED
+        self._mgmt_classes: Union[List[Any], str] = enums.VALUE_INHERITED
+        self._mgmt_parameters: Union[Dict[Any, Any], str] = enums.VALUE_INHERITED
 
         if self._is_subobject:
             self._filename = enums.VALUE_INHERITED
@@ -424,13 +424,17 @@ class Profile(item.Item):
         return self._resolve("enable_ipxe")
 
     @enable_ipxe.setter  # type: ignore[no-redef]
-    def enable_ipxe(self, enable_ipxe: bool):
+    def enable_ipxe(self, enable_ipxe: Union[str, bool]):
         r"""
         Setter for the ``enable_ipxe`` property.
 
         :param enable_ipxe: New boolean value for enabling iPXE.
         :raises TypeError: In case after the conversion, the new value is not of type ``bool``.
         """
+        if enable_ipxe == enums.VALUE_INHERITED:
+            self._enable_ipxe = enums.VALUE_INHERITED
+            return
+
         enable_ipxe = input_converters.input_boolean(enable_ipxe)
         if not isinstance(enable_ipxe, bool):  # type: ignore
             raise TypeError("enable_ipxe needs to be of type bool")
@@ -448,13 +452,17 @@ class Profile(item.Item):
         return self._resolve("enable_menu")
 
     @enable_menu.setter  # type: ignore[no-redef]
-    def enable_menu(self, enable_menu: bool):
+    def enable_menu(self, enable_menu: Union[str, bool]):
         """
         Setter for the ``enable_menu`` property.
 
         :param enable_menu: New boolean value for enabling the menu.
         :raises TypeError: In case the boolean could not be converted successfully.
         """
+        if enable_menu == enums.VALUE_INHERITED:
+            self._enable_menu = enums.VALUE_INHERITED
+            return
+
         enable_menu = input_converters.input_boolean(enable_menu)
         if not isinstance(enable_menu, bool):  # type: ignore
             raise TypeError("enable_menu needs to be of type bool")

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -995,7 +995,7 @@ class NetworkInterface:
 
         :param _dict: The dict with the parameter.
         """
-        for (key, value) in list(_dict.items()):
+        for key, value in list(_dict.items()):
             (field, _) = key.split("-", 1)
             field = field.replace("_", "").replace("-", "")
 
@@ -1452,6 +1452,8 @@ class System(Item):
         :getter: Returns the value for ``proxy``.
         :setter: Sets the value for the property ``proxy``.
         """
+        if self.profile != "":
+            return self._resolve("proxy")
         return self._resolve("proxy_url_int")
 
     @proxy.setter  # type: ignore[no-redef]
@@ -1684,13 +1686,17 @@ class System(Item):
         return self._resolve("enable_ipxe")
 
     @enable_ipxe.setter  # type: ignore[no-redef]
-    def enable_ipxe(self, enable_ipxe: bool):
+    def enable_ipxe(self, enable_ipxe: Union[str, bool]):
         """
         Sets whether the system will use iPXE for booting.
 
         :param enable_ipxe: If ipxe should be enabled or not.
         :raises TypeError: In case enable_ipxe is not a boolean.
         """
+        if enable_ipxe == enums.VALUE_INHERITED:
+            self._enable_ipxe = enums.VALUE_INHERITED
+            return
+
         enable_ipxe = input_converters.input_boolean(enable_ipxe)
         if not isinstance(enable_ipxe, bool):  # type: ignore
             raise TypeError("enable_ipxe needs to be of type bool")
@@ -1783,12 +1789,16 @@ class System(Item):
         return self._resolve("virt_cpus")
 
     @virt_cpus.setter  # type: ignore[no-redef]
-    def virt_cpus(self, num: int):
+    def virt_cpus(self, num: Union[int, str]):
         """
         Setter for the virt_cpus of the System class.
 
         :param num: The new value for the number of CPU cores.
         """
+        if num == enums.VALUE_INHERITED:
+            self._virt_cpus = enums.VALUE_INHERITED
+            return
+
         self._virt_cpus = validate.validate_virt_cpus(num)
 
     @InheritableProperty

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -353,13 +353,15 @@ def validate_virt_file_size(num: Union[str, int, float]) -> Union[str, float]:
     return num
 
 
-def validate_virt_auto_boot(value: Union[str, bool, int]) -> bool:
+def validate_virt_auto_boot(value: Union[str, bool, int]) -> Union[bool, str]:
     """
     For Virt only.
     Specifies whether the VM should automatically boot upon host reboot 0 tells Koan not to auto_boot virtuals.
 
     :param value: May be True or False.
     """
+    if value == enums.VALUE_INHERITED:
+        return enums.VALUE_INHERITED
     value = input_converters.input_boolean(value)
     if not isinstance(value, bool):  # type: ignore
         raise TypeError("virt_auto_boot needs to be of type bool.")

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -16,6 +16,15 @@ from cobbler.utils import signatures
 from tests.conftest import does_not_raise
 
 
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="distro_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
 def test_object_creation(cobbler_api: CobblerAPI):
     """
     Verify that the constructor is working as expected.
@@ -562,3 +571,46 @@ def test_find_distro_path(
 
     # Assert
     assert result == tmp_path.as_posix()
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    distro = Distro(cobbler_api)
+
+    # Act
+    for key, key_value in distro.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(distro, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(distro, new_key)
+            setattr(distro, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(distro, new_key)

--- a/tests/items/file_test.py
+++ b/tests/items/file_test.py
@@ -1,12 +1,22 @@
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.file import File
 
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="file_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -16,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(distro, File)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     file = File(cobbler_api)
 
@@ -27,7 +37,7 @@ def test_make_clone(cobbler_api):
     assert clone != file
 
 
-def test_to_dict(cobbler_api):
+def test_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     titem = File(cobbler_api)
 
@@ -38,7 +48,7 @@ def test_to_dict(cobbler_api):
     assert isinstance(result, dict)
 
 
-def test_to_dict_resolved(cobbler_api):
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     titem = File(cobbler_api)
 
@@ -54,7 +64,7 @@ def test_to_dict_resolved(cobbler_api):
 
 
 @pytest.mark.parametrize("value,expected_exception", [(False, does_not_raise())])
-def test_is_dir(cobbler_api, value, expected_exception):
+def test_is_dir(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     file = File(cobbler_api)
 
@@ -64,3 +74,46 @@ def test_is_dir(cobbler_api, value, expected_exception):
 
         # Assert
         assert file.is_dir is value
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    file = File(cobbler_api)
+
+    # Act
+    for key, key_value in file.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(file, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(file, new_key)
+            setattr(file, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(file, new_key)

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -10,7 +10,16 @@ from cobbler.utils import signatures
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="image_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -20,7 +29,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(image, Image)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -31,7 +40,7 @@ def test_make_clone(cobbler_api):
     assert image != result
 
 
-def test_arch(cobbler_api):
+def test_arch(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -42,7 +51,7 @@ def test_arch(cobbler_api):
     assert image.arch == enums.Archs.X86_64
 
 
-def test_autoinstall(cobbler_api):
+def test_autoinstall(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -53,7 +62,7 @@ def test_autoinstall(cobbler_api):
     assert image.autoinstall == ""
 
 
-def test_file(cobbler_api):
+def test_file(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -64,7 +73,7 @@ def test_file(cobbler_api):
     assert image.file == "/tmp/test"
 
 
-def test_os_version(cobbler_api):
+def test_os_version(cobbler_api: CobblerAPI):
     # Arrange
     signatures.load_signatures("/var/lib/cobbler/distro_signatures.json")
     image = Image(cobbler_api)
@@ -77,7 +86,7 @@ def test_os_version(cobbler_api):
     assert image.os_version == "sles15generic"
 
 
-def test_breed(cobbler_api):
+def test_breed(cobbler_api: CobblerAPI):
     # Arrange
     signatures.load_signatures("/var/lib/cobbler/distro_signatures.json")
     image = Image(cobbler_api)
@@ -89,7 +98,7 @@ def test_breed(cobbler_api):
     assert image.breed == "suse"
 
 
-def test_image_type(cobbler_api):
+def test_image_type(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -100,7 +109,7 @@ def test_image_type(cobbler_api):
     assert image.image_type == enums.ImageTypes.DIRECT
 
 
-def test_virt_cpus(cobbler_api):
+def test_virt_cpus(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -111,7 +120,7 @@ def test_virt_cpus(cobbler_api):
     assert image.virt_cpus == 5
 
 
-def test_network_count(cobbler_api):
+def test_network_count(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -122,7 +131,7 @@ def test_network_count(cobbler_api):
     assert image.network_count == 2
 
 
-def test_virt_auto_boot(cobbler_api):
+def test_virt_auto_boot(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -142,7 +151,7 @@ def test_virt_auto_boot(cobbler_api):
     ],
 )
 def test_virt_file_size(
-    cobbler_api, input_virt_file_size, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_virt_file_size, expected_exception, expected_result
 ):
     # Arrange
     image = Image(cobbler_api)
@@ -155,7 +164,7 @@ def test_virt_file_size(
         assert image.virt_file_size == expected_result
 
 
-def test_virt_disk_driver(cobbler_api):
+def test_virt_disk_driver(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -166,7 +175,7 @@ def test_virt_disk_driver(cobbler_api):
     assert image.virt_disk_driver == enums.VirtDiskDrivers.RAW
 
 
-def test_virt_ram(cobbler_api):
+def test_virt_ram(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -177,7 +186,7 @@ def test_virt_ram(cobbler_api):
     assert image.virt_ram == 5
 
 
-def test_virt_type(cobbler_api):
+def test_virt_type(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -188,7 +197,7 @@ def test_virt_type(cobbler_api):
     assert image.virt_type == enums.VirtType.AUTO
 
 
-def test_virt_bridge(cobbler_api):
+def test_virt_bridge(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -199,7 +208,7 @@ def test_virt_bridge(cobbler_api):
     assert image.virt_bridge == "testbridge"
 
 
-def test_virt_path(cobbler_api):
+def test_virt_path(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -210,7 +219,7 @@ def test_virt_path(cobbler_api):
     assert image.virt_path == ""
 
 
-def test_menu(cobbler_api):
+def test_menu(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -221,7 +230,7 @@ def test_menu(cobbler_api):
     assert image.menu == ""
 
 
-def test_display_name(cobbler_api):
+def test_display_name(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -232,7 +241,7 @@ def test_display_name(cobbler_api):
     assert image.display_name == ""
 
 
-def test_supported_boot_loaders(cobbler_api):
+def test_supported_boot_loaders(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -240,7 +249,7 @@ def test_supported_boot_loaders(cobbler_api):
     assert image.supported_boot_loaders == ["grub", "pxe", "ipxe"]
 
 
-def test_boot_loaders(cobbler_api):
+def test_boot_loaders(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -274,3 +283,46 @@ def test_to_dict_resolved(create_image: Callable[[], Image]):
     assert isinstance(result, dict)
     assert result.get("autoinstall") == "default.ks"
     assert enums.VALUE_INHERITED not in str(result)
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    image = Image(cobbler_api)
+
+    # Act
+    for key, key_value in image.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(image, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(image, new_key)
+            setattr(image, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(image, new_key)

--- a/tests/items/menu_test.py
+++ b/tests/items/menu_test.py
@@ -1,8 +1,20 @@
+import pytest
+
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.menu import Menu
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="menu_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -12,7 +24,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(distro, Menu)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     menu = Menu(cobbler_api)
 
@@ -23,7 +35,7 @@ def test_make_clone(cobbler_api):
     assert menu != result
 
 
-def test_display_name(cobbler_api):
+def test_display_name(cobbler_api: CobblerAPI):
     # Arrange
     menu = Menu(cobbler_api)
 
@@ -34,7 +46,7 @@ def test_display_name(cobbler_api):
     assert menu.display_name == ""
 
 
-def test_to_dict(cobbler_api):
+def test_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     titem = Menu(cobbler_api)
 
@@ -45,7 +57,7 @@ def test_to_dict(cobbler_api):
     assert isinstance(result, dict)
 
 
-def test_to_dict_resolved(cobbler_api):
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     titem = Menu(cobbler_api)
 
@@ -55,3 +67,46 @@ def test_to_dict_resolved(cobbler_api):
     # Assert
     assert isinstance(result, dict)
     assert enums.VALUE_INHERITED not in str(result)
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    menu = Menu(cobbler_api)
+
+    # Act
+    for key, key_value in menu.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(menu, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(menu, new_key)
+            setattr(menu, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(menu, new_key)

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -4,12 +4,24 @@ from ipaddress import AddressValueError
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.system import NetworkInterface
 
 from tests.conftest import does_not_raise
 
 
-def test_network_interface_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="interface_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_network_interface_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -19,7 +31,7 @@ def test_network_interface_object_creation(cobbler_api):
     assert isinstance(interface, NetworkInterface)
 
 
-def test_network_interface_to_dict(cobbler_api):
+def test_network_interface_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -34,7 +46,7 @@ def test_network_interface_to_dict(cobbler_api):
     assert len(result) == 23
 
 
-def test_network_interface_to_dict_resolved(cobbler_api):
+def test_network_interface_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -56,7 +68,7 @@ def test_network_interface_to_dict_resolved(cobbler_api):
 )
 def test_network_interface_from_dict(
     caplog,
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     input_dict,
     modified_field,
     expected_result,
@@ -93,7 +105,9 @@ def test_deserialize():
         (0, "", pytest.raises(TypeError)),
     ],
 )
-def test_dhcp_tag(cobbler_api, input_dhcp_tag, expected_result, expected_exception):
+def test_dhcp_tag(
+    cobbler_api: CobblerAPI, input_dhcp_tag, expected_result, expected_exception
+):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -106,7 +120,7 @@ def test_dhcp_tag(cobbler_api, input_dhcp_tag, expected_result, expected_excepti
         assert interface.dhcp_tag == expected_result
 
 
-def test_cnames(cobbler_api):
+def test_cnames(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -118,7 +132,7 @@ def test_cnames(cobbler_api):
     assert interface.cnames == []
 
 
-def test_static_routes(cobbler_api):
+def test_static_routes(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -139,7 +153,9 @@ def test_static_routes(cobbler_api):
         ([], "", pytest.raises(TypeError)),
     ],
 )
-def test_static(cobbler_api, input_static, expected_result, expected_exception):
+def test_static(
+    cobbler_api: CobblerAPI, input_static, expected_result, expected_exception
+):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -161,7 +177,9 @@ def test_static(cobbler_api, input_static, expected_result, expected_exception):
         ([], "", pytest.raises(TypeError)),
     ],
 )
-def test_management(cobbler_api, input_management, expected_result, expected_exception):
+def test_management(
+    cobbler_api: CobblerAPI, input_management, expected_result, expected_exception
+):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -183,7 +201,7 @@ def test_management(cobbler_api, input_management, expected_result, expected_exc
     ],
 )
 def test_dns_name(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -221,7 +239,7 @@ def test_dns_name(
 )
 def test_mac_address(
     mocker,
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -248,7 +266,7 @@ def test_mac_address(
         assert interface.mac_address == expected_result
 
 
-def test_netmask(cobbler_api):
+def test_netmask(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -260,7 +278,7 @@ def test_netmask(cobbler_api):
     assert interface.netmask == ""
 
 
-def test_if_gateway(cobbler_api):
+def test_if_gateway(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -282,7 +300,7 @@ def test_if_gateway(cobbler_api):
     ],
 )
 def test_virt_bridge(
-    cobbler_api, input_virt_bridge, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_virt_bridge, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -309,7 +327,7 @@ def test_virt_bridge(
     ],
 )
 def test_interface_type(
-    cobbler_api, input_interface_type, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_interface_type, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -331,7 +349,7 @@ def test_interface_type(
     ],
 )
 def test_interface_master(
-    cobbler_api, input_interface_master, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_interface_master, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -353,7 +371,7 @@ def test_interface_master(
     ],
 )
 def test_bonding_opts(
-    cobbler_api, input_bonding_opts, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_bonding_opts, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -375,7 +393,7 @@ def test_bonding_opts(
     ],
 )
 def test_bridge_opts(
-    cobbler_api, input_bridge_opts, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_bridge_opts, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -398,7 +416,7 @@ def test_bridge_opts(
     ],
 )
 def test_ip_address(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -433,7 +451,7 @@ def test_ip_address(
     ],
 )
 def test_ipv6_address(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -467,7 +485,7 @@ def test_ipv6_address(
     ],
 )
 def test_ipv6_prefix(
-    cobbler_api, input_ipv6_prefix, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_ipv6_prefix, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -490,7 +508,7 @@ def test_ipv6_prefix(
     ],
 )
 def test_ipv6_secondaries(
-    cobbler_api, input_secondaries, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_secondaries, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -514,7 +532,7 @@ def test_ipv6_secondaries(
     ],
 )
 def test_ipv6_default_gateway(
-    cobbler_api, input_address, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_address, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -528,7 +546,7 @@ def test_ipv6_default_gateway(
         assert interface.ipv6_default_gateway == expected_result
 
 
-def test_ipv6_static_routes(cobbler_api):
+def test_ipv6_static_routes(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -547,7 +565,9 @@ def test_ipv6_static_routes(cobbler_api):
         (0, "", pytest.raises(TypeError)),
     ],
 )
-def test_ipv6_mtu(cobbler_api, input_ipv6_mtu, expected_result, expected_exception):
+def test_ipv6_mtu(
+    cobbler_api: CobblerAPI, input_ipv6_mtu, expected_result, expected_exception
+):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -567,7 +587,7 @@ def test_ipv6_mtu(cobbler_api, input_ipv6_mtu, expected_result, expected_excepti
         (0, "", pytest.raises(TypeError)),
     ],
 )
-def test_mtu(cobbler_api, input_mtu, expected_result, expected_exception):
+def test_mtu(cobbler_api: CobblerAPI, input_mtu, expected_result, expected_exception):
     # Arrange
     interface = NetworkInterface(cobbler_api)
 
@@ -590,7 +610,7 @@ def test_mtu(cobbler_api, input_mtu, expected_result, expected_exception):
     ],
 )
 def test_connected_mode(
-    cobbler_api, input_connected_mode, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_connected_mode, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api)
@@ -612,7 +632,7 @@ def test_connected_mode(
     ],
 )
 def test_modify_interface(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     input_modify_interface,
     expected_modified_field,
     expected_value,
@@ -627,3 +647,46 @@ def test_modify_interface(
 
         # Assert
         assert getattr(interface, expected_modified_field) == expected_value
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    interface = NetworkInterface(cobbler_api)
+
+    # Act
+    for key, key_value in interface.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(interface, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(interface, new_key)
+            setattr(interface, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(interface, new_key)

--- a/tests/items/package_test.py
+++ b/tests/items/package_test.py
@@ -1,8 +1,22 @@
+import pytest
+
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.package import Package
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="package_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # & Act
@@ -12,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(package, Package)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     package = Package(cobbler_api)
 
@@ -23,7 +37,7 @@ def test_make_clone(cobbler_api):
     assert package != result
 
 
-def test_installer(cobbler_api):
+def test_installer(cobbler_api: CobblerAPI):
     # Arrange
     package = Package(cobbler_api)
 
@@ -34,7 +48,7 @@ def test_installer(cobbler_api):
     assert package.installer == ""
 
 
-def test_version(cobbler_api):
+def test_version(cobbler_api: CobblerAPI):
     # Arrange
     package = Package(cobbler_api)
 
@@ -45,7 +59,7 @@ def test_version(cobbler_api):
     assert package.version == ""
 
 
-def test_to_dict(cobbler_api):
+def test_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     titem = Package(cobbler_api)
 
@@ -56,7 +70,7 @@ def test_to_dict(cobbler_api):
     assert isinstance(result, dict)
 
 
-def test_to_dict_resolved(cobbler_api):
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     titem = Package(cobbler_api)
 
@@ -66,3 +80,46 @@ def test_to_dict_resolved(cobbler_api):
     # Assert
     assert isinstance(result, dict)
     assert enums.VALUE_INHERITED not in str(result)
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    titem = Package(cobbler_api)
+
+    # Act
+    for key, key_value in titem.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(titem, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(titem, new_key)
+            setattr(titem, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(titem, new_key)

--- a/tests/items/repo_test.py
+++ b/tests/items/repo_test.py
@@ -1,12 +1,22 @@
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.repo import Repo
 
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="repo_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -16,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(repo, Repo)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -27,7 +37,7 @@ def test_make_clone(cobbler_api):
     assert result != repo
 
 
-def test_to_dict(cobbler_api):
+def test_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     titem = Repo(cobbler_api)
 
@@ -39,7 +49,7 @@ def test_to_dict(cobbler_api):
     assert result.get("proxy") == enums.VALUE_INHERITED
 
 
-def test_to_dict_resolved(cobbler_api):
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     titem = Repo(cobbler_api)
 
@@ -55,7 +65,7 @@ def test_to_dict_resolved(cobbler_api):
 # Properties Tests
 
 
-def test_mirror(cobbler_api):
+def test_mirror(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -66,7 +76,7 @@ def test_mirror(cobbler_api):
     assert repo.mirror == "https://mymirror.com"
 
 
-def test_mirror_type(cobbler_api):
+def test_mirror_type(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -77,7 +87,7 @@ def test_mirror_type(cobbler_api):
     assert repo.mirror_type == enums.MirrorType.BASEURL
 
 
-def test_keep_updated(cobbler_api):
+def test_keep_updated(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -88,7 +98,7 @@ def test_keep_updated(cobbler_api):
     assert not repo.keep_updated
 
 
-def test_yumopts(cobbler_api):
+def test_yumopts(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -99,7 +109,7 @@ def test_yumopts(cobbler_api):
     assert testrepo.yumopts == {}
 
 
-def test_rsyncopts(cobbler_api):
+def test_rsyncopts(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -110,7 +120,7 @@ def test_rsyncopts(cobbler_api):
     assert testrepo.rsyncopts == {}
 
 
-def test_environment(cobbler_api):
+def test_environment(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -121,7 +131,7 @@ def test_environment(cobbler_api):
     assert testrepo.environment == {}
 
 
-def test_priority(cobbler_api):
+def test_priority(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -132,7 +142,7 @@ def test_priority(cobbler_api):
     assert testrepo.priority == 5
 
 
-def test_rpm_list(cobbler_api):
+def test_rpm_list(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -156,7 +166,7 @@ def test_rpm_list(cobbler_api):
     ],
 )
 def test_createrepo_flags(
-    cobbler_api, input_flags, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_flags, expected_exception, expected_result
 ):
     # Arrange
     testrepo = Repo(cobbler_api)
@@ -169,7 +179,7 @@ def test_createrepo_flags(
         assert testrepo.createrepo_flags == expected_result
 
 
-def test_breed(cobbler_api):
+def test_breed(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -180,7 +190,7 @@ def test_breed(cobbler_api):
     assert repo.breed == enums.RepoBreeds.YUM
 
 
-def test_os_version(cobbler_api):
+def test_os_version(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
     testrepo.breed = "yum"
@@ -203,7 +213,7 @@ def test_os_version(cobbler_api):
         ("", pytest.raises(ValueError)),
     ],
 )
-def test_arch(cobbler_api, value, expected_exception):
+def test_arch(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -218,7 +228,7 @@ def test_arch(cobbler_api, value, expected_exception):
             assert testrepo.arch == value
 
 
-def test_mirror_locally(cobbler_api):
+def test_mirror_locally(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -229,7 +239,7 @@ def test_mirror_locally(cobbler_api):
     assert not testrepo.mirror_locally
 
 
-def test_apt_components(cobbler_api):
+def test_apt_components(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -240,7 +250,7 @@ def test_apt_components(cobbler_api):
     assert testrepo.apt_components == []
 
 
-def test_apt_dists(cobbler_api):
+def test_apt_dists(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -259,7 +269,9 @@ def test_apt_dists(cobbler_api):
         (0, pytest.raises(TypeError), ""),
     ],
 )
-def test_proxy(cobbler_api, input_proxy, expected_exception, expected_result):
+def test_proxy(
+    cobbler_api: CobblerAPI, input_proxy, expected_exception, expected_result
+):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -269,3 +281,48 @@ def test_proxy(cobbler_api, input_proxy, expected_exception, expected_result):
 
         # Assert
         assert testrepo.proxy == expected_result
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    testrepo = Repo(cobbler_api)
+
+    # Act
+    for key, key_value in testrepo.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(testrepo, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            elif new_key == "proxy":
+                settings_name = "proxy_url_ext"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(testrepo, new_key)
+            setattr(testrepo, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(testrepo, new_key)

--- a/tests/items/resource_test.py
+++ b/tests/items/resource_test.py
@@ -1,8 +1,22 @@
+import pytest
+
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.resource import Resource
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="resource_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -12,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(distro, Resource)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -23,7 +37,7 @@ def test_make_clone(cobbler_api):
     assert result != resource
 
 
-def test_to_dict(cobbler_api):
+def test_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     titem = Resource(cobbler_api)
 
@@ -34,7 +48,7 @@ def test_to_dict(cobbler_api):
     assert isinstance(result, dict)
 
 
-def test_to_dict_resolved(cobbler_api):
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     titem = Resource(cobbler_api)
 
@@ -49,7 +63,7 @@ def test_to_dict_resolved(cobbler_api):
 # Properties Tests
 
 
-def test_action(cobbler_api):
+def test_action(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -60,7 +74,7 @@ def test_action(cobbler_api):
     assert resource.action == enums.ResourceAction.CREATE
 
 
-def test_group(cobbler_api):
+def test_group(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -71,7 +85,7 @@ def test_group(cobbler_api):
     assert resource.group == "test"
 
 
-def test_mode(cobbler_api):
+def test_mode(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -82,7 +96,7 @@ def test_mode(cobbler_api):
     assert resource.mode == "test"
 
 
-def test_owner(cobbler_api):
+def test_owner(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -93,7 +107,7 @@ def test_owner(cobbler_api):
     assert resource.owner == "test"
 
 
-def test_path(cobbler_api):
+def test_path(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -104,7 +118,7 @@ def test_path(cobbler_api):
     assert resource.path == "test"
 
 
-def test_template(cobbler_api):
+def test_template(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -113,3 +127,46 @@ def test_template(cobbler_api):
 
     # Assert
     assert resource.template == "test"
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    resource = Resource(cobbler_api)
+
+    # Act
+    for key, key_value in resource.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(resource, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(resource, new_key)
+            setattr(resource, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(resource, new_key)

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -17,6 +17,17 @@ from cobbler.items.system import NetworkInterface, System
 from tests.conftest import does_not_raise
 
 
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="profile_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
 def test_object_creation(cobbler_api: CobblerAPI):
     """
     Test that verifies that the object constructor can be successfully used.
@@ -1010,3 +1021,138 @@ def test_display_name(cobbler_api: CobblerAPI):
 
     # Assert
     assert system.display_name == ""
+
+
+def test_profile_inherit(mocker, test_settings, create_distro: Callable[[], Distro]):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    distro = create_distro()
+    api = distro.api
+    mocker.patch.object(api, "settings", return_value=test_settings)
+    distro.arch = enums.Archs.X86_64
+    profile = Profile(api)
+    profile.name = "test_profile_inherit"
+    profile.distro = distro.name
+    api.add_profile(profile)
+    system = System(api)
+    system.profile = profile.name
+
+    # Act
+    for key, key_value in system.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(system, new_key)
+            settings_name = new_key
+            parent_obj = None
+            if hasattr(profile, settings_name):
+                parent_obj = profile
+            elif hasattr(distro, settings_name):
+                parent_obj = distro
+            else:
+                if new_key == "owners":
+                    settings_name = "default_ownership"
+                elif new_key == "proxy":
+                    settings_name = "proxy_url_int"
+
+                if hasattr(test_settings, f"default_{settings_name}"):
+                    settings_name = f"default_{settings_name}"
+                if hasattr(test_settings, settings_name):
+                    parent_obj = test_settings
+
+            if parent_obj is not None:
+                setting = getattr(parent_obj, settings_name)
+                if new_key == "autoinstall":
+                    new_value = "default.ks"
+                elif new_key == "boot_loaders":
+                    new_value = ["grub"]
+                elif new_key == "next_server_v4":
+                    new_value = "10.10.10.10"
+                elif new_key == "next_server_v6":
+                    new_value = "fd00::"
+                elif isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value.update({"test_inheritance": "test_inheritance"})
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(parent_obj, settings_name, new_value)
+
+            prev_value = getattr(system, new_key)
+            setattr(system, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(system, new_key)
+
+
+def test_image_inherit(mocker, test_settings, create_image: Callable[[], Image]):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    image = create_image()
+    api = image.api
+    mocker.patch.object(api, "settings", return_value=test_settings)
+    system = System(api)
+    system.image = image.name
+
+    # Act
+    for key, key_value in system.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(system, new_key)
+            settings_name = new_key
+            parent_obj = None
+            if hasattr(image, settings_name):
+                parent_obj = image
+            else:
+                if new_key == "owners":
+                    settings_name = "default_ownership"
+                elif new_key == "proxy":
+                    settings_name = "proxy_url_int"
+
+                if hasattr(test_settings, f"default_{settings_name}"):
+                    settings_name = f"default_{settings_name}"
+                if hasattr(test_settings, settings_name):
+                    parent_obj = test_settings
+
+            if parent_obj is not None:
+                setting = getattr(parent_obj, settings_name)
+                if new_key == "autoinstall":
+                    new_value = "default.ks"
+                elif new_key == "boot_loaders":
+                    new_value = ["grub"]
+                elif new_key == "next_server_v4":
+                    new_value = "10.10.10.10"
+                elif new_key == "next_server_v6":
+                    new_value = "fd00::"
+                elif isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value.update({"test_inheritance": "test_inheritance"})
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(parent_obj, settings_name, new_value)
+
+            prev_value = getattr(system, new_key)
+            setattr(system, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(system, new_key)


### PR DESCRIPTION
## Linked Items

Fixes #3557 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->
Inheritance of some non-string properties has been fixed

## Behaviour changes

Old: some inheritable non-string properties cannot be set to   `<inherit>>`

New: for all inherited properties it is possible to set the value `<<inherit>>`

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
