### PR TITLE
Add signature for Alma/Rocky Minimal ISOs

### DIFF
--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -127,7 +127,8 @@
       },
       "rhel8": {
         "signatures": [
-          "BaseOS"
+          "BaseOS",
+          "Minimal"
         ],
         "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*8[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,
@@ -154,7 +155,8 @@
       },
       "rhel9": {
         "signatures": [
-          "BaseOS"
+          "BaseOS",
+          "Minimal"
         ],
         "version_file": "(redhat|sl|slf|almalinux|centos|centos-linux|centos-stream|oraclelinux|rocky|vzlinux)-release-(?!notes)([\\w]*-)*9[\\.-]+(.*)\\.rpm",
         "version_file_regex": null,


### PR DESCRIPTION
## Linked Items

Fixes #3285 - at least @emyr666 's  comments about minimal ISOs, though I don't think that is what the issue was originally about.

## Description

Recognize Alma/Rocky minimal ISO layout

## Behaviour changes

Old: cobbler import fails

New: cobbler import works

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

no tests in 3.2 it seems