### PR TITLE
Enable dhcp sync to work on single system

### DIFF
--- a/changelog.d/3710.changed
+++ b/changelog.d/3710.changed
@@ -1,0 +1,1 @@
+Provide sync_single_system for DHCP modules to improve performance

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -463,9 +463,9 @@ class CobblerSync:
         """
         # rebuild system_list file in webdir
         if self.settings.manage_dhcp:
-            self.dhcp.regen_ethers()
+            self.dhcp.sync_single_system(system_obj)
         if self.settings.manage_dns:
-            self.dns.regen_hosts()
+            self.dns.add_single_hosts_entry(system_obj)
         # write the PXE files for the system
         self.tftpd.sync_single_system(system_obj)
 
@@ -498,6 +498,11 @@ class CobblerSync:
             )
             if pxe_filename is not None:
                 filesystem_helpers.rmtree(os.path.join(bootloc, "esxi", pxe_filename))
+
+        if self.settings.manage_dhcp:
+            self.dhcp.remove_single_system(system_obj)
+        if self.settings.manage_dns:
+            self.dns.remove_single_hosts_entry(system_obj)
 
     def remove_single_menu(self, rebuild_menu: bool = True) -> None:
         """

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -499,7 +499,7 @@ class Collection(Generic[ITEM]):
                     # we don't need openvz containers to be network bootable
                     if ref.virt_type == enums.VirtType.OPENVZ:
                         ref.netboot_enabled = False
-                    self.api.sync_systems(systems=[ref.name])
+                    self.lite_sync.add_single_system(ref)
                 elif isinstance(ref, profile.Profile):
                     # we don't need openvz containers to be network bootable
                     if ref.virt_type == "openvz":  # type: ignore

--- a/cobbler/modules/managers/__init__.py
+++ b/cobbler/modules/managers/__init__.py
@@ -11,7 +11,7 @@ other tool or administrator.
 
 import logging
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, List
 
 from cobbler import templar
 
@@ -82,6 +82,26 @@ class ManagerModule:
         self.write_configs()
         return self.restart_service()
 
+    def sync_single_system(self, system: "System") -> int:
+        """
+        This synchronizes data for a single system. The default implementation is
+        to trigger full synchronization. Manager modules can overwrite this method
+        to improve performance.
+
+        :param system: A system to be added.
+        """
+        del system  # unused var
+        self.regen_ethers()
+        return self.sync()
+
+    def remove_single_system(self, system_obj: "System") -> None:
+        """
+        This method removes a single system.
+        """
+        del system_obj  # unused var
+        self.regen_ethers()
+        self.sync()
+
 
 class DhcpManagerModule(ManagerModule):
     """
@@ -105,6 +125,28 @@ class DnsManagerModule(ManagerModule):
         """
         TODO
         """
+
+    def add_single_hosts_entry(self, system: "System") -> None:
+        """
+        This method adds a single system to the host file.
+        DNS manager modules can implement this method to improve performance.
+        Otherwise, this method defaults to a full host regeneration.
+
+        :param system: A system to be added.
+        """
+        del system  # unused var
+        self.regen_hosts()
+
+    def remove_single_hosts_entry(self, system: "System") -> None:
+        """
+        This method removes a single system from the host file.
+        DNS manager modules can implement this method to improve performance.
+        Otherwise, this method defaults to a full host regeneration.
+
+        :param system: A system to be removed.
+        """
+        del system  # unused var
+        self.regen_hosts()
 
 
 class TftpManagerModule(ManagerModule):
@@ -134,17 +176,4 @@ class TftpManagerModule(ManagerModule):
         TODO
 
         :param distro: TODO
-        """
-
-    @abstractmethod
-    def sync_single_system(
-        self,
-        system: "System",
-        menu_items: Optional[Dict[str, Union[str, Dict[str, str]]]] = None,
-    ) -> None:
-        """
-        TODO
-
-        :param system: TODO
-        :param menu_items: TODO
         """

--- a/cobbler/modules/managers/dnsmasq.py
+++ b/cobbler/modules/managers/dnsmasq.py
@@ -8,15 +8,15 @@ This is some of the code behind 'cobbler sync'.
 # SPDX-FileCopyrightText: John Eckersberg <jeckersb@redhat.com>
 
 import time
-from typing import TYPE_CHECKING, Dict, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
 
+from cobbler import utils
 from cobbler.modules.managers import DhcpManagerModule, DnsManagerModule
-from cobbler.utils import process_management
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.items.distro import Distro
-    from cobbler.items.profile import Profile
+    from cobbler.items.system import System
 
 
 MANAGER = None
@@ -45,16 +45,33 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
         """
         return "dnsmasq"
 
-    def sync_dhcp(self) -> None:
-        self.write_configs()
-        self.restart_service()
+    def __init__(self, api: "CobblerAPI"):
+        super().__init__(api)
+        self.config: Dict[str, Any] = {}
+        self.cobbler_hosts_file = self.api.settings().dnsmasq_hosts_file
+        self.ethers_file = self.api.settings().dnsmasq_ethers_file
+
+        utils.create_files_if_not_existing([self.cobbler_hosts_file, self.ethers_file])
 
     def write_configs(self) -> None:
         """
         DHCP files are written when ``manage_dhcp`` is set in our settings.
 
         :raises OSError
