### PR TITLE
Add background_load_items

### DIFF
--- a/changelog.d/3677.added
+++ b/changelog.d/3677.added
@@ -1,0 +1,1 @@
+Add background_load_items

--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -87,6 +87,8 @@ def do_xmlrpc_rw(cobbler_api: CobblerAPI, port: int) -> None:
     while True:
         try:
             logger.info("Cobbler startup completed %s", start_time)
+            # Start background load_items task
+            xinterface.proxied.background_load_items()
             server.serve_forever()
         except IOError:
             # interrupted? try to serve again

--- a/tests/xmlrpcapi/background_test.py
+++ b/tests/xmlrpcapi/background_test.py
@@ -68,3 +68,12 @@ class TestBackground:
 
         # Assert
         assert result
+
+    def test_background_load_items(self, remote):
+        # Arrange
+
+        # Act
+        result = remote.background_load_items()
+
+        # Assert
+        assert result


### PR DESCRIPTION
## Linked Items

Fixes #3676 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Adds a background task to load collection items into memory immediately after lazy start.

## Behaviour changes

Old: Collection items were loaded into memory only the first time they were accessed.

New: Collection items are loaded into memory by a background task or when they are accessed for the first time if the background task has not yet loaded them.

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
