### PR TITLE
Backport 3.3: Add compatibility with the file binary version below 5.37

### DIFF
--- a/changelog.d/3680.added
+++ b/changelog.d/3680.added
@@ -1,0 +1,1 @@
+Add compatibility with the file binary version below 5.37

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -19,7 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 
-from typing import Dict, List, Callable, Any, Optional
+from typing import Dict, List, Callable, Any, Optional, Tuple
 
 import glob
 import gzip
@@ -126,7 +126,11 @@ class _ImportSignatureManager(ManagerModule):
                     return f.readlines()
             except:
                 pass
-        if ftype.mime_type == "application/x-ms-wim":
+        if (
+            ftype.mime_type == "application/x-ms-wim"
+            or self.file_version < (5, 37)
+            and filename.lower().endswith(".wim")
+        ):
             cmd = "/usr/bin/wiminfo"
             if os.path.exists(cmd):
                 cmd = "%s %s" % (cmd, filename)
@@ -142,6 +146,30 @@ class _ImportSignatureManager(ManagerModule):
                 ftype.mime_type, filename,
             )
         return []
+
+    def get_file_version(self) -> Tuple[int, int]:
+        """
+        This calls file and asks for the version number.
+
+        :return: The major file version number.
+        """
+        cmd = "/usr/bin/file"
+        if os.path.exists(cmd):
+            cmd = f"{cmd} -v"
+            version_list = utils.subprocess_get(cmd).splitlines()
+            if len(version_list) < 1:
+                return (0, 0)
+            version_list = version_list[0].split("-")
+            if len(version_list) != 2 or version_list[0] != "file":
+                return (0, 0)
+            version_list = version_list[1].split(".")
+            if len(version_list) < 2:
+                return (0, 0)
+            version: List[int] = []
+            for v in version_list:
+                version.append(int(v))
+            return (version[0], version[1])
+        return (0, 0)
 
     def run(self, path: str, name: str, network_root=None, autoinstall_file=None, arch: Optional[str] = None,
             breed=None, os_version=None):
@@ -163,6 +191,7 @@ class _ImportSignatureManager(ManagerModule):
         self.arch = arch
         self.breed = breed
         self.os_version = os_version
+        self.file_version: Tuple[int, int] = self.get_file_version()
 
         self.path = path
         self.rootdir = path
@@ -195,78 +224,11 @@ class _ImportSignatureManager(ManagerModule):
 
         # now walk the filesystem looking for distributions that match certain patterns
         self.logger.info("Adding distros from path %s:", self.path)
+        if self.breed == "windows":
+            self.import_winpe()
+
         distros_added = []
         import_walker(self.path, self.distro_adder, distros_added)
