### PR TITLE
Backport: Bash completion

### DIFF
--- a/changelog.d/3604.fixed
+++ b/changelog.d/3604.fixed
@@ -1,0 +1,1 @@
+Fixed infinite recursion of bash completion

--- a/config/bash/completion/cobbler
+++ b/config/bash/completion/cobbler
@@ -7,10 +7,10 @@ _cobbler_completions()
 
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    cobbler_type=${COMP_WORDS[1]}
     COMPREPLY=()
-    TYPE="distro profile system repo image mgmtclass package file aclsetup buildiso import list replicate report reposync sync validateks version signature hardlink"
-    ACTION="add edit copy list remove rename report mkloaders"
+    ITEMS="distro profile system mgmtclass package file repo image"
+    ACTIONS="aclsetup buildiso import list replicate report reposync sync version signature hardlink validate-autoinstalls mkloaders"
+    ACTION="add copy edit find list remove rename report"
     opts=(
         [distro]="--ctime --depth --mtime --source-repos --tree-build-time --uid --arch --autoinstall-meta --boot-files --boot-loaders --breed --comment --fetchable-files --initrd --kernel --kernel-options --kernel-options-post --mgmt-classes --name --os-version --owners --redhat-management-key --template-files --in-place --help"
         [profile]="--ctime --depth --mtime --uid --autoinstall --autoinstall-meta --boot-files --comment --dhcp-tag --distro --enable-ipxe --enable-menu --fetchable-files --kernel-options --kernel-options-post --mgmt-classes --mgmt-parameters --name --name-servers --name-servers-search --next-server --owners --parent --proxy --redhat-management-key --repos --server --template-files --virt-auto-boot --virt-bridge --virt-cpus --virt-disk-driver --virt-file-size --virt-path --virt-ram --virt-type --in-place --help"
@@ -22,67 +22,158 @@ _cobbler_completions()
         [file]="--ctime --depth --mtime --uid --action --comment --group --is-dir --mode --name --owner --owners --path --template --in-place --help"
         [import]="--arch --breed --os-version --path --name --available-as --autoinstall --rsync-flags --help"
         [buildiso]="--iso --profiles --systems --tempdir --distro --standalone --source --exclude-dns --mkisofs-opts --help"
+        [replicate]="--master --distros --profiles --systems --repos-pattern --images --prune --omit-data --help"
+        [sync]="--dns --dhcp --systems --help"
+        [reposync]="--only --tries --no-fail --help"
     )
 
-    while :; do
-        case "${prev}" in
-            cobbler)
-                COMPREPLY=($(compgen -W "${TYPE}" -- ${cur}))
-                return 0
-                ;;
-            distro|repo|image|mgmtclass|package|file)
+    if [ "$COMP_CWORD" -eq "1" ]; then
+        COMPREPLY=($(compgen -W "${ITEMS} ${ACTIONS}" -- ${cur}))
+        return 0
+    else
+        cobbler_type="${COMP_WORDS[1]}"
+    fi
+
+    # Check some special flags before doing normal completion.
+    case "${prev}" in
+        --name)
+            if [ -d "/var/lib/cobbler/collections/${cobbler_type}s" ]; then
+                conf="$(ls /var/lib/cobbler/collections/${cobbler_type}s)"
+                : "${conf//.json/}"
+                COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            fi
+            return 0
+            ;;
+        --distro)
+            conf="$(ls /var/lib/cobbler/collections/distros)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --image)
+            conf="$(ls /var/lib/cobbler/collections/images)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --profile)
+            conf="$(ls /var/lib/cobbler/collections/profiles)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --repos)
+            conf="$(ls /var/lib/cobbler/collections/repos)"
+            : "${conf//.json/}"
+            COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            return 0
+            ;;
+        --path|--tempdir|--kernel|--initrd)
+            # https://superuser.com/a/564776
+            local IFS=$'\n'
+            local LASTCHAR=' '
+
+            COMPREPLY=($(compgen -o plusdirs -f -- "${COMP_WORDS[COMP_CWORD]}"))
+
+            if [ ${#COMPREPLY[@]} = 1 ]; then
+                [ -d "$COMPREPLY" ] && LASTCHAR=/
+                COMPREPLY=$(printf %q%s "$COMPREPLY" "$LASTCHAR")
+            else
+                for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
+                    [ -d "${COMPREPLY[$i]}" ] && COMPREPLY[$i]=${COMPREPLY[$i]}/
+                done
+            fi
+
+            return 0
+            ;;
+    esac
+
+    case "$cobbler_type" in
+        distro|repo|image|mgmtclass|package|file)
+            if [ "$COMP_CWORD" -eq "2" ]; then
                 COMPREPLY=($(compgen -W "${ACTION}" -- ${cur}))
                 return 0
-                ;;
-            profile|system)
-                COMPREPLY=($(compgen -W "${ACTION} getks" -- ${cur}))
+            else
+                item_subaction="${COMP_WORDS[2]}"
+                case "$item_subaction" in
+                    add|edit)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
+                        return 0
+                        ;;
+                    list)
+                        return 0
+                        ;;
+                    copy|rename)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]} --newname" -- ${cur}))
+                        return 0
+                        ;;
+                    remove|report)
+                        COMPREPLY=($(compgen -W "--name" -- ${cur}))
+                        return 0
+                        ;;
+                    *)
+                        return 0
+                        ;;
+                esac
+            fi
+            ;;
+        profile|system)
+            if [ "$COMP_CWORD" -eq "2" ]; then
+                COMPREPLY=($(compgen -W "${ACTION} get-autoinstall" -- ${cur}))
                 return 0
