### PR TITLE
Make profile available in the interface dictionary for dhcp temp…

### DIFF
--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -150,9 +150,6 @@ class IscManager:
                     dhcp_tag = interface["dhcp_tag"]
                     host = interface["dns_name"]
 
-                if distro is not None:
-                    interface["distro"] = distro.to_dict()
-
                 if mac is None or mac == "":
                     # can't write a DHCP entry for this system
                     continue
@@ -184,6 +181,12 @@ class IscManager:
                 interface["enable_gpxe"] = blended_system["enable_gpxe"]
                 interface["name_servers"] = blended_system["name_servers"]
                 interface["mgmt_parameters"] = blended_system["mgmt_parameters"]
+
+                if profile is not None:
+                    interface["profile"] = profile.to_dict()
+
+                if distro is not None:
+                    interface["distro"] = distro.to_dict()
 
                 # Explicitly declare filename for other (non x86) archs as in DHCP discover package mostly the
                 # architecture cannot be differed due to missing bits...


### PR DESCRIPTION
…late rendering

## Linked Items

Backport of #3639 for 3.2.

## Description
Makes the profile available in the interface dictionary.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
