### PR TITLE
Add debugging help to docs

### DIFF
--- a/changelog.d/3672.added
+++ b/changelog.d/3672.added
@@ -1,0 +1,1 @@
+Added debugging info to autoinstall documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,6 +13,14 @@ enabled by usage of 'Koan' on the remote system. Update server features include 
 mirrors with automated installation files. Cobbler has a command line interface, WebUI, and extensive Python and
 XML-RPC APIs for integration with external scripts and applications.
 
+Content of this Documentation
+#############################
+
+This site contains the user manual for Cobbler.
+
+If you are looking for guides for developers, please visit our developer wiki on GitHub:
+https://github.com/cobbler/cobbler/wiki
+
 If you want to explore tools or scripts which are using Cobbler please use the GitHub Topic:
 https://github.com/topics/cobbler
 

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -164,25 +164,11 @@ install. To re-enable PXE for a specific system, run the following command:
 
     cobbler system edit --name=name --netboot-enabled=1
 
-Automatic installation tracking
-===============================
-
-Cobbler knows how to keep track of the status of automatic installation of machines.
-
-.. code-block:: shell
-
-    cobbler status
-
-Using the status command will show when Cobbler thinks a machine started automatic installation and when it finished,
-provided the proper snippets are found in the automatic installation template. This is a good way to track machines that
-may have gone interactive (or stalled/crashed) during automatic installation.
-
 Containerization
 ################
 
 We have a test-image which you can find in the Cobbler repository and an old image made by the community:
 https://github.com/osism/docker-cobbler
-
 
 Web-Interface
 #############

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -31,17 +31,6 @@ API
 Cobbler also makes itself available as an XML-RPC API for use by higher level management software. Learn more at
 https://cobbler.github.io
 
-Triggers
-########
-
-Triggers provide a way to integrate Cobbler with arbitrary 3rd party software without modifying Cobbler's code. When
-adding a distro, profile, system, or repo, all scripts in ``/var/lib/cobbler/triggers/add`` are executed for the
-particular object type. Each particular file must be executable and it is executed with the name of the item being added
-as a parameter. Deletions work similarly -- delete triggers live in ``/var/lib/cobbler/triggers/delete``. Order of
-execution is arbitrary, and Cobbler does not ship with any triggers by default. There are also other kinds of triggers
--- these are described on the Cobbler Wiki. For larger configurations, triggers should be written in Python -- in which
-case they are installed differently. This is also documented on the Wiki.
-
 Images
 ######
 

--- a/docs/user-guide/automatic-installation.rst
+++ b/docs/user-guide/automatic-installation.rst
@@ -109,7 +109,31 @@ may have gone interactive (or stalled/crashed) during automatic installation.
 Debugging of unattended installations
 #####################################
 
-For further debugging it might be helpful to use other tools like a serial console to record the screen during the boot process.
-Since some information will not be shown on screen long enough to read it it is recommended to record the screen output.
+There are different tools for debugging automatic installations. In general it is recommended to use something to record the
+output of the screen, since some important information may only be visible for a short amount of time. Examples are
+BMC (with IPMI SOL or HTML5 KVM), a dedicated serial console or a networked KVM.
 
+Here is a short list of some important stages during automatic installations and the most frequently occuring errors there:
 
+* Firmware/EFI:
+  * Wrong boot device
+* DHCP request:
+  * Wrong VLAN/Network
+  * Cable issues
+  * Firewall issues
+* TFTP request:
+  * Typo in cobbler settings
+  * inheritance issues
+  * VM restarted with daemon started but not enabled
+  * tftp timeout
+* Kernel & Initrd:
+  * Missing hardware drivers
+* HTTP requests towards Cobbler:
+  * Firewall/Proxy issues
+  * Cobbler timeout
+  * Cheetah templating errors
+* Installation:
+  * Incorrect escaping (syntax errors)
+  * remote ressources unavailable
+* Reboot:
+  * Loop due to enabled netboot

--- a/docs/user-guide/automatic-installation.rst
+++ b/docs/user-guide/automatic-installation.rst
@@ -92,3 +92,24 @@ To check for potential errors in auto-installation files, prior to installation,
 This function will check all profile and system auto-installation files for detectable errors. Since ``pykickstart`` and
 related tools are not future-version aware in most cases, there may be some false positives. It should be noted that
 ``cobbler validate-autoinstalls`` runs on the rendered autoinstall output, not autoinstall templates themselves.
+
+Automatic installation tracking
+###############################
+
+Cobbler knows how to keep track of the status of automatic installation of machines.
+
+.. code-block:: shell
+
+    cobbler status
+
+Using the status command will show when Cobbler thinks a machine started automatic installation and when it finished,
+provided the proper snippets are found in the automatic installation template. This is a good way to track machines that
+may have gone interactive (or stalled/crashed) during automatic installation.
+
+Debugging of unattended installations
+#####################################
+
+For further debugging it might be helpful to use other tools like a serial console to record the screen during the boot process.
+Since some information will not be shown on screen long enough to read it it is recommended to record the screen output.
+
+


### PR DESCRIPTION
## Linked Items

Fixes https://github.com/cobbler/cobbler/issues/3672

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

This PR updates some of the documentation for Cobbler. It adds some context about the content to the landing page, deduplicates a section about Triggers and moves some of the autoinstallation documentation into the right section. Also it adds a note about how to debug unattended installations.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [x] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