-                ;;
-            import|buildiso)
+            else
+                item_subaction="${COMP_WORDS[2]}"
+                case "$item_subaction" in
+                    add|edit)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
+                        return 0
+                        ;;
+                    list)
+                        return 0
+                        ;;
+                    copy|rename)
+                        COMPREPLY=($(compgen -W "${opts[${cobbler_type}]} --newname" -- ${cur}))
+                        return 0
+                        ;;
+                    get-autoinstall|remove|report)
+                        COMPREPLY=($(compgen -W "--name" -- ${cur}))
+                        return 0
+                        ;;
+                    *)
+                        return 0
+                        ;;
+                esac
+            fi
+            ;;
+        import|buildiso|replicate|sync|reposync)
+            # FIXME: sync - --systems and --dhcp/--dns are mutually exclusive
+            # FIXME: reposync - --no-fail is the only real flag, the other options are key-value pairs
+            if [ "$COMP_CWORD" -ge "2" ]; then
                 COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
+            fi
+            return 0
+            ;;
+        signature)
+            SIGNATURE_OPTIONS="reload report update"
+            SIGNATURE_RELOAD_FLAGS="--filename"
+            SIGNATURE_REPORT_FLAGS="--name"
+            
+            if [ "$COMP_CWORD" -eq "2" ]; then
+                COMPREPLY=($(compgen -W "${SIGNATURE_OPTIONS}" -- ${cur}))
                 return 0
-                ;;
-            add|edit)
-                COMPREPLY=($(compgen -W "${opts[${cobbler_type}]}" -- ${cur}))
-                return 0
-                ;;
-            list)
-                return 0
-                ;;
-            copy|rename)
-                COMPREPLY=($(compgen -W "${opts[${cobbler_type}]} --newname" -- ${cur}))
-                return 0
-                ;;
-            getks|remove|report)
-                COMPREPLY=($(compgen -W "--name" -- ${cur}))
-                return 0
-                ;;
-            --name)
-                if [ -d "/var/lib/cobbler/config/${cobbler_type}s.d" ]; then
-                    conf="$(ls /var/lib/cobbler/config/${cobbler_type}s.d)"
-                    : "${conf//.json/}"
-                    COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
+            elif [ "$COMP_CWORD" -eq "3" ]; then
+                if [ "$prev" == "reload" ]; then
+                    COMPREPLY=($(compgen -W "${SIGNATURE_RELOAD_FLAGS}" -- ${cur}))
+                elif [ "$prev" == "report" ]; then
+                    COMPREPLY=($(compgen -W "${SIGNATURE_REPORT_FLAGS}" -- ${cur}))
                 fi
-                return 0
-                : "${conf//.json/}"
-                COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
-                return 0
-                ;;
-            --profile)
-                conf="$(ls /var/lib/cobbler/config/profiles.d)"
-                : "${conf//.json/}"
-                COMPREPLY=( $(compgen -W "$(echo $_)" -- ${cur}) )
-                return 0
-                ;;
-            *)
-               if [[ ${COMP_CWORD} -gt 2 ]]; then
-                   prev="${COMP_WORDS[2]}"
-               else
-                   return 0
-               fi
-               ;;
-        esac
-    done
+            fi
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
 }
 
 complete -F _cobbler_completions cobbler

--- a/docs/user-guide/dhcp-management.rst
+++ b/docs/user-guide/dhcp-management.rst
@@ -27,7 +27,7 @@ By default, Cobbler updates the DHCP configuration file each time you run ``cobb
 Remember to use ``cobbler sync`` when you use this feature.
 
 ``isc`` DHCP
-########
+############
 
 Helpful links:
 
@@ -40,7 +40,7 @@ Templates used during generation:
 * ``/etc/cobbler/dhcp6.template``
 
 ``dnsmasq`` DHCP
-############
+################
 
 Helpful links:
 
@@ -52,7 +52,7 @@ Templates used during generation:
 * ``/etc/cobbler/dnsmasq.template``
 
 ``Kea`` DHCP
-########
+############
 
 Support for Kea is a not yet implemented feature request: https://github.com/cobbler/cobbler/issues/3609
 

--- a/docs/user-guide/dns-management.rst
+++ b/docs/user-guide/dns-management.rst
@@ -17,7 +17,7 @@ All managed files will be updated each time ``cobbler sync`` is run, and not unt
 to use ``cobbler sync`` when using this feature.
 
 `bind` DNS
-########
+##########
 
 If using BIND, you must define the zones to be managed with. This is done with two options
 
@@ -41,7 +41,7 @@ Templates used during generation:
 * ``/etc/cobbler/zone_templates/<name-of-zone>``
 
 `dnsmasq` DNS
-###########
+#############
 
 If using dnsmasq, the template is ``/etc/cobbler/dnsmasq.template``. Read this file and understand how dnsmasq works
 before proceeding.
@@ -56,7 +56,7 @@ Templates used during generation:
 * ``/etc/cobbler/dnsmasq.template``
 
 `ndjbdns` DNS
-###########
+#############
 
 If using ndjbdns, the template is ``/etc/cobbler/ndjbdns.template``. Read the file and understand how ndjbdns works
 before proceeding.


### PR DESCRIPTION
## Linked Items

Fixes #3604

## Description

This PR backports the fix for the Bash completion that crashed due to an infinite recursion in the Bash code.

## Behaviour changes

Old: Bash completion crashes when trying to complete certain arguments like `--tempdir` for `cobbler buildiso`

New: The CLI now autocompletes rudimentary arguments again and doesn't crash.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
