### PR TITLE
Fix initrd.magic for ipxe

### DIFF
--- a/changelog.d/3561.fixed
+++ b/changelog.d/3561.fixed
@@ -1,0 +1,1 @@
+Fix initrd.magic in ipxe.template

--- a/docs/user-guide/http-api.rst
+++ b/docs/user-guide/http-api.rst
@@ -139,7 +139,7 @@ Example Output:
 .. code-block:: text
 
     :example_profile
-    kernel /images/example_distro/vmlinuz   initrd=initrd.magic
+    kernel /images/example_distro/vmlinuz
     initrd /images/example_distro/initramfs
     boot
 

--- a/system-tests/tests/svc-ipxe-profile
+++ b/system-tests/tests/svc-ipxe-profile
@@ -14,7 +14,7 @@ cobbler system add --name testbed --profile fake --image fakeimage
 # Prepare expected result
 cat >${tmp}/a <<-EOF
 :fake
-kernel /images/fake/vmlinuz   initrd=initrd.magic
+kernel /images/fake/vmlinuz  
 initrd /images/fake/initramfs
 boot
 

--- a/templates/boot_loader_conf/ipxe.template
+++ b/templates/boot_loader_conf/ipxe.template
@@ -11,7 +11,7 @@
 iseq \${smbios/manufacturer} HP && exit ||
 sanboot --no-describe --drive 0x80
 #else
-kernel $kernel_path $kernel_options initrd=initrd.magic
+kernel $kernel_path $kernel_options
 #for $init in $initrd
 initrd $init
 #end for


### PR DESCRIPTION
## Linked Items

Fixes #3475 

## Description

Removing `initrd.magic` from `ipxe.template`

## Behaviour changes

Old: Windows cannot be installed

New: Windows can be installed, but for older versions of the Linux kernel it is possible to add `initrd=initrd.magic` to `kernel-options`:
```
cobbler distro edit --kernel-options=initrd=initrd.magic
```

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
