### PR TITLE
Modules: scm_track - Fix pushing to repositories

### DIFF
--- a/changelog.d/3590.fixed
+++ b/changelog.d/3590.fixed
@@ -1,0 +1,1 @@
+scm_track: Pushing to remote repositories via the "scm_push_script" settings works again

--- a/cobbler/modules/scm_track.py
+++ b/cobbler/modules/scm_track.py
@@ -64,7 +64,7 @@ def run(api: "CobblerAPI", args: Any):
         )
 
         if push_script:
-            utils.subprocess_call([push_script], shell=False)
+            utils.subprocess_call(push_script.split(" "), shell=False)
 
         os.chdir(old_dir)
         return 0
@@ -84,11 +84,11 @@ def run(api: "CobblerAPI", args: Any):
         utils.subprocess_call(["hg", "add templates"], shell=False)
         utils.subprocess_call(["hg", "add snippets"], shell=False)
         utils.subprocess_call(
-            ["hg", "commit", "-m", "API", "update", "--user", author], shell=False
+            ["hg", "commit", "-m", "API update", "--user", author], shell=False
         )
 
         if push_script:
-            utils.subprocess_call([push_script], shell=False)
+            utils.subprocess_call(push_script.split(" "), shell=False)
 
         os.chdir(old_dir)
         return 0


### PR DESCRIPTION
## Linked Items

Fixes #3590

## Description

This PR fixes an issue with the `scm_track` that the `push_script` setting cannot be used to push to a remote repository.

## Behaviour changes

Old: If anything else then `""` is set to `push_script` then Cobbler crashes.

New: Cobbler can complete actions where `scm_track` is used.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