+        :raises ValueError
         """
+        self.config = self.gen_full_config()
+        self._write_configs(self.config)
+
+    def _write_configs(self, config_data: Optional[Dict[Any, Any]] = None) -> None:
+        """
+        Internal function to write DHCP files.
+
+        :raises OSError
+        :raises ValueError
+        """
+        if not config_data:
+            raise ValueError("No config to write.")
 
         settings_file = "/etc/dnsmasq.conf"
         template_file = "/etc/cobbler/dnsmasq.template"
@@ -65,60 +82,19 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
         except Exception as error:
             raise OSError(f"error writing template to file: {template_file}") from error
 
+        config_copy = config_data.copy()  # template rendering changes the passed dict
+        self.logger.info("Writing %s", settings_file)
+        self.templar.render(template_data, config_copy, settings_file)
+
+    def gen_full_config(self) -> Dict[str, str]:
+        """Generate DHCP configuration for all systems."""
         system_definitions: Dict[str, str] = {}
 
-        # we used to just loop through each system, but now we must loop
-        # through each network interface of each system.
-
         for system in self.systems:
-
-            if not system.is_management_supported(cidr_ok=False):
-                continue
-
-            profile: Optional["Profile"] = system.get_conceptual_parent()  # type: ignore
-            if profile is None:
-                raise ValueError("Profile for system not found!")
-            distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
-            if distro is None:
-                raise ValueError("Distro for system not found!")
-            for interface in system.interfaces.values():
-
-                mac = interface.mac_address
-                ip_address = interface.ip_address
-                host = interface.dns_name
-                ipv6 = interface.ipv6_address
-
-                if not mac:
-                    # can't write a DHCP entry for this system
-                    continue
-
-                # In many reallife situations there is a need to control the IP address and hostname for a specific
-                # client when only the MAC address is available. In addition to that in some scenarios there is a need
-                # to explicitly label a host with the applicable architecture in order to correctly handle situations
-                # where we need something other than ``pxelinux.0``. So we always write a dhcp-host entry with as much
-                # info as possible to allow maximum control and flexibility within the dnsmasq config.
-
-                systxt = "dhcp-host=net:" + distro.arch.value.lower() + "," + mac
-
-                if host != "":
-                    systxt += "," + host
-
-                if ip_address != "":
-                    systxt += "," + ip_address
-                if ipv6 != "":
-                    systxt += f",[{ipv6}]"
-
-                systxt += "\n"
-
-                dhcp_tag = interface.dhcp_tag
-                if dhcp_tag == "":
-                    dhcp_tag = "default"
-
-                if dhcp_tag not in system_definitions:
-                    system_definitions[dhcp_tag] = ""
-                system_definitions[dhcp_tag] = system_definitions[dhcp_tag] + systxt
-
-        # We are now done with the looping through each interface of each system.
+            system_config = self._gen_system_config(system)
+            system_definitions = utils.merge_dicts_recursive(
+                system_definitions, system_config, str_append=True
+            )
 
         metadata = {
             "insert_cobbler_system_definitions": system_definitions.get("default", ""),
@@ -126,17 +102,169 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
             "cobbler_server": self.settings.server,
             "next_server_v4": self.settings.next_server_v4,
             "next_server_v6": self.settings.next_server_v6,
+            "addn_host_file": self.cobbler_hosts_file,
         }
 
         # now add in other DHCP expansions that are not tagged with "default"
-        for system in list(system_definitions.keys()):
-            if system == "default":
+        for dhcp_tag, system_str in system_definitions.items():
+            if dhcp_tag == "default":
                 continue
-            metadata[
-                f"insert_cobbler_system_definitions_{system}"
-            ] = system_definitions[system]
+            metadata[f"insert_cobbler_system_definitions_{dhcp_tag}"] = system_str
 
-        self.templar.render(template_data, metadata, settings_file)
+        return metadata
+
+    def remove_single_system(self, system_obj: "System") -> None:
+        """
+        This method removes a single system.
+
+        :param system_obj: System to be removed.
+        """
+        if not self.config:
+            self.config = self.gen_full_config()
+
+        system_config = self._gen_system_config(system_obj)
+        for dhcp_tag, system_iface_config in system_config.items():
+            config_key = "insert_cobbler_system_definitions"
+            if dhcp_tag != "default":
+                config_key = f"insert_cobbler_system_definitions_{dhcp_tag}"
+            if system_iface_config not in self.config[config_key]:
+                continue
+            self.config[config_key] = self.config[config_key].replace(
+                system_iface_config, ""
+            )
+
+        self._write_configs(self.config)
+        self.remove_single_ethers_entry(system_obj)
+
+    def _gen_system_config(
+        self,
+        system_obj: "System",
+    ) -> Dict[str, str]:
+        """
+        Generate dnsmasq config for a single system.
+
+        :param system_obj: System to generate dnsmasq config for
+        """
+        # we used to just loop through each system, but now we must loop
+        # through each network interface of each system.
+        system_definitions: Dict[str, str] = {}
+
+        if not system_obj.is_management_supported(cidr_ok=False):
+            self.logger.debug(
+                "%s does not meet precondition: MAC, IPv4, or IPv6 address is required.",
+                system_obj.name,
+            )
+            return {}
+
+        profile = system_obj.get_conceptual_parent()
+        if profile is None:
+            raise ValueError("Profile for system not found!")
+        distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
+        if distro is None:
+            raise ValueError("Distro for system not found!")
+
+        for interface in system_obj.interfaces.values():
+            mac = interface.mac_address
+            ip_address = interface.ip_address
+            host = interface.dns_name
+            ipv6 = interface.ipv6_address
+
+            if not mac:
+                # can't write a DHCP entry for this system
+                continue
+
+            # In many reallife situations there is a need to control the IP address and hostname for a specific
+            # client when only the MAC address is available. In addition to that in some scenarios there is a need
+            # to explicitly label a host with the applicable architecture in order to correctly handle situations
+            # where we need something other than ``pxelinux.0``. So we always write a dhcp-host entry with as much
+            # info as possible to allow maximum control and flexibility within the dnsmasq config.
+
+            systxt = "dhcp-host=net:" + distro.arch.value.lower() + "," + mac
+
+            if host != "":
+                systxt += "," + host
+
+            if ip_address != "":
+                systxt += "," + ip_address
+            if ipv6 != "":
+                systxt += f",[{ipv6}]"
+
+            systxt += "\n"
+
+            dhcp_tag = interface.dhcp_tag
+            if dhcp_tag == "":
+                dhcp_tag = "default"
+
+            if dhcp_tag not in system_definitions:
+                system_definitions[dhcp_tag] = ""
+
+            system_definitions[dhcp_tag] = system_definitions[dhcp_tag] + systxt
+
+        return system_definitions
+
+    def _find_unique_dhcp_entries(
+        self, dhcp_entries: str, config_key: str
+    ) -> Tuple[str, str]:
+        """
+        This method checks the dhcp entries in the current config and returns
+        only those that are unique.
+
+        This is necessary because the sync_single_system method is used for
+        both adding and modifying a single system.
+        """
+        unique_entries = ""
+        duplicate_entries = ""
+        for dhcp_entry in dhcp_entries.split("\n"):
+            if dhcp_entry and dhcp_entry not in self.config[config_key]:
+                unique_entries += f"{dhcp_entry}\n"
+            else:
+                duplicate_entries += f"{dhcp_entry}\n"
+        return unique_entries, duplicate_entries
+
+    def _parse_mac_from_dnsmasq_entries(self, entries: str) -> List[str]:
+        return [entry.split(",")[1] for entry in entries.split("\n") if entry]
+
+    def sync_single_system(self, system: "System"):
+        """
+        Synchronize data for a single system.
+
+        :param system: A system to be added.
+        """
+        if not self.config:
+            # cache miss, need full sync for consistent data
+            self.regen_ethers()
+            return self.sync()
+
+        system_config = self._gen_system_config(system)
+        updated_dhcp_entries: Dict[str, str] = {}
+        duplicate_dhcp_entries = ""
+        for iface_tag, dhcp_entries in system_config.items():
+            config_key = "insert_cobbler_system_definitions"
+            if iface_tag != "default":
+                config_key = f"insert_cobbler_system_definitions_{iface_tag}"
+            (
+                unique_dhcp_entries,
+                duplicate_dhcp_entries,
+            ) = self._find_unique_dhcp_entries(dhcp_entries, config_key)
+            updated_dhcp_entries[config_key] = unique_dhcp_entries
+            self.config = utils.merge_dicts_recursive(
+                self.config, {config_key: unique_dhcp_entries}, str_append=True
+            )
+
+        if all(not dhcp_entry for dhcp_entry in updated_dhcp_entries.values()):
+            # No entries were updated. Therefore, User removed
+            # or modified already existing mac address and we don't
+            # know which mac address that was. Consequently, trigger
+            # a full sync to keep DNS and DHCP entries consistent.
+            self.regen_ethers()
+            return self.sync()
+
+        duplicate_macs = self._parse_mac_from_dnsmasq_entries(duplicate_dhcp_entries)
+        self.sync_single_ethers_entry(system, duplicate_macs)
+
+        self.config["date"] = time.asctime(time.gmtime())
+        self._write_configs(self.config)
+        return self.restart_service()
 
     def regen_ethers(self) -> None:
         """
