### PR TITLE
Make profile available in the interface dictionary for dhcp temp…

### DIFF
--- a/changelog.d/3638.added
+++ b/changelog.d/3638.added
@@ -1,0 +1,1 @@
+Make profile available in the interface dictionary for dhcp template redering

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -146,9 +146,6 @@ class _IscManager(DhcpManagerModule):
                     dhcp_tag = interface["dhcp_tag"]
                     host = interface["dns_name"]
 
-                if distro is not None:
-                    interface["distro"] = distro.to_dict()
-
                 if mac == "":
                     # can't write a DHCP entry for this system
                     continue
@@ -178,6 +175,12 @@ class _IscManager(DhcpManagerModule):
                 interface["owner"] = blended_system["name"]
                 interface["enable_ipxe"] = blended_system["enable_ipxe"]
                 interface["name_servers"] = blended_system["name_servers"]
+
+                if profile is not None:
+                    interface["profile"] = profile.to_dict()
+
+                if distro is not None:
+                    interface["distro"] = distro.to_dict()
 
                 # For esxi/UEFI export filename_esxi as path to efi bootloader
                 if distro and distro.os_version.startswith("esxi"):
@@ -329,8 +332,6 @@ class _IscManager(DhcpManagerModule):
                     dhcp_tag = interface["dhcp_tag"]
                     host = interface["dns_name"]
 
-                interface["distro"] = distro.to_dict()
-
                 if not mac or not ip_v6:
                     # can't write a DHCP entry for this system
                     self.logger.warning("%s has no IPv6 or MAC address", system.name)
@@ -359,6 +360,12 @@ class _IscManager(DhcpManagerModule):
                 interface["hostname"] = blended_system["hostname"]
                 interface["owner"] = blended_system["name"]
                 interface["name_servers"] = blended_system["name_servers"]
+
+                if profile is not None:
+                    interface["profile"] = profile.to_dict()
+
+                if distro is not None:
+                    interface["distro"] = distro.to_dict()
 
                 # Explicitly declare filename for other (non x86) archs as in DHCP discover package mostly the
                 # architecture cannot be differed due to missing bits...


### PR DESCRIPTION
…late rendering

## Linked Items

Fixes #3638 

## Description

Makes the profile available in the interface dictionary.

## Behaviour changes
Allows you to do:
```
#for dhcp_tag in $dhcp_tags.keys():
# group for Cobbler DHCP tag: $dhcp_tag
group {
        #for mac in $dhcp_tags[$dhcp_tag].keys():
            #set iface = $dhcp_tags[$dhcp_tag][$mac]
           #if $iface.dns_name:
              ## EL7 and Ubuntu 18 incorrectly does not prefix the ID with a null
              #if "-7" in $iface.profile.name or "ubuntu-18" in $iface.profile.name
        option dhcp-client-identifier "$iface.dns_name";
            #else
        option dhcp-client-identifier "\000$iface.dns_name";
            #end if
```

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

Not sure here