### PR TITLE
Add support for cnames in dnsmasq. (release33 syntax)

### DIFF
--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -169,14 +169,21 @@ class _DnsmasqManager(ManagerModule):
             for (_, interface) in system.interfaces.items():
                 mac = interface.mac_address
                 host = interface.dns_name
+                cnames = " ".join(interface.cnames)
                 ip = interface.ip_address
                 ipv6 = interface.ipv6_address
                 if not mac:
                     continue
                 if host is not None and host != "" and ipv6 is not None and ipv6 != "":
-                    fh.write(ipv6 + "\t" + host + "\n")
+                    if cnames:
+                        fh.write(ipv6 + "\t" + host + ' ' + cnames + "\n")
+                    else:
+                        fh.write(ipv6 + "\t" + host + "\n")
                 elif host is not None and host != "" and ip is not None and ip != "":
-                    fh.write(ip + "\t" + host + "\n")
+                    if cnames:
+                        fh.write(ip + "\t" + host + ' ' + cnames + "\n")
+                    else:
+                        fh.write(ip + "\t" + host + "\n")
         fh.close()
 
     def restart_service(self):


### PR DESCRIPTION
## Linked Items

Fixes Support for cnames for dnsmasq https://github.com/cobbler/cobbler/issues/1643

## Description

for the release33 syntax this time, update function regen_hosts() in cobbler/modules/managers/dnsmasq.py
to add cnames to /var/lib/cobbler/cobbler_hosts

## Behaviour changes

cobbler append the cnames after the dns_name in /var/lib/cobbler/cobbler_hosts

## Category

This is related to a:

- [ ] Bugfix
- [x ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