@@ -145,52 +273,167 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
         """
         # dnsmasq knows how to read this database of MACs -> IPs, so we'll keep it up to date every time we add a
         # system.
-        with open("/etc/ethers", "w", encoding="UTF-8") as ethers_fh:
+        with open(self.ethers_file, "w", encoding="UTF-8") as ethers_fh:
             for system in self.systems:
-                if not system.is_management_supported(cidr_ok=False):
-                    continue
-                for interface in system.interfaces.values():
-                    mac = interface.mac_address
-                    ip_address = interface.ip_address
-                    if not mac:
-                        # can't write this w/o a MAC address
-                        continue
-                    if ip_address != "":
-                        ethers_fh.write(mac.upper() + "\t" + ip_address + "\n")
+                ethers_entry = self._gen_single_ethers_entry(system)
+                if ethers_entry:
+                    ethers_fh.write(ethers_entry)
+
+    def _gen_single_ethers_entry(
+        self, system_obj: "System", duplicate_macs: Optional[List[str]] = None
+    ):
+        """
+        Generate an ethers entry for a system, such as:
+        00:1A:2B:3C:4D:5E\t1.2.3.4\n
+        01:2B:3C:4D:5E:6F\t1.2.4.4\n
+        """
+        if not system_obj.is_management_supported(cidr_ok=False):
+            self.logger.debug(
+                "%s does not meet precondition: MAC, IPv4, or IPv6 address is required.",
+                system_obj.name,
+            )
+            return ""
+
+        output = ""
+        for interface in system_obj.interfaces.values():
+            mac = interface.mac_address
+            ip_address = interface.ip_address
+            if not mac:
+                # can't write this w/o a MAC address
+                continue
+            if duplicate_macs and mac in duplicate_macs:
+                # explicitly skipping mac address
+                continue
+            if ip_address != "":
+                output += mac.upper() + "\t" + ip_address + "\n"
+        return output
+
+    def sync_single_ethers_entry(
+        self, system: "System", duplicate_macs: Optional[List[str]] = None
+    ):
+        """
+        This appends a new single system entry to the ethers file.
+
+        :param system: A system to be added.
+        """
+        # dnsmasq knows how to read this database of MACs -> IPs, so we'll keep it up to date every time we add a
+        # system.
+        with open(self.ethers_file, "a", encoding="UTF-8") as ethers_fh:
+            host_entry = self._gen_single_ethers_entry(system, duplicate_macs)
+            if host_entry:
+                ethers_fh.write(host_entry)
+
+    def remove_single_ethers_entry(
+        self,
+        system: "System",
+    ):
+        """
+        This adds a new single system entry to the ethers file.
+
+        :param system: A system to be removed.
+        """
+        # dnsmasq knows how to read this database of MACs -> IPs, so we'll keep it up to date every time we add a
+        # system.
+        ethers_entry = self._gen_single_ethers_entry(system)
+        if not ethers_entry:
+            return
+        mac_addresses = self._extract_mac_from_ethers_entry(ethers_entry)
+        utils.remove_lines_in_file(self.ethers_file, mac_addresses)
+
+    def _extract_mac_from_ethers_entry(self, ethers_entry: str) -> List[str]:
+        """
+        One ethers entry can contain multiple MAC addresses.
+        This method transforms:
+
+        00:1A:2B:3C:4D:5E\t1.2.3.4\n
+        01:2B:3C:4D:5E:6F\t1.2.4.4\n
+
+        To:
+
+        ["00:1A:2B:3C:4D:5E", "01:2B:3C:4D:5E:6F"]
+        """
+        return [line.split("\t")[0] for line in ethers_entry.split("\n") if line]
+
+    def remove_single_hosts_entry(self, system: "System"):
+        """
+        This removes a single system entry from the Cobbler hosts file.
+
+        :param system: A system to be removed.
+        """
+        host_entry = self._gen_single_host_entry(system)
+        if not host_entry:
+            return
+        utils.remove_lines_in_file(self.cobbler_hosts_file, [host_entry])
+
+    def _gen_single_host_entry(
+        self,
+        system_obj: "System",
+    ):
+        if not system_obj.is_management_supported(cidr_ok=False):
+            self.logger.debug(
+                "%s does not meet precondition: MAC, IPv4, or IPv6 address is required.",
+                system_obj.name,
+            )
+            return ""
+
+        output = ""
+        for _, interface in system_obj.interfaces.items():
+            mac = interface.mac_address
+            host = interface.dns_name
+            cnames = " ".join(interface.cnames)
+            ipv4 = interface.ip_address
+            ipv6 = interface.ipv6_address
+            if not mac:
+                continue
+            if host != "" and ipv6 != "":
+                output += ipv6 + "\t" + host
+            elif host != "" and ipv4 != "":
+                output += ipv4 + "\t" + host
+            if cnames:
+                output += " " + cnames + "\n"
+            else:
+                output += "\n"
+        return output
+
+    def add_single_hosts_entry(
+        self,
+        system: "System",
+    ):
+        """
+        This adds a single system entry to the hosts file.
+
+        :param system: A system to be added.
+        """
+        host_entries = self._gen_single_host_entry(system)
+        if not host_entries:
+            return
+
+        # This method can be used for editing, so
+        # remove duplicate entries first
+        with open(self.cobbler_hosts_file, "r", encoding="UTF-8") as fd:
+            for host_line in fd:
+                host_line = host_line.strip()
+                if host_line and host_line in host_entries:
+                    host_entries = host_entries.replace(f"{host_line}\n", "")
+
+        if not host_entries.strip():
+            # No new entries present, we should trigger a full sync
+            self.regen_hosts()
+            return
+
+        with open(self.cobbler_hosts_file, "a", encoding="UTF-8") as regen_hosts_fd:
+            regen_hosts_fd.write(host_entries)
 
     def regen_hosts(self) -> None:
         """
         This rewrites the hosts file and thus also rewrites the dns config.
         """
         # dnsmasq knows how to read this database for host info (other things may also make use of this later)
-        with open(
-            "/var/lib/cobbler/cobbler_hosts", "w", encoding="UTF-8"
-        ) as regen_hosts_fd:
+        with open(self.cobbler_hosts_file, "w", encoding="UTF-8") as regen_hosts_fd:
             for system in self.systems:
-                if not system.is_management_supported(cidr_ok=False):
-                    continue
-                for (_, interface) in system.interfaces.items():
-                    mac = interface.mac_address
-                    host = interface.dns_name
-                    cnames = " ".join(interface.cnames)
-                    ipv4 = interface.ip_address
-                    ipv6 = interface.ipv6_address
-                    if not mac:
-                        continue
-                    if host != "" and ipv6 != "":
-                        if cnames:
-                            regen_hosts_fd.write(
-                                ipv6 + "\t" + host + " " + cnames + "\n"
-                            )
-                        else:
-                            regen_hosts_fd.write(ipv6 + "\t" + host + "\n")
-                    elif host != "" and ipv4 != "":
-                        if cnames:
-                            regen_hosts_fd.write(
-                                ipv4 + "\t" + host + " " + cnames + "\n"
-                            )
-                        else:
-                            regen_hosts_fd.write(ipv4 + "\t" + host + "\n")
+                host_entry = self._gen_single_host_entry(system)
+                if host_entry:
+                    regen_hosts_fd.write(host_entry)
 
     def restart_service(self) -> int:
         """
@@ -198,7 +441,7 @@ class _DnsmasqManager(DnsManagerModule, DhcpManagerModule):
         """
         service_name = "dnsmasq"
         if self.settings.restart_dhcp:
-            return_code_service_restart = process_management.service_restart(
+            return_code_service_restart = utils.process_management.service_restart(
                 service_name
             )
             if return_code_service_restart != 0:

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -9,7 +9,7 @@ This is some of the code behind 'cobbler sync'.
 
 import shutil
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set
 
 from cobbler import enums, utils
 from cobbler.enums import Archs
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.items.distro import Distro
     from cobbler.items.profile import Profile
+    from cobbler.items.system import NetworkInterface, System
 
 MANAGER = None
 
@@ -47,367 +48,291 @@ class _IscManager(DhcpManagerModule):
         self.settings_file_v4 = utils.dhcpconf_location(enums.DHCP.V4)
         self.settings_file_v6 = utils.dhcpconf_location(enums.DHCP.V6)
 
-    def sync_dhcp(self) -> None:
-        self.write_configs()
+        # cache config to allow adding systems incrementally
+        self.config: Dict[str, Any] = {}
+        self.generic_entry_cnt = 0
+
+    def sync_single_system(self, system: "System"):
+        """
+        Update the config with data for a single system, write it to the filesysemt, and restart DHCP service.
+        :param system: System object to generate the config for.
+        """
+        if not self.config:
+            # cache miss, need full sync for consistent data
+            return self.sync()
+
+        profile: Optional["Profile"] = system.get_conceptual_parent()  # type: ignore
+        distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
+        blend_data = utils.blender(self.api, False, system)
+
+        system_config = self._gen_system_config(system, blend_data, distro)
+
+        if all(
+            mac in self.config.get("dhcp_tags", {}).get(dhcp_tag, {})
+            for dhcp_tag, interface in system_config.items()
+            for mac in interface
+        ):
+            # All interfaces in the added system are already cached. Therefore,
+            # user might have removed an interface and we don't know which.
+            # Trigger full sync.
+            return self.sync()
+
+        self.config = utils.merge_dicts_recursive(
+            self.config,
+            {"dhcp_tags": system_config},
+        )
+        self.config["date"] = time.asctime(time.gmtime())
+        self._write_configs(self.config)
+        return self.restart_service()
+
+    def remove_single_system(self, system_obj: "System") -> None:
+        if not self.config:
+            self.write_configs()
+            return
+
+        profile: Optional["Profile"] = system_obj.get_conceptual_parent()  # type: ignore
+        distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
+        blend_data = utils.blender(self.api, False, system_obj)
+
+        system_config = self._gen_system_config(system_obj, blend_data, distro)
+        for dhcp_tag, mac_addresses in system_config.items():
+            for mac_address in mac_addresses:
+                self.config.get("dhcp_tags", {}).get(dhcp_tag, {}).pop(mac_address, "")
+        self.config["date"] = time.asctime(time.gmtime())
+        self._write_configs(self.config)
         self.restart_service()
 
-    def write_v4_config(
-        self, template_file: str = "/etc/cobbler/dhcp.template"
-    ) -> None:
+    def _gen_system_config(
+        self,
+        system_obj: "System",
+        system_blend_data: Dict[str, Any],
+        distro_obj: Optional["Distro"],
+    ) -> Dict[str, Any]:
         """
-        DHCPv4 files are written when ``manage_dhcp_v4`` is set in our settings.
+        Generate DHCP config for a single system.
 
