### PR TITLE
Accept InfiniBand MAC addresses

### DIFF
--- a/changelog.d/3660.fixed
+++ b/changelog.d/3660.fixed
@@ -1,0 +1,1 @@
+Accept InfiniBand MAC address in interfaces

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -31,6 +31,9 @@ RE_URL = re.compile(
     r"^[a-zA-Z\d-]{,63}(\.[a-zA-Z\d-]{,63})*$"
 )  # https://stackoverflow.com/a/2894918
 RE_SCRIPT_NAME = re.compile(r"[a-zA-Z0-9_\-.]+")
+RE_INFINIBAND_MAC = re.compile(
+    "^" + ":".join(["([0-9A-F]{1,2})"] * 20) + "$", re.IGNORECASE
+)
 
 # blacklist invalid values to the repo statement in autoinsts
 AUTOINSTALL_REPO_BLACKLIST = ["enabled", "gpgcheck", "gpgkey"]
@@ -85,7 +88,7 @@ def mac_address(mac: str, for_item: bool = True) -> str:
         if mac == "":
             return mac
 
-    if not netaddr.valid_mac(mac):  # type: ignore
+    if not netaddr.valid_mac(mac) and RE_INFINIBAND_MAC.match(mac) is None:  # type: ignore
         raise ValueError(f"Invalid mac address format ({mac})")
 
     return mac

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -234,6 +234,11 @@ def test_dns_name(
         ("AA:BB", "", pytest.raises(ValueError)),
         (0, "", pytest.raises(TypeError)),
         ("random", "AA:BB:CC:DD:EE:FF", does_not_raise()),
+        (
+            "80:00:0a:43:fe:80:00:00:00:00:00:00:0e:fa:aa:bb:cc:dd:ee:ff",
+            "80:00:0a:43:fe:80:00:00:00:00:00:00:0e:fa:aa:bb:cc:dd:ee:ff",
+            does_not_raise(),
+        ),
         ("AA:AA:AA:AA:AA:AA", "", pytest.raises(ValueError)),
     ],
 )


### PR DESCRIPTION
## Linked Items

Fixes #3660 

## Description

Accepts InfiniBand MAC addresses

## Behaviour changes

Old: cobbler would reject InfiniBand MAC addresses

New: cobbler accepts InfiniBand MAC addresses

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were extended
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
