### PR TITLE
Release33 configparser

### DIFF
--- a/changelog.d/3606.fixed
+++ b/changelog.d/3606.fixed
@@ -1,0 +1,1 @@
+Removed from Python 3.12 SafeConfigParser replaced with ConfigParser

--- a/cobbler/modules/authorization/configfile.py
+++ b/cobbler/modules/authorization/configfile.py
@@ -9,7 +9,7 @@ not authz_allowall, which will most likely NOT do what you want.
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
 
-from configparser import SafeConfigParser
+from configparser import ConfigParser
 
 import os
 from typing import Dict
@@ -34,7 +34,7 @@ def __parse_config() -> Dict[str, dict]:
     """
     if not os.path.exists(CONFIG_FILE):
         return {}
-    config = SafeConfigParser()
+    config = ConfigParser()
     config.read(CONFIG_FILE)
     alldata = {}
     groups = config.sections()


### PR DESCRIPTION
## Linked Items

Fixes #3606 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Handles removal of SafeConfigParser in Python 3.12

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
