### PR TITLE
Backport autoinstall snippet fixes

### DIFF
--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -85,6 +85,6 @@
         #end if
     #end if
 #end if
+#echo $nopxe
 #echo $save_autoinstall
 #echo $runpost
-#echo $nopxe

--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -14,14 +14,14 @@
 #set os_version = $getVar('os_version','')
 #set srv = $getVar('http_server','')
 #set autoinstall = $getVar('autoinstall','')
-#set run_install_triggers = $str($getVar('run_install_triggers',''))
-#set pxe_just_once = $str($getVar('pxe_just_once',''))
+#set run_install_triggers = $getVar('run_install_triggers','')
+#set pxe_just_once = $getVar('pxe_just_once','')
 #set nopxe = ""
 #set save_autoinstall = ""
 #set runpost = ""
 #if $system_name != ''
     ## PXE JUST ONCE
-    #if $pxe_just_once == "True"
+    #if $pxe_just_once
         #if $breed == 'redhat'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
@@ -47,7 +47,7 @@
         #end if
     #end if
     ## RUN POST TRIGGER
-    #if $run_install_triggers == "True"
+    #if $run_install_triggers
         #if $breed == 'redhat'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'

--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -14,17 +14,10 @@
     #if $pxe_just_once == "True"
         #if $breed == 'redhat'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
-        #else if $breed == 'suse'
-            #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
-        #else if $breed == 'vmware'
-            #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
-        #else if $breed == 'debian' or $breed == 'ubuntu'
-            #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
         #else
-            ## default to wget
-            #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null;" % (srv, system_name)
+            #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
         #end if
     #end if
     ## SAVE AUTO INSTALLATION
@@ -45,13 +38,9 @@
     #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
-        #else if $breed == 'suse'
-            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
-        #else if $breed == 'vmware'
-            #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "system", system_name)
-        #else if $breed == 'debian' or $breed == 'ubuntu'
+        #else
             #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #end if
     #end if
@@ -74,13 +63,9 @@
     #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else if $breed == 'suse'
-            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else if $breed == 'vmware'
-            #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
-        #else if $breed == 'debian' or $breed == 'ubuntu'
+        #else
             #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
         #end if
     #end if

--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -11,7 +11,7 @@
 #set runpost = ""
 #if $system_name != ''
     ## PXE JUST ONCE
-    #if $pxe_just_once in [ "1", "true", "yes", "y" ]
+    #if $pxe_just_once == "True"
         #if $breed == 'redhat'
             #set nopxe = "\ncurl \"http://%s/cblr/svc/op/nopxe/system/%s\" -o /dev/null" % (srv, system_name)
         #else if $breed == 'suse'
@@ -42,7 +42,7 @@
         #end if
     #end if
     ## RUN POST TRIGGER
-    #if $run_install_triggers in [ "1", "true", "yes", "y" ]
+    #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
         #else if $breed == 'suse'
@@ -71,7 +71,7 @@
         #end if
     #end if
     ## RUN POST TRIGGER
-    #if $run_install_triggers in [ "1", "true", "yes", "y" ]
+    #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
         #else if $breed == 'suse'

--- a/autoinstall_snippets/autoinstall_done
+++ b/autoinstall_snippets/autoinstall_done
@@ -1,5 +1,15 @@
 #set system_name = $getVar('system_name','')
 #set profile_name = $getVar('profile_name','')
+#if $system_name != ''
+    #set object_type = 'system'
+    #set object_name = $system_name
+#else if $profile_name != ''
+    #set object_type = 'profile'
+    #set object_name = $profile_name
+#else
+    #set object_type = ''
+    #set object_name = ''
+#end if
 #set breed = $getVar('breed','')
 #set os_version = $getVar('os_version','')
 #set srv = $getVar('http_server','')
@@ -20,53 +30,30 @@
             #set nopxe = "\nwget \"http://%s/cblr/svc/op/nopxe/system/%s\" -O /dev/null" % (srv, system_name)
         #end if
     #end if
+#end if
+#if $object_type != ''
     ## SAVE AUTO INSTALLATION
     #if $autoinstall != ''
         #if $breed == 'redhat'
-            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.ks" % (srv, "system", system_name)
+            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.ks" % (srv, object_type, object_name)
         #else if $breed == 'suse'
-            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.xml" % (srv, "system", system_name)
+            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.xml" % (srv, object_type, object_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
-            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.ks" % (srv, "system", system_name)
+            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.ks" % (srv, object_type, object_name)
         #else if $breed == 'vmware'
-            #set save_autoinstall = "\nwget \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -O /var/log/cobbler.ks" % (srv, "system", system_name)
+            #set save_autoinstall = "\nwget \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -O /var/log/cobbler.ks" % (srv, object_type, object_name)
         #else if $breed == 'debian' or $breed == 'ubuntu'
-            #set save_autoinstall = "\nwget \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -O /var/log/cobbler.seed" % (srv, "system", system_name)
+            #set save_autoinstall = "\nwget \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -O /var/log/cobbler.seed" % (srv, object_type, object_name)
         #end if
     #end if
     ## RUN POST TRIGGER
     #if $run_install_triggers == "True"
         #if $breed == 'redhat'
