### PR TITLE
Backport fix for PXE boot filename

### DIFF
--- a/templates/etc/dhcp.template
+++ b/templates/etc/dhcp.template
@@ -134,7 +134,7 @@ subnet 192.168.1.0 netmask 255.255.255.0 {
                 next-server $iface.next_server;
             #end if
             #if $iface.filename:
-                filename $filename
+                filename "$iface.filename";
             #end if
             #if $iface.name_servers:
                 #set $mynameservers = ','.join($iface.name_servers)


### PR DESCRIPTION
## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Fixes dhcpd.conf generation with per-system DHCP PXE boot filename configured.  This is part of c321834da9d1837ed485902c9eeba32232fc2c96

## Behaviour changes

Old: 
```
/etc/dhcp/dhcpd.conf line 600: semicolon expected.
            filename grub/
                          ^
```
New: Successful dhcpd.conf generation

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
