### PR TITLE
Backport lazy collection init

### DIFF
--- a/changelog.d/3596.added
+++ b/changelog.d/3596.added
@@ -1,0 +1,1 @@
+Added lazy loading of collections during application startup

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -26,7 +26,7 @@ import tempfile
 import threading
 from configparser import ConfigParser
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 
 from schema import SchemaError
 
@@ -1835,6 +1835,13 @@ class CobblerAPI:
         Cobbler internal use only.
         """
         return self._collection_mgr.deserialize()
+
+    def deserialize_item(self, obj) -> Dict[str, Any]:
+        """
+        Load cobbler item from disk.
+        Cobbler internal use only.
+        """
+        return self._collection_mgr.deserialize_one_item(obj)
 
     # ==========================================================================
 

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -44,7 +44,7 @@ class Distros(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_distro = distro.Distro(api)
+        new_distro = distro.Distro(api, **item_dict)
         new_distro.from_dict(item_dict)
         return new_distro
 

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -41,7 +41,7 @@ class Files(collection.Collection):
         """
         Return a File forged from item_dict
         """
-        new_file = file.File(api)
+        new_file = file.File(api, **item_dict)
         new_file.from_dict(item_dict)
         return new_file
 

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -35,7 +35,7 @@ class Images(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_image = image.Image(api)
+        new_image = image.Image(api, **item_dict)
         new_image.from_dict(item_dict)
         return new_image
 

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -200,25 +200,33 @@ class CollectionManager:
         """
         old_cache_enabled = self.api.settings().cache_enabled
         self.api.settings().cache_enabled = False
-        for collection in (
-            self._menus,
-            self._distros,
-            self._repos,
-            self._profiles,
-            self._images,
-            self._systems,
-            self._mgmtclasses,
-            self._packages,
-            self._files,
+        for args in (
+            (self._menus, True),
+            (self._distros, False),
+            (self._repos, False),
+            (self._profiles, True),
+            (self._images, False),
+            (self._systems, False),
+            (self._mgmtclasses, False),
+            (self._packages, False),
+            (self._files, False),
         ):
             try:
-                serializer.deserialize(collection)
+                serializer.deserialize(collection=args[0], topological=args[1])
             except Exception as error:
                 raise CX(
-                    f"serializer: error loading collection {collection.collection_type()}: {error}."
+                    f"serializer: error loading collection {args[0].collection_type()}: {error}."
                     f"Check your settings!"
                 ) from error
         self.api.settings().cache_enabled = old_cache_enabled
+
+    def deserialize_one_item(self, obj) -> dict:
+        """
+        Load a collection item from disk
+        :param obj: collection item
+        """
+        collection_type = self.get_items(obj.COLLECTION_TYPE).collection_types()
+        return serializer.deserialize_item(collection_type, obj.name)
 
     def get_items(
         self, collection_type: str

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -45,7 +45,7 @@ class Menus(collection.Collection):
         :param item_dict: The seed data.
         :return: A new menu instance.
         """
-        new_menu = menu.Menu(api)
+        new_menu = menu.Menu(api, **item_dict)
         new_menu.from_dict(item_dict)
         return new_menu
 

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -45,7 +45,7 @@ class Mgmtclasses(collection.Collection):
         :param item_dict: TODO
         :returns: TODO
         """
-        new_mgmtclass = mgmtclass.Mgmtclass(api)
+        new_mgmtclass = mgmtclass.Mgmtclass(api, **item_dict)
         new_mgmtclass.from_dict(item_dict)
         return new_mgmtclass
 

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -41,7 +41,7 @@ class Packages(collection.Collection):
         """
         Return a Package forged from item_dict
         """
-        new_package = package.Package(api)
+        new_package = package.Package(api, **item_dict)
         new_package.from_dict(item_dict)
         return new_package
 

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -41,7 +41,7 @@ class Profiles(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_profile = profile.Profile(api)
+        new_profile = profile.Profile(api, **item_dict)
         new_profile.from_dict(item_dict)
         return new_profile
 

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -44,7 +44,7 @@ class Repos(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_repo = repo.Repo(api)
+        new_repo = repo.Repo(api, **item_dict)
         new_repo.from_dict(item_dict)
         return new_repo
 

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -46,7 +46,7 @@ class Systems(collection.Collection):
         :param item_dict: TODO
         :returns: TODO
         """
-        new_system = system.System(api)
+        new_system = system.System(api, **item_dict)
         new_system.from_dict(item_dict)
         return new_system
 

--- a/cobbler/cobblerd.py
+++ b/cobbler/cobblerd.py
@@ -85,6 +85,8 @@ def do_xmlrpc_rw(cobbler_api: CobblerAPI, port):
     while True:
         try:
             logger.info("Cobbler startup completed %s", start_time)
+            # Start background load_items task
+            xinterface.proxied.background_load_items()
             server.serve_forever()
         except IOError:
             # interrupted? try to serve again

--- a/cobbler/decorator.py
+++ b/cobbler/decorator.py
@@ -4,7 +4,29 @@ This module provides decorators that are required for Cobbler to work as expecte
 # The idea for the subclassed property decorators is from: https://stackoverflow.com/a/59313599/4730773
 
 
-class InheritableProperty(property):
+from typing import Any, Optional
+
+from cobbler.items import item
+
+
+class LazyProperty(property):
+    """
+    This property is supposed to provide a way to override the lazy-read value getter.
+    """
+
+    def __get__(self, obj: Any, objtype: Optional[type] = None):
+        if obj is None:
+            return self
+        if (
+            isinstance(obj, item.Item)
+            and not obj.inmemory
+            and obj._has_initialized  # pyright: ignore [reportPrivateUsage]
+        ):
+            obj.deserialize()
+        return self.fget(obj)
+
+
+class InheritableProperty(LazyProperty):
     """
     This property is supposed to provide a way to identify properties in code that can be set to inherit.
     """

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -26,7 +26,7 @@ from cobbler.items import item
 from cobbler import utils
 from cobbler.cexceptions import CX
 from cobbler import grub
-from cobbler.decorator import InheritableProperty
+from cobbler.decorator import InheritableProperty, LazyProperty
 
 
 class Distro(item.Item):
@@ -66,6 +66,7 @@ class Distro(item.Item):
         self._remote_boot_initrd = ""
         self._remote_grub_initrd = ""
         self._supported_boot_loaders = []
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -122,6 +123,8 @@ class Distro(item.Item):
         Check if a distro object is valid. If invalid an exception is raised.
         """
         super().check_if_valid()
+        if not self.inmemory:
+            return
         if self.kernel is None:
             raise CX("Error with distro %s - kernel is required" % self.name)
 
@@ -129,7 +132,7 @@ class Distro(item.Item):
     # specific methods for item.Distro
     #
 
-    @property
+    @LazyProperty
     def parent(self):
         """
         Distros don't have parent objects.
@@ -145,7 +148,7 @@ class Distro(item.Item):
         """
         self.logger.warning("Setting the parent of a distribution is not supported. Ignoring action!")
 
-    @property
+    @LazyProperty
     def kernel(self) -> str:
         """
         Specifies a kernel. The kernel parameter is a full path, a filename in the configured kernel directory or a
@@ -175,7 +178,7 @@ class Distro(item.Item):
             )
         self._kernel = kernel
 
-    @property
+    @LazyProperty
     def remote_boot_kernel(self) -> str:
         """
         URL to a remote kernel. If the bootloader supports this feature, it directly tries to retrieve the kernel and
@@ -210,7 +213,7 @@ class Distro(item.Item):
         self._remote_grub_kernel = parsed_url
         self._remote_boot_kernel = remote_boot_kernel
 
-    @property
+    @LazyProperty
     def tree_build_time(self) -> float:
         """
         Represents the import time of the distro. If not imported, this field is not meaningful.
@@ -235,7 +238,7 @@ class Distro(item.Item):
             raise TypeError("datestamp needs to be of type float")
         self._tree_build_time = datestamp
 
-    @property
+    @LazyProperty
     def breed(self) -> str:
         """
         The repository system breed. This decides some defaults for most actions with a repo in Cobbler.
@@ -254,7 +257,7 @@ class Distro(item.Item):
         """
         self._breed = validate.validate_breed(breed)
 
-    @property
+    @LazyProperty
     def os_version(self) -> str:
         r"""
         The operating system version which the image contains.
@@ -273,7 +276,7 @@ class Distro(item.Item):
         """
         self._os_version = validate.validate_os_version(os_version, self.breed)
 
-    @property
+    @LazyProperty
     def initrd(self) -> str:
         """
         Specifies an initrd image. Path search works as in set_kernel. File must be named appropriately.
@@ -301,7 +304,7 @@ class Distro(item.Item):
             return
         raise ValueError("initrd not found")
 
-    @property
+    @LazyProperty
     def remote_grub_kernel(self) -> str:
         """
         This is tied to the ``remote_boot_kernel`` property. It contains the URL of that field in a format which grub
@@ -311,7 +314,7 @@ class Distro(item.Item):
         """
         return self._remote_grub_kernel
 
-    @property
+    @LazyProperty
     def remote_grub_initrd(self) -> str:
         r"""
         This is tied to the ``remote_boot_initrd`` property. It contains the URL of that field in a format which grub
@@ -321,7 +324,7 @@ class Distro(item.Item):
         """
         return self._remote_grub_initrd
 
-    @property
+    @LazyProperty
     def remote_boot_initrd(self) -> str:
         r"""
         URL to a remote initrd. If the bootloader supports this feature, it directly tries to retrieve the initrd and
@@ -355,7 +358,7 @@ class Distro(item.Item):
         self._remote_grub_initrd = parsed_url
         self._remote_boot_initrd = remote_boot_initrd
 
-    @property
+    @LazyProperty
     def source_repos(self) -> list:
         """
         A list of http:// URLs on the Cobbler server that point to yum configuration files that can be used to
@@ -378,7 +381,7 @@ class Distro(item.Item):
             raise TypeError("Field source_repos in object distro needs to be of type list.")
         self._source_repos = repos
 
-    @property
+    @LazyProperty
     def arch(self):
         """
         The field is mainly relevant to PXE provisioning.
@@ -403,7 +406,7 @@ class Distro(item.Item):
         """
         self._arch = enums.Archs.to_enum(arch)
 
-    @property
+    @LazyProperty
     def supported_boot_loaders(self):
         """
         Some distributions, particularly on powerpc, can only be netbooted using specific bootloaders.

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -20,6 +20,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import uuid
 
 from cobbler import utils
+from cobbler.decorator import LazyProperty
 from cobbler.items import resource
 
 from cobbler.cexceptions import CX
@@ -46,6 +47,7 @@ class File(resource.Resource):
         self._has_initialized = False
 
         self._is_dir = False
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -65,15 +67,6 @@ class File(resource.Resource):
         cloned.uid = uuid.uuid4().hex
         return cloned
 
-    def from_dict(self, dictionary: dict):
-        """
-        Initializes the object with attributes from the dictionary.
-
-        :param dictionary: The dictionary with values.
-        """
-        self._remove_depreacted_dict_keys(dictionary)
-        super().from_dict(dictionary)
-
     def check_if_valid(self):
         """
         Checks if the object is valid. This is the case if name, path, owner, group, and mode are set.
@@ -82,6 +75,8 @@ class File(resource.Resource):
         :raises CX: Raised in case a required argument is missing
         """
         super().check_if_valid()
+        if not self.inmemory:
+            return
         if not self.path:
             raise CX("path is required")
         if not self.owner:
@@ -97,7 +92,7 @@ class File(resource.Resource):
     # specific methods for item.File
     #
 
-    @property
+    @LazyProperty
     def is_dir(self):
         """
         Is this a directory or not.

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -23,7 +23,7 @@ from typing import Union
 from cobbler import autoinstall_manager, enums, utils, validate
 from cobbler.cexceptions import CX
 from cobbler.items import item
-from cobbler.decorator import InheritableProperty
+from cobbler.decorator import InheritableProperty, LazyProperty
 
 
 class Image(item.Item):
@@ -64,6 +64,7 @@ class Image(item.Item):
         self._virt_ram: Union[str, int] = enums.VALUE_INHERITED
         self._virt_type: Union[str, enums.VirtType] = enums.VirtType.INHERITED
         self._supported_boot_loaders = []
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -94,18 +95,21 @@ class Image(item.Item):
 
         :param dictionary: The dictionary with values.
         """
+        old_has_initialized = self._has_initialized
+        self._has_initialized = False
         if "name" in dictionary:
             self.name = dictionary["name"]
         if "parent" in dictionary:
             self.parent = dictionary["parent"]
         self._remove_depreacted_dict_keys(dictionary)
+        self._has_initialized = old_has_initialized
         super().from_dict(dictionary)
 
     #
     # specific methods for item.Image
     #
 
-    @property
+    @LazyProperty
     def arch(self) -> enums.Archs:
         """
         Represents the architecture the image has. If deployed to a physical host this should be enforced, a virtual
@@ -127,7 +131,7 @@ class Image(item.Item):
         """
         self._arch = enums.Archs.to_enum(arch)
 
-    @property
+    @InheritableProperty
     def autoinstall(self) -> str:
         """
         Property for the automatic installation file path, this must be a local file.
@@ -153,7 +157,7 @@ class Image(item.Item):
         autoinstall_mgr = autoinstall_manager.AutoInstallationManager(self.api)
         self._autoinstall = autoinstall_mgr.validate_autoinstall_template_file_path(autoinstall)
 
-    @property
+    @LazyProperty
     def file(self) -> str:
         """
         Stores the image location. This should be accessible on all nodes that need to access it.
@@ -214,7 +218,7 @@ class Image(item.Item):
 
         self._file = uri
 
-    @property
+    @LazyProperty
     def os_version(self) -> str:
         r"""
         The operating system version which the image contains.
@@ -233,7 +237,7 @@ class Image(item.Item):
         """
         self._os_version = validate.validate_os_version(os_version, self.breed)
 
-    @property
+    @LazyProperty
     def breed(self) -> str:
         r"""
         The operating system breed.
@@ -252,7 +256,7 @@ class Image(item.Item):
         """
         self._breed = validate.validate_breed(breed)
 
-    @property
+    @LazyProperty
     def image_type(self) -> enums.ImageTypes:
         """
         Indicates what type of image this is.
@@ -293,7 +297,7 @@ class Image(item.Item):
                              % ", ".join(list(map(str, enums.ImageTypes))))
         self._image_type = image_type
 
-    @property
+    @LazyProperty
     def virt_cpus(self) -> int:
         """
         The amount of vCPU cores used in case the image is being deployed on top of a VM host.
@@ -312,7 +316,7 @@ class Image(item.Item):
         """
         self._virt_cpus = validate.validate_virt_cpus(num)
 
-    @property
+    @LazyProperty
     def network_count(self) -> int:
         """
         Represents the number of virtual NICs this image has.
@@ -339,7 +343,7 @@ class Image(item.Item):
             raise TypeError("Field network_count of object image needs to be of type int.")
         self._network_count = network_count
 
-    @property
+    @InheritableProperty
     def virt_auto_boot(self) -> bool:
         r"""
         Whether the VM should be booted when booting the host or not.
@@ -358,7 +362,7 @@ class Image(item.Item):
         """
         self._virt_auto_boot = validate.validate_virt_auto_boot(num)
 
-    @property
+    @LazyProperty
     def virt_file_size(self) -> float:
         r"""
         The size of the image and thus the usable size for the guest.
@@ -381,7 +385,7 @@ class Image(item.Item):
         """
         self._virt_file_size = validate.validate_virt_file_size(num)
 
-    @property
+    @LazyProperty
     def virt_disk_driver(self) -> enums.VirtDiskDrivers:
         """
         The type of disk driver used for storing the image.
@@ -400,7 +404,7 @@ class Image(item.Item):
         """
         self._virt_disk_driver = enums.VirtDiskDrivers.to_enum(driver)
 
-    @property
+    @LazyProperty
     def virt_ram(self) -> int:
         """
         The amount of RAM given to the guest in MB.
@@ -419,7 +423,7 @@ class Image(item.Item):
         """
         self._virt_ram = validate.validate_virt_ram(num)
 
-    @property
+    @LazyProperty
     def virt_type(self) -> enums.VirtType:
         """
         The type of image used.
@@ -438,7 +442,7 @@ class Image(item.Item):
         """
         self._virt_type = enums.VirtType.to_enum(vtype)
 
-    @property
+    @LazyProperty
     def virt_bridge(self) -> str:
         r"""
         The name of the virtual bridge used for networking.
@@ -459,7 +463,7 @@ class Image(item.Item):
         """
         self._virt_bridge = validate.validate_virt_bridge(vbridge)
 
-    @property
+    @LazyProperty
     def virt_path(self) -> str:
         """
         Represents the location where the image for the VM is stored.
@@ -478,7 +482,7 @@ class Image(item.Item):
         """
         self._virt_path = validate.validate_virt_path(path)
 
-    @property
+    @LazyProperty
     def menu(self) -> str:
         """
         Property to represent the menu which this image should be put into.
@@ -502,7 +506,7 @@ class Image(item.Item):
                 raise CX("menu %s not found" % menu)
         self._menu = menu
 
-    @property
+    @LazyProperty
     def supported_boot_loaders(self):
         """
         Read only property which represents the subset of settable bootloaders.

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -21,6 +21,7 @@ import uuid
 from typing import List, Optional
 
 from cobbler.cexceptions import CX
+from cobbler.decorator import LazyProperty
 from cobbler.items import item
 
 
@@ -41,6 +42,7 @@ class Menu(item.Item):
         self._has_initialized = False
 
         self._display_name = ""
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -60,20 +62,11 @@ class Menu(item.Item):
         cloned.uid = uuid.uuid4().hex
         return cloned
 
-    def from_dict(self, dictionary: dict):
-        """
-        Initializes the object with attributes from the dictionary.
-
-        :param dictionary: The dictionary with values.
-        """
-        self._remove_depreacted_dict_keys(dictionary)
-        super().from_dict(dictionary)
-
     #
     # specific methods for item.Menu
     #
 
-    @property
+    @LazyProperty
     def display_name(self) -> str:
         """
         Returns the display name.

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -19,6 +19,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 import uuid
 from typing import Union
+from cobbler.decorator import LazyProperty
 
 from cobbler.items import item
 from cobbler import utils
@@ -49,6 +50,7 @@ class Mgmtclass(item.Item):
         self._class_name = ""
         self._files = []
         self._packages = []
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -69,20 +71,11 @@ class Mgmtclass(item.Item):
         cloned.uid = uuid.uuid4().hex
         return cloned
 
-    def from_dict(self, dictionary: dict):
-        """
-        Initializes the object with attributes from the dictionary.
-
-        :param dictionary: The dictionary with values.
-        """
-        self._remove_depreacted_dict_keys(dictionary)
-        super().from_dict(dictionary)
-
     #
     # specific methods for item.Mgmtclass
     #
 
-    @property
+    @LazyProperty
     def packages(self) -> list:
         """
         Packages property.
@@ -101,7 +94,7 @@ class Mgmtclass(item.Item):
         """
         self._packages = utils.input_string_or_list(packages)
 
-    @property
+    @LazyProperty
     def files(self) -> list:
         """
         Files property.
@@ -120,7 +113,7 @@ class Mgmtclass(item.Item):
         """
         self._files = utils.input_string_or_list(files)
 
-    @property
+    @LazyProperty
     def params(self) -> dict:
         """
         Params property.
@@ -143,7 +136,7 @@ class Mgmtclass(item.Item):
         except TypeError as e:
             raise TypeError("invalid value for params") from e
 
-    @property
+    @LazyProperty
     def is_definition(self) -> bool:
         """
         Is_definition property.
@@ -166,7 +159,7 @@ class Mgmtclass(item.Item):
             raise TypeError("Field is_defintion from mgmtclass must be of type bool.")
         self._is_definition = isdef
 
-    @property
+    @LazyProperty
     def class_name(self) -> str:
         """
         The name of the management class.

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -18,6 +18,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 02110-1301  USA
 """
 import uuid
+from cobbler.decorator import LazyProperty
 
 from cobbler.items import resource
 
@@ -44,6 +45,7 @@ class Package(resource.Resource):
 
         self._installer = ""
         self._version = ""
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -63,20 +65,11 @@ class Package(resource.Resource):
         cloned.uid = uuid.uuid4().hex
         return cloned
 
-    def from_dict(self, dictionary: dict):
-        """
-        Initializes the object with attributes from the dictionary.
-
-        :param dictionary: The dictionary with values.
-        """
-        self._remove_depreacted_dict_keys(dictionary)
-        super().from_dict(dictionary)
-
     #
     # specific methods for item.Package
     #
 
-    @property
+    @LazyProperty
     def installer(self) -> str:
         """
         Installer property.
@@ -98,7 +91,7 @@ class Package(resource.Resource):
             raise TypeError("Field installer of package object needs to be of type str!")
         self._installer = installer.lower()
 
-    @property
+    @LazyProperty
     def version(self) -> str:
         """
         Version property.

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -16,6 +16,7 @@ import uuid
 from typing import Union
 
 from cobbler import enums
+from cobbler.decorator import LazyProperty
 
 from cobbler.items import item
 
@@ -41,6 +42,7 @@ class Resource(item.Item):
         self._group = ""
         self._path = ""
         self._template = ""
+
         if not self._has_initialized:
             self._has_initialized = True
 
@@ -60,20 +62,11 @@ class Resource(item.Item):
         cloned.uid = uuid.uuid4().hex
         return cloned
 
-    def from_dict(self, dictionary: dict):
-        """
-        Initializes the object with attributes from the dictionary.
-
-        :param dictionary: The dictionary with values.
-        """
-        self._remove_depreacted_dict_keys(dictionary)
-        super().from_dict(dictionary)
-
     #
     # specific methods for item.File
     #
 
-    @property
+    @LazyProperty
     def action(self) -> enums.ResourceAction:
         """
         Action property.
@@ -96,7 +89,7 @@ class Resource(item.Item):
         """
         self._action = enums.ResourceAction.to_enum(action)
 
-    @property
+    @LazyProperty
     def group(self) -> str:
         """
         Group property.
@@ -118,7 +111,7 @@ class Resource(item.Item):
             raise TypeError("Field group of object resource needs to be of type str!")
         self._group = group
 
-    @property
+    @LazyProperty
     def mode(self) -> str:
         """
         Mode property.
@@ -140,7 +133,7 @@ class Resource(item.Item):
             raise TypeError("Field mode in object resource needs to be of type str!")
         self._mode = mode
 
-    @property
+    @LazyProperty
     def owner(self) -> str:
         """
         Owner property.
@@ -162,7 +155,7 @@ class Resource(item.Item):
             raise TypeError("Field owner in object resource needs to be of type str!")
         self._owner = owner
 
-    @property
+    @LazyProperty
     def path(self) -> str:
         """
         Path property.
@@ -184,7 +177,7 @@ class Resource(item.Item):
             raise TypeError("Field path in object resource needs to be of type str!")
         self._path = path
 
-    @property
+    @LazyProperty
     def template(self) -> str:
         """
         Template property.

--- a/cobbler/serializer.py
+++ b/cobbler/serializer.py
@@ -26,6 +26,7 @@ import os
 import sys
 import time
 import traceback
+from typing import Any, Dict
 
 from cobbler import module_loader
 
@@ -129,7 +130,20 @@ def deserialize(collection, topological: bool = True):
     __release_lock()
 
 
-def __get_storage_module(collection_type):
+def deserialize_item(collection_type: str, item_name: str) -> Dict[str, Any]:
+    """
+    Load a collection item from disk.
+    :param collection_type: The collection type to deserialize.
+    :param item_name: The collection item name to deserialize.
+    """
+    __grab_lock()
+    storage_module = __get_storage_module(collection_type)
+    result = storage_module.deserialize_item(collection_type, item_name)
+    __release_lock()
+    return result
+
+
+def __get_storage_module(collection_type: str):
     """
     Look up serializer in /etc/cobbler/modules.conf
 

--- a/cobbler/settings/migrations/V3_3_5.py
+++ b/cobbler/settings/migrations/V3_3_5.py
@@ -2,9 +2,10 @@
 Migration from V3.3.4 to V3.3.5
 """
 # SPDX-License-Identifier: GPL-2.0-or-later
-# SPDX-FileCopyrightText: 2022 Dominik Gedon <dgedon@suse.de>
+# SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
+from schema import Optional, Schema, SchemaError # type: ignore
 
 from schema import Optional, Schema, SchemaError
 
@@ -243,7 +244,7 @@ def validate(settings: dict) -> bool:
     :return: True if valid settings dict otherwise False.
     """
     try:
-        schema.validate(settings)
+        schema.validate(settings)  # type: ignore
     except SchemaError:
         return False
     return True
@@ -256,19 +257,19 @@ def normalize(settings: dict) -> dict:
     :param settings: The settings dict to validate.
     :return: The validated dict.
     """
-    return schema.validate(settings)
+    return schema.validate(settings)  # type: ignore
 
 
 def migrate(settings: dict) -> dict:
     """
-    Migration of the settings ``settings`` to version V3.3.1 settings
+    Migration of the settings ``settings`` to version V3.3.4 settings
 
     :param settings: The settings dict to migrate
     :return: The migrated dict
     """
 
     if not V3_3_4.validate(settings):
-        raise SchemaError("V3.3.4: Schema error while validating")
+        raise SchemaError("V3.3.3: Schema error while validating")
 
     # rename keys and update their value
     # add missing keys

--- a/cobbler/settings/migrations/V3_3_5.py
+++ b/cobbler/settings/migrations/V3_3_5.py
@@ -5,7 +5,7 @@ Migration from V3.3.4 to V3.3.5
 # SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
-from schema import Optional, Schema, SchemaError # type: ignore
+from schema import Optional, Schema, SchemaError  # type: ignore
 
 from schema import Optional, Schema, SchemaError
 
@@ -231,6 +231,7 @@ schema = Schema(
         Optional("windows_template_dir", default="/etc/cobbler/windows"): str,
         Optional("samba_distro_share", default="DISTRO"): str,
         Optional("cache_enabled"): bool,
+        Optional("lazy_start", default=False): bool,
     },
     ignore_extra_keys=False,
 )

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -574,6 +574,15 @@ signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
 # editing objects.
 cache_enabled: true
 
+# Set to true to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+# of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+# collections in the database, a projection query is made that includes only the names of the collection elements.
+# The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+# performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+# also launched, which, when idle, fills in all the properties of the elements of the collections.
+# Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+lazy_start: false
+
 # Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
 # this file.
 include: [ "/etc/cobbler/settings.d/*.settings" ]

--- a/docker/develop/scripts/setup-mongodb.sh
+++ b/docker/develop/scripts/setup-mongodb.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+wget -O /tmp/mongodb.asc https://pgp.mongodb.com/server-5.0.asc
+rpm --import /tmp/mongodb.asc
+zypper addrepo --gpgcheck "https://repo.mongodb.org/zypper/suse/15/mongodb-org/5.0/x86_64/" mongodb
+zypper -n install mongodb-org
+mkdir -p /data/db

--- a/docker/develop/scripts/setup-supervisor.sh
+++ b/docker/develop/scripts/setup-supervisor.sh
@@ -7,7 +7,11 @@ cp /code/docker/develop/supervisord/supervisord.conf /etc/
 echo "Setup openLDAP"
 /code/docker/develop/scripts/setup-openldap.sh
 
+echo "Setup MongoDB"
+/code/docker/develop/scripts/setup-mongodb.sh
+
 echo "Install Cobbler"
+git config --global --add safe.directory /code
 cd /code || exit
 make install
 

--- a/docker/develop/supervisord/conf.d/mongodb.conf
+++ b/docker/develop/supervisord/conf.d/mongodb.conf
@@ -1,0 +1,7 @@
+[program:mongo]
+command=/usr/bin/mongod --bind_ip_all
+autorestart=true
+stderr_logfile=/dev/stdout
+stderr_logfile_maxbytes = 0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes = 0

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -1116,6 +1116,20 @@ Flags to use for yumdownloader. Not all versions may support ``--resolve``.
 
 default: ``"--resolve"``
 
+lazy_start
+##########
+
+Set to ``True`` to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+collections in the database, a projection query is made that includes only the names of the collection elements.
+The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+also launched, which, when idle, fills in all the properties of the elements of the collections.
+Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+
+default: ``False``
+
+
 ``modules.conf``
 ################
 

--- a/tests/items/inmemory_test.py
+++ b/tests/items/inmemory_test.py
@@ -1,0 +1,246 @@
+"""
+TODO
+"""
+
+from unittest import mock
+from typing import Callable
+
+import pathlib
+import os
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.items.package import Package
+from cobbler.items.file import File
+from cobbler.items.mgmtclass import Mgmtclass
+from cobbler.items.repo import Repo
+from cobbler.items.image import Image
+from cobbler.items.distro import Distro
+from cobbler.items.menu import Menu
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+from cobbler.cobbler_collections import manager
+
+
+@pytest.fixture(scope="function")
+def inmemory_api() -> CobblerAPI:
+    """
+    TODO
+    """
+    CobblerAPI.__shared_state = {}
+    CobblerAPI.__has_loaded = False
+    api = CobblerAPI()
+    api.settings().lazy_start = True
+    manager.CollectionManager.has_loaded = False
+    manager.CollectionManager.__shared_state = {}
+    api._collection_mgr = manager.CollectionManager(api)
+    return api
+
+builtin_open = open  # save the unpatched version
+
+
+def mock_open(*args, **kwargs):
+    if args[0] == "/etc/cobbler/settings.yaml":
+        # mocked open for path "foo"
+        return mock.mock_open(read_data="lazy_start: True")(*args, **kwargs)
+    # unpatched version for every other path
+    return builtin_open(*args, **kwargs)
+
+
+@mock.patch("builtins.open", mock_open)
+def test_inmemory(
+    inmemory_api: CobblerAPI,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
+):
+    """
+    TODO
+    """
+    # Arrange
+    test_package = Package(inmemory_api)
+    test_package.from_dict({"name": "test_package", "comment": "test comment"})
+    inmemory_api.add_package(test_package)
+    test_file = File(inmemory_api)
+    test_file.from_dict({
+        "name": "test_file",
+        "path": "test path",
+        "owner": "test owner",
+        "group": "test group",
+        "mode": "test mode",
+        "is_dir": True,
+        "comment": "test comment",
+    })
+    inmemory_api.add_file(test_file)
+    test_mgmtclass = Mgmtclass(inmemory_api)
+    test_mgmtclass.from_dict({
+        "name": "test_mgmtclass",
+        "packages": [test_package.name],
+        "files": [test_file.name],
+        "comment": "test comment",
+    })
+    inmemory_api.add_mgmtclass(test_mgmtclass)
+    test_repo = Repo(inmemory_api)
+    test_repo.from_dict({"name": "test_repo", "comment": "test comment"})
+    inmemory_api.add_repo(test_repo)
+    test_menu1 = Menu(inmemory_api)
+    test_menu1.from_dict({"name": "test_menu1", "comment": "test comment"})
+    inmemory_api.add_menu(test_menu1)
+    test_menu2 = Menu(inmemory_api)
+    test_menu2.from_dict({
+        "name": "test_menu2",
+        "parent": test_menu1.name,
+        "comment": "test comment",
+    })
+    inmemory_api.add_menu(test_menu2)
+
+    directory = create_kernel_initrd(fk_kernel, fk_initrd)
+    (pathlib.Path(directory) / "images").mkdir()
+    test_distro = Distro(inmemory_api)
+    test_distro.from_dict({
+        "name": "test_distro",
+        "kernel": str(os.path.join(directory, fk_kernel)),
+        "initrd": str(os.path.join(directory, fk_initrd)),
+        "mgmt_classes": test_mgmtclass.name,
+        "comment": "test comment",
+    })
+    inmemory_api.add_distro(test_distro)
+
+    test_profile1 = Profile(inmemory_api)
+    test_profile1.from_dict({
+        "name": "test_profile1",
+        "distro": test_distro.name,
+        "enable_menu": False,
+        "repos": [test_repo.name],
+        "menu": test_menu1.name,
+        "comment": "test comment",
+    })
+    inmemory_api.add_profile(test_profile1)
+    test_profile2 = Profile(inmemory_api)
+    test_profile2.from_dict({
+        "name": "test_profile2",
+        "parent": test_profile1.name,
+        "enable_menu": False,
+        "menu": test_menu2.name,
+        "comment": "test comment",
+    })
+    inmemory_api.add_profile(test_profile2)
+    test_profile3 = Profile(inmemory_api)
+    test_profile3.from_dict({
+        "name": "test_profile3",
+        "parent": test_profile1.name,
+        "enable_menu": False,
+        "mgmt_classes": test_mgmtclass.name,
+        "repos": [test_repo.name],
+        "menu": test_menu1.name,
+        "comment": "test comment",
+    })
+    inmemory_api.add_profile(test_profile3)
+    test_image = Image(inmemory_api)
+    test_image.from_dict({"name": "test_image", "menu": test_menu1.name, "comment": "test comment"})
+    inmemory_api.add_image(test_image)
+    test_system1 = System(inmemory_api)
+    test_system1.from_dict({
+        "name": "test_system1",
+        "profile": test_profile1.name,
+        "comment": "test comment",
+    })
+    inmemory_api.add_system(test_system1)
+    test_system2 = System(inmemory_api)
+    test_system2.from_dict({"name": "test_system2", "image": test_image.name, "comment": "test comment"})
+    inmemory_api.add_system(test_system2)
+
+    inmemory_api.systems().listing.pop(test_system2.name)
+    inmemory_api.systems().listing.pop(test_system1.name)
+    inmemory_api.images().listing.pop(test_image.name)
+    inmemory_api.profiles().listing.pop(test_profile3.name)
+    inmemory_api.profiles().listing.pop(test_profile2.name)
+    inmemory_api.profiles().listing.pop(test_profile1.name)
+    inmemory_api.distros().listing.pop(test_distro.name)
+    inmemory_api.menus().listing.pop(test_menu2.name)
+    inmemory_api.menus().listing.pop(test_menu1.name)
+    inmemory_api.repos().listing.pop(test_repo.name)
+    inmemory_api.mgmtclasses().listing.pop(test_mgmtclass.name)
+    inmemory_api.files().listing.pop(test_file.name)
+    inmemory_api.packages().listing.pop(test_package.name)
+
+    inmemory_api.deserialize()
+
+    test_package = inmemory_api.find_package("test_package")
+    test_file = inmemory_api.find_file("test_file")
+    test_mgmtclass = inmemory_api.find_mgmtclass("test_mgmtclass")
+    test_repo = inmemory_api.find_repo("test_repo")
+    test_menu1 = inmemory_api.find_menu("test_menu1")
+    test_menu2 = inmemory_api.find_menu("test_menu2")
+    test_distro = inmemory_api.find_distro("test_distro")
+    test_profile1 = inmemory_api.find_profile("test_profile1")
+    test_profile2 = inmemory_api.find_profile("test_profile2")
+    test_profile3 = inmemory_api.find_profile("test_profile3")
+    test_image = inmemory_api.find_image("test_image")
+    test_system1 = inmemory_api.find_system("test_system1")
+    test_system2 = inmemory_api.find_system("test_system2")
+
+    # Act
+    result = True
+    for collection in [
+        "package",
+        "file",
+        "mgmtclass",
+        "repo",
+        "distro",
+        "menu",
+        "image",
+        "profile",
+        "system",
+    ]:
+        for obj in inmemory_api.get_items(collection):
+            result = obj.inmemory is False if result else result
+            result = obj.__dict__["_comment"] == "" if result else result
+
+    comment = test_system1.comment if result else result
+    result = test_package.inmemory if result else result
+    result = test_file.inmemory if result else result
+    result = test_mgmtclass.inmemory if result else result
+    result = test_repo.inmemory if result else result
+    result = test_menu1.inmemory if result else result
+    result = not test_menu2.inmemory if result else result
+    result = test_distro.inmemory if result else result
+    result = test_profile1.inmemory if result else result
+    result = not test_profile2.inmemory if result else result
+    result = not test_profile3.inmemory if result else result
+    result = not test_image.inmemory if result else result
+    result = test_system1.inmemory if result else result
+    result = not test_system2.inmemory if result else result
+
+    result = test_package.__dict__["_comment"] == "test comment" if result else result
+    result = test_file.__dict__["_comment"] == "test comment" if result else result
+    result = test_mgmtclass.__dict__["_comment"] == "test comment" if result else result
+    result = test_repo.__dict__["_comment"] == "test comment" if result else result
+    result = test_menu1.__dict__["_comment"] == "test comment" if result else result
+    result = test_menu2.__dict__["_comment"] == "" if result else result
+    result = test_distro.__dict__["_comment"] == "test comment" if result else result
+    result = test_profile1.__dict__["_comment"] == "test comment" if result else result
+    result = test_profile2.__dict__["_comment"] == "" if result else result
+    result = test_profile3.__dict__["_comment"] == "" if result else result
+    result = test_image.__dict__["_comment"] == "" if result else result
+    result = test_system1.__dict__["_comment"] == "test comment" if result else result
+    result = test_system2.__dict__["_comment"] == "" if result else result
+
+    # Cleanup
+    inmemory_api.remove_system(test_system1)
+    inmemory_api.remove_system(test_system2)
+    inmemory_api.remove_image(test_image)
+    inmemory_api.remove_profile(test_profile3)
+    inmemory_api.remove_profile(test_profile2)
+    inmemory_api.remove_profile(test_profile1)
+    inmemory_api.remove_distro(test_distro)
+    inmemory_api.remove_menu(test_menu2)
+    inmemory_api.remove_menu(test_menu1)
+    inmemory_api.remove_repo(test_repo)
+    inmemory_api.remove_mgmtclass(test_mgmtclass)
+    inmemory_api.remove_package(test_package)
+    inmemory_api.remove_file(test_file)
+
+    # Assert
+    assert result

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -456,7 +456,7 @@ def test_dump_vars(cobbler_api):
     # Assert
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 149
+    assert len(result) == 150
 
 
 @pytest.mark.parametrize(

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -220,6 +220,9 @@ def test_mac_address(
     system = create_system(profile.name)
     system.interfaces["default"].mac_address = "AA:AA:AA:AA:AA:AA"
     cobbler_api.add_system(system)
+    system2 = create_system(profile_name=profile.name, name="test_system2")
+    system2.interfaces["default"].mac_address = "random"
+    cobbler_api.add_system(system2)
     mocker.patch("cobbler.utils.get_random_mac", return_value="AA:BB:CC:DD:EE:FF")
     interface = NetworkInterface(cobbler_api)
 

--- a/tests/modules/serializer/mongodb_test.py
+++ b/tests/modules/serializer/mongodb_test.py
@@ -1,0 +1,46 @@
+"""
+TODO
+"""
+
+import copy
+import pytest
+from cobbler.cexceptions import CX
+from cobbler.modules.serializers import mongodb
+
+from tests.conftest import does_not_raise
+
+@pytest.mark.parametrize(
+    "item_name,expected_exception",
+    [
+        (
+            "testitem",
+            does_not_raise(),
+        ),
+        (
+            None,
+            pytest.raises(CX),
+        ),
+    ],
+)
+def test_deserialize_item(item_name: str, expected_exception):
+    """
+    TODO
+    """
+    # Arrange
+    collection_type = "distro"
+    input_value = {"name": item_name, "arch": "x86_64"}
+    test_item = copy.deepcopy(input_value)
+    if item_name is not None:
+        mongodb.__connect()
+        mongodb.mongodb[collection_type].insert_one(test_item)
+
+    expected_value = input_value.copy()
+    expected_value["inmemory"] = True
+
+    # Act
+    with expected_exception:
+        result = mongodb.deserialize_item(collection_type, item_name)
+        print(result)
+
+        # Assert
+        assert result in (expected_value, {"inmemory": True})

--- a/tests/serializer_test.py
+++ b/tests/serializer_test.py
@@ -1,0 +1,23 @@
+"""
+TODO
+"""
+
+from cobbler import serializer
+
+def test_deserialize_item(mocker):
+    """
+    TODO
+    """
+    # Arrange
+    module_mock = mocker.MagicMock()
+    storage_mock = mocker.patch("cobbler.serializer.__get_storage_module", return_value=module_mock)
+    input_collection_type = "test"
+    input_name = "testitem"
+
+    # Act
+    serializer.deserialize_item(input_collection_type, input_name)
+
+    # Assert
+    module_mock.deserialize_item.assert_called_with(
+        input_collection_type, input_name
+    )

--- a/tests/settings/migrations/migrations_test.py
+++ b/tests/settings/migrations/migrations_test.py
@@ -252,4 +252,4 @@ def test_migrate_v3_3_5():
     new_settings = V3_3_5.migrate(old_settings_dict)
 
     # Assert
-    assert V3_3_4.validate(new_settings)
+    assert V3_3_5.validate(new_settings)

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -180,4 +180,4 @@ def test_normalize_v3_3_5():
     new_settings = V3_3_5.normalize(old_settings_dict)
 
     # Assert
-    assert len(new_settings) == 130
+    assert len(new_settings) == 131

--- a/tests/test_data/V3_3_5/settings.yaml
+++ b/tests/test_data/V3_3_5/settings.yaml
@@ -570,6 +570,15 @@ signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
 # editing objects.
 cache_enabled: false
 
+# Set to true to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+# of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+# collections in the database, a projection query is made that includes only the names of the collection elements.
+# The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+# performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+# also launched, which, when idle, fills in all the properties of the elements of the collections.
+# Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+lazy_start: false
+
 # Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
 # this file.
 include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -259,7 +259,7 @@ def test_blender(cobbler_api):
     result = utils.blender(cobbler_api, False, root_item)
 
     # Assert
-    assert len(result) == 162
+    assert len(result) == 163
     # Must be present because the settings have it
     assert "server" in result
     # Must be present because it is a field of distro

--- a/tests/xmlrpcapi/background_test.py
+++ b/tests/xmlrpcapi/background_test.py
@@ -68,3 +68,12 @@ class TestBackground:
 
         # Assert
         assert result
+
+    def test_background_load_items(self, remote):
+        # Arrange
+
+        # Act
+        result = remote.background_load_items()
+
+        # Assert
+        assert result


### PR DESCRIPTION
## Linked Items

Fixes #3596

## Description

This PR attempts to backport the lazy collection init. This will be off per default.

This is a follow up to #3634 as I sadly can't reopen it.

## Behaviour changes

Old: Cobbler wasn't available until all items are fully loaded.

New: Cobbler will startup up with only the item names in memory until the item is first accessed.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