-        :param template_file: The location of the DHCP template.
+        :param system_obj: System to generate DHCP config for
+        :param system_blend_data: utils.blender() data for the System
+        :param distro_object: Optional, is used to access distro-specific information like arch when present
         """
-
-        blender_cache: Dict[str, Any] = {}
-
-        with open(template_file, "r", encoding="UTF-8") as template_fd:
-            template_data = template_fd.read()
-
-        # Use a simple counter for generating generic names where a hostname is not available.
-        counter = 0
-
-        # We used to just loop through each system, but now we must loop through each network interface of each system.
         dhcp_tags: Dict[str, Any] = {"default": {}}
+        processed_system_master_interfaces: Set[str] = set()
+        ignore_macs: Set[str] = set()
+        if not system_obj.is_management_supported(cidr_ok=False):
+            self.logger.debug(
+                "%s does not meet precondition: MAC, IPv4, or IPv6 address is required.",
+                system_obj.name,
+            )
+            return {}
 
-        # FIXME: ding should evolve into the new dhcp_tags dict
-        ding: Dict[str, Any] = {}
-        ignore_macs: List[str] = []
-
-        for system in self.systems:
-            if not system.is_management_supported(cidr_ok=False):
+        profile: Optional["Profile"] = system_obj.get_conceptual_parent()  # type: ignore
+        for iface_name, iface_obj in system_obj.interfaces.items():
+            iface = iface_obj.to_dict()
+            mac = iface_obj.mac_address
+            if (
+                not self.settings.always_write_dhcp_entries
+                and not system_blend_data["netboot_enabled"]
+                and iface["static"]
+            ):
+                continue
+            if not mac:
+                self.logger.warning("%s has no MAC address", system_obj.name)
                 continue
 
-            profile: Optional["Profile"] = system.get_conceptual_parent()  # type: ignore
-            if profile is None:
-                raise ValueError("Profile for System not found!")
-            distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
-
-            # if distro is None then the profile is really an image record
-            for (name, system_interface) in list(system.interfaces.items()):
-
-                # We make a copy because we may modify it before adding it to the dhcp_tags and we don't want to affect
-                # the master copy.
-                interface = system_interface.to_dict()
-
-                if interface["if_gateway"]:
-                    interface["gateway"] = system_interface.if_gateway
-                else:
-                    interface["gateway"] = system.gateway
-
-                mac = system_interface.mac_address
-
-                if interface["interface_type"] in (
-                    "bond_slave",
-                    "bridge_slave",
-                    "bonded_bridge_slave",
-                ):
-
-                    if interface["interface_master"] not in system.interfaces:
-                        # Can't write DHCP entry; master interface does not exist
-                        continue
-
-                    # We may have multiple bonded interfaces, so we need a composite index into ding.
-                    name_master = f"{system.name}-{interface['interface_master']}"
-                    if name_master not in ding:
-                        ding[name_master] = {interface["interface_master"]: []}
-
-                    if len(ding[name_master][interface["interface_master"]]) == 0:
-                        ding[name_master][interface["interface_master"]].append(mac)
-                    else:
-                        ignore_macs.append(mac)
-
-                    ip_address = system.interfaces[
-                        interface["interface_master"]
-                    ].ip_address
-                    netmask = system.interfaces[interface["interface_master"]].netmask
-                    dhcp_tag = system.interfaces[interface["interface_master"]].dhcp_tag
-                    host = system.interfaces[interface["interface_master"]].dns_name
-
-                    if ip_address == "":
-                        for (interface_name, interface_object) in list(
-                            system.interfaces.items()
-                        ):
-                            if (
-                                interface_name.startswith(
-                                    interface["interface_master"] + "."
-                                )
-                                and interface_object.ip_address != ""
-                            ):
-                                ip_address = interface_object.ip_address
-                                break
-
-                    interface["ip_address"] = ip_address
-                    interface["netmask"] = netmask
-                else:
-                    ip_address = interface["ip_address"]
-                    netmask = interface["netmask"]
-                    dhcp_tag = interface["dhcp_tag"]
-                    host = interface["dns_name"]
-
-                if mac == "":
-                    # can't write a DHCP entry for this system
+            iface["gateway"] = iface_obj.if_gateway or system_obj.gateway
+            if iface["interface_type"] in (
+                "bond_slave",
+                "bridge_slave",
+                "bonded_bridge_slave",
+            ):
+                if iface["interface_master"] not in system_obj.interfaces:
+                    # Can't write DHCP entry: master interface does not exist
                     continue
 
-                counter = counter + 1
-
-                # the label the entry after the hostname if possible
-                if host is not None and host != "":
-                    if name != "eth0":
-                        interface["name"] = f"{host}-{name}"
-                    else:
-                        interface["name"] = host
+                master_name = iface["interface_master"]
+                master_iface = system_obj.interfaces[master_name]
+                # There may be multiple bonded interfaces, need composite index
+                system_master_name = f"{system_obj.name}-{master_name}"
+                if system_master_name not in processed_system_master_interfaces:
+                    processed_system_master_interfaces.add(system_master_name)
                 else:
-                    interface["name"] = f"generic{counter:d}"
-
-                # add references to the system, profile, and distro for use in the template
-                if system.name in blender_cache:
-                    blended_system = blender_cache[system.name]
-                else:
-                    blended_system = utils.blender(self.api, False, system)
-                    blender_cache[system.name] = blended_system
-
-                interface["next_server_v4"] = blended_system["next_server_v4"]
-                interface["filename"] = blended_system.get("filename")
-                interface["netboot_enabled"] = blended_system["netboot_enabled"]
-                interface["hostname"] = blended_system["hostname"]
-                interface["owner"] = blended_system["name"]
-                interface["enable_ipxe"] = blended_system["enable_ipxe"]
-                interface["name_servers"] = blended_system["name_servers"]
-
-                if profile is not None:
-                    interface["profile"] = profile.to_dict()
-
-                if distro is not None:
-                    interface["distro"] = distro.to_dict()
-
-                # For esxi/UEFI export filename_esxi as path to efi bootloader
-                if distro and distro.os_version.startswith("esxi"):
-                    interface["filename_esxi"] = "/".join(
-                        (
-                            "esxi/system",
-                            # In case the config filename is None we take an empty string.
-                            system.get_config_filename(interface=name, loader="pxe")
-                            or "",
-                            "mboot.efi",
-                        )
+                    ignore_macs.add(mac)
+                # IPv4
+                iface["netmask"] = master_iface.netmask
+                iface["ip_address"] = master_iface.ip_address
+                if not iface["ip_address"]:
+                    iface["ip_address"] = self._find_ip_addr(
+                        system_obj.interfaces, prefix=master_name, ip_version="ipv4"
                     )
+                # IPv6
+                iface["ipv6_address"] = master_iface.ipv6_address
+                if not iface["ipv6_address"]:
+                    iface["ipv6_address"] = self._find_ip_addr(
+                        system_obj.interfaces, prefix=master_name, ip_version="ipv6"
+                    )
+                # common
+                host = master_iface.dns_name
+                dhcp_tag = master_iface.dhcp_tag
+            else:
+                # TODO: simplify _slave / non_slave branches
+                host = iface["dns_name"]
+                dhcp_tag = iface["dhcp_tag"]
 
-                # Explicitly declare filename for other (non x86) archs as in DHCP discover package mostly the
-                # architecture cannot be differed due to missing bits...
-                if distro is not None and not interface.get("filename"):
-                    if distro.arch in [
-                        Archs.PPC,
-                        Archs.PPC64,
-                        Archs.PPC64LE,
-                        Archs.PPC64EL,
-                    ]:
-                        interface["filename"] = "grub/grub.ppc64le"
-                    elif distro.arch == Archs.AARCH64:
-                        interface["filename"] = "grub/grubaa64.efi"
-
-                if not self.settings.always_write_dhcp_entries:
-                    if not interface["netboot_enabled"] and interface["static"]:
-                        continue
-
-                if dhcp_tag == "":
-                    dhcp_tag = blended_system.get("dhcp_tag", "")
-                    if dhcp_tag == "":
-                        dhcp_tag = "default"
-
-                if dhcp_tag not in dhcp_tags:
-                    dhcp_tags[dhcp_tag] = {mac: interface}
+            if distro_obj is not None:
+                iface["distro"] = distro_obj.to_dict()
+            if profile is not None:
+                iface["profile"] = profile.to_dict()  # type: ignore
+            if host:
+                if iface_name == "eth0":
+                    iface["name"] = host
                 else:
-                    dhcp_tags[dhcp_tag][mac] = interface
+                    iface["name"] = f"{host}-{iface_name}"
+            else:
+                self.generic_entry_cnt += 1
+                iface["name"] = f"generic{self.generic_entry_cnt:d}"
 
-        # Remove macs from redundant slave interfaces from dhcp_tags otherwise you get duplicate ip's in the installer.
-        for dhcp_tag_key in list(dhcp_tags.keys()):
-            for mac in list(dhcp_tags[dhcp_tag_key].keys()):
+            for key in (
+                "next_server_v6",
+                "next_server_v4",
+                "filename",
+                "netboot_enabled",
+                "hostname",
+                "enable_ipxe",
+                "name_servers",
+            ):
+                iface[key] = system_blend_data[key]
+            iface["owner"] = system_blend_data["name"]
+            # esxi
+            if distro_obj is not None and distro_obj.os_version.startswith("esxi"):
+                iface["filename_esxi"] = (
+                    "esxi/system",
+                    # config filename can be None
+                    system_obj.get_config_filename(interface=iface_name, loader="pxe")
+                    or "",
+                    "mboot.efi",
+                )
+            elif distro_obj is not None and not iface["filename"]:
+                if distro_obj.arch in (
+                    Archs.PPC,
+                    Archs.PPC64,
+                    Archs.PPC64LE,
+                    Archs.PPC64EL,
+                ):
+                    iface["filename"] = "grub/grub.ppc64le"
+                elif distro_obj.arch == Archs.AARCH64:
+                    iface["filename"] = "grub/grubaa64.efi"
+
+            if not dhcp_tag:
+                dhcp_tag = system_blend_data.get("dhcp_tag", "")
+                if dhcp_tag == "":
+                    dhcp_tag = "default"
+            if dhcp_tag not in dhcp_tags:
+                dhcp_tags[dhcp_tag] = {mac: iface}
+            else:
+                dhcp_tags[dhcp_tag][mac] = iface
+
+        for macs in dhcp_tags.values():
+            for mac in macs:
                 if mac in ignore_macs:
-                    del dhcp_tags[dhcp_tag_key][mac]
+                    del macs[mac]
 
-        # we are now done with the looping through each interface of each system
+        return dhcp_tags
+
+    def _find_ip_addr(
+        self,
+        interfaces: Dict[str, "NetworkInterface"],
+        prefix: str,
+        ip_version: str,
+    ) -> str:
+        """Find the first interface with an IP address that begins with prefix."""
+
+        if ip_version.lower() == "ipv4":
+            attr_name = "ip_address"
+        elif ip_version.lower() == "ipv6":
+            attr_name = "ipv6_address"
+        else:
+            return ""
+
+        for name, obj in interfaces:
+            if name.startswith(prefix + ".") and hasattr(obj, attr_name):
+                return getattr(obj, attr_name)
+        return ""
+
+    def gen_full_config(self) -> Dict[str, Any]:
+        """Generate DHCP configuration for all systems."""
+        dhcp_tags: Dict[str, Any] = {"default": {}}
+        self.generic_entry_cnt = 0
+        for system in self.systems:
+            profile: Optional["Profile"] = system.get_conceptual_parent()  # type: ignore
+            if profile is None:
+                continue
+            distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
+            blended_system = utils.blender(self.api, False, system)
+            new_tags = self._gen_system_config(system, blended_system, distro)
+            dhcp_tags = utils.merge_dicts_recursive(dhcp_tags, new_tags)
+
         metadata = {
             "date": time.asctime(time.gmtime()),
             "cobbler_server": f"{self.settings.server}:{self.settings.http_port}",
             "next_server_v4": self.settings.next_server_v4,
-            "dhcp_tags": dhcp_tags,
-        }
-
-        self.logger.info("generating %s", self.settings_file_v4)
-        self.templar.render(template_data, metadata, self.settings_file_v4)
-
-    def write_v6_config(
-        self, template_file: str = "/etc/cobbler/dhcp6.template"
-    ) -> None:
-        """
-        DHCPv6 files are written when ``manage_dhcp_v6`` is set in our settings.
-
-        :param template_file: The location of the DHCP template.
-        """
-
-        blender_cache: Dict[str, Any] = {}
-
-        with open(template_file, "r", encoding="UTF-8") as template_fd:
-            template_data = template_fd.read()
-
-        # Use a simple counter for generating generic names where a hostname is not available.
-        counter = 0
-
-        # We used to just loop through each system, but now we must loop through each network interface of each system.
-        dhcp_tags: Dict[str, Any] = {"default": {}}
-
-        # FIXME: ding should evolve into the new dhcp_tags dict
-        ding: Dict[Any, Any] = {}
-        ignore_macs: List[str] = []
-
-        for system in self.systems:
-            if not system.is_management_supported(cidr_ok=False):
-                continue
-
-            profile: Optional["Profile"] = system.get_conceptual_parent()  # type: ignore
-            if profile is None:
-                raise ValueError("Profile not found!")
-            distro: Optional["Distro"] = profile.get_conceptual_parent()  # type: ignore
-            if distro is None:
-                raise ValueError("Distro not found!")
-
-            # if distro is None then the profile is really an image record
-            for (name, system_interface) in list(system.interfaces.items()):
-
-                # We make a copy because we may modify it before adding it to the dhcp_tags and we don't want to affect
-                # the master copy.
-                interface = system_interface.to_dict()
-
-                if interface["if_gateway"]:
-                    interface["gateway"] = interface["if_gateway"]
-                else:
-                    interface["gateway"] = system.gateway
-
-                mac = interface["mac_address"]
-
-                if interface["interface_type"] in (
-                    "bond_slave",
-                    "bridge_slave",
-                    "bonded_bridge_slave",
-                ):
-
-                    if interface["interface_master"] not in system.interfaces:
-                        # Can't write DHCP entry; master interface does not exist
-                        continue
-
-                    # We may have multiple bonded interfaces, so we need a composite index into ding.
-                    name_master = f"{system.name}-{interface['interface_master']}"
-                    if name_master not in ding:
-                        ding[name_master] = {interface["interface_master"]: []}
-
-                    if len(ding[name_master][interface["interface_master"]]) == 0:
-                        ding[name_master][interface["interface_master"]].append(mac)
-                    else:
-                        ignore_macs.append(mac)
-
-                    ip_v6 = system.interfaces[
-                        interface["interface_master"]
-                    ].ipv6_address
-                    dhcp_tag = system.interfaces[interface["interface_master"]].dhcp_tag
-                    host = system.interfaces[interface["interface_master"]].dns_name
-
-                    if not ip_v6:
-                        for (interface_name, interface_object) in list(
-                            system.interfaces.items()
-                        ):
-                            if (
-                                interface_name.startswith(
-                                    interface["interface_master"] + "."
-                                )
-                                and interface_object.ipv6_address != ""
-                            ):
-                                ip_v6 = interface_object.ipv6_address
-                                break
-
-                    interface["ipv6_address"] = ip_v6
-                else:
-                    ip_v6 = interface["ipv6_address"]
-                    dhcp_tag = interface["dhcp_tag"]
-                    host = interface["dns_name"]
-
-                if not mac or not ip_v6:
-                    # can't write a DHCP entry for this system
-                    self.logger.warning("%s has no IPv6 or MAC address", system.name)
-                    continue
-                counter = counter + 1
-
-                # the label the entry after the hostname if possible
-                if host:
-                    if name != "eth0":
-                        interface["name"] = f"{host}-{name}"
-                    else:
-                        interface["name"] = host
-                else:
-                    interface["name"] = f"generic{counter:d}"
-
-                # add references to the system, profile, and distro for use in the template
-                if system.name in blender_cache:
-                    blended_system = blender_cache[system.name]
-                else:
-                    blended_system = utils.blender(self.api, False, system)
-                    blender_cache[system.name] = blended_system
-
-                interface["next_server_v6"] = blended_system["next_server_v6"]
-                interface["filename"] = blended_system.get("filename")
-                interface["netboot_enabled"] = blended_system["netboot_enabled"]
-                interface["hostname"] = blended_system["hostname"]
-                interface["owner"] = blended_system["name"]
-                interface["name_servers"] = blended_system["name_servers"]
-
-                if profile is not None:
-                    interface["profile"] = profile.to_dict()
-
-                if distro is not None:
-                    interface["distro"] = distro.to_dict()
-
-                # Explicitly declare filename for other (non x86) archs as in DHCP discover package mostly the
-                # architecture cannot be differed due to missing bits...
-                if not interface.get("filename"):
-                    if distro.arch == Archs.PPC:
-                        interface["filename"] = "grub/grub.ppc"
-                    elif distro.arch == Archs.PPC64:
-                        interface["filename"] = "grub/grub.ppc64"
-                    elif distro.arch == Archs.PPC64LE:
-                        interface["filename"] = "grub/grub.ppc64le"
-                    elif distro.arch == Archs.AARCH64:
-                        interface["filename"] = "grub/grubaa64.efi"
-
-                if not self.settings.always_write_dhcp_entries:
-                    if not interface["netboot_enabled"] and interface["static"]:
-                        continue
-
-                if dhcp_tag == "":
-                    dhcp_tag = blended_system.get("dhcp_tag", "")
-                    if dhcp_tag == "":
-                        dhcp_tag = "default"
-
-                if dhcp_tag not in dhcp_tags:
-                    dhcp_tags[dhcp_tag] = {mac: interface}
-                else:
-                    dhcp_tags[dhcp_tag][mac] = interface
-
-        # Remove macs from redundant slave interfaces from dhcp_tags otherwise you get duplicate ip's in the installer.
-        for dhcp_tag_key in list(dhcp_tags.keys()):
-            for mac_address in list(dhcp_tags[dhcp_tag_key].keys()):
-                if mac_address in ignore_macs:
-                    del dhcp_tags[dhcp_tag_key][mac_address]
-
-        # we are now done with the looping through each interface of each system
-        metadata = {
-            "date": time.asctime(time.gmtime()),
             "next_server_v6": self.settings.next_server_v6,
             "dhcp_tags": dhcp_tags,
         }
+        return metadata
 
-        self.logger.info("generating %s", self.settings_file_v6)
-        self.templar.render(template_data, metadata, self.settings_file_v6)
+    def _write_config(
+        self,
+        config_data: Dict[Any, Any],
+        template_file: str,
+        settings_file: str,
+    ) -> None:
+        """DHCP files are written when ``manage_dhcp_v4`` or ``manage_dhcp_v6``
+        is set in the settings for the respective version. DHCPv4 files are
+        written when ``manage_dhcp_v4`` is set in our settings.
+
+        :param config_data: DHCP data to write.
+        :param template_file: The location of the DHCP template.
+        :param settings_file: The location of the final config file.
+        """
+        try:
+            with open(template_file, "r", encoding="UTF-8") as template_fd:
+                template_data = template_fd.read()
+        except OSError as e:
+            self.logger.error("Can't read dhcp template '%s':\n%s", template_file, e)
+            return
+        config_copy = config_data.copy()  # template rendering changes the passed dict
+        self.logger.info("Writing %s", settings_file)
+        self.templar.render(template_data, config_copy, settings_file)
+
+    def write_v4_config(
+        self,
+        config_data: Optional[Dict[Any, Any]] = None,
+        template_file: str = "/etc/cobbler/dhcp.template",
+    ):
+        """Write DHCP files for IPv4.
+
+        :param config_data: DHCP data to write.
+        :param template_file: The location of the DHCP template.
+        :param settings_file: The location of the final config file.
+        """
+        if not config_data:
+            raise ValueError("No config to write.")
+        self._write_config(config_data, template_file, self.settings_file_v4)
+
+    def write_v6_config(
+        self,
+        config_data: Optional[Dict[Any, Any]] = None,
+        template_file: str = "/etc/cobbler/dhcp6.template",
+    ):
+        """Write DHCP files for IPv6.
+
+        :param config_data: DHCP data to write.
+        :param template_file: The location of the DHCP template.
+        :param settings_file: The location of the final config file.
+        """
+        if not config_data:
+            raise ValueError("No config to write.")
+        self._write_config(config_data, template_file, self.settings_file_v6)
 
     def restart_dhcp(self, service_name: str, version: int) -> int:
         """
