### PR TITLE
Also need to "flatten" ks_meta for koan

### DIFF
--- a/cobbler/utils.py
+++ b/cobbler/utils.py
@@ -683,6 +683,8 @@ def flatten(data: dict) -> Optional[dict]:
         data["yumopts"] = dict_to_string(data["yumopts"])
     if "autoinstall_meta" in data:
         data["autoinstall_meta"] = dict_to_string(data["autoinstall_meta"])
+    if "ks_meta" in data:
+        data["ks_meta"] = dict_to_string(data["ks_meta"])
     if "template_files" in data:
         data["template_files"] = dict_to_string(data["template_files"])
     if "boot_files" in data:


### PR DESCRIPTION
## Linked Items

Fixes #3701 


## Description
koan expects ks_meta to be a space separated string, not a dictionary.  This should also help with https://github.com/cobbler/koan/issues/84

## Behaviour changes

Old: 
`{'tree': 'http://@@http_server@@/cblr/links/debian-12.5.0-x86_64'}`
New: <!-- This is the new way Cobbler behaves -->
`http://@@http_server@@/cblr/links/debian-12.5.0-x86_64`
## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->

I'm not sure why this wasn't caught by `test_get_systems_koan`