### PR TITLE
Bash: Rewrite autocompletion to prevent infinite loop

### DIFF
--- a/changelog.d/3150.fixed
+++ b/changelog.d/3150.fixed
@@ -1,0 +1,1 @@
+Fixed infinite recursion of bash completion

--- a/config/bash/completion/cobbler
+++ b/config/bash/completion/cobbler
@@ -7,10 +7,10 @@ _cobbler_completions()
 
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    cobbler_type=${COMP_WORDS[1]}
     COMPREPLY=()
-    TYPE="distro profile system repo image aclsetup buildiso import list replicate report reposync sync version signature hardlink"
-    ACTION="add edit copy list remove rename report mkloaders"
+    ITEMS="distro profile system repo image"
+    ACTIONS="aclsetup buildiso import list replicate report reposync sync version signature hardlink validate-autoinstalls mkloaders"
+    ACTION="add copy edit find list remove rename report"
     opts=(
         [distro]="--ctime --depth --mtime --source-repos --tree-build-time --uid --arch --autoinstall-meta --boot-files --boot-loaders --breed --comment --fetchable-files --initrd --kernel --kernel-options --kernel-options-post --name --os-version --owners --redhat-management-key --template-files --in-place --help"
         [profile]="--ctime --depth --mtime --uid --autoinstall --autoinstall-meta --boot-files --comment --dhcp-tag --distro --enable-ipxe --enable-menu --fetchable-files --kernel-options --kernel-options-post --name --name-servers --name-servers-search --next-server --owners --parent --proxy --redhat-management-key --repos --server --template-files --virt-auto-boot --virt-bridge --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-ram --virt-type --in-place --help"
@@ -19,67 +19,158 @@ _cobbler_completions()
         [image]="--ctime --depth --mtime --parent --uid --arch --autoinstall --breed --comment --file --image-type --name --network-count --os-version --owners --virt-auto-boot --virt-bridge --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-ram --virt-type --in-place --help"
         [import]="--arch --breed --os-version --path --name --available-as --autoinstall --rsync-flags --help"
         [buildiso]="--iso --profiles --systems --tempdir --distro --standalone --source --exclude-dns --mkisofs-opts --help"
+        [replicate]="--master --distros --profiles --systems --repos-pattern --images --prune --omit-data --help"
+        [sync]="--dns --dhcp --systems --help"
+        [reposync]="--only --tries --no-fail --help"
     )
 
-    while :; do
-        case "${prev}" in
-            cobbler)
-                COMPREPLY=($(compgen -W "${TYPE}" -- ${cur}))
-                return 0
-                ;;
-            distro|repo|image)
+    if [ "$COMP_CWORD" -eq "1" ]; then
+        COMPREPLY=($(compgen -W "${ITEMS} ${ACTIONS}" -- ${cur}))
+        return 0
+    else
+        cobbler_type="${COMP_WORDS[1]}"
+    fi
+
+    # Check some special flags before doing normal completion.
+    case "${prev}" in
+        --name)
+            if [ -d "/var/lib/cobbler/collections/${cobbler_type}s" ]; then
+                conf="$(ls /var/lib/cobbler/collections/${cobbler_type}s)"
+                : "${conf//.json/}"
+                COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            fi
+            return 0
+            ;;
+        --distro)
+            conf="$(ls /var/lib/cobbler/collections/distros)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --image)
+            conf="$(ls /var/lib/cobbler/collections/images)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --profile)
+            conf="$(ls /var/lib/cobbler/collections/profiles)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --repos)
+            conf="$(ls /var/lib/cobbler/collections/repos)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --path|--tempdir|--kernel|--initrd)
+            # https://superuser.com/a/564776
+            local IFS=$'\n'
+            local LASTCHAR=' '
+
+            COMPREPLY=($(compgen -o plusdirs -f -- "${COMP_WORDS[COMP_CWORD]}"))
+
+            if [ ${#COMPREPLY[@]} = 1 ]; then
+                [ -d "$COMPREPLY" ] && LASTCHAR=/
+                COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+            else
+                for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
+                    [ -d "${COMPREPLY[$i]}" ] && COMPREPLY[$i]=${COMPREPLY[$i]}/
+                done
+            fi
+
+            return 0
+            ;;
+    esac
+
+    case "$cobbler_type" in
+        distro|repo|image)
+            if [ "$COMP_CWORD" -eq "2" ]; then
                 COMPREPLY=($(compgen -W "${ACTION}" -- ${cur}))
                 return 0
-                ;;
-            profile|system)
-                COMPREPLY=($(compgen -W "${ACTION} getks" -- ${cur}))
+            else
+                item_subaction="${COMP_WORDS[2]}"
+                case "$item_subaction" in
+                    add|edit)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
+                        return 0
+                        ;;
+                    list)
+                        return 0
+                        ;;
+                    copy|rename)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]} --newname" -- ${cur}))
+                        return 0
+                        ;;
+                    remove|report)
+                        COMPREPLY=($(compgen -W "--name" -- ${cur}))
+                        return 0
+                        ;;
+                    *)
+                        return 0
+                        ;;
+                esac
+            fi
+            ;;
+        profile|system)
+            if [ "$COMP_CWORD" -eq "2" ]; then
+                COMPREPLY=($(compgen -W "${ACTION} get-autoinstall" -- ${cur}))
                 return 0
