### PR TITLE
[backport][3.3] docker: add build of debs for Debian 12 Bookworm

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -55,3 +55,11 @@ jobs:
         shell: 'script -q -e -c "bash {0}"'
         run: |
           ./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile
+  build-debian12-debs:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build a Debian 12 Package
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          ./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ test-debian10: ## Executes the testscript for testing cobbler in a docker contai
 test-debian11: ## Executes the testscript for testing cobbler in a docker container on Debian 11.
 	./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile
 
+test-debian12: ## Executes the testscript for testing cobbler in a docker container on Debian 12.
+	./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile
+
 system-test: ## Runs the system tests
 	$(MAKE) -C system-tests
 

--- a/changelog.d/3566.added
+++ b/changelog.d/3566.added
@@ -1,0 +1,1 @@
+Add build of debs for Debian 12 Bookworm

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -108,7 +108,7 @@
 %endif
 
 # Debian 11 moved to the C implementation of createrepo
-%if 0%{?debian} == 11
+%if 0%{?debian} >= 11
 %define createrepo_pkg createrepo-c
 %endif
 

--- a/docker/debs/Debian_12/Debian12.dockerfile
+++ b/docker/debs/Debian_12/Debian12.dockerfile
@@ -1,0 +1,81 @@
+# vim: ft=dockerfile
+
+FROM debian:12
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# TERM=screen is fairly neutral and works with xterm for example, for others
+# you might need to pass -e TERM=<terminal>, like rxvt-unicode.
+ENV TERM screen
+ENV OSCODENAME bookworm
+
+# Add repo for debbuild and install all packages required
+# hadolint ignore=DL3008,DL3015,DL4006
+RUN apt-get update -qq && \
+    apt-get install -qqy gnupg curl && \
+    /bin/sh -c "echo 'deb http://download.opensuse.org/repositories/Debian:/debbuild/Debian_12/ /' > /etc/apt/sources.list.d/debbuild.list" && \
+    curl -sL http://download.opensuse.org/repositories/Debian:/debbuild/Debian_12/Release.key | apt-key add - && \
+    apt-get update -qq && \
+    apt-get install -qqy \
+    debbuild \
+    debbuild-macros \
+    wget \
+    pycodestyle \
+    pyflakes3 \
+    python3-cheetah  \
+    python3-coverage \
+    python3-wheel   \
+    python3-distro \
+    python3-distutils \
+    python3-dnspython \
+    python3-dns  \
+    python3-dnsq  \
+    python3-magic  \
+    python3-ldap \
+    python3-netaddr \
+    python3-pip \
+    python3-pycodestyle \
+    python3-pytest \
+    python3-setuptools \
+    python3-simplejson  \
+    python3-sphinx \
+    python3-tz \
+    python3-yaml \
+    python3-schema \
+    liblocale-gettext-perl \
+    lsb-release \
+    xz-utils \
+    bzip2 \
+    dpkg-dev \
+    tftpd-hpa \
+    createrepo-c \
+    rsync \
+    xorriso\
+    fence-agents\
+    fakeroot \
+    patch \
+    pax \
+    git \
+    hardlink \
+    apache2 \
+    libapache2-mod-wsgi-py3 \
+    iproute2 \
+    systemd \
+    systemd-sysv \
+    supervisor && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Make /bin/sh point to bash, not dash
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
+
+COPY ./docker/debs/Debian_10/supervisord/supervisord.conf /etc/supervisord.conf
+COPY ./docker/debs/Debian_10/supervisord/conf.d /etc/supervisord/conf.d
+
+COPY . /usr/src/cobbler
+WORKDIR /usr/src/cobbler
+
+VOLUME /usr/src/cobbler/deb-build
+
+CMD ["/bin/bash", "-c", "make debs"]

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -104,6 +104,7 @@ However we provide docker files for
 - CentOS 8
 - Debian 10 Buster
 - Debian 11 Bullseye
+- Debian 12 Bookworm
 
 which will give you packages which will work better then building from source yourself.
 
@@ -116,6 +117,7 @@ To build the packages you to need to execute the following in the root folder of
 - CentOS 8: ``./docker/rpms/build-and-install-rpms.sh el8 docker/rpms/CentOS_8/CentOS8.dockerfile``
 - Debian 10: ``./docker/debs/build-and-install-debs.sh deb10 docker/debs/Debian_10/Debian10.dockerfile``
 - Debian 11: ``./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile``
+- Debian 12: ``./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile``
 
 After executing the scripts you should have one folder owned by ``root`` which was created during the build. It is
 either called ``rpm-build`` or ``deb-build``. In these directories you should find the built packages. They are


### PR DESCRIPTION
## Linked Items

Backport of #3566 for 3.3.

## Description

This commit adds a Dockerfile to build the debs for Debian 12.

Update the installation guide to provide the build and install command for Debian 12. Also add Debian 12 to the Makefile and GH Action jobs

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
