### PR TITLE
Add performance testsuite dependencies

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -145,7 +145,8 @@ RUN zypper install --no-recommends -y \
     python3-pytest                    \
     python3-pytest-cov                \
     python3-pytest-mock               \
-    python3-pytest-pythonpath \
+    python3-pytest-pythonpath         \
+    python3-pytest-benchmark          \
     && zypper clean
 
 # Enable the Apache Modules

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -24,7 +24,7 @@ ENV container docker
 ENV DISTRO SUSE
 
 # Custom repository
-RUN zypper ar https://download.opensuse.org/repositories/home:/cobbler-project:/release33/15.4/ "Cobbler 3.3.x release project (15.4)" \
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release33/15.4/systemsmanagement:cobbler:release33.repo \
     && zypper --gpg-auto-import-keys refresh
 
 # Runtime & dev dependencies


### PR DESCRIPTION
## Linked Items

Split-Out of #3703

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This adds the dependencies for the performance testsuite to the release33 branch development dockerfile.

## Behaviour changes

Old: Performance testsuite fails due to missing pytest flags.

New: Performance testsuite passes.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
