### PR TITLE
buildiso: Introduce exclude-systems CLI option and distro autodetection

### DIFF
--- a/changelog.d/3665.added
+++ b/changelog.d/3665.added
@@ -1,0 +1,1 @@
+buildiso: make distro option optional and add exclude-systems option

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -515,7 +515,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         return str(self.distctr)
 
     def _generate_boot_loader_configs(
-        self, profiles: List[Profile], systems: List[System], exclude_dns: bool
+        self, profiles: List["Profile"], systems: List["System"], exclude_dns: bool
     ) -> LoaderCfgsParts:
         """Generate boot loader configuration.
 
@@ -535,7 +535,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         return loader_config_parts
 
     def _generate_profiles_loader_configs(
-        self, profiles: List[Profile], loader_cfg_parts: LoaderCfgsParts
+        self, profiles: List["Profile"], loader_cfg_parts: LoaderCfgsParts
     ) -> None:
         """Generate isolinux configuration for profiles.
 
@@ -598,7 +598,7 @@ class NetbootBuildiso(buildiso.BuildIso):
 
     def _generate_systems_loader_configs(
         self,
-        systems: List[System],
+        systems: List["System"],
         exclude_dns: bool,
         loader_cfg_parts: LoaderCfgsParts,
     ) -> None:
@@ -675,7 +675,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         buildisodir: str = "",
         profiles: Optional[List[str]] = None,
         xorrisofs_opts: str = "",
-        distro_name: str = "",
+        distro_name: Optional[str] = None,
         systems: Optional[List[str]] = None,
         exclude_dns: bool = False,
         esp: Optional[str] = None,
@@ -713,9 +713,9 @@ class NetbootBuildiso(buildiso.BuildIso):
         if distro_name:
             distro_obj = self.parse_distro(distro_name)
         elif len(profile_list) > 0:
-            distro_obj = profile_list[0].get_conceptual_parent()
+            distro_obj = profile_list[0].get_conceptual_parent()  # type: ignore[reportGeneralTypeIssues]
         elif len(system_list) > 0:
-            distro_obj = system_list[0].get_conceptual_parent()
+            distro_obj = system_list[0].get_conceptual_parent()  # type: ignore[reportGeneralTypeIssues]
 
         if distro_obj is None:
             raise ValueError("Unable to find suitable distro and none set by caller")

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2155,7 +2155,7 @@ class CobblerAPI:
         profiles: Optional[List[str]] = None,
         systems: Optional[List[str]] = None,
         buildisodir: str = "",
-        distro_name: str = "",
+        distro_name: Optional[str] = None,
         standalone: bool = False,
         airgapped: bool = False,
         source: str = "",

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2160,6 +2160,7 @@ class CobblerAPI:
         airgapped: bool = False,
         source: str = "",
         exclude_dns: bool = False,
+        exclude_systems: bool = False,
         xorrisofs_opts: str = "",
         esp: Optional[str] = None,
     ) -> None:
@@ -2176,6 +2177,7 @@ class CobblerAPI:
         :param airgapped: This option implies ``standalone=True``.
         :param source: If the iso should be offline available this is the path to the sources of the image.
         :param exclude_dns: Whether the repositories have to be locally available or the internet is reachable.
+        :param exclude_systems: Whether system entries should be skipped or generated.
         :param xorrisofs_opts: ``xorrisofs`` options to include additionally.
         :param esp: location of the ESP partition, e.g. for secure boot.
         """
@@ -2199,6 +2201,7 @@ class CobblerAPI:
             systems=systems,
             exclude_dns=exclude_dns,
             esp=esp,
+            exclude_systems=exclude_systems,
         )
 
     # ==========================================================================

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2171,8 +2171,7 @@ class CobblerAPI:
         :param profiles: Use these profiles only
         :param systems: Use these systems only
         :param buildisodir: This overwrites the directory from the settings in which the iso is built in.
-        :param distro_name: Used with ``--standalone`` and ``--airgapped`` to create a distro-based ISO including all
-                       associated.
+        :param distro_name: Use this distro architecture. If not used, autodetected from profiles or systems.
         :param standalone: This means that no network connection is needed to install the generated iso.
         :param airgapped: This option implies ``standalone=True``.
         :param source: If the iso should be offline available this is the path to the sources of the image.

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -2175,6 +2175,12 @@ class CobblerCLI:
                 help="(OPTIONAL) prevents addition of name server addresses to the kernel boot options",
             )
             self.parser.add_option(
+                "--exclude-systems",
+                dest="exclude_systems",
+                action="store_true",
+                help="(OPTIONAL) prevents writing system records",
+            )
+            self.parser.add_option(
                 "--mkisofs-opts",
                 dest="mkisofs_opts",
                 help="(OPTIONAL) extra options for xorrisofs",

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -237,6 +237,7 @@ class CobblerXMLRPCInterface:
                 self.options.get("airgapped", False),
                 self.options.get("source", ""),
                 self.options.get("exclude_dns", False),
+                self.options.get("exclude_systems", False),
                 self.options.get("xorrisofs_opts", ""),
                 self.options.get("esp", None),
             )

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -232,7 +232,7 @@ class CobblerXMLRPCInterface:
                 self.options.get("profiles", None),
                 self.options.get("systems", None),
                 self.options.get("buildisodir", ""),
-                self.options.get("distro", ""),
+                self.options.get("distro", None),
                 self.options.get("standalone", False),
                 self.options.get("airgapped", False),
                 self.options.get("source", ""),

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -169,21 +169,20 @@ def test_netboot_generate_boot_loader_configs(
     assert len(matching_grub_system_kopts) == 1
     assert len(matching_isolinux_system_kopts) == 1
 
+
 def test_netboot_generate_boot_loader_config_for_profile_only(
     cobbler_api, create_distro, create_profile, create_system
 ):
     test_distro = create_distro()
-    test_distro.kernel_options = 'test_distro_option=distro'
+    test_distro.kernel_options = "test_distro_option=distro"
     test_profile = create_profile(test_distro.name)
-    test_profile.kernel_options = 'test_profile_option=profile'
+    test_profile.kernel_options = "test_profile_option=profile"
     test_system = create_system(test_profile.name)
-    test_system.kernel_options = 'test_system_option=system'
+    test_system.kernel_options = "test_system_option=system"
     build_iso = NetbootBuildiso(cobbler_api)
 
     # Act
-    result = build_iso._generate_boot_loader_configs(
-        [test_profile], [], True
-    )
+    result = build_iso._generate_boot_loader_configs([test_profile], [], True)
     matching_isolinux_kernel = [
         part for part in result.isolinux if "KERNEL /1.krn" in part
     ]
@@ -222,7 +221,7 @@ def test_netboot_generate_boot_loader_config_for_profile_only(
         matching_grub_distro_kopts,
         matching_grub_profile_kopts,
         matching_isolinux_distro_kopts,
-        matching_isolinux_profile_kopts
+        matching_isolinux_profile_kopts,
     ]:
         print(iterable_to_check)
         # one entry for the profile, and none for the system
@@ -231,6 +230,7 @@ def test_netboot_generate_boot_loader_config_for_profile_only(
     # there are no system entries
     assert len(matching_grub_system_kopts) == 0
     assert len(matching_isolinux_system_kopts) == 0
+
 
 def test_filter_system(
     cobbler_api: CobblerAPI,

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -119,7 +119,7 @@ def test_netboot_generate_boot_loader_configs(
 
     # Act
     result = build_iso._generate_boot_loader_configs(  # type: ignore[reportPrivateUsage]
-        [test_profile.name], [test_system.name], True
+        [test_profile], [test_system], True
     )
     matching_isolinux_kernel = [
         part for part in result.isolinux if "KERNEL /1.krn" in part
@@ -171,18 +171,21 @@ def test_netboot_generate_boot_loader_configs(
 
 
 def test_netboot_generate_boot_loader_config_for_profile_only(
-    cobbler_api, create_distro, create_profile, create_system
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str], System],
 ):
     test_distro = create_distro()
-    test_distro.kernel_options = "test_distro_option=distro"
+    test_distro.kernel_options = "test_distro_option=distro"  # type: ignore
     test_profile = create_profile(test_distro.name)
-    test_profile.kernel_options = "test_profile_option=profile"
+    test_profile.kernel_options = "test_profile_option=profile"  # type: ignore
     test_system = create_system(test_profile.name)
-    test_system.kernel_options = "test_system_option=system"
+    test_system.kernel_options = "test_system_option=system"  # type: ignore
     build_iso = NetbootBuildiso(cobbler_api)
 
     # Act
-    result = build_iso._generate_boot_loader_configs([test_profile], [], True)
+    result = build_iso._generate_boot_loader_configs([test_profile], [], True)  # type: ignore[reportPrivateUsage]
     matching_isolinux_kernel = [
         part for part in result.isolinux if "KERNEL /1.krn" in part
     ]
@@ -279,10 +282,12 @@ def test_filter_profile(
 def test_netboot_run(
     cobbler_api: CobblerAPI,
     create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
     tmpdir: Any,
 ):
     # Arrange
     test_distro = create_distro()
+    create_profile(test_distro.name)
     build_iso = NetbootBuildiso(cobbler_api)
     iso_location = tmpdir.join("autoinst.iso")
 
@@ -293,16 +298,15 @@ def test_netboot_run(
     assert iso_location.exists()
 
 
-def test_netboot_run_nodistro(
-    cobbler_api,
-    create_distro,
-    create_profile,
-    create_loaders,
-    tmpdir,
+def test_netboot_run_autodetect_distro(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    tmpdir: Any,
 ):
     # Arrange
     test_distro = create_distro()
-    test_profile = create_profile(test_distro.name)
+    create_profile(test_distro.name)
     build_iso = NetbootBuildiso(cobbler_api)
     iso_location = tmpdir.join("autoinst.iso")
 
@@ -329,6 +333,27 @@ def test_standalone_run(
     build_iso.run(
         iso=str(iso_location), distro_name=test_distro.name, source=str(iso_source)
     )
+
+    # Assert
+    assert iso_location.exists()
+
+
+def test_standalone_run_autodetect_distro(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    tmpdir_factory: pytest.TempPathFactory,
+):
+    # Arrange
+    iso_directory = tmpdir_factory.mktemp("isodir")
+    iso_source = tmpdir_factory.mktemp("isosource")
+    iso_location: Any = iso_directory.join("autoinst.iso")  # type: ignore
+    test_distro = create_distro()
+    create_profile(test_distro.name)
+    build_iso = StandaloneBuildiso(cobbler_api)
+
+    # Act
+    build_iso.run(iso=str(iso_location), source=str(iso_source))
 
     # Assert
     assert iso_location.exists()


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This commit makes --distro option optional, if not provided first profile or first system is used to get the distro automatically.

This commit introduces --exclude-systems option. This instructs buildiso to not write any system records entries to the isolinux/grub config. Useful particularly when only profile entries are requested.

## Behaviour changes

Old: `buildiso --distro` is mandatory option. There is no way to export config only for specific profiles if systems exists too.

New: `--distro` is optional, determined from first profile or system if not set. Use `--exclude-systems` to export configuration only for provided profiles.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
