### PR TITLE
Use curl instead of the missing wget for the breed suse

### DIFF
--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -22,7 +22,7 @@
 #if $system_name != ''
     ## PXE JUST ONCE
     #if $pxe_just_once
-        #if $breed == 'redhat'
+        #if $breed == 'redhat' or $breed == 'suse'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
@@ -48,7 +48,7 @@
     #end if
     ## RUN POST TRIGGER
     #if $run_install_triggers
-        #if $breed == 'redhat'
+        #if $breed == 'redhat' or $breed == 'suse'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, object_type, object_name)

--- a/autoinstall_snippets/autoinstall_start
+++ b/autoinstall_snippets/autoinstall_start
@@ -17,7 +17,7 @@
 #if $object_type != ''
     ## RUN PRE TRIGGER
     #if $run_install_triggers
-        #if $breed == 'redhat'
+        #if $breed == 'redhat' or $breed == 'suse'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, object_type, object_name)

--- a/changelog.d/3611.fixed
+++ b/changelog.d/3611.fixed
@@ -1,0 +1,1 @@
+Use curl instead of the missing wget for the breed suse in the autoinstall_* snippets


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/cobbler/cobbler/issues/3611

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

It checks for the breed `suse`, and if match, it creates code with `curl` instead of the default `wget`

## Behaviour changes

Old: on openSUSE tumbleweed got error message "wget: command not found".

New: no error message, trigger properly called

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
