### PR TITLE
Signatures: Update default signatures URL

### DIFF
--- a/changelog.d/3696.added
+++ b/changelog.d/3696.added
@@ -1,0 +1,1 @@
+Use new default URL for the signatures file

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -572,7 +572,7 @@ iso_template_dir: "/etc/cobbler/iso"
 
 # Signatures
 signature_path: "/var/lib/cobbler/distro_signatures.json"
-signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+signature_url: "https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json"
 
 # Set to "true" to enable Cobbler's dynamic DNS updates.
 nsupdate_enabled: false

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -939,7 +939,7 @@ signature_url
 Updates to the signatures may happen more often then we have releases. To enable you to import new version we provide
 the most up to date signatures we offer on this like. You may host this file for yourself and adjust it for your needs.
 
-default: ``https://cobbler.github.io/signatures/3.0.x/latest.json``
+default: ``https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json``
 
 tftpboot_location
 #################

--- a/system-tests/tests/svc-settings
+++ b/system-tests/tests/svc-settings
@@ -143,7 +143,7 @@ cat >${tmp}/a <<-EOF
     "server": "192.168.1.1",
     "sign_puppet_certs_automatically": false,
     "signature_path": "/var/lib/cobbler/distro_signatures.json",
-    "signature_url": "https://cobbler.github.io/signatures/3.0.x/latest.json",
+    "signature_url": "https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json",
     "syslinux_dir": "/usr/share/syslinux",
     "syslinux_memdisk_folder": "/usr/share/syslinux",
     "syslinux_pxelinux_folder": "/usr/share/syslinux",

--- a/tests/test_data/V3_4_0/settings.yaml
+++ b/tests/test_data/V3_4_0/settings.yaml
@@ -568,7 +568,7 @@ puppet_version: 2
 
 # Signatures
 signature_path: "/var/lib/cobbler/distro_signatures.json"
-signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+signature_url: "https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json"
 
 # Set to "true" to enable Cobbler's dynamic DNS updates.
 nsupdate_enabled: false

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -173,7 +173,10 @@ def test_read_file_contents():
 @pytest.mark.parametrize(
     "remote_url,expected_result",
     [
-        ("https://cobbler.github.io/signatures/latest.json", True),
+        (
+            "https://cobbler.github.io/libcobblersignatures/data/v2/distro_signatures.json",
+            True,
+        ),
         ("https://cobbler.github.io/signatures/not_existing", False),
     ],
 )


### PR DESCRIPTION
## Linked Items

Fixes #3696 

## Description

This PR changes the default URL from the Cobbler website to the signatures that are hosted in libcobblersignatures.

## Behaviour changes

Old: Outdated signatures location was being used.

New: The new default URL points to the current source of the signatures file.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