-            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
+            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else if $breed == 'vmware' and $os_version == 'esx4'
-            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "system", system_name)
+            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else
-            #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "system", system_name)
-        #end if
-    #end if
-#else if $profile_name != ''
-    ## SAVE KICKSTART
-    #if $autoinstall != ''
-        #if $breed == 'redhat'
-            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.ks" % (srv, "profile", profile_name)
-        #else if $breed == 'suse'
-            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.xml" % (srv, "profile", profile_name)
-        #else if $breed == 'vmware' and $os_version == 'esx4'
-            #set save_autoinstall = "\ncurl \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -o /root/cobbler.ks" % (srv, "profile", profile_name)
-        #else if $breed == 'vmware'
-            #set save_autoinstall = "\nwget \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -O /var/log/cobbler.ks" % (srv, "profile", profile_name)
-        #else if $breed == 'debian' or $breed == 'ubuntu'
-            #set save_autoinstall = "\nwget \"http://%s/cblr/svc/op/autoinstall/%s/%s\" -O /var/log/cobbler.seed" % (srv, "profile", profile_name)
-        #end if
-    #end if
-    ## RUN POST TRIGGER
-    #if $run_install_triggers == "True"
-        #if $breed == 'redhat'
-            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else if $breed == 'vmware' and $os_version == 'esx4'
-            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else
-            #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
+            #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/post/%s/%s\" -O /dev/null" % (srv, object_type, object_name)
         #end if
     #end if
 #end if

--- a/autoinstall_snippets/autoinstall_start
+++ b/autoinstall_snippets/autoinstall_start
@@ -12,11 +12,11 @@
 #end if
 #set breed = $getVar('breed','')
 #set srv = $getVar('http_server','')
-#set run_install_triggers = $str($getVar('run_install_triggers',''))
+#set run_install_triggers = $getVar('run_install_triggers','')
 #set runpre = ""
 #if $object_type != ''
     ## RUN PRE TRIGGER
-    #if $run_install_triggers == "True"
+    #if $run_install_triggers
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else

--- a/autoinstall_snippets/autoinstall_start
+++ b/autoinstall_snippets/autoinstall_start
@@ -1,25 +1,26 @@
 #set system_name = $getVar('system_name','')
 #set profile_name = $getVar('profile_name','')
+#if $system_name != ''
+    #set object_type = 'system'
+    #set object_name = $system_name
+#else if $profile_name != ''
+    #set object_type = 'profile'
+    #set object_name = $profile_name
+#else
+    #set object_type = ''
+    #set object_name = ''
+#end if
 #set breed = $getVar('breed','')
 #set srv = $getVar('http_server','')
 #set run_install_triggers = $str($getVar('run_install_triggers',''))
 #set runpre = ""
-#if $system_name != ''
+#if $object_type != ''
     ## RUN PRE TRIGGER
     #if $run_install_triggers == "True"
         #if $breed == 'redhat'
-            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "system", system_name)
+            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
         #else
-            #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
-        #end if
-    #end if
-#else if $profile_name != ''
-    ## RUN PRE TRIGGER
-    #if $run_install_triggers == "True"
-        #if $breed == 'redhat'
-            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else
-            #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
+            #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, object_type, object_name)
         #end if
     #end if
 #end if

--- a/autoinstall_snippets/autoinstall_start
+++ b/autoinstall_snippets/autoinstall_start
@@ -9,11 +9,7 @@
     #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "system", system_name)
-        #else if $breed == 'suse'
-            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "system", system_name)
-        #else if $breed == 'vmware'
-            #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
-        #else if $breed == 'debian' or $breed == 'ubuntu'
+        #else
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "system", system_name)
         #end if
     #end if
@@ -22,9 +18,7 @@
     #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else if $breed == 'suse'
-            #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
-        #else if $breed == 'vmware'
+        #else
             #set runpre = "\nwget \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -O /dev/null" % (srv, "profile", profile_name)
         #end if
     #end if

--- a/autoinstall_snippets/autoinstall_start
+++ b/autoinstall_snippets/autoinstall_start
@@ -6,7 +6,7 @@
 #set runpre = ""
 #if $system_name != ''
     ## RUN PRE TRIGGER
-    #if $run_install_triggers in [ "1", "true", "yes", "y" ]
+    #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "system", system_name)
         #else if $breed == 'suse'
@@ -19,7 +19,7 @@
     #end if
 #else if $profile_name != ''
     ## RUN PRE TRIGGER
-    #if $run_install_triggers in [ "1", "true", "yes", "y" ]
+    #if $run_install_triggers == "True"
         #if $breed == 'redhat'
             #set runpre = "\ncurl \"http://%s/cblr/svc/op/trig/mode/pre/%s/%s\" -o /dev/null" % (srv, "profile", profile_name)
         #else if $breed == 'suse'


### PR DESCRIPTION
## Linked Items

Fixes #2783 
# Description
While fixed in 3.3, this was never backported to 3.2.
## Behaviour changes

Old: pxe_just_once and post triggers not executed

New: pxe_just_once and post triggers executed

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
