### PR TITLE
Backport: scm_track commit command

### DIFF
--- a/cobbler/modules/scm_track.py
+++ b/cobbler/modules/scm_track.py
@@ -67,7 +67,7 @@ def run(api, args):
         utils.subprocess_call(["git", "add", "--all", "collections"], shell=False)
         utils.subprocess_call(["git", "add", "--all", "templates"], shell=False)
         utils.subprocess_call(["git", "add", "--all", "snippets"], shell=False)
-        utils.subprocess_call(["git", "commit", "-m", "API", "update", "--author", author], shell=False)
+        utils.subprocess_call(["git", "commit", "-m", "API update", "--author", author], shell=False)
 
         if push_script:
             utils.subprocess_call([push_script], shell=False)


### PR DESCRIPTION
## Linked Items

Fixes #3591

## Description

Currently when enabling `scm_track` with the git module then you will receive an error in version 3.3.3 that says:

```
error: pathspec 'update' did not match any file(s) known to git
```

## Behaviour changes

Old: `scm_track` displays errors on changes

New: `scm_track` can successfully commit to Git.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
