### PR TITLE
CI: Fixup manual benchmark workflow

### DIFF
--- a/.github/workflows/performance_testing_automated.yml
+++ b/.github/workflows/performance_testing_automated.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   run_performance_tests:
+    name: Run Performance Tests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +27,6 @@ jobs:
       - name: Run the Performance Tests inside the Docker Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-only --benchmark-autosave tests/performance"
+          docker exec -u 0 -it cobbler bash -c "pytest --benchmark-only --benchmark-autosave tests/performance"
       - name: Stop and remove the container
         run: docker stop cobbler && docker rm cobbler

--- a/.github/workflows/performance_testing_automated.yml
+++ b/.github/workflows/performance_testing_automated.yml
@@ -15,6 +15,10 @@ jobs:
         run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:main
       - name: Run previously built Docker Container
         run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:main
+      - name: Trust the git repository inside the container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "git config --global --add safe.directory /code"
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/performance_testing_manual.yml
+++ b/.github/workflows/performance_testing_manual.yml
@@ -35,5 +35,5 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-report
-          path: .benchmark/*.json
+          path: .benchmarks/
           if-no-files-found: error

--- a/.github/workflows/performance_testing_manual.yml
+++ b/.github/workflows/performance_testing_manual.yml
@@ -20,6 +20,10 @@ jobs:
         run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:main
       - name: Run previously built Docker Container
         run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:main
+      - name: Trust the git repository inside the container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "git config --global --add safe.directory /code"
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -47,6 +47,10 @@ jobs:
         run: docker pull registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:main
       - name: Run previously built Docker Container
         run: docker run --privileged -t -d -v $PWD:/code --name cobbler registry.opensuse.org/systemsmanagement/cobbler/github-ci/containers/cobbler-test-github:main
+      - name: Trust the git repository inside the container
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          docker exec -u 0 -it cobbler bash -c "git config --global --add safe.directory /code"
       - name: Setup Cobbler in the Container
         shell: 'script -q -e -c "bash {0}"'
         run: |

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Run the Tests inside the Docker Container
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-skip && git config --global --add safe.directory /code && coverage xml && codecov --token=1064928c-6477-41be-9ac2-7ce5e6d1fd8b --commit=${GITHUB_SHA}"
+          docker exec -u 0 -it cobbler bash -c "pytest --cov=./cobbler --benchmark-skip && git config --global --add safe.directory /code && coverage xml"
       - name: Stop and remove the container
         run: docker stop cobbler && docker rm cobbler
       # https://github.com/actions/upload-artifact


### PR DESCRIPTION
## Linked Items

This is a follow-up for #3694

## Description

This PR is cleaning up the testing workflows:

- It fixes the folder pattern for the upload of the generated benchmark JSON files.
- It trusts the git repository inside the container so the commit sha is reported by `cobbler version`.
- It removes the codecov upload from the unit testing workflow.
- It removed the coverage generation during the integration testing.

## Behaviour changes

Old: Manual benchmark generation failed due to an incorrect path in the upload files action.

New: Hopefully, the upload succeeds after the tests ran.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
