### PR TITLE
Docker: Fix adding repository to the image

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -24,7 +24,7 @@ ENV container docker
 ENV DISTRO SUSE
 
 # Custom repository
-RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release33/15.4/systemsmanagement:cobbler:release33.repo \
+RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release33/15.4/ "Cobbler 3.3.x release project" \
     && zypper --gpg-auto-import-keys refresh
 
 # Runtime & dev dependencies


### PR DESCRIPTION
## Linked Items

Fixup for #3711 

## Description

The OBS doesn't like the `.repo` format for adding repositories. As such we need to switch to the normal one. Locally this just works fine.

```
[   39s] STEP 17/36: ENV DISTRO SUSE
[   39s] STEP 18/36: RUN zypper ar https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release33/15.4/systemsmanagement:cobbler:release33.repo     && zypper --gpg-auto-import-keys refresh
[   39s] If only one argument is used, it must be a URI pointing to a .repo file.
```

## Behaviour changes

Old: CI fails to build new image

New: Hopefully CI likes us

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
