### PR TITLE
Autoinstallgen: Fix object not subscriptable error

### DIFF
--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -305,9 +305,9 @@ class AutoInstallationManager:
         self.logger.info("----------------------------")
         self.logger.debug("osversion: %s", os_version)
         if is_profile:
-            self.generate_autoinstall(profile=obj)
+            self.generate_autoinstall(profile=obj.name)
         else:
-            self.generate_autoinstall(system=obj)
+            self.generate_autoinstall(system=obj.name)
         last_errors = self.autoinstallgen.get_last_errors()
         if len(last_errors) > 0:
             return [False, TEMPLATING_ERROR, last_errors]


### PR DESCRIPTION
## Linked Items

Fixes #3597

## Description

Cobbler crashes during the `validate-autoinstalls` command in the following way:

```
4ba1e7db90e0:~ # cobbler validate-autoinstalls
task started: 2024-02-15_111343_validate_autoinstall_files
task started (id=Automated installation files validation, time=Thu Feb 15 11:13:43 2024)
validate_autoinstall_files
----------------------------
Exception occurred: <class 'TypeError'>
Exception value: unhashable type: 'Profile'
Exception Info:
!!! TASK FAILED !!!
```

## Behaviour changes

Old: `cobbler validate-autoinstalls` crashes when more than one profile or system is added.

New: The command behaves as expected.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