@@ -438,10 +363,24 @@ class _IscManager(DhcpManagerModule):
         return return_code_service_restart
 
     def write_configs(self) -> None:
+        """
+        DHCP files are written when ``manage_dhcp`` is set in our settings.
+
+        :raises OSError
+        :raises ValueError
+        """
+        self.generic_entry_cnt = 0
+        self.config = self.gen_full_config()
+        self._write_configs(self.config)
+
+    def _write_configs(self, data: Optional[Dict[Any, Any]] = None) -> None:
+        if not data:
+            raise ValueError("No config to write.")
+
         if self.settings.manage_dhcp_v4:
-            self.write_v4_config()
+            self.write_v4_config(data)
         if self.settings.manage_dhcp_v6:
-            self.write_v6_config()
+            self.write_v6_config(data)
 
     def restart_service(self) -> int:
         if not self.settings.restart_dhcp:

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -176,6 +176,8 @@ class Settings:
         self.default_virt_file_size = 5.0
         self.default_virt_ram = 512
         self.default_virt_type = "kvm"
+        self.dnsmasq_ethers_file = "/etc/ethers"
+        self.dnsmasq_hosts_file = "/var/lib/cobbler/cobbler_hosts"
         self.enable_ipxe = False
         self.enable_menu = True
         self.extra_settings_list: List[str] = []

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -1,5 +1,5 @@
 """
-Migration from V3.3.1 to V3.3.2
+Migration from V3.3.3 to V3.4.0
 """
 
 # SPDX-License-Identifier: GPL-2.0-or-later
