### PR TITLE
Better permissions for web.ss

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -337,7 +337,7 @@ rm %{buildroot}%{_sysconfdir}/cobbler/cobbler_web.conf
 
 # ghosted files
 touch %{buildroot}%{_sharedstatedir}/cobbler/web.ss
-chmod 0600 %{buildroot}%{_sharedstatedir}/cobbler/web.ss
+chmod 0640 %{buildroot}%{_sharedstatedir}/cobbler/web.ss
 
 
 %pre
@@ -532,7 +532,7 @@ sed -i -e "s/SECRET_KEY = ''/SECRET_KEY = \'$RAND_SECRET\'/" %{_datadir}/cobbler
 %{apache_dir}/cobbler_webui_content/
 %else
 %attr(-,%{apache_user},%{apache_group}) %{_datadir}/cobbler/web
-%ghost %attr(0660,%{apache_user},root) %{_sharedstatedir}/cobbler/web.ss
+%ghost %attr(0640,root,%{apache_group}) %{_sharedstatedir}/cobbler/web.ss
 %dir %attr(700,%{apache_user},root) %{_sharedstatedir}/cobbler/webui_sessions
 %attr(-,%{apache_user},%{apache_group}) %{apache_dir}/cobbler_webui_content/
 %endif

--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -52,7 +52,7 @@ def regen_ss_file():
     with open("/dev/urandom", 'rb') as fd:
         data = fd.read(512)
 
-    with open(ssfile, 'wb', 0o660) as fd:
+    with open(ssfile, 'wb', 0o640) as fd:
         fd.write(binascii.hexlify(data))
 
     http_user = "apache"
@@ -61,7 +61,7 @@ def regen_ss_file():
         http_user = "www-data"
     elif family == "suse":
         http_user = "wwwrun"
-    os.lchown("/var/lib/cobbler/web.ss", pwd.getpwnam(http_user)[2], -1)
+    os.lchown(ssfile, 0, pwd.getpwnam(http_user)[3])
 
 
 def do_xmlrpc_rw(cobbler_api: CobblerAPI, settings, port):


### PR DESCRIPTION
## Linked Items

Fixes #2183

## Description
cobblerd is the only process that needs to write web.ss and it just needs to be readable by root and the web server user.

## Behaviour changes

Old: SELinux dac_override denials when restarting cobblerd

New: No SELinux denials

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
