### PR TITLE
Add more Fedora like distros for building

### DIFF
--- a/distro_build_configs.sh
+++ b/distro_build_configs.sh
@@ -24,7 +24,7 @@ if [ "$DISTRO" = "" ] && [ -r /etc/os-release ];then
 	sle*|*suse*)
 	    DISTRO="SUSE"
 	    ;;
-	fedora*|centos*|rhel*|rocky*)
+	fedora*|ol*|centos*|rhel*|rocky*|alma*|anolis*)
 	    DISTRO="FEDORA"
 	    ;;
 	ubuntu*|debian*)


### PR DESCRIPTION
## Description

Allows building on more RedHat like distros

## Behaviour changes

Old: Files go into wrong directories on AlmaLinux
New: Files go into correct directories on AlmaLinux

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
