### PR TITLE
Add EFI chainloader for SLE-Micro

### DIFF
--- a/changelog.d/3675.added
+++ b/changelog.d/3675.added
@@ -1,0 +1,1 @@
+Add EFI chainloader for SLE-Micro

--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -2,6 +2,8 @@ menuentry "local" --class gnu-linux --class gnu --class os {
   if search --no-floppy --file /efi/boot/fallback.efi --set ; then
     if [ -f /efi/opensuse/shim.efi ] ; then
       chainloader /efi/opensuse/grub.efi
+    elif [ -f /efi/sle/shim.efi ] ; then
+      chainloader /efi/sle/grub.efi
     elif [ -f /efi/sles/shim.efi ] ; then
       chainloader /efi/sles/grub.efi
     elif [ -f /efi/redhat/grub.efi ]; then
@@ -19,6 +21,8 @@ menuentry "local" --class gnu-linux --class gnu --class os {
     search -s root -n -f /efi/boot/bootx64.efi
     if [ -f (${root})/efi/opensuse/grub.efi ] ; then
       chainloader (${root})/efi/opensuse/grub.efi
+    elif [ -f (${root})/efi/sle/grub.efi ] ; then
+      chainloader (${root})/efi/sle/grub.efi
     elif [ -f (${root})/efi/sles/grub.efi ] ; then
       chainloader (${root})/efi/sles/grub.efi
     elif [ -f (${root})/efi/grub/grub.efi ] ; then


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Add support of SLE-Micro to the chainload file

## Behaviour changes

Old: a node booting PXE with SLE-Micro was unable to boot correctly

New: a node booting PXE with SLE-Micro can boot correctly

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
