### PR TITLE
DNS - Bind: Fix bind_zonefiles key error during "cobbler sync"

### DIFF
--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -270,7 +270,8 @@ class _BindManager(ManagerModule):
 
         metadata = {'forward_zones': self.__forward_zones().keys(),
                     'reverse_zones': [],
-                    'zone_include': ''}
+                    'zone_include': '',
+                    'bind_zonefiles': self.settings.bind_zonefile_path}
 
         for zone in metadata['forward_zones']:
             txt = """
@@ -327,7 +328,8 @@ zone "%(arpa)s." {
 
         metadata = {'forward_zones': self.__forward_zones().keys(),
                     'reverse_zones': [],
-                    'zone_include': ''}
+                    'zone_include': '',
+                    'bind_zonefiles': self.settings.bind_zonefile_path}
 
         for zone in metadata['forward_zones']:
             txt = """

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -7,7 +7,7 @@
 # hadolint global ignore=DL3037
 
 # WARNING! This is not in any way production ready. It is just for testing!
-FROM opensuse/leap:15.3
+FROM opensuse/leap:15.4
 
 # Define labels according to https://en.opensuse.org/Building_derived_containers
 # labelprefix=org.opensuse.example
@@ -24,7 +24,7 @@ ENV container docker
 ENV DISTRO SUSE
 
 # Custom repository
-RUN zypper ar https://download.opensuse.org/repositories/home:/cobbler-project:/release33/15.3/ "Cobbler 3.3.x release project (15.3)" \
+RUN zypper ar https://download.opensuse.org/repositories/home:/cobbler-project:/release33/15.4/ "Cobbler 3.3.x release project (15.4)" \
     && zypper --gpg-auto-import-keys refresh
 
 # Runtime & dev dependencies
@@ -41,6 +41,7 @@ RUN zypper install --no-recommends -y \
     gzip                       \
     ipmitool                   \
     make                       \
+    bind                       \    
     python3                    \
     python3-Sphinx             \
     python3-coverage           \

--- a/docker/develop/supervisord/conf.d/named.conf
+++ b/docker/develop/supervisord/conf.d/named.conf
@@ -1,0 +1,9 @@
+[program:named]
+command=/usr/sbin/named -f -d 3 -u named
+user=named
+autostart=false
+autorestart=true
+stderr_logfile=/var/log/supervisord/%(program_name)s_stderr.log
+stderr_logfile_maxbytes=10MB
+stdout_logfile=/var/log/supervisord/%(program_name)s_stdout.log
+stdout_logfile_maxbytes=10MB


### PR DESCRIPTION
## Linked Items

Fixes #3588

## Description

Currently a missing key in the metadata dictionary on the release33 branch of Cobbler causes the `cobbler sync` operation to file during the generation of `/etc/named.conf` and `/etc/secondary.conf`.

## Behaviour changes

Old: `cobbler sync` fails when `mange_dns` is enabled.

New: `cobbler sync` succeeds when `manage_dns` is enabled.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