-
-        if len(distros_added) == 0:
-            if self.breed == "windows":
-                cmd_path = "/usr/bin/wimexport"
-                bootwim_path = os.path.join(self.path, "sources", "boot.wim")
-                dest_path = os.path.join(self.path, "boot")
-                if os.path.exists(cmd_path) and os.path.exists(bootwim_path):
-                    winpe_path = os.path.join(dest_path, "winpe.wim")
-                    if not os.path.exists(dest_path):
-                        utils.mkdir(dest_path)
-                    rc = utils.subprocess_call([cmd_path, bootwim_path, "1",
-                                               winpe_path, "--boot"], shell=False)
-                    if rc == 0:
-                        cmd = ["/usr/bin/wimdir %s 1 | /usr/bin/grep -i '^/Windows/Boot/PXE$'" % winpe_path]
-                        pxe_path = utils.subprocess_get(cmd, shell=True)[0:-1]
-                        cmd = ["/usr/bin/wimdir %s 1 | /usr/bin/grep -i '^/Windows/System32/config/SOFTWARE$'"
-                               % winpe_path]
-                        config_path = utils.subprocess_get(cmd, shell=True)[0:-1]
-                        cmd_path = "/usr/bin/wimextract"
-                        rc = utils.subprocess_call([cmd_path, bootwim_path, "1",
-                                                    "%s/pxeboot.n12" % pxe_path,
-                                                    "%s/bootmgr.exe" % pxe_path,
-                                                    config_path,
-                                                    "--dest-dir=%s" % dest_path,
-                                                    "--no-acls", "--no-attributes"], shell=False)
-                        if rc == 0:
-                            if HAS_HIVEX:
-                                software = os.path.join(dest_path, os.path.basename(config_path))
-                                h = hivex.Hivex(software, write=True)
-                                root = h.root()
-                                nodes: List[Any] = [root]
-                                pat = "X:\\$windows.~bt"
-
-                                while len(nodes) > 0:
-                                    n = nodes.pop()
-                                    nodes.extend(h.node_children(n))
-
-                                    new_values = []
-                                    update_flag = False
-                                    key_vals = h.node_values(n)
-                                    for key_val in key_vals:
-                                        key = h.value_key(key_val)
-                                        val = h.node_get_value(n, key)
-                                        val_type, val_value = h.value_value(val)
-                                        if pat in key:
-                                            key = key.replace(pat, "X:")
-                                            update_flag = True
-                                        if val_type in (REG_SZ, REG_EXPAND_SZ):
-                                            val_string = h.value_string(val)
-                                            if pat in val_string:
-                                                val_string = val_string.replace(pat, "X:")
-                                                val_value = (val_string + "\0").encode(encoding="utf-16le")
-                                                update_flag = True
-                                        new_val = {"key": key, "t": val_type, "value": val_value,}
-                                        new_values.append(new_val)
-
-                                    if update_flag:
-                                        h.node_set_values(n, new_values)
-                                h.commit(software)
-
-                                cmd_path = "/usr/bin/wimupdate"
-                                rc = utils.subprocess_call([cmd_path, winpe_path, "--command=add %s %s"
-                                                           % (software, config_path)], shell=False)
-                                os.remove(software)
-                            else:
-                                self.logger.info(
-                                    "python3-hivex not found. If you need Automatic Windows "
-                                    "Installation support, please install."
-                                )
-                            import_walker(self.path, self.distro_adder, distros_added)
 
         if len(distros_added) == 0:
             self.logger.warning("No distros imported, bailing out")
@@ -394,6 +356,8 @@ class _ImportSignatureManager(ManagerModule):
                     kernel = os.path.join(dirname, x)
                 else:
                     pae_kernel = os.path.join(dirname, x)
+            elif self.breed == "windows" and "wimboot" in self.signature["kernel_file"]:
+                kernel = os.path.join(self.settings.tftpboot_location, "wimboot")
 
             # if we've collected a matching kernel and initrd pair, turn them in and add them to the list
             if initrd is not None and kernel is not None:
@@ -504,21 +468,30 @@ class _ImportSignatureManager(ManagerModule):
             else:
                 new_profile.virt_type = enums.VirtType.KVM
 
-            if self.breed == "windows":
+            if self.breed == "windows":  # type: ignore
                 dest_path = os.path.join(self.path, "boot")
                 kernel_path = f"http://@@http_server@@/images/{name}/wimboot"
                 if new_distro.os_version in ("xp", "2003"):
                     kernel_path = "pxeboot.0"
-                bootmgr_path = os.path.join(dest_path, "bootmgr.exe")
+                bootmgr = "bootmgr.exe"
+                if "wimboot" in kernel:
+                    bootmgr = "bootmgr.efi"
+                bootmgr_path = os.path.join(dest_path, bootmgr)
                 bcd_path = os.path.join(dest_path, "bcd")
                 winpe_path = os.path.join(dest_path, "winpe.wim")
-                if os.path.exists(bootmgr_path) and os.path.exists(bcd_path) and os.path.exists(winpe_path):
-                    new_profile.autoinstall_meta = {"kernel": kernel_path,
-                                                    "bootmgr": "bootmgr.exe",
-                                                    "bcd": "bcd",
-                                                    "winpe": "winpe.wim",
-                                                    "answerfile": "autounattended.xml",
-                                                    "post_install_script": "post_install.cmd"}
+                if (
+                    os.path.exists(bootmgr_path)
+                    and os.path.exists(bcd_path)
+                    and os.path.exists(winpe_path)
+                ):
+                    new_profile.autoinstall_meta = {
+                        "kernel": kernel_path,
+                        "bootmgr": bootmgr,
+                        "bcd": "bcd",
+                        "winpe": "winpe.wim",
+                        "answerfile": "autounattended.xml",
+                        "post_install_script": "post_install.cmd",
+                    }
 
             self.api.add_profile(new_profile, save=True)
 
