### PR TITLE
CI: Add changelog automation

### DIFF
--- a/.github/workflows/newsfragment_checker.yml
+++ b/.github/workflows/newsfragment_checker.yml
@@ -1,0 +1,36 @@
+name: newsfragment_checker
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          cache: pip
+      - name: Install system dependencies
+        run: >-
+          sudo apt-get install -y
+          tar
+          make
+          apache2-dev
+          libsasl2-dev
+          libldap2-dev
+          libssl-dev
+          tree
+      - name: Install python dependencies
+        run: pip install coverage && pip install .[changelog]
+      - name: Show target branch
+        run: >-
+          echo "Target branch is: $GITHUB_BASE_REF"
+      - name: Get added newsfragments
+        if: ( ! contains(github.event.pull_request.labels.*.name, 'no changelog') )
+        run: towncrier check --compare-with origin/$GITHUB_BASE_REF
+      - name: Print result
+        run: echo "Newsfragment added"

--- a/changelog.d/changelog_template.jinja
+++ b/changelog.d/changelog_template.jinja
@@ -1,0 +1,14 @@
+{% if sections[""] %}
+{% for category, val in definitions.items() if category in sections[""] %}
+
+## {{ definitions[category]['name'] }}
+
+{% for text, values in sections[""][category].items() %}
+- {{ text }} {{ values|join(', ') }}
+{% endfor %}
+
+{% endfor %}
+{% else %}
+No significant changes.
+
+{% endif %}

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -1,0 +1,41 @@
+[tool.towncrier]
+directory = "changelog.d"
+filename = "changelog/v{version}.md"
+package = "cobbler"
+start_string = "<!-- towncrier release notes start -->\n"
+underlines = ["", "", ""]
+template = "changelog.d/changelog_template.jinja"
+title_format = "# Cobbler [{version}](https://github.com/cobbler/cobbler/tree/v{version}) - {project_date}"
+issue_format = "[#{issue}](https://github.com/cobbler/cobbler/issues/{issue})"
+single_file = false
+wrap = true
+
+[[tool.towncrier.type]]
+directory = "security"
+name = "Security"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "removed"
+name = "Removed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecated"
+name = "Deprecated"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "added"
+name = "Added"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "changed"
+name = "Changed"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "fixed"
+name = "Fixed"
+showcontent = true


### PR DESCRIPTION
## Linked Items

Fixes no issue

## Description

This adds the towncrier configuration to the `release33` branch so I don't have to manually write the changelog.

I have decided to not add automation to automatically submit the changelog via a PR or to add the automation to increase the version as it is more overhead getting this to work than just doing it manually.

## Behaviour changes

Old: Changelog was manually generated.

New: Changelog is autogenerated.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