@@ -72,6 +72,8 @@ schema = Schema(
         Optional("default_virt_file_size"): float,
         Optional("default_virt_ram"): int,
         Optional("default_virt_type"): str,
+        Optional("dnsmasq_ethers_file"): str,
+        Optional("dnsmasq_hosts_file"): str,
         Optional("enable_ipxe"): bool,
         Optional("enable_menu"): bool,
         Optional("extra_settings_list"): [str],

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -222,6 +222,15 @@ default_virt_type: kvm
 # The virtualization disk format
 default_virt_disk_driver: "raw"
 
+# The path to the ethers file used by the dnsmasq manager module.
+# Note that if you change this path, you might have to reconfigure
+# external systems that also use the file. See `man 5 ethers`
+# for more information about the file and its uses.
+dnsmasq_ethers_file: "/etc/ethers"
+
+# The path to the hosts file used by the dnsmasq manager module.
+dnsmasq_hosts_file: "/var/lib/cobbler/cobbler_hosts"
+
 # enable iPXE booting? Enabling this option will cause Cobbler
 # to copy the undionly.kpxe file to the tftp root directory,
 # and if a profile/system is configured to boot via iPXE it will

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -408,6 +408,21 @@ The on-disk format for the virtualization disk.
 
 default: ``raw``
 
+dnsmasq_ethers_file
+###################
+
+The path to the ethers file used by the dnsmasq manager module. Note that if you change this path, you might have to reconfigure
+external systems that also use the file. See ``man 5 ethers`` for more information about the file and its uses.
+
+default: ``/etc/ethers``
+
+dnsmasq_hosts_file
+##################
+
+The path to the hosts file used by the dnsmasq manager module.
+
+default: ``/var/lib/cobbler/cobbler_hosts``
+
 default_virt_file_size
 ######################
 

--- a/templates/etc/dnsmasq.template
+++ b/templates/etc/dnsmasq.template
@@ -6,7 +6,7 @@
 #no-poll
 #enable-dbus
 read-ethers
-addn-hosts = /var/lib/cobbler/cobbler_hosts
+addn-hosts = $addn_host_file
 
 dhcp-range=192.168.1.5,192.168.1.200
 dhcp-option=66,$next_server_v4

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -503,7 +503,7 @@ def test_dump_vars(cobbler_api: CobblerAPI):
     print(result)
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 155
+    assert len(result) == 157
 
 
 @pytest.mark.parametrize(

--- a/tests/modules/managers/dnsmasq_test.py
+++ b/tests/modules/managers/dnsmasq_test.py
@@ -1,11 +1,53 @@
 import time
 from unittest.mock import MagicMock
 
+import pytest
+from pytest_mock.plugin import MockerFixture
+
+from cobbler import utils
+from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.system import NetworkInterface, System
 from cobbler.modules.managers import dnsmasq
+from cobbler.settings import Settings
 from cobbler.templar import Templar
+
+
+@pytest.fixture
+def cobbler_api():
+    """
+    Mock to prevent the full creation of a CobblerAPI and Settings object.
+    """
+    settings_mock = MagicMock(name="cobbler_api_mock", spec=Settings)
+    settings_mock.server = "192.168.1.1"
+    settings_mock.next_server_v4 = "192.168.1.1"
+    settings_mock.next_server_v6 = "::1"
+    settings_mock.default_virt_type = "auto"
+    settings_mock.restart_dhcp = True
+    settings_mock.default_virt_disk_driver = "raw"
+    settings_mock.cache_enabled = False
+    settings_mock.allow_duplicate_hostnames = True
+    settings_mock.allow_duplicate_macs = True
+    settings_mock.allow_duplicate_ips = True
+    settings_mock.dnsmasq_hosts_file = "/var/lib/cobbler/cobbler_hosts"
+    settings_mock.dnsmasq_ethers_file = "/etc/ethers"
+    api_mock = MagicMock(autospec=True, spec=CobblerAPI)
+    api_mock.settings.return_value = settings_mock
+    return api_mock
+
+
+def _generate_test_system(cobbler_api: CobblerAPI):
+    mock_system = System(cobbler_api)
+    mock_system.name = "test_manager_regen_ethers_system"
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
+    mock_system.interfaces["default"].dns_name = "host.example.org"
+    mock_system.interfaces["default"].mac_address = "AA:BB:CC:DD:EE:FF"
+    mock_system.interfaces["default"].ip_address = "192.168.1.2"
+    mock_system.interfaces["default"].ipv6_address = "::1"
+    return mock_system
 
 
 def test_register():
@@ -18,19 +60,23 @@ def test_register():
 
 def test_manager_what():
     # Arrange & Act & Assert
-    assert dnsmasq._DnsmasqManager.what() == "dnsmasq"
+    assert dnsmasq._DnsmasqManager.what() == "dnsmasq"  # type: ignore
 
 
-def test_get_manager(cobbler_api):
+def test_get_manager(cobbler_api: CobblerAPI):
     # Arrange & Act
     result = dnsmasq.get_manager(cobbler_api)
 
     # Assert
-    isinstance(result, dnsmasq._DnsmasqManager)
+    assert isinstance(result, dnsmasq._DnsmasqManager)  # type: ignore
 
 
-def test_manager_write_configs(mocker, cobbler_api):
+def test_manager_write_configs(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     # Arrange
+    system_dns = "host.example.org"
+    system_mac = "aa:bb:cc:dd:ee:ff"
+    system_ip4 = "192.168.1.2"
+    system_ip6 = "::1"
     mocker.patch(
         "time.gmtime",
         return_value=time.struct_time((2000, 1, 1, 0, 0, 0, 0, 1, 1)),
@@ -44,15 +90,15 @@ def test_manager_write_configs(mocker, cobbler_api):
     mock_system.interfaces = {
         "default": NetworkInterface(cobbler_api, mock_system.name)
     }
-    mock_system.interfaces["default"].dns_name = "host.example.org"
-    mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
-    mock_system.interfaces["default"].ip_address = "192.168.1.2"
-    mock_system.interfaces["default"].ipv6_address = "::1"
+    mock_system.interfaces["default"].dns_name = system_dns
+    mock_system.interfaces["default"].mac_address = system_mac
+    mock_system.interfaces["default"].ip_address = system_ip4
+    mock_system.interfaces["default"].ipv6_address = system_ip6
     mocker.patch.object(mock_system, "get_conceptual_parent", return_value=mock_profile)
     mocker.patch.object(mock_profile, "get_conceptual_parent", return_value=mock_distro)
     dnsmasq.MANAGER = None
     test_manager = dnsmasq.get_manager(cobbler_api)
-    test_manager.systems = [mock_system]
+    test_manager.systems = [mock_system]  # type: ignore
     test_manager.templar = MagicMock(spec=Templar, autospec=True)
 
     # Act
@@ -62,69 +108,228 @@ def test_manager_write_configs(mocker, cobbler_api):
     test_manager.templar.render.assert_called_once_with(
         "test",
         {
-            "insert_cobbler_system_definitions": "dhcp-host=net:x86_64,aa:bb:cc:dd:ee:ff,host.example.org,192.168.1.2,[::1]\n",
+            "insert_cobbler_system_definitions": f"dhcp-host=net:x86_64,{system_mac},{system_dns},{system_ip4},[{system_ip6}]\n",
             "date": "Mon Jan  1 00:00:00 2000",
-            "cobbler_server": "192.168.1.1",
-            "next_server_v4": "192.168.1.1",
-            "next_server_v6": "::1",
+            "cobbler_server": cobbler_api.settings().server,
+            "next_server_v4": cobbler_api.settings().next_server_v4,
+            "next_server_v6": cobbler_api.settings().next_server_v6,
+            "addn_host_file": cobbler_api.settings().dnsmasq_hosts_file,
         },
         "/etc/dnsmasq.conf",
     )
 
 
-def test_manager_regen_ethers(mocker, cobbler_api):
+def test_manager_sync_single_system(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     # Arrange
-    mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
-    mock_system = System(cobbler_api)
-    mock_system.name = "test_manager_regen_ethers_system"
-    mock_system.interfaces = {
-        "default": NetworkInterface(cobbler_api, mock_system.name)
+    mock_system_definition = (
+        "dhcp-host=net:x86_64,bb:bb:cc:dd:ee:ff,test.example.org,192.168.1.3,[::1]\n"
+    )
+    mock_config = {
+        "insert_cobbler_system_definitions": mock_system_definition,
+        "date": "Mon Jan  1 00:00:00 2000",
+        "cobbler_server": cobbler_api.settings().server,
+        "next_server_v4": cobbler_api.settings().next_server_v4,
+        "next_server_v6": cobbler_api.settings().next_server_v6,
+        "addn_host_file": cobbler_api.settings().dnsmasq_hosts_file,
     }
-    mock_system.interfaces["default"].dns_name = "host.example.org"
-    mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
-    mock_system.interfaces["default"].ip_address = "192.168.1.2"
-    mock_system.interfaces["default"].ipv6_address = "::1"
+    mocker.patch(
+        "time.gmtime",
+        return_value=time.struct_time((2000, 1, 1, 0, 0, 0, 0, 1, 1)),
+    )
+    mocker.patch("builtins.open", mocker.mock_open(read_data="test"))
+    mock_distro = Distro(cobbler_api)
+    mock_distro.arch = "x86_64"
+    mock_profile = Profile(cobbler_api)
+    mock_system = _generate_test_system(cobbler_api)
+    mocker.patch.object(mock_system, "get_conceptual_parent", return_value=mock_profile)
+    mocker.patch.object(mock_profile, "get_conceptual_parent", return_value=mock_distro)
     dnsmasq.MANAGER = None
     test_manager = dnsmasq.get_manager(cobbler_api)
-    test_manager.systems = [mock_system]
+    mock_write_configs = MagicMock()
+    mock_sync_single_ethers_entry = MagicMock()
+    test_manager._write_configs = mock_write_configs  # type: ignore
+    test_manager.sync_single_ethers_entry = mock_sync_single_ethers_entry
+    test_manager.restart_service = MagicMock()
+    test_manager.config = mock_config
+    system_mac = mock_system.interfaces["default"].mac_address
+    system_dns = mock_system.interfaces["default"].dns_name
+    system_ip4 = mock_system.interfaces["default"].ip_address
+    system_ip6 = mock_system.interfaces["default"].ipv6_address
+
+    expected_config = mock_config.copy()
+    expected_config[
+        "insert_cobbler_system_definitions"
+    ] += f"dhcp-host=net:x86_64,{system_mac},{system_dns},{system_ip4},[{system_ip6}]\n"
+
+    # Act
+    test_manager.sync_single_system(mock_system)
+
+    # Assert
+    mock_sync_single_ethers_entry.assert_called_with(mock_system, [])
+    mock_write_configs.assert_called_with(expected_config)
+
+
+def test_manager_regen_ethers(mocker: "MockerFixture", cobbler_api: CobblerAPI):
+    # Arrange
+    mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
+    mock_system = _generate_test_system(cobbler_api)
+    dnsmasq.MANAGER = None
+    test_manager = dnsmasq.get_manager(cobbler_api)
+    test_manager.systems = [mock_system]  # type: ignore
+    system_mac = mock_system.interfaces["default"].mac_address.upper()
+    system_ip4 = mock_system.interfaces["default"].ip_address
 
     # Act
     test_manager.regen_ethers()
 
     # Assert
-    mock_builtins_open.assert_called_once_with("/etc/ethers", "w", encoding="UTF-8")
+    mock_builtins_open.assert_called_once_with(
+        cobbler_api.settings().dnsmasq_ethers_file, "w", encoding="UTF-8"
+    )
     write_handle = mock_builtins_open()
-    write_handle.write.assert_called_once_with("AA:BB:CC:DD:EE:FF\t192.168.1.2\n")
+    write_handle.write.assert_called_once_with(f"{system_mac}\t{system_ip4}\n")
 
 
-def test_manager_regen_hosts(mocker, cobbler_api):
+def test_manager_remove_single_ethers_entry(cobbler_api: CobblerAPI):
     # Arrange
-    mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
-    mock_system = System(cobbler_api)
-    mock_system.name = "test_manager_regen_hosts_system"
-    mock_system.interfaces = {
-        "default": NetworkInterface(cobbler_api, mock_system.name)
-    }
-    mock_system.interfaces["default"].dns_name = "host.example.org"
-    mock_system.interfaces["default"].mac_address = "AA:BB:CC:DD:EE:FF"
-    mock_system.interfaces["default"].ip_address = "192.168.1.2"
-    mock_system.interfaces["default"].ipv6_address = "::1"
+    mock_remove_line_in_file = MagicMock()
+    mock_system = _generate_test_system(cobbler_api)
     dnsmasq.MANAGER = None
     test_manager = dnsmasq.get_manager(cobbler_api)
-    test_manager.systems = [mock_system]
+    utils.remove_lines_in_file = mock_remove_line_in_file  # type: ignore
+    system_mac = mock_system.interfaces["default"].mac_address.upper()
+
+    # Act
+    test_manager.remove_single_ethers_entry(mock_system)
+
+    # Assert
+    mock_remove_line_in_file.assert_called_once_with(
+        cobbler_api.settings().dnsmasq_ethers_file, [system_mac]
+    )
+
+
+def test_manager_remove_single_hosts_entry(cobbler_api: CobblerAPI):
+    # Arrange
+    mock_remove_line_in_file = MagicMock()
+    mock_system = _generate_test_system(cobbler_api)
+    dnsmasq.MANAGER = None
+    test_manager = dnsmasq.get_manager(cobbler_api)
+    utils.remove_lines_in_file = mock_remove_line_in_file  # type: ignore
+    system_ip_addr = mock_system.interfaces["default"].ipv6_address
+    system_dns = mock_system.interfaces["default"].dns_name
+
+    # Act
+    test_manager.remove_single_hosts_entry(mock_system)
+
+    # Assert
+    mock_remove_line_in_file.assert_called_once_with(
+        cobbler_api.settings().dnsmasq_hosts_file, [f"{system_ip_addr}\t{system_dns}\n"]
+    )
+
+
+def test_manager_sync_single_ethers_entry(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI
+):
+    # Arrange
+    mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
+    mock_system = _generate_test_system(cobbler_api)
+    dnsmasq.MANAGER = None
+    test_manager = dnsmasq.get_manager(cobbler_api)
+    system_mac = mock_system.interfaces["default"].mac_address.upper()
+    system_ip4 = mock_system.interfaces["default"].ip_address
+
+    # Act
+    test_manager.sync_single_ethers_entry(mock_system)
+
+    # Assert
+    mock_builtins_open.assert_called_once_with(
+        cobbler_api.settings().dnsmasq_ethers_file, "a", encoding="UTF-8"
+    )
+    write_handle = mock_builtins_open()
+    write_handle.write.assert_called_once_with(f"{system_mac}\t{system_ip4}\n")
+
+
+def test_manager_regen_hosts(mocker: "MockerFixture", cobbler_api: CobblerAPI):
+    # Arrange
+    mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
+    mock_system = _generate_test_system(cobbler_api)
+    dnsmasq.MANAGER = None
+    test_manager = dnsmasq.get_manager(cobbler_api)
+    test_manager.systems = [mock_system]  # type: ignore
+    system_dns = mock_system.interfaces["default"].dns_name
+    system_ip6 = mock_system.interfaces["default"].ipv6_address
 
     # Act
     test_manager.regen_hosts()
 
     # Assert
     mock_builtins_open.assert_called_once_with(
-        "/var/lib/cobbler/cobbler_hosts", "w", encoding="UTF-8"
+        cobbler_api.settings().dnsmasq_hosts_file, "w", encoding="UTF-8"
     )
     write_handle = mock_builtins_open()
-    write_handle.write.assert_called_once_with("::1\thost.example.org\n")
+    write_handle.write.assert_called_once_with(f"{system_ip6}\t{system_dns}\n")
 
 
-def test_manager_restart_service(mocker, cobbler_api):
+def test_manager_add_single_hosts_entry(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI
+):
+    # Arrange
+    mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
+    mock_system = _generate_test_system(cobbler_api)
+    dnsmasq.MANAGER = None
+    test_manager = dnsmasq.get_manager(cobbler_api)
+    system_dns = mock_system.interfaces["default"].dns_name
+    system_ip6 = mock_system.interfaces["default"].ipv6_address
+
+    # Act
+    test_manager.add_single_hosts_entry(mock_system)
+
+    # Assert
+    mock_builtins_open.assert_called_with(
+        cobbler_api.settings().dnsmasq_hosts_file, "a", encoding="UTF-8"
+    )
+    write_handle = mock_builtins_open()
+    write_handle.write.assert_called_with(f"{system_ip6}\t{system_dns}\n")
+
+
+def test_manager_remove_single_system(mocker: "MockerFixture", cobbler_api: CobblerAPI):
+    # Arrange
+    mocker.patch(
+        "time.gmtime",
+        return_value=time.struct_time((2000, 1, 1, 0, 0, 0, 0, 1, 1)),
+    )
+    mock_system = _generate_test_system(cobbler_api)
+    mock_profile = Profile(cobbler_api)
+    mock_distro = Distro(cobbler_api)
+    mock_distro.arch = "x86_64"
+    dnsmasq.MANAGER = None
+    test_manager = dnsmasq.get_manager(cobbler_api)
+    test_manager.systems = [mock_system]  # type: ignore
+    mock_write_configs = MagicMock()
+    mock_remove_single_ethers_entry = MagicMock()
+    test_manager._write_configs = mock_write_configs  # type: ignore
+    test_manager.remove_single_ethers_entry = mock_remove_single_ethers_entry
+    mocker.patch.object(mock_system, "get_conceptual_parent", return_value=mock_profile)
+    mocker.patch.object(mock_profile, "get_conceptual_parent", return_value=mock_distro)
+
+    # Act
+    test_manager.remove_single_system(mock_system)
+
+    # Assert
+    mock_write_configs.assert_called_once_with(
+        {
+            "insert_cobbler_system_definitions": "",
+            "date": "Mon Jan  1 00:00:00 2000",
+            "cobbler_server": cobbler_api.settings().server,
+            "next_server_v4": cobbler_api.settings().next_server_v4,
+            "next_server_v6": cobbler_api.settings().next_server_v6,
+            "addn_host_file": cobbler_api.settings().dnsmasq_hosts_file,
+        }
+    )
+    mock_remove_single_ethers_entry.assert_called_with(mock_system)
+
+
+def test_manager_restart_service(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     # Arrange
     mock_service_restart = mocker.patch(
         "cobbler.utils.process_management.service_restart", return_value=0

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -212,7 +212,7 @@ def test_blender(cobbler_api):  # type: ignore
     result = utils.blender(cobbler_api, False, root_item)  # type: ignore
 
     # Assert
-    assert len(result) == 169
+    assert len(result) == 171
     # Must be present because the settings have it
     assert "server" in result
     # Must be present because it is a field of distro
@@ -611,3 +611,82 @@ def test_filelock():
     # Running time for Thread must be higher than 1 second, as
     # the lock was locked when thread started.
     assert thread_times[1] - thread_times[0] >= datetime.timedelta(seconds=1)
+
+
+def test_merge_dicts_recursive():
+    # Arrange
+    base = {  # type: ignore
+        "toplevel_1": 1,
+        "toplevel_2": 2,
+        "nested_dict": {"default": {"deep_key_1": []}},
+    }
+    update = {
+        "toplevel_1": "One",
+        "nested_dict": {"default": {"deep_key_1": True, "deep_key_2": None}},
+    }
+
+    expected = {
+        "toplevel_1": "One",
+        "toplevel_2": 2,
+        "nested_dict": {"default": {"deep_key_1": True, "deep_key_2": None}},
+    }
+
+    # Act
+    result = utils.merge_dicts_recursive(base, update)  # type: ignore
+
+    # Assert
+    assert expected == result
+
+
+def test_merge_dicts_recursive_extend():
+    # Arrange
+    base = {
+        "str-key": "Hello, ",
+    }
+    update = {
+        "str-key": "World!",
+    }
+
+    expected = {
+        "str-key": "Hello, World!",
+    }
+
+    # Act
+    result = utils.merge_dicts_recursive(base, update, True)
+
+    # Assert
+    assert expected == result
+
+
+def test_merge_dicts_recursive_extend_deep():
+    # Arrange
+    base = {
+        "default": {"str-key": "Hello, "},
+    }
+    update = {
+        "default": {"str-key": "World!"},
+    }
+
+    expected = {
+        "default": {"str-key": "Hello, World!"},
+    }
+
+    # Act
+    result = utils.merge_dicts_recursive(base, update, True)
+
+    # Assert
+    assert expected == result
+
+
+def test_create_files_if_not_existing(tmp_path: Path):
+    # Arrange
+    file1 = str(tmp_path / "a")
+    file2 = str(tmp_path / "b" / "c")
+    files = [file1, file2]
+
+    # Act
+    utils.create_files_if_not_existing(files)
+
+    # Assert
+    assert os.path.exists(file1)
+    assert os.path.exists(file2)


### PR DESCRIPTION
## Linked Items

Related issue discussions: https://github.com/SUSE/spacewalk/issues/23775, https://github.com/SUSE/spacewalk/issues/16572

Related upstream issue: https://github.com/cobbler/cobbler/issues/3728

## Description

Whenever we add a single system, the DNS/DHCP managers iterate over all systems to regenerate DNS/DHCP configs. This can cause issues when user manages a large number of systems (1000+).

This PR extends commits from @agraul and @meaksh to modify the `isc` and `dnsmasq` managers to implement functionality to add only a single system, i.e. to cache the current configuration, and when adding a single system, only generate configuration for that one system instead of always iterating through all systems and generating  config for every single one.

Managers that do not implement the new methods will preserve the current behavior of regenerating the whole configuration, so that the changes are backwards compatible.

The logic of generating configuration for both the `isc` and `dnsmasq` managers is preserved. I have fixed tests (e.g. adding typing and fixing small issues I noticed) as well as added new tests that should cover base cases of each of the added methods in the modified managers.

## Behaviour changes

### When adding a new system

The `isc` and `dnsmasq` managers: 

**Old**: generate config for all stored systems.

**New**: generate config for only the system to be added.

### When removing a system

The `isc` and `dnsmasq` managers:

**Old**: generate config for all stored systems -> the removed system is absent, so it is not included

**New**: remove configuration only for the system to be removed

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

I am marking this as a new feature, though I'm not totally sure here - it can be a bugfix, feature, or refactoring depending on one's point of view.

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