-                ;;
-            import|buildiso)
+            else
+                item_subaction="${COMP_WORDS[2]}"
+                case "$item_subaction" in
+                    add|edit)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
+                        return 0
+                        ;;
+                    list)
+                        return 0
+                        ;;
+                    copy|rename)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]} --newname" -- ${cur}))
+                        return 0
+                        ;;
+                    get-autoinstall|remove|report)
+                        COMPREPLY=($(compgen -W "--name" -- ${cur}))
+                        return 0
+                        ;;
+                    *)
+                        return 0
+                        ;;
+                esac
+            fi
+            ;;
+        import|buildiso|replicate|sync|reposync)
+            # FIXME: sync - --systems and --dhcp/--dns are mutually exclusive
+            # FIXME: reposync - --no-fail is the only real flag, the other options are key-value pairs
+            if [ "$COMP_CWORD" -ge "2" ]; then
                 COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
+            fi
+            return 0
+            ;;
+        signature)
+            SIGNATURE_OPTIONS="reload report update"
+            SIGNATURE_RELOAD_FLAGS="--filename"
+            SIGNATURE_REPORT_FLAGS="--name"
+            
+            if [ "$COMP_CWORD" -eq "2" ]; then
+                COMPREPLY=($(compgen -W "${SIGNATURE_OPTIONS}" -- ${cur}))
                 return 0
-                ;;
-            add|edit)
-                COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
-                return 0
-                ;;
-            list)
-                return 0
-                ;;
-            copy|rename)
-                COMPREPLY=($(compgen -W "${opts[${cobbler_type}]} --newname" -- ${cur}))
-                return 0
-                ;;
-            getks|remove|report)
-                COMPREPLY=($(compgen -W "--name" -- ${cur}))
-                return 0
-                ;;
-            --name)
-                if [ -d "/var/lib/cobbler/config/${cobbler_type}s.d" ]; then
-                    conf="$(ls /var/lib/cobbler/config/${cobbler_type}s.d)"
-                    : "${conf//.json/}"
-                    COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            elif [ "$COMP_CWORD" -eq "3" ]; then
+                if [ "$prev" == "reload" ]; then
+                    COMPREPLY=($(compgen -W "${SIGNATURE_RELOAD_FLAGS}" -- ${cur}))
+                elif [ "$prev" == "report" ]; then
+                    COMPREPLY=($(compgen -W "${SIGNATURE_REPORT_FLAGS}" -- ${cur}))
                 fi
-                return 0
-                : "${conf//.json/}"
-                COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
-                return 0
-                ;;
-            --profile)
-                conf="$(ls /var/lib/cobbler/config/profiles.d)"
-                : "${conf//.json/}"
-                COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
-                return 0
-                ;;
-            *)
-               if [[ ${COMP_CWORD} -gt 2 ]]; then
-                   prev="${COMP_WORDS[2]}"
-               else
-                   return 0
-               fi
-               ;;
-        esac
-    done
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 complete -F _cobbler_completions cobbler


### PR DESCRIPTION
## Linked Items

Fixes #3150

## Description

After consultation of the bash maintainer at SUSE it became evident that using an infinite loop for parsing arguments isn't the best idea. After removing the loop a tree like structure with some shortcuts before offered itself as a viable new structure.

## Behaviour changes

Old: Bash completion did run into an infinite loop for some arguments.

New: The bash completion is offering assistance for some arguments like `--name` and doesn't run into infinite loops anymore.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
