### PR TITLE
Fix downloads with proxy_url_ext set

### DIFF
--- a/cobbler/download_manager.py
+++ b/cobbler/download_manager.py
@@ -36,7 +36,10 @@ class DownloadManager:
         self.cert = ()
         if self.settings.proxy_url_ext:
             # requests wants a dict like:  protocol: proxy_uri
-            self.proxies = self.settings.proxy_url_ext
+            self.proxies = {
+                "http": self.settings.proxy_url_ext,
+                "https": self.settings.proxy_url_ext,
+            }
         else:
             self.proxies = {}
 


### PR DESCRIPTION
## Linked Items

Fixes #3699 

## Description

Fixes downloads with proxy_url_ext set.

## Behaviour changes

Old: 
```
  File "/usr/lib/python3.9/site-packages/requests/sessions.py", line 712, in merge_environment_settings
    no_proxy = proxies.get('no_proxy') if proxies is not None else None
```

New: 
```
Successfully got file from https://cobbler.github.io/signatures/3.0.x/latest.json
```
## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
