### PR TITLE
Rename occurences of grubx86 to grubx64

### DIFF
--- a/changelog.d/3623.fixed
+++ b/changelog.d/3623.fixed
@@ -1,0 +1,1 @@
+This PR changes the default name of the grub2-efi bootloader to grubx64.efi to match the default that we have in our DHCPv4 template.

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -299,6 +299,9 @@ sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i config/cobbler/settings.yaml
 %endif
 
 %build
+if [ -d "%{_sourcedir}/%{name}-%{version}/.git" ]; then
+    cp -r %{_sourcedir}/%{name}-%{version}/.git %{_builddir}/%{name}-%{version}
+fi
 %if 0%{?fedora} || 0%{?rhel}
 . distro_build_configs.sh FEDORA
 %else

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -73,7 +73,7 @@ bootloaders_formats:
       - net
       - ofnet
   x86_64-efi:
-    binary_name: grubx86.efi
+    binary_name: grubx64.efi
     extra_modules:
       - chain
       - efinet

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -53,7 +53,7 @@ bootloaders_formats:
       - net
       - ofnet
   x86_64-efi:
-    binary_name: grubx86.efi
+    binary_name: grubx64.efi
     extra_modules:
       - chain
       - efinet

--- a/system-tests/tests/svc-settings
+++ b/system-tests/tests/svc-settings
@@ -212,7 +212,7 @@ cat >${tmp}/a <<-EOF
             ]
         },
         "x86_64-efi": {
-            "binary_name": "grubx86.efi",
+            "binary_name": "grubx64.efi",
             "extra_modules": [
                 "chain",
                 "efinet"

--- a/templates/etc/dhcp6.template
+++ b/templates/etc/dhcp6.template
@@ -35,7 +35,7 @@ option dhcp6.bootfile-url code 59 = string ;
 class "pxeclients" {
     match if substring (option vendor-class-identifier, 0, 9) = "PXEClient";
     if substring (option vendor-class-identifier, 15, 5) = "00007" {
-        option dhcp6.bootfile-url "tftp://[$next_server_v6]/grub/grubx86.efi";
+        option dhcp6.bootfile-url "tftp://[$next_server_v6]/grub/grubx64.efi";
     }
     else if substring (option vendor-class-identifier, 15, 5) = "00000" {
         option dhcp6.bootfile-url "tftp://[$next_server_v6]/grub/grub.0";

--- a/tests/actions/buildiso_test.py
+++ b/tests/actions/buildiso_test.py
@@ -47,7 +47,7 @@ class TestBuildiso:
     @pytest.mark.parametrize(
         "input_arch,result_binary_name,expected_exception",
         [
-            (enums.Archs.X86_64, "grubx86.efi", does_not_raise()),
+            (enums.Archs.X86_64, "grubx64.efi", does_not_raise()),
             (enums.Archs.PPC, "grub.ppc64le", does_not_raise()),
             (enums.Archs.PPC64, "grub.ppc64le", does_not_raise()),
             (enums.Archs.PPC64EL, "grub.ppc64le", does_not_raise()),

--- a/tests/test_data/V3_3_4/settings.yaml
+++ b/tests/test_data/V3_3_4/settings.yaml
@@ -74,7 +74,7 @@ bootloaders_formats:
       - net
       - ofnet
   x86_64-efi:
-    binary_name: grubx86.efi
+    binary_name: grubx64.efi
     extra_modules:
       - chain
       - efinet


### PR DESCRIPTION
## Linked Items

Fixes #3623

## Description

This PR changes the default name of the `grub2-efi` bootloader to `grubx64.efi` to match the default that we have in our DHCPv4 template.

I performed no automatic migration of this bugfix from 3.3.3 since users may have manually adjusted one of the two locations (`dhcp.template`/`settings.yaml`) already.

## Behaviour changes

Old: Systems cannot PXE out of the box due to a mismatch of settings and DHCP template.

New: Systems should be able to PXE out of the box.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 