### PR TITLE
python3-yaml missing in Build-Depends

### DIFF
--- a/changelog.d/3668.fixed
+++ b/changelog.d/3668.fixed
@@ -1,0 +1,1 @@
+Added python3-yaml to debian build-dependencies to fix unittests.

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Build-Depends:
  python3-cheetah,
  python3-dns,
  python3-sphinx,
+ python3-yaml,
  dh-python,
  debhelper (>=12)
 Standards-Version: 4.5.1


### PR DESCRIPTION
Added missing build dependency, python3-yaml is needed for unittests.

## Linked Items

Fixes #3668 

## Description

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [X] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous
