### PR TITLE
[BACKPORT] SPEC: Add extra guard for RPM build on Fedora

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -299,7 +299,11 @@ sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i config/cobbler/settings.yaml
 %endif
 
 %build
+%if 0%{?fedora} || 0%{?rhel}
+. distro_build_configs.sh FEDORA
+%else
 . distro_build_configs.sh
+%endif
 
 # Check distro specific variables for consistency
 [ "${DOCPATH}" != %{_mandir} ] && echo "ERROR: DOCPATH: ${DOCPATH} does not match %{_mandir}"
@@ -318,7 +322,11 @@ sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i config/cobbler/settings.yaml
 make man
 
 %install
+%if 0%{?fedora} || 0%{?rhel}
+. distro_build_configs.sh FEDORA
+%else
 . distro_build_configs.sh
+%endif
 %py3_install
 
 # cobbler

--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -24,7 +24,7 @@ export SYSLINUX_DIR="/usr/share/syslinux"
 export GRUB_MOD_FOLDER="/usr/share/grub2"
 
 # First parameter is DISTRO if provided
-[ $# -ge 2 ] && DISTRO="$1"
+[ $# -ge 1 ] && DISTRO="$1"
 
 if [ "$DISTRO" = "" ] && [ -r /etc/os-release ];then
     source /etc/os-release


### PR DESCRIPTION
## Linked Items

Fixes #3584 

## Description

This is so that in the openSUSE Build Service (OBS) the build receives the correct metadata since the /etc/os-release file is not containing the desired information.

## Behaviour changes

Old: Build for Fedora is broken

New: Build for Fedora works

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
