### PR TITLE
Fix downloads with proxy_url_ext set

### DIFF
--- a/changelog.d/2472.fixed
+++ b/changelog.d/2472.fixed
@@ -1,0 +1,1 @@
+Fix downloads with proxy_url_ext set

--- a/cobbler/download_manager.py
+++ b/cobbler/download_manager.py
@@ -29,7 +29,14 @@ class DownloadManager:
         with open("/etc/cobbler/settings.yaml", encoding="UTF-8") as main_settingsfile:
             ydata = yaml.safe_load(main_settingsfile)
         # requests wants a dict like:  protocol: proxy_uri
-        self.proxies = ydata.get("proxy_url_ext", {})
+        proxy_url_ext = ydata.get("proxy_url_ext", "")
+        if proxy_url_ext:
+            self.proxies = {
+                "http": proxy_url_ext,
+                "https": proxy_url_ext,
+            }
+        else:
+            self.proxies = {}
 
     def urlread(
         self,


### PR DESCRIPTION
## Linked Items

Fixes #2472 

## Description
Creates a dictionary for use with requests.

## Behaviour changes

Old: 
```
  File "/usr/lib/python3.9/site-packages/requests/sessions.py", line 712, in merge_environment_settings
    no_proxy = proxies.get('no_proxy') if proxies is not None else None
```

New:
```
Successfully got file from https://cobbler.github.io/signatures/3.0.x/latest.json
```

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
Note that I haven't yet tested this on the main branch, just a similar change on the release32 branch.