### PR TITLE
Fix MongoDB collection  names

### DIFF
--- a/changelog.d/3563.fixed
+++ b/changelog.d/3563.fixed
@@ -1,0 +1,1 @@
+Fix MongoDB collection names

--- a/cobbler/modules/serializers/__init__.py
+++ b/cobbler/modules/serializers/__init__.py
@@ -2,7 +2,7 @@
 This module contains code to persist the in memory state of Cobbler on a target. The name of the target should be the
 name of the Python file. Cobbler is currently only tested against the file serializer.
 """
-from typing import TYPE_CHECKING, Any, Dict, List
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
@@ -49,7 +49,9 @@ class StorageBase:
             "The implementation for the configured serializer is missing!"
         )
 
-    def deserialize_raw(self, collection_type: str) -> List[Dict[str, Any]]:
+    def deserialize_raw(
+        self, collection_type: str
+    ) -> Union[List[Optional[Dict[str, Any]]], Dict[str, Any]]:
         """
         Get a collection from mongodb and parse it into an object.
 

--- a/tests/modules/serializer/mongodb_test.py
+++ b/tests/modules/serializer/mongodb_test.py
@@ -3,6 +3,7 @@ from typing import ContextManager
 
 import pytest
 
+from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.modules.serializers import mongodb
 
@@ -10,7 +11,7 @@ from tests.conftest import does_not_raise
 
 
 @pytest.fixture
-def mongodb_obj(cobbler_api):
+def mongodb_obj(cobbler_api: CobblerAPI):
     return mongodb.storage_factory(cobbler_api)
 
 
@@ -27,7 +28,7 @@ def test_what():
     assert mongodb.what() == "serializer/mongodb"
 
 
-def test_storage_factory(cobbler_api):
+def test_storage_factory(cobbler_api: CobblerAPI):
     # Arrange & Act
     result = mongodb.storage_factory(cobbler_api)
 
@@ -38,7 +39,7 @@ def test_storage_factory(cobbler_api):
 def test_serialize_item(mocker, mongodb_obj):
     # Arrange
     mock_collection = mocker.MagicMock()
-    mock_collection.collection_type.return_value = "distro"
+    mock_collection.collection_types.return_value = "distros"
     mock_item = mocker.MagicMock()
     mock_item.name = "testitem"
     mock_item.arch = "x86_64"
@@ -48,13 +49,13 @@ def test_serialize_item(mocker, mongodb_obj):
     mongodb_obj.serialize_item(mock_collection, mock_item)
 
     # Assert
-    assert len(list(mongodb_obj.mongodb["cobbler"]["distro"].find())) == 1
+    assert len(list(mongodb_obj.mongodb["cobbler"]["distros"].find())) == 1
 
 
 def test_serialize_delete(mocker, mongodb_obj):
     # Arrange
     mock_collection = mocker.MagicMock()
-    mock_collection.collection_type.return_value = "distro"
+    mock_collection.collection_types.return_value = "distros"
     mock_item = mocker.MagicMock()
     mock_item.name = "testitem"
 
@@ -62,13 +63,13 @@ def test_serialize_delete(mocker, mongodb_obj):
     mongodb_obj.serialize_delete(mock_collection, mock_item)
 
     # Assert
-    assert len(list(mongodb_obj.mongodb["cobbler"]["distro"].find())) == 0
+    assert len(list(mongodb_obj.mongodb["cobbler"]["distros"].find())) == 0
 
 
 def test_serialize(mocker, mongodb_obj):
     # Arrange
     mock_collection = mocker.MagicMock()
-    mock_collection.collection_type.return_value = "distro"
+    mock_collection.collection_types.return_value = "distros"
     mock_serialize_item = mocker.patch.object(mongodb_obj, "serialize_item")
     mock_collection.__iter__ = mocker.Mock(return_value=iter(["item1"]))
 
@@ -81,7 +82,7 @@ def test_serialize(mocker, mongodb_obj):
 
 def test_deserialize_raw(mongodb_obj):
     # Arrange
-    collection_type = "distro"
+    collection_type = "distros"
     mongodb_obj.mongodb["cobbler"][collection_type].insert_one(
         {"name": "testitem", "arch": "x86_64"}
     )
@@ -100,7 +101,7 @@ def test_deserialize_raw(mongodb_obj):
 def test_deserialize(mocker, mongodb_obj):
     # Arrange
     mock_collection = mocker.MagicMock()
-    mock_collection.collection_type.return_value = "distro"
+    mock_collection.collection_types.return_value = "distros"
     input_topological = True
     return_deserialize_raw = []
     mock_deserialize_raw = mocker.patch.object(
@@ -133,7 +134,7 @@ def test_deserialize_item(
     mongodb_obj: mongodb.MongoDBSerializer, item_name: str, expected_exception
 ):
     # Arrange
-    collection_type = "distro"
+    collection_type = "distros"
     input_value = {"name": item_name, "arch": "x86_64"}
     test_item = copy.deepcopy(input_value)
     if item_name is not None:


### PR DESCRIPTION
## Linked Items

Fixes #3562 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Changed MongoDB collection names. The mistake may have occurred due to the use of the `collection_type` parameter name in MongoDBSerializer methods.

## Behaviour changes

Old: MongoDB collection names follow `collection.collection_type()`.

New: MongoDB collection names follow `collection.collection_types()`.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [X] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
