### PR TITLE
[Backport] Modules: scm_track - Fix pushing to repositories

### DIFF
--- a/changelog.d/3621.fixed
+++ b/changelog.d/3621.fixed
@@ -1,0 +1,1 @@
+scm_track: Pushing to remote repositories via the "scm_push_script" settings works again

--- a/cobbler/modules/scm_track.py
+++ b/cobbler/modules/scm_track.py
@@ -70,7 +70,7 @@ def run(api, args):
         utils.subprocess_call(["git", "commit", "-m", "API update", "--author", author], shell=False)
 
         if push_script:
-            utils.subprocess_call([push_script], shell=False)
+            utils.subprocess_call(push_script.split(" "), shell=False)
 
         os.chdir(old_dir)
         return 0
@@ -89,10 +89,10 @@ def run(api, args):
         utils.subprocess_call(["hg", "add collections"], shell=False)
         utils.subprocess_call(["hg", "add templates"], shell=False)
         utils.subprocess_call(["hg", "add snippets"], shell=False)
-        utils.subprocess_call(["hg", "commit", "-m", "API", "update", "--user", author], shell=False)
+        utils.subprocess_call(["hg", "commit", "-m", "API update", "--user", author], shell=False)
 
         if push_script:
-            utils.subprocess_call([push_script], shell=False)
+            utils.subprocess_call(push_script.split(" "), shell=False)
 
         os.chdir(old_dir)
         return 0

--- a/setup.py
+++ b/setup.py
@@ -494,7 +494,10 @@ if __name__ == "__main__":
         ],
         extras_require={
             "lint": ["pyflakes", "pycodestyle"],
-            "test": ["pytest", "pytest-cov", "codecov", "pytest-mock"]
+            "test": ["pytest", "pytest-cov", "codecov", "pytest-mock"],
+            # We require the current version to properly detect duplicate issues
+            # See: https://github.com/twisted/towncrier/releases/tag/22.8.0
+            "changelog": ["towncrier>=22.8.0"],
         },
         packages=find_packages(exclude=["*tests*"]),
         scripts=[

--- a/tests/modules/scm_track_test.py
+++ b/tests/modules/scm_track_test.py
@@ -72,7 +72,7 @@ def test_run_hg(mocker):
          mocker.call(["hg", "add collections"], shell=False),
          mocker.call(["hg", "add templates"], shell=False),
          mocker.call(["hg", "add snippets"], shell=False),
-         mocker.call(["hg", "commit", "-m", "API", "update", "--user", settings_mock.scm_track_author], shell=False),
+         mocker.call(["hg", "commit", "-m", "API update", "--user", settings_mock.scm_track_author], shell=False),
          mocker.call(["/bin/true"], shell=False)]
     )
     assert result == 0


### PR DESCRIPTION
## Linked Items

Fixes #3621

## Description

Cobbler crashed when enabling `scm_track`. Especially the `scm_track_push_script` setting didn't work due to a `subprocess.call` refactoring.

## Behaviour changes

Old: Cobbler crashes when using `scm_track`

New: Cobbler is able to push to remote repositories with the `scm_track` module.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
