### PR TITLE
Change `--bootproto=none` to `--no-activate` for unconfigured static …

### DIFF
--- a/autoinstall_snippets/network_config
+++ b/autoinstall_snippets/network_config
@@ -61,7 +61,7 @@
                             #set $network_str = $network_str + " --nameserver=" + $name_servers[0]
                         #end if
                     #else
-                        #set $network_str = "--bootproto=none"
+                        #set $network_str = "--no-activate"
                     #end if
                 #else
                     #set $network_str = "--bootproto=dhcp"

--- a/changelog.d/3651.fixed
+++ b/changelog.d/3651.fixed
@@ -1,0 +1,1 @@
+Change `--bootproto=none` to `--no-activate` for unconfigured static interfaces


### PR DESCRIPTION
…interfaces

## Linked Items

Fixes #3651 


## Description

Change `--bootproto=none` to `--no-activate` for unconfigured static interfaces

## Behaviour changes

Old: Would trigger an anaconda error

New: anaconda should not configure the interface

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
