### PR TITLE
Backport - mkloaders: Fix path to linux.c32 for symlink

### DIFF
--- a/changelog.d/3580.fixed
+++ b/changelog.d/3580.fixed
@@ -1,0 +1,1 @@
+Fix path to linux.c32 for symlink in mkloaders

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -150,14 +150,14 @@ class MkLoaders:
         libcom32_c32_path = self.syslinux_folder.joinpath("libcom32.c32")
         if syslinux_version > 4 and libcom32_c32_path.exists():
             symlink(
-                self.syslinux_pxelinux_folder.joinpath("linux.c32"),
+                self.syslinux_folder.joinpath("linux.c32"),
                 self.bootloaders_dir.joinpath("linux.c32"),
                 skip_existing=True,
             )
             # Make libcom32.c32
             # 'linux.c32' depends on 'libcom32.c32'
             symlink(
-                self.syslinux_pxelinux_folder.joinpath("libcom32.c32"),
+                self.syslinux_folder.joinpath("libcom32.c32"),
                 self.bootloaders_dir.joinpath("libcom32.c32"),
                 skip_existing=True,
             )


### PR DESCRIPTION
## Linked Items

Fixes #3580

## Description

Fix the path as per https://github.com/cobbler/cobbler/issues/3574#issuecomment-1920778051

## Behaviour changes

Old: cobbler mkloaders was broken

New: cobbler mkloaders is not broken

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