@@ -913,6 +886,200 @@ class _ImportSignatureManager(ManagerModule):
         :param distribution: Not used currently.
         """
         return
+
+    # ==========================================================================
+    # windows-specific
+
+    def import_winpe(self) -> None:
+        """
+        Preparing a Windows distro for network boot.
+        """
+        winpe_path = self.extract_winpe(self.path)
+
+        # For Windows, file paths are case-insensitive within a WinPE image, but for wimlib-utils
+        # they are not. And wimlib-utils does not provide options for case-insensitive search
+        # and extraction of files from this image other than setting the WIMLIB_IMAGEX_IGNORE_CASE
+        # environment variable.
+        wimdir_result = utils.subprocess_get(
+            ["/usr/bin/wimdir", winpe_path, "1"], shell=False
+        )
+        wim_file_list = wimdir_result.split("\n")
+        file_dict = {
+            "/windows/boot/pxe/pxeboot.n12": "",
+            "/windows/boot/pxe/bootmgr.exe": "",
+            "/windows/boot/efi/bootmgr.efi": "",
+            "/windows/system32/config/software": "",
+        }
+        for wim_file in wim_file_list:
+            if wim_file.lower() in file_dict:
+                file_dict[wim_file.lower()] = wim_file
+
+        file_list = [
+            file_dict["/windows/boot/efi/bootmgr.efi"],
+            file_dict["/windows/system32/config/software"],
+        ]
+        if "wimboot" not in self.signature["kernel_file"]:
+            file_list.extend(
+                [
+                    file_dict["/windows/boot/pxe/pxeboot.n12"],
+                    file_dict["/windows/boot/pxe/bootmgr.exe"],
+                ]
+            )
+
+        self.extract_files_from_wim(winpe_path, file_list)
+        self.update_winpe(winpe_path, file_dict["/windows/system32/config/software"])
+
+    def extract_winpe(self, distro_path: str) -> str:
+        """
+        Extracting winpe.wim from boot.win.
+
+        :param distro_path: The directory where the Windows distro is located.
+        :return: The path to the extracted WinPE image.
+        :raises CX
+        """
+        bootwim_path = os.path.join(distro_path, "sources", "boot.wim")
+        dest_path = os.path.join(distro_path, "boot")
+
+        if not os.path.exists(bootwim_path):
+            error_msg = f"{bootwim_path} not found!"
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        winpe_path = os.path.join(dest_path, "winpe.wim")
+        if not os.path.exists(dest_path):
+            utils.mkdir(dest_path)
+        if os.path.exists(winpe_path):
+            utils.rmfile(winpe_path)
+        if (
+            utils.subprocess_call(
+                ["/usr/bin/wimexport", bootwim_path, "1", winpe_path, "--boot"],
+                shell=False,
+            )
+            != 0
+        ):
+            error_msg = f"Cannot extract {winpe_path} from {bootwim_path}!"
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        return winpe_path
+
+    def update_winpe(self, winpe_path: str, win_registry: str) -> None:
+        """
+        Update WinPE image for network boot.
+
+        :param winpe_path: The path to WinPE image.
+        :param win_registry: The path to the Windows registry in the WinPE image.
+        :raises CX
+        """
+        if not HAS_HIVEX:
+            error_msg = (
+                "python3-hivex not found. If you need Automatic Windows "
+                "Installation support, please install."
+            )
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        software = os.path.join(
+            os.path.dirname(winpe_path), os.path.basename(win_registry).lower()
+        )
+        hivex_obj = hivex.Hivex(software, write=True)  # type: ignore
+        nodes: List[Any] = [hivex_obj.root()]  # type: ignore
+
+        while len(nodes) > 0:
+            node = nodes.pop()
+            nodes.extend(hivex_obj.node_children(node))  # type: ignore
+            self.reg_node_update(hivex_obj, node)
+
+        hivex_obj.commit(software)  # type: ignore
+
+        utils.subprocess_call(
+            [
+                "/usr/bin/wimupdate",
+                winpe_path,
+                f"--command=add {software} {win_registry}",
+            ],
+            shell=False,
+        )
+        os.remove(software)
+
+    def reg_node_update(self, hivex_obj: Any, node: Any) -> None:
+        """
+        Replacement of the substring X:\\$windows.~bt with X: in the Windows registry node.
+
+        :param hivex_obj: Hivex object.
+        :param node: The registry node.
+        """
+        new_values: List[Optional[Dict[str, Any]]] = []
+        update_flag = False
+        key_vals: List[Any] = hivex_obj.node_values(node)  # type: ignore
+        pat = "X:\\$windows.~bt"
+
+        for key_val in key_vals:
+            key: str = hivex_obj.value_key(key_val)  # type: ignore
+            val = hivex_obj.node_get_value(node, key)  # type: ignore
+            val_type: int
+            val_value: bytes
+            val_type, val_value = hivex_obj.value_value(val)  # type: ignore
+            if pat in key:
+                key = key.replace(pat, "X:")
+                update_flag = True
+            if val_type in (REG_SZ, REG_EXPAND_SZ):
+                val_string: str = hivex_obj.value_string(val)  # type: ignore
+                if pat in val_string:
+                    val_string = val_string.replace(pat, "X:")
+                    val_value = (val_string + "\0").encode(encoding="utf-16le")
+                    update_flag = True
+            new_values.append(
+                {
+                    "key": key,
+                    "t": val_type,
+                    "value": val_value,
+                }
+            )
+
+        if update_flag:
+            hivex_obj.node_set_values(node, new_values)  # type: ignore
+
+    def extract_files_from_wim(self, winpe_path: str, wim_files: List[str]) -> None:
+        """
+        Extracting files from winpe.win.
+
+        :param winpe_path: The path to the WinPE image.
+        :param wim_files: The list of files to extract.
+        :raises CX
+        """
+        dest_path = os.path.dirname(winpe_path)
+        cmd_args = [
+            "/usr/bin/wimextract",
+            winpe_path,
+            "1",
+        ]
+        cmd_args.extend(wim_files)
+        cmd_args.extend(
+            [
+                f"--dest-dir={dest_path}",
+                "--no-acls",
+                "--no-attributes",
+            ]
+        )
+        if (
+            utils.subprocess_call(
+                cmd_args,
+                shell=False,
+            )
+            != 0
+        ):
+            error_msg = f'Cannot extract "{wim_files}" files from {winpe_path}!'
+            self.logger.error(error_msg)
+            raise CX(error_msg)
+
+        for wim_file_path in wim_files:
+            wim_file = os.path.basename(wim_file_path)
+            if wim_file != wim_file.lower():
+                os.rename(
+                    os.path.join(dest_path, wim_file),
+                    os.path.join(dest_path, wim_file.lower()),
+                )
 
 
 # ==========================================================================

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1131,7 +1131,11 @@ class TFTPGen:
             return ""
 
         result = self.write_pxe_file(None, system, profile, distro, arch, image, format='ipxe')
-        return "" if not result else result
+        if not result:
+            return ""
+        result_split = result.splitlines(True)
+        result_split[0] = "#!ipxe\n"
+        return "".join(result_split)
 
     def generate_bootcfg(self, what: str, name: str) -> str:
         """

--- a/system-tests/tests/svc-ipxe-profile
+++ b/system-tests/tests/svc-ipxe-profile
@@ -13,7 +13,7 @@ cobbler profile add --name fake --distro fake
 cobbler system add --name testbed --profile fake --image fakeimage
 # Prepare expected result
 cat >${tmp}/a <<-EOF
-:fake
+#!ipxe
 kernel /images/fake/vmlinuz   initrd=initrd.magic
 initrd /images/fake/initramfs
 boot

--- a/templates/boot_loader_conf/ipxe.template
+++ b/templates/boot_loader_conf/ipxe.template
@@ -14,7 +14,7 @@
 iseq \${smbios/manufacturer} HP && exit ||
 sanboot --no-describe --drive 0x80
 #else
-kernel $kernel_path $kernel_options initrd=initrd.magic
+kernel $kernel_path $kernel_options
 #for $init in $initrd
 initrd $init
 #end for


### PR DESCRIPTION
## Linked Items

Fixes #3285 #3475 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This PR fixes an issue that was introduced with adding Windows support. It prevented all "cobbler import"s from running successfully.

## Behaviour changes

Old: "cobbler import" fails

New: "cobbler import" succeedes

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [X] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
