### PR TITLE
add uyuni authentication endpoint

### DIFF
--- a/changelog.d/3631.added
+++ b/changelog.d/3631.added
@@ -1,0 +1,1 @@
+Add new setting for uyuni authentication endpoint

--- a/cobbler/modules/authentication/spacewalk.py
+++ b/cobbler/modules/authentication/spacewalk.py
@@ -112,10 +112,13 @@ def authenticate(api_handle: "CobblerAPI", username: str, password: str) -> bool
     # pylint: enable=line-too-long
     if api_handle is None:
         raise CX("api_handle required. Please don't call this without it.")
-    server = api_handle.settings().redhat_management_server
+    server = "https://" + api_handle.settings().redhat_management_server
+    if api_handle.settings().uyuni_authentication_endpoint:
+        server = api_handle.settings().uyuni_authentication_endpoint
+
     user_enabled = api_handle.settings().redhat_management_permissive
 
-    spacewalk_url = f"https://{server}/rpc/api"
+    spacewalk_url = f"{server}/rpc/api"
     with ServerProxy(spacewalk_url, verbose=True) as client:
         if username == "taskomatic_user" or __looks_like_a_token(password):
             # The tokens are lowercase hex, but a password can also be lowercase hex, so we have to try it as both a

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -241,6 +241,7 @@ class Settings:
         self.redhat_management_permissive = False
         self.redhat_management_server = "xmlrpc.rhn.redhat.com"
         self.redhat_management_key = ""
+        self.uyuni_authentication_endpoint = ""
         self.register_new_installs = False
         self.remove_old_puppet_certs_automatically = False
         self.replicate_repo_rsync_options = "-avzH"

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -124,6 +124,7 @@ schema = Schema(
         Optional("redhat_management_permissive"): bool,
         Optional("redhat_management_server"): str,
         Optional("redhat_management_key"): str,
+        Optional("uyuni_authentication_endpoint"): str,
         Optional("register_new_installs"): bool,
         Optional("remove_old_puppet_certs_automatically"): bool,
         Optional("replicate_repo_rsync_options"): str,

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -391,6 +391,11 @@ nopxe_with_triggers: true
 # authentication within Cobbler Web and Cobbler XMLRPC.
 redhat_management_server: "xmlrpc.rhn.redhat.com"
 
+# This setting is only used by the code that supports using uyuni/SUSE Manager
+# authentication within Cobbler Web and Cobbler XMLRPC. This is the endpoint for 
+# uyuni/SUSE Manager authentication: if empty redhat_management_server will be used.
+uyuni_authentication_endpoint: ""
+
 # If the key "modules.authentication.module" in this file is set to the value "authentication.spacewalk"
 # Satellite/Spacewalk's auth system is used. Cobbler does not allow user-based access into Cobbler Web and
 # Cobbler XMLRPC by default.

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -785,6 +785,16 @@ Cobbler XML-RPC.
 
 default: ``"xmlrpc.rhn.redhat.com"``
 
+uyuni_authentication_endpoint
+#################################
+
+This setting is only used by the code that supports using uyuni/SUSE Manager authentication within Cobbler Web and Cobbler XMLRPC.
+This is the endpoint for uyuni/SUSE Manager authentication: if empty redhat_management_server will be used.
+
+e.g.: ``uyuni_authentication_endpoint: http://localhost``
+
+default: ``""``
+
 redhat_management_key
 #####################
 

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -503,7 +503,7 @@ def test_dump_vars(cobbler_api: CobblerAPI):
     print(result)
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 154
+    assert len(result) == 155
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -209,7 +209,7 @@ def test_blender(cobbler_api):  # type: ignore
     result = utils.blender(cobbler_api, False, root_item)  # type: ignore
 
     # Assert
-    assert len(result) == 168
+    assert len(result) == 169
     # Must be present because the settings have it
     assert "server" in result
     # Must be present because it is a field of distro


### PR DESCRIPTION
## Linked Items

## Description

Use an alternative  than `redhat_management_server` as uyuni XMLRPC API endpoint. This would allow more flexibility to connect `cobbler` and `uyuni`. Default configuration would not be afftected by this change since the value is empty by default: this would also help to not cause regression.

Issue: https://github.com/cobbler/cobbler/issues/3631

## Behaviour changes

New: 
- add `spacewalk_authentication_endpoint` param. This is string represents an alternative endpoint to `redhat_management_server` uyuni XMLRPC API.  Default is empty, in this case `redhat_management_server` would be used as before this change.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
