### PR TITLE
Non-unique collection indexes

### DIFF
--- a/changelog.d/3721.added
+++ b/changelog.d/3721.added
@@ -1,0 +1,1 @@
+Add non-unique collection indexes

--- a/changelog.d/3816.fixed
+++ b/changelog.d/3816.fixed
@@ -1,0 +1,1 @@
+Children of a profile now get correctly synced after an edit

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -760,6 +760,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a general item. This method should not be used by an external api. Please use the specific
@@ -770,6 +771,7 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         to_delete: Optional["BaseItem"] = None
         if isinstance(ref, str):
@@ -784,6 +786,7 @@ class CobblerAPI:
             recursive=recursive,
             with_delete=delete,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def remove_distro(
@@ -792,6 +795,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a distribution from Cobbler.
@@ -800,6 +804,7 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
             "distro",
@@ -807,6 +812,7 @@ class CobblerAPI:
             recursive=recursive,
             delete=delete,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def remove_profile(
@@ -815,6 +821,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a profile from Cobbler.
@@ -823,6 +830,7 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
             "profile",
@@ -830,6 +838,7 @@ class CobblerAPI:
             recursive=recursive,
             delete=delete,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def remove_system(
@@ -838,6 +847,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a system from Cobbler.
@@ -846,6 +856,7 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
             "system",
@@ -853,6 +864,7 @@ class CobblerAPI:
             recursive=recursive,
             delete=delete,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def remove_repo(
@@ -861,6 +873,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a repository from Cobbler.
@@ -869,9 +882,15 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
-            "repo", ref, recursive=recursive, delete=delete, with_triggers=with_triggers
+            "repo",
+            ref,
+            recursive=recursive,
+            delete=delete,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def remove_image(
@@ -880,6 +899,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a image from Cobbler.
@@ -888,6 +908,7 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
             "image",
@@ -895,6 +916,7 @@ class CobblerAPI:
             recursive=recursive,
             delete=delete,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def remove_menu(
@@ -903,6 +925,7 @@ class CobblerAPI:
         recursive: bool = False,
         delete: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Remove a menu from Cobbler.
@@ -911,9 +934,15 @@ class CobblerAPI:
         :param recursive: If the item should recursively should delete dependencies on itself.
         :param delete: Not known what this parameter does exactly.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
-            "menu", ref, recursive=recursive, delete=delete, with_triggers=with_triggers
+            "menu",
+            ref,
+            recursive=recursive,
+            delete=delete,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     # ==========================================================================
@@ -1084,6 +1113,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add an abstract item to a collection of its specific items. This is not meant for external use. Please reefer
@@ -1094,6 +1124,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.log(f"add_item({what})", [ref.name])
         self.get_items(what).add(
@@ -1101,6 +1132,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def add_distro(
@@ -1109,6 +1141,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add a distribution to Cobbler.
@@ -1117,6 +1150,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.add_item(
             "distro",
@@ -1124,6 +1158,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def add_profile(
@@ -1132,6 +1167,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add a profile to Cobbler.
@@ -1140,6 +1176,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.add_item(
             "profile",
@@ -1147,6 +1184,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def add_system(
@@ -1155,6 +1193,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add a system to Cobbler.
@@ -1163,6 +1202,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.add_item(
             "system",
@@ -1170,6 +1210,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def add_repo(
@@ -1178,6 +1219,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add a repository to Cobbler.
@@ -1186,6 +1228,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.add_item(
             "repo",
@@ -1193,6 +1236,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def add_image(
@@ -1201,6 +1245,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add an image to Cobbler.
@@ -1209,6 +1254,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.add_item(
             "image",
@@ -1216,6 +1262,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     def add_menu(
@@ -1224,6 +1271,7 @@ class CobblerAPI:
         check_for_duplicate_names: bool = False,
         save: bool = True,
         with_triggers: bool = True,
+        with_sync: bool = True,
     ) -> None:
         """
         Add a submenu to Cobbler.
@@ -1232,6 +1280,7 @@ class CobblerAPI:
         :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
         :param save: If the item should be persisted.
         :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.add_item(
             "menu",
@@ -1239,6 +1288,7 @@ class CobblerAPI:
             check_for_duplicate_names=check_for_duplicate_names,
             save=save,
             with_triggers=with_triggers,
+            with_sync=with_sync,
         )
 
     # ==========================================================================

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -498,12 +498,14 @@ class Collection(Generic[ITEM]):
                         ref.enable_menu = False
                     self.lite_sync.add_single_profile(ref)
                     self.api.sync_systems(
-                        systems=self.find(
-                            "system",
-                            return_list=True,
-                            no_errors=False,
-                            **{"profile": ref.name},
-                        )  # type: ignore
+                        systems=[
+                            x.name  # type: ignore
+                            for x in self.api.find_system(  # type: ignore
+                                return_list=True,
+                                no_errors=False,
+                                **{"profile": ref.name},
+                            )
+                        ]  # type: ignore
                     )
                 elif isinstance(ref, distro.Distro):
                     self.lite_sync.add_single_distro(ref)

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -82,6 +82,7 @@ class Distros(collection.Collection[distro.Distro]):
                     recursive=recursive,
                     delete=with_delete,
                     with_triggers=with_triggers,
+                    with_sync=with_sync,
                 )
 
         if with_delete:

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -73,7 +73,7 @@ class Images(collection.Collection[image.Image]):
             if not isinstance(kids, list):
                 raise ValueError("Expected list or None from find_items!")
             for k in kids:
-                self.api.remove_system(k, recursive=True)
+                self.api.remove_system(k, recursive=True, with_sync=with_sync)
 
         if with_delete:
             if with_triggers:

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -1,6 +1,7 @@
 """
 Cobbler module that at runtime holds all menus in Cobbler.
 """
+
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: Copyright 2021 Yuriy Chelpanov <yuriy.chelpanov@gmail.com>
 
@@ -81,6 +82,7 @@ class Menus(collection.Collection[menu.Menu]):
                     recursive=False,
                     delete=with_delete,
                     with_triggers=with_triggers,
+                    with_sync=with_sync,
                 )
 
         if with_delete:

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -63,6 +63,7 @@ class Profiles(collection.Collection[profile.Profile]):
             # Will never happen, but we want to make mypy happy.
             raise CX("Ambiguous match detected!")
 
+        print(f"Profiles remove: {name}, recursive={recursive}")
         if recursive:
             kids = obj.descendants
             kids.sort(key=lambda x: -x.depth)
@@ -73,6 +74,7 @@ class Profiles(collection.Collection[profile.Profile]):
                     recursive=False,
                     delete=with_delete,
                     with_triggers=with_triggers,
+                    with_sync=with_sync,
                 )
 
         if with_delete:

--- a/cobbler/items/abstract/base_item.py
+++ b/cobbler/items/abstract/base_item.py
@@ -184,16 +184,11 @@ class BaseItem(ABC):
 
         :param uid: The new uid.
         """
-        if self._uid != uid and self.COLLECTION_TYPE != BaseItem.COLLECTION_TYPE:
-            collection = self.api.get_items(self.COLLECTION_TYPE)
-            with collection.lock:
-                item = collection.get(self.name)
-                if item is not None and item.uid == self._uid:
-                    # Update uid index
-                    indx_dict = collection.indexes["uid"]
-                    del indx_dict[self._uid]
-                    indx_dict[uid] = self.name
+        old_uid = self._uid
         self._uid = uid
+        self.api.get_items(self.COLLECTION_TYPE).update_index_value(
+            self, "uid", old_uid, uid
+        )
 
     @property
     def ctime(self) -> float:

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -225,7 +225,9 @@ class Image(BootableItem):
 
         :param arch: The new architecture to set.
         """
+        old_arch = self._arch
         self._arch = enums.Archs.to_enum(arch)
+        self.api.images().update_index_value(self, "arch", old_arch, self._arch)
 
     @InheritableProperty
     def autoinstall(self) -> str:
@@ -610,7 +612,9 @@ class Image(BootableItem):
             menu_list = self.api.menus()
             if not menu_list.find(name=menu):
                 raise CX(f"menu {menu} not found")
+        old_menu = self._menu
         self._menu = menu
+        self.api.images().update_index_value(self, "menu", old_menu, menu)
 
     @LazyProperty
     def display_name(self) -> str:

--- a/cobbler/items/network_interface.py
+++ b/cobbler/items/network_interface.py
@@ -351,10 +351,11 @@ class NetworkInterface:
                 raise ValueError(
                     f'DNS name duplicate found "{dns_name}". Object with the conflict has the name "{match.name}"'
                 )
-        self.__api.systems().update_interface_index_value(
-            self, "dns_name", self._dns_name, dns_name
-        )
+        old_dns_name = self._dns_name
         self._dns_name = dns_name
+        self.__api.systems().update_interface_index_value(
+            self, "dns_name", old_dns_name, dns_name
+        )
 
     @property
     def ip_address(self) -> str:
@@ -391,10 +392,11 @@ class NetworkInterface:
                 raise ValueError(
                     f'IP address duplicate found "{address}". Object with the conflict has the name "{match.name}"'
                 )
-        self.__api.systems().update_interface_index_value(
-            self, "ip_address", self._ip_address, address
-        )
+        old_ip_address = self._ip_address
         self._ip_address = address
+        self.__api.systems().update_interface_index_value(
+            self, "ip_address", old_ip_address, address
+        )
 
     @property
     def mac_address(self) -> str:
@@ -434,10 +436,11 @@ class NetworkInterface:
                 raise ValueError(
                     f'MAC address duplicate found "{address}". Object with the conflict has the name "{match.name}"'
                 )
-        self.__api.systems().update_interface_index_value(
-            self, "mac_address", self._mac_address, address
-        )
+        old_mac_address = self._mac_address
         self._mac_address = address
+        self.__api.systems().update_interface_index_value(
+            self, "mac_address", old_mac_address, address
+        )
 
     @property
     def netmask(self) -> str:
@@ -654,10 +657,11 @@ class NetworkInterface:
                     f'IPv6 address duplicate found "{address}". Object with the conflict has the name'
                     f'"{match.name}"'
                 )
-        self.__api.systems().update_interface_index_value(
-            self, "ipv6_address", self._ipv6_address, address
-        )
+        old_ipv6_address = self._ipv6_address
         self._ipv6_address = address
+        self.__api.systems().update_interface_index_value(
+            self, "ipv6_address", old_ipv6_address, address
+        )
 
     @property
     def ipv6_prefix(self) -> str:

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -337,8 +337,11 @@ class Profile(BootableItem):
         """
         if not isinstance(distro_name, str):  # type: ignore
             raise TypeError("distro_name needs to be of type str")
+        items = self.api.profiles()
+        old_distro = self._distro
         if not distro_name:
             self._distro = ""
+            items.update_index_value(self, "distro", old_distro, "")
             return
         distro = self.api.distros().find(name=distro_name)
         if distro is None or isinstance(distro, list):
@@ -347,6 +350,7 @@ class Profile(BootableItem):
         self.depth = (
             distro.depth + 1
         )  # reset depth if previously a subprofile and now top-level
+        items.update_index_value(self, "distro", old_distro, distro_name)
 
     @InheritableProperty
     def name_servers(self) -> List[str]:
@@ -800,7 +804,9 @@ class Profile(BootableItem):
 
         :param repos: The new repositories which will be set.
         """
+        old_repos = self._repos
         self._repos = validate.validate_repos(repos, self.api, bypass_check=False)
+        self.api.profiles().update_index_value(self, "repos", old_repos, self._repos)
 
     @InheritableProperty
     def redhat_management_key(self) -> str:
@@ -898,7 +904,9 @@ class Profile(BootableItem):
             menu_list = self.api.menus()
             if not menu_list.find(name=menu):
                 raise CX(f"menu {menu} not found")
+        old_menu = self._menu
         self._menu = menu
+        self.api.profiles().update_index_value(self, "menu", old_menu, menu)
 
     @LazyProperty
     def display_name(self) -> str:

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -293,6 +293,63 @@ class Settings:
         self.samba_distro_share = "DISTRO"
         self.cache_enabled = False
         self.lazy_start = False
+        self.memory_indexes = {
+            "distro": {
+                "uid": {"nonunique": False, "disabled": False},
+                "arch": {"nonunique": True, "disabled": False},
+            },
+            "image": {
+                "uid": {"nonunique": False, "disabled": False},
+                "arch": {"nonunique": True, "disabled": False},
+                "menu": {"nonunique": True, "disabled": False},
+            },
+            "menu": {
+                "uid": {"nonunique": False, "disabled": False},
+                "parent": {
+                    "nonunique": True,
+                    "disabled": False,
+                },
+            },
+            "profile": {
+                "uid": {"nonunique": False, "disabled": False},
+                "parent": {
+                    "nonunique": True,
+                    "disabled": False,
+                },
+                "distro": {"nonunique": True, "disabled": False},
+                "arch": {"nonunique": True, "disabled": False},
+                "menu": {"nonunique": True, "disabled": False},
+                "repos": {"nonunique": True, "disabled": False},
+            },
+            "repo": {
+                "uid": {"nonunique": False, "disabled": False},
+            },
+            "system": {
+                "uid": {"nonunique": False, "disabled": False},
+                "image": {"nonunique": True, "disabled": False},
+                "profile": {"nonunique": True, "disabled": False},
+                "mac_address": {
+                    "property": "get_mac_addresses",
+                    "nonunique": self.allow_duplicate_macs,
+                    "disabled": self.allow_duplicate_macs,
+                },
+                "ip_address": {
+                    "property": "get_ipv4_addresses",
+                    "nonunique": self.allow_duplicate_ips,
+                    "disabled": self.allow_duplicate_ips,
+                },
+                "ipv6_address": {
+                    "property": "get_ipv6_addresses",
+                    "nonunique": self.allow_duplicate_ips,
+                    "disabled": self.allow_duplicate_ips,
+                },
+                "dns_name": {
+                    "property": "get_dns_names",
+                    "nonunique": self.allow_duplicate_hostnames,
+                    "disabled": self.allow_duplicate_hostnames,
+                },
+            },
+        }
 
     def to_dict(self, resolved: bool = False) -> Dict[str, Any]:
         """

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -174,6 +174,125 @@ schema = Schema(
         Optional("cache_enabled"): bool,
         Optional("autoinstall_scheme"): str,
         Optional("lazy_start"): bool,
+        Optional("memory_indexes"): {
+            Optional("distro"): {
+                Optional("uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("arch"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("image"): {
+                Optional("uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("arch"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("menu"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("menu"): {
+                Optional("uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("parent"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("profile"): {
+                Optional("uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("parent"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("distro"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("arch"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("menu"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("repos"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("repo"): {
+                Optional("uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("system"): {
+                Optional("uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("image"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("profile"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("mac_address"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("ip_address"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("ipv6_address"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("dns_name"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+        },
     },  # type: ignore
     ignore_extra_keys=False,
 )

--- a/config/cobbler/settings.yaml
+++ b/config/cobbler/settings.yaml
@@ -9,15 +9,15 @@ auto_migrate_settings: false
 
 # If "true", Cobbler will allow insertions of system records that duplicate the "--dns-name" information of other system
 # records. In general, this is undesirable and should be left "false".
-allow_duplicate_hostnames: false
+allow_duplicate_hostnames: &allow_duplicate_hostnames false
 
 # If "true", Cobbler will allow insertions of system records that duplicate the ip address information of other system
 # records. In general, this is undesirable and should be left "false".
-allow_duplicate_ips: false
+allow_duplicate_ips: &allow_duplicate_ips false
 
 # If "true", Cobbler will allow insertions of system records that duplicate the MAC address information of other system
 # records. In general, this is undesirable.
-allow_duplicate_macs: false
+allow_duplicate_macs: &allow_duplicate_macs false
 
 # If "true", Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can
 # only change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
@@ -643,3 +643,81 @@ autoinstall_scheme: "http"
 # also launched, which, when idle, fills in all the properties of the elements of the collections.
 # Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
 lazy_start: false
+
+# Indexing collections in memory can speed up access to collections with a large number of elements.
+memory_indexes:
+    distro:
+        uid:
+            nonunique: false
+            disabled: false
+        arch:
+            nonunique: true
+            disabled: false
+    image:
+        uid:
+            nonunique: false
+            disabled: false
+        arch:
+            nonunique: true
+            disabled: false
+        menu:
+            nonunique: true
+            disabled: false
+    menu:
+        uid:
+            nonunique: false
+            disabled: false
+        parent:
+            property: "get_parent"
+            nonunique: true
+            disabled: false
+    profile:
+        uid:
+            nonunique: false
+            disabled: false
+        parent:
+            property: "get_parent"
+            nonunique: true
+            disabled: false
+        distro:
+            nonunique: true
+            disabled: false
+        arch:
+            nonunique: true
+            disabled: false
+        menu:
+            nonunique: true
+            disabled: false
+        repos:
+            nonunique: true
+            disabled: false
+    repo:
+        uid:
+            nonunique: false
+            disabled: false
+    system:
+        uid:
+            nonunique: false
+            disabled: false
+        image:
+            nonunique: true
+            disabled: false
+        profile:
+            nonunique: true
+            disabled: false
+        mac_address:
+            property: "get_mac_addresses"
+            nonunique: *allow_duplicate_macs
+            disabled: *allow_duplicate_macs
+        ip_address:
+            property: "get_ipv4_addresses"
+            nonunique: *allow_duplicate_ips
+            disabled: *allow_duplicate_ips
+        ipv6_address:
+            property: "get_ipv6_addresses"
+            nonunique: *allow_duplicate_ips
+            disabled: *allow_duplicate_ips
+        dns_name:
+            property: "get_dns_names"
+            nonunique: *allow_duplicate_hostnames
+            disabled: *allow_duplicate_hostnames

--- a/tests/cobbler_collections/image_collection_test.py
+++ b/tests/cobbler_collections/image_collection_test.py
@@ -1,0 +1,359 @@
+import os.path
+from typing import Callable
+
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import images
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import image, menu
+
+
+@pytest.fixture
+def image_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (Images) of a generic collection.
+    """
+    return cobbler_api.images()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    # Arrange & Act
+    image_collection = images.Images(collection_mgr)
+
+    # Assert
+    assert isinstance(image_collection, images.Images)
+
+
+def test_factory_produce(cobbler_api: CobblerAPI, image_collection: images.Images):
+    # Arrange & Act
+    result_image = image_collection.factory_produce(cobbler_api, {})
+
+    # Assert
+    assert isinstance(result_image, image.Image)
+
+
+def test_get(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_get"
+    create_image(name)
+
+    # Act
+    item = image_collection.get(name)
+    fake_item = image_collection.get("fake_name")
+
+    # Assert
+    assert isinstance(item, image.Image)
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_find"
+    create_image(name)
+
+    # Act
+    result = image_collection.find(name, True, True)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_to_list"
+    create_image(name)
+
+    # Act
+    result = image_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    image_collection: images.Images,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
+):
+    # Arrange
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    test_kernel = os.path.join(folder, fk_kernel)
+    item_list = [{"name": "test_from_list", "file": test_kernel}]
+
+    # Act
+    image_collection.from_list(item_list)
+
+    # Assert
+    assert len(image_collection.listing) == 1
+    assert len(image_collection.indexes["uid"]) == 1
+    assert len(image_collection.indexes["arch"]) == 1
+    assert len(image_collection.indexes["menu"]) == 1
+
+
+def test_copy(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_copy"
+    item1 = create_image(name)
+
+    # Act
+    new_item_name = "test_copy_new"
+    image_collection.copy(item1, new_item_name)
+    item2 = image_collection.find(new_item_name, False)
+
+    # Assert
+    assert len(image_collection.listing) == 2
+    assert name in image_collection.listing
+    assert new_item_name in image_collection.listing
+    assert len(image_collection.indexes["uid"]) == 2
+    assert isinstance(item2, image.Image)
+    assert (image_collection.indexes["uid"])[item1.uid] == name
+    assert (image_collection.indexes["uid"])[item2.uid] == new_item_name
+    assert (image_collection.indexes["arch"])[item1.arch.value] == {name, new_item_name}
+    assert (image_collection.indexes["arch"])[item2.arch.value] == {name, new_item_name}
+    assert (image_collection.indexes["menu"])[item1.menu] == {name, new_item_name}
+    assert (image_collection.indexes["menu"])[item2.menu] == {name, new_item_name}
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+    input_new_name: str,
+):
+    # Arrange
+    item1 = create_image("test_rename")
+
+    # Act
+    image_collection.rename(item1, input_new_name)
+
+    # Assert
+    assert input_new_name in image_collection.listing
+    assert image_collection.listing[input_new_name].name == input_new_name
+    assert (image_collection.indexes["uid"])[item1.uid] == input_new_name
+    assert (image_collection.indexes["arch"])[item1.arch.value] == {input_new_name}
+    assert (image_collection.indexes["menu"])[item1.menu] == {input_new_name}
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_collection_add"
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    item1 = image.Image(cobbler_api)
+    item1.name = name
+    item1.file = os.path.join(folder, fk_initrd)
+
+    # Act
+    image_collection.add(item1)
+
+    # Assert
+    assert name in image_collection.listing
+    assert item1.uid in image_collection.indexes["uid"]
+    assert item1.arch.value in image_collection.indexes["arch"]
+    assert item1.menu in image_collection.indexes["menu"]
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_duplicate_add"
+    create_image(name)
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    item2 = image.Image(cobbler_api)
+    item2.name = name
+    item2.file = os.path.join(folder, fk_initrd)
+
+    # Act & Assert
+    with pytest.raises(CX):
+        image_collection.add(item2, check_for_duplicate_names=True)
+
+
+def test_remove(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_remove"
+    item1 = create_image(name)
+    assert name in image_collection.listing
+    assert len(image_collection.indexes["uid"]) == 1
+    assert (image_collection.indexes["uid"])[item1.uid] == item1.name
+    assert len(image_collection.indexes["arch"]) == 1
+    assert (image_collection.indexes["arch"])[item1.arch.value] == {item1.name}
+    assert len(image_collection.indexes["menu"]) == 1
+    assert (image_collection.indexes["menu"])[item1.menu] == {item1.name}
+
+    # Act
+    image_collection.remove(name)
+
+    # Assert
+    assert name not in image_collection.listing
+    assert len(image_collection.indexes["uid"]) == 0
+    assert len(image_collection.indexes["arch"]) == 0
+    assert len(image_collection.indexes["menu"]) == 0
+
+
+def test_indexes(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+
+    # Assert
+    assert len(image_collection.indexes) == 3
+    assert len(image_collection.indexes["uid"]) == 0
+    assert len(image_collection.indexes["arch"]) == 0
+    assert len(image_collection.indexes["menu"]) == 0
+
+
+def test_add_to_indexes(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_add_to_indexes"
+    item1 = create_image(name)
+
+    # Act
+    del (image_collection.indexes["uid"])[item1.uid]
+    del (image_collection.indexes["arch"])[item1.arch.value]
+    del (image_collection.indexes["menu"])[item1.menu]
+    image_collection.add_to_indexes(item1)
+
+    # Assert
+    assert item1.uid in image_collection.indexes["uid"]
+    assert item1.arch.value in image_collection.indexes["arch"]
+    assert item1.menu in image_collection.indexes["menu"]
+
+
+def test_remove_from_indexes(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_remove_from_indexes"
+    item1 = create_image(name)
+
+    # Act
+    image_collection.remove_from_indexes(item1)
+
+    # Assert
+    assert item1.uid not in image_collection.indexes["uid"]
+    assert item1.arch.value not in image_collection.indexes["arch"]
+    assert item1.menu not in image_collection.indexes["menu"]
+
+
+def test_update_indexes(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "test_update_indexes"
+    item1 = create_image(name)
+    uid1_test = "test_uid"
+    menu1 = menu.Menu(cobbler_api)
+    menu1.name = "test_update_indexes"
+    cobbler_api.menus().add(menu1)
+
+    # Act
+    item1.uid = uid1_test
+    item1.arch = enums.Archs.I386
+    item1.menu = menu1.name
+
+    # Assert
+    assert image_collection.indexes["uid"][uid1_test] == name
+    assert image_collection.indexes["arch"][enums.Archs.I386.value] == {name}
+    assert image_collection.indexes["menu"][menu1.name] == {name}
+
+
+def test_find_by_indexes(
+    cobbler_api: CobblerAPI,
+    create_image: Callable[[str], image.Image],
+    image_collection: images.Images,
+):
+    # Arrange
+    name = "to_be_removed"
+    item1 = create_image(name)
+    kargs1 = {"uid": item1.uid}
+    kargs2 = {"uid": "fake_uid"}
+    kargs3 = {"fake_index": item1.uid}
+    kargs4 = {"menu": ""}
+    kargs5 = {"menu": "fake_menu"}
+    kargs6 = {"arch": item1.arch.value}
+    kargs7 = {"arch": "fake_arch"}
+
+    # Act
+    result1 = image_collection.find_by_indexes(kargs1)
+    result2 = image_collection.find_by_indexes(kargs2)
+    result3 = image_collection.find_by_indexes(kargs3)
+    result4 = image_collection.find_by_indexes(kargs4)
+    result5 = image_collection.find_by_indexes(kargs5)
+    result6 = image_collection.find_by_indexes(kargs6)
+    result7 = image_collection.find_by_indexes(kargs7)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == item1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1
+    assert result4 is not None
+    assert len(result4) == 1
+    assert len(kargs4) == 0
+    assert result5 is None
+    assert len(kargs5) == 0
+    assert result6 is not None
+    assert len(result6) == 1
+    assert len(kargs6) == 0
+    assert result7 is None
+    assert len(kargs7) == 0

--- a/tests/cobbler_collections/menu_collection_test.py
+++ b/tests/cobbler_collections/menu_collection_test.py
@@ -1,0 +1,326 @@
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import menus
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import menu
+
+
+@pytest.fixture
+def menu_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (Menus) of a generic collection.
+    """
+    return cobbler_api.menus()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    # Arrange & Act
+    menu_collection = menus.Menus(collection_mgr)
+
+    # Assert
+    assert isinstance(menu_collection, menus.Menus)
+
+
+def test_factory_produce(cobbler_api: CobblerAPI, menu_collection: menus.Menus):
+    # Arrange & Act
+    result_menu = menu_collection.factory_produce(cobbler_api, {})
+
+    # Assert
+    assert isinstance(result_menu, menu.Menu)
+
+
+def test_get(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_get"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+
+    # Act
+    item = menu_collection.get(name)
+    fake_item = menu_collection.get("fake_name")
+
+    # Assert
+    assert isinstance(item, menu.Menu)
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_find"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+
+    # Act
+    result = menu_collection.find(name, True, True)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_to_list"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+
+    # Act
+    result = menu_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    item_list = [{"name": "test_from_list", "display_name": "test_display_name"}]
+
+    # Act
+    menu_collection.from_list(item_list)
+
+    # Assert
+    assert len(menu_collection.listing) == 1
+    assert len(menu_collection.indexes["uid"]) == 1
+    assert len(menu_collection.indexes["parent"]) == 1
+
+
+def test_copy(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_copy"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+
+    # Act
+    new_item_name = "test_copy_new"
+    menu_collection.copy(item1, new_item_name)
+    item2 = menu_collection.find(new_item_name, False)
+    assert isinstance(item2, menu.Menu)
+    item2.parent = name
+
+    # Assert
+    assert len(menu_collection.listing) == 2
+    assert name in menu_collection.listing
+    assert new_item_name in menu_collection.listing
+    assert len(menu_collection.indexes["uid"]) == 2
+    assert (menu_collection.indexes["uid"])[item1.uid] == name
+    assert (menu_collection.indexes["uid"])[item2.uid] == new_item_name
+    assert len(menu_collection.indexes["parent"]) == 2
+    assert menu_collection.indexes["parent"] == {"": {item1.name}, name: {item2.name}}
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+    input_new_name: str,
+):
+    # Arrange
+    old_name = "test_rename"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = old_name
+    menu_collection.add(item1)
+
+    # Act
+    menu_collection.rename(item1, input_new_name)
+
+    # Assert
+    assert input_new_name in menu_collection.listing
+    assert menu_collection.listing[input_new_name].name == input_new_name
+    assert len(menu_collection.indexes["parent"]) == 1
+    assert (menu_collection.indexes["uid"])[item1.uid] == input_new_name
+    assert old_name not in (menu_collection.indexes["parent"])[item1.get_parent]
+    assert input_new_name in (menu_collection.indexes["parent"])[item1.get_parent]
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_collection_add"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+
+    # Act
+    menu_collection.add(item1)
+
+    # Assert
+    assert name in menu_collection.listing
+    assert item1.uid in menu_collection.indexes["uid"]
+    assert item1.get_parent in menu_collection.indexes["parent"]
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "duplicate_name"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+    item2 = menu.Menu(cobbler_api)
+    item2.name = name
+
+    # Act & Assert
+    with pytest.raises(CX):
+        menu_collection.add(item2, check_for_duplicate_names=True)
+
+
+def test_remove(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_remove"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+    assert name in menu_collection.listing
+    assert len(menu_collection.indexes["uid"]) == 1
+    assert (menu_collection.indexes["uid"])[item1.uid] == item1.name
+    assert item1.name in (menu_collection.indexes["parent"])[item1.get_parent]
+
+    # Act
+    menu_collection.remove(name)
+
+    # Assert
+    assert name not in menu_collection.listing
+    assert len(menu_collection.indexes["uid"]) == 0
+    assert len(menu_collection.indexes["parent"]) == 0
+
+
+def test_indexes(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+
+    # Assert
+    assert len(menu_collection.indexes) == 2
+    assert len(menu_collection.indexes["uid"]) == 0
+    assert len(menu_collection.indexes["parent"]) == 0
+
+
+def test_add_to_indexes(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_add_to_indexes"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+
+    # Act
+    del (menu_collection.indexes["uid"])[item1.uid]
+    del (menu_collection.indexes["parent"])[item1.get_parent]
+    menu_collection.add_to_indexes(item1)
+
+    # Assert
+    #    assert 0 == 1
+    assert item1.uid in menu_collection.indexes["uid"]
+    assert item1.get_parent in menu_collection.indexes["parent"]
+
+
+def test_remove_from_indexes(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_remove_from_indexes"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+
+    # Act
+    menu_collection.remove_from_indexes(item1)
+
+    # Assert
+    assert item1.uid not in menu_collection.indexes["uid"]
+    assert item1.get_parent not in menu_collection.indexes["parent"]
+
+
+def test_update_indexes(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_update_indexes"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+    uid1_test = "test_uid"
+
+    # Act
+    item1.uid = uid1_test
+
+    # Assert
+    assert menu_collection.indexes["uid"][uid1_test] == name
+
+
+def test_find_by_indexes(
+    cobbler_api: CobblerAPI,
+    menu_collection: menus.Menus,
+):
+    # Arrange
+    name = "test_find_by_indexes"
+    item1 = menu.Menu(cobbler_api)
+    item1.name = name
+    menu_collection.add(item1)
+    kargs1 = {"uid": item1.uid}
+    kargs2 = {"uid": "fake_uid"}
+    kargs3 = {"fake_index": item1.uid}
+    kargs4 = {"parent": ""}
+    kargs5 = {"parent": "fake_parent"}
+
+    # Act
+    result1 = menu_collection.find_by_indexes(kargs1)
+    result2 = menu_collection.find_by_indexes(kargs2)
+    result3 = menu_collection.find_by_indexes(kargs3)
+    result4 = menu_collection.find_by_indexes(kargs4)
+    result5 = menu_collection.find_by_indexes(kargs5)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == item1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1
+    assert result4 is not None
+    assert len(result4) == 1
+    assert len(kargs4) == 0
+    assert result5 is None
+    assert len(kargs5) == 0

--- a/tests/cobbler_collections/profile_collection_test.py
+++ b/tests/cobbler_collections/profile_collection_test.py
@@ -1,0 +1,552 @@
+"""
+TODO
+"""
+
+from typing import Any, Callable
+
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import profiles
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import distro, menu, profile, repo
+
+
+@pytest.fixture(name="profile_collection")
+def fixture_profile_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (Profiles) of a generic collection.
+    """
+    return cobbler_api.profiles()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    """
+    TODO
+    """
+    # Arrange & Act
+    test_profile_collection = profiles.Profiles(collection_mgr)
+
+    # Assert
+    assert isinstance(test_profile_collection, profiles.Profiles)
+
+
+def test_factory_produce(
+    cobbler_api: CobblerAPI, profile_collection: profiles.Profiles
+):
+    """
+    TODO
+    """
+    # Arrange & Act
+    result_profile = profile_collection.factory_produce(cobbler_api, {})
+
+    # Assert
+    assert isinstance(result_profile, profile.Profile)
+
+
+def test_get(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_get"
+    create_distro()
+    create_profile(name)
+
+    # Act
+    item = profile_collection.get(name)
+    fake_item = profile_collection.get("fake_name")
+
+    # Assert
+    assert item is not None
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_find"
+    create_distro()
+    create_profile(name)
+
+    # Act
+    result = profile_collection.find(name, True, True)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_to_list"
+    create_distro()
+    create_profile(name)
+
+    # Act
+    result = profile_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_from_list"
+    distro1 = create_distro()
+    item_list = [
+        {
+            "name": name,
+            "distro": distro1.name,
+        },
+    ]
+
+    # Act
+    profile_collection.from_list(item_list)
+
+    # Assert
+    assert len(profile_collection.listing) == 1
+    for indx in profile_collection.indexes.values():
+        assert len(indx) == 1
+
+
+def test_copy(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # pylint: disable=protected-access
+    # Arrange
+    name = "test_copy"
+    create_distro()
+    profile1 = create_profile(name)
+
+    # Act
+    new_item_name = "test_copy_successful"
+    profile_collection.copy(profile1, new_item_name)
+    profile2 = profile_collection.find(new_item_name, False)
+
+    # Assert
+    assert isinstance(profile2, profile.Profile)
+    assert len(profile_collection.listing) == 2
+    assert name in profile_collection.listing
+    assert new_item_name in profile_collection.listing
+    for key, value in profile_collection.indexes.items():
+        indx_prop = cobbler_api.settings().memory_indexes["profile"][key]
+        attr_val1 = profile_collection._get_index_property(profile1, key)  # type: ignore[reportPrivateUsage]
+        attr_val2 = profile_collection._get_index_property(profile2, key)  # type: ignore[reportPrivateUsage]
+        if isinstance(attr_val1, list):
+            attr_val1 = ""
+        elif isinstance(attr_val1, enums.ConvertableEnum):
+            attr_val1 = attr_val1.value
+        if isinstance(attr_val2, list):
+            attr_val2 = ""
+        elif isinstance(attr_val2, enums.ConvertableEnum):
+            attr_val2 = attr_val2.value
+        if indx_prop["nonunique"]:
+            assert len(value) == 1
+            assert value[attr_val1] == {name, new_item_name}
+            assert value[attr_val2] == {name, new_item_name}
+        else:
+            assert len(value) == 2
+            assert value[attr_val1] == name
+            assert value[attr_val2] == new_item_name
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+    input_new_name: str,
+):
+    """
+    TODO
+    """
+    # pylint: disable=protected-access
+    # Arrange
+    name = "test_rename"
+    create_distro()
+    profile1 = create_profile(name)
+
+    # Act
+    profile_collection.rename(profile1, input_new_name)
+
+    # Assert
+    assert input_new_name in profile_collection.listing
+    assert profile_collection.listing[input_new_name].name == input_new_name
+    for key, value in profile_collection.indexes.items():
+        indx_prop = cobbler_api.settings().memory_indexes["profile"][key]
+        attr_val = profile_collection._get_index_property(profile1, key)  # type: ignore[reportPrivateUsage]
+        if isinstance(attr_val, list):
+            attr_val = ""
+        elif isinstance(attr_val, enums.ConvertableEnum):
+            attr_val = attr_val.value
+        if indx_prop["nonunique"]:
+            assert value[attr_val] == {input_new_name}
+        else:
+            assert value[attr_val] == input_new_name
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # pylint: disable=protected-access
+    # Arrange
+    name = "test_collection_add"
+    distro1 = create_distro()
+    profile1 = profile.Profile(cobbler_api)
+    profile1.name = name
+    profile1.distro = distro1.name
+
+    # Act
+    profile_collection.add(profile1)
+
+    # Assert
+    assert name in profile_collection.listing
+    assert profile_collection.listing[name].name == name
+    for key, value in profile_collection.indexes.items():
+        indx_prop = cobbler_api.settings().memory_indexes["profile"][key]
+        attr_val = profile_collection._get_index_property(profile1, key)  # type: ignore[reportPrivateUsage]
+        if isinstance(attr_val, list):
+            attr_val = ""
+        elif isinstance(attr_val, enums.ConvertableEnum):
+            attr_val = attr_val.value
+        if indx_prop["nonunique"]:
+            assert value[attr_val] == {name}
+        else:
+            assert value[attr_val] == name
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_duplicate_add"
+    distro1 = create_distro()
+    create_profile(name)
+    profile2 = profile.Profile(cobbler_api)
+    profile2.name = name
+    profile2.distro = distro1.name
+
+    # Act & Assert
+    assert len(profile_collection.indexes["uid"]) == 1
+    with pytest.raises(CX):
+        profile_collection.add(profile2, check_for_duplicate_names=True)
+    for key, _ in profile_collection.indexes.items():
+        assert len(profile_collection.indexes[key]) == 1
+
+
+def test_remove(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_remove"
+    create_distro()
+    create_profile(name)
+    assert name in profile_collection.listing
+
+    # Pre-Assert to validate if the index is in its correct state
+    for key, _ in profile_collection.indexes.items():
+        assert len(profile_collection.indexes[key]) == 1
+
+    # Act
+    profile_collection.remove(name)
+
+    # Assert
+    assert name not in profile_collection.listing
+    for key, _ in profile_collection.indexes.items():
+        assert len(profile_collection.indexes[key]) == 0
+
+
+def test_indexes(
+    cobbler_api: CobblerAPI,
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+
+    # Assert
+    assert len(profile_collection.indexes) == 6
+    assert len(profile_collection.indexes["uid"]) == 0
+    assert len(profile_collection.indexes["parent"]) == 0
+    assert len(profile_collection.indexes["distro"]) == 0
+    assert len(profile_collection.indexes["arch"]) == 0
+    assert len(profile_collection.indexes["menu"]) == 0
+    assert len(profile_collection.indexes["repos"]) == 0
+
+
+def test_add_to_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # pylint: disable=protected-access
+    # Arrange
+    name = "test_add_to_indexes"
+    create_distro()
+    profile1 = create_profile(name)
+    for key, value in profile_collection.indexes.items():
+        attr_val = profile_collection._get_index_property(profile1, key)  # type: ignore[reportPrivateUsage]
+        if isinstance(attr_val, list):
+            attr_val = ""
+        elif isinstance(attr_val, enums.ConvertableEnum):
+            attr_val = attr_val.value
+        del value[attr_val]
+
+    # Act
+    profile_collection.add_to_indexes(profile1)
+
+    # Assert
+    for key, value in profile_collection.indexes.items():
+        indx_prop = cobbler_api.settings().memory_indexes["profile"][key]
+        attr_val = profile_collection._get_index_property(profile1, key)  # type: ignore[reportPrivateUsage]
+        if isinstance(attr_val, list):
+            attr_val = ""
+        elif isinstance(attr_val, enums.ConvertableEnum):
+            attr_val = attr_val.value
+        if indx_prop["nonunique"]:
+            assert {attr_val: {profile1.name}} == value
+        else:
+            assert {attr_val: profile1.name} == value
+
+
+def test_update_profile_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Any,
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_update_profile_indexes"
+    distro1: distro.Distro = create_distro()
+    distro2: distro.Distro = create_distro("test_update_profile_indexes_new")
+    profile1 = create_profile(name)
+    profile2 = profile.Profile(cobbler_api)
+    profile2.name = "test_update_profile2"
+    profile2.distro = distro2.name
+    profile_collection.add(profile2)
+    menu1 = menu.Menu(cobbler_api)
+    menu1.name = name
+    cobbler_api.menus().add(menu1)
+    repo1 = repo.Repo(cobbler_api)
+    repo1.name = name
+    cobbler_api.repos().add(repo1)
+
+    # Act
+    original_uid = profile1.uid
+    original_distro = distro1.name
+    original_menu = profile1.menu
+    profile1.uid = "test_uid"
+    profile1.parent = profile2.name
+    profile1.distro = distro2.name
+    profile1.menu = menu1.name
+    profile1.repos = repo1.name
+    profile2.repos = [repo1.name]
+
+    # Assert
+    assert original_uid not in profile_collection.indexes["uid"]
+    assert profile_collection.indexes["uid"]["test_uid"] == profile1.name
+    assert profile1.name not in profile_collection.indexes["parent"]
+    assert profile_collection.indexes["parent"][profile1.get_parent] == {profile1.name}
+    assert original_distro not in profile_collection.indexes["distro"]
+    assert profile_collection.indexes["distro"][profile1.distro.name] == {  # type: ignore[reportOptionalMemberAccess]
+        profile1.name,
+        profile2.name,
+    }
+    assert profile1.name not in profile_collection.indexes["menu"][original_menu]
+    assert profile_collection.indexes["menu"][profile1.menu] == {profile1.name}
+    assert profile_collection.indexes["repos"][repo1.name] == {
+        profile1.name,
+        profile2.name,
+    }
+
+
+def test_remove_from_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_remove_from_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    profile2 = profile.Profile(cobbler_api)
+    profile2.name = "test_remove_from_indexe2"
+    profile2.distro = distro1.name
+    profile_collection.add(profile2)
+    profile1.parent = profile2.name
+    menu1 = menu.Menu(cobbler_api)
+    menu1.name = name
+    cobbler_api.menus().add(menu1)
+    profile1.menu = menu1.name
+    repo1 = repo.Repo(cobbler_api)
+    repo1.name = name
+    cobbler_api.repos().add(repo1)
+    profile1.repos = repo1.name
+
+    # Act
+    profile_collection.remove_from_indexes(profile1)
+
+    # Assert
+    assert profile1.uid not in profile_collection.indexes["uid"]
+    assert profile1.get_parent not in profile_collection.indexes["parent"]
+    assert profile_collection.indexes["distro"][profile1.distro.name] == {profile2.name}  # type: ignore[reportOptionalMemberAccess]
+    assert profile_collection.indexes["arch"][profile1.arch.value] == {profile2.name}  # type: ignore[reportOptionalMemberAccess]
+    assert profile1.menu not in profile_collection.indexes["menu"]
+    assert profile1.repos[0] not in profile_collection.indexes["repos"]
+
+    # Cleanup
+    profile_collection.add_to_indexes(profile1)
+
+
+def test_find_by_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    profile_collection: profiles.Profiles,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_find_by_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    kargs1 = {"uid": profile1.uid}
+    kargs2 = {"uid": "fake_uid"}
+    kargs3 = {"fake_index": profile1.uid}
+    kargs4 = {"parent": ""}
+    kargs5 = {"parent": "fake_parent"}
+    kargs6 = {"menu": ""}
+    kargs7 = {"parent": "fake_menu"}
+    kargs8 = {"repos": ""}
+    kargs9 = {"repos": "fake_repos"}
+    kargs10 = {"distro": distro1.name}
+    kargs11 = {"repos": "fake_distro"}
+    kargs12 = {"arch": profile1.arch.value}  # type: ignore[reportOptionalMemberAccess]
+    kargs13 = {"repos": "fake_arch"}
+
+    # Act
+    result1 = profile_collection.find_by_indexes(kargs1)
+    result2 = profile_collection.find_by_indexes(kargs2)
+    result3 = profile_collection.find_by_indexes(kargs3)
+    result4 = profile_collection.find_by_indexes(kargs4)
+    result5 = profile_collection.find_by_indexes(kargs5)
+    result6 = profile_collection.find_by_indexes(kargs6)
+    result7 = profile_collection.find_by_indexes(kargs7)
+    result8 = profile_collection.find_by_indexes(kargs8)
+    result9 = profile_collection.find_by_indexes(kargs9)
+    result10 = profile_collection.find_by_indexes(kargs10)
+    result11 = profile_collection.find_by_indexes(kargs11)
+    result12 = profile_collection.find_by_indexes(kargs12)
+    result13 = profile_collection.find_by_indexes(kargs13)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == profile1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1
+    assert result4 is not None
+    assert len(result4) == 1
+    assert len(kargs4) == 0
+    assert result5 is None
+    assert len(kargs5) == 0
+    assert result6 is not None
+    assert len(result6) == 1
+    assert len(kargs6) == 0
+    assert result7 is None
+    assert len(kargs7) == 0
+    assert result8 is not None
+    assert len(result8) == 1
+    assert len(kargs8) == 0
+    assert result9 is None
+    assert len(kargs9) == 0
+    assert result10 is not None
+    assert len(result10) == 1
+    assert len(kargs10) == 0
+    assert result11 is None
+    assert len(kargs11) == 0
+    assert result12 is not None
+    assert len(result12) == 1
+    assert len(kargs12) == 0
+    assert result13 is None
+    assert len(kargs13) == 0

--- a/tests/cobbler_collections/repo_collection_test.py
+++ b/tests/cobbler_collections/repo_collection_test.py
@@ -1,0 +1,304 @@
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import repos
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import repo
+
+
+@pytest.fixture
+def repo_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (Repos) of a generic collection.
+    """
+    return cobbler_api.repos()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    # Arrange & Act
+    repo_collection = repos.Repos(collection_mgr)
+
+    # Assert
+    assert isinstance(repo_collection, repos.Repos)
+
+
+def test_factory_produce(cobbler_api: CobblerAPI, repo_collection: repos.Repos):
+    # Arrange & Act
+    result_repo = repo_collection.factory_produce(cobbler_api, {})
+
+    # Assert
+    assert isinstance(result_repo, repo.Repo)
+
+
+def test_get(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_get"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+
+    # Act
+    item = repo_collection.get(name)
+    fake_item = repo_collection.get("fake_name")
+
+    # Assert
+    assert isinstance(item, repo.Repo)
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_find"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+
+    # Act
+    result = repo_collection.find(name, True, True)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_to_list"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+
+    # Act
+    result = repo_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    item_list = [{"name": "test_from_list"}]
+
+    # Act
+    repo_collection.from_list(item_list)
+
+    # Assert
+    assert len(repo_collection.listing) == 1
+    assert len(repo_collection.indexes["uid"]) == 1
+
+
+def test_copy(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_copy"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+
+    # Act
+    new_item_name = "test_copy_new"
+    repo_collection.copy(item1, new_item_name)
+    item2 = repo_collection.find(new_item_name, False)
+    assert isinstance(item2, repo.Repo)
+    item2.parent = name
+
+    # Assert
+    assert len(repo_collection.listing) == 2
+    assert name in repo_collection.listing
+    assert new_item_name in repo_collection.listing
+    assert len(repo_collection.indexes["uid"]) == 2
+    assert (repo_collection.indexes["uid"])[item1.uid] == name
+    assert (repo_collection.indexes["uid"])[item2.uid] == new_item_name
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+    input_new_name: str,
+):
+    # Arrange
+    old_name = "test_rename"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = old_name
+    repo_collection.add(item1)
+
+    # Act
+    repo_collection.rename(item1, input_new_name)
+
+    # Assert
+    assert input_new_name in repo_collection.listing
+    assert repo_collection.listing[input_new_name].name == input_new_name
+    assert (repo_collection.indexes["uid"])[item1.uid] == input_new_name
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_collection_add"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+
+    # Act
+    repo_collection.add(item1)
+
+    # Assert
+    assert name in repo_collection.listing
+    assert item1.uid in repo_collection.indexes["uid"]
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "duplicate_name"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+    item2 = repo.Repo(cobbler_api)
+    item2.name = name
+
+    # Act & Assert
+    with pytest.raises(CX):
+        repo_collection.add(item2, check_for_duplicate_names=True)
+
+
+def test_remove(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_remove"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+    assert name in repo_collection.listing
+    assert len(repo_collection.indexes["uid"]) == 1
+    assert (repo_collection.indexes["uid"])[item1.uid] == item1.name
+
+    # Act
+    repo_collection.remove(name)
+
+    # Assert
+    assert name not in repo_collection.listing
+    assert len(repo_collection.indexes["uid"]) == 0
+
+
+def test_indexes(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+
+    # Assert
+    assert len(repo_collection.indexes) == 1
+    assert len(repo_collection.indexes["uid"]) == 0
+
+
+def test_add_to_indexes(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_add_to_indexes"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+
+    # Act
+    del (repo_collection.indexes["uid"])[item1.uid]
+    repo_collection.add_to_indexes(item1)
+
+    # Assert
+    #    assert 0 == 1
+    assert item1.uid in repo_collection.indexes["uid"]
+
+
+def test_remove_from_indexes(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_remove_from_indexes"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+
+    # Act
+    repo_collection.remove_from_indexes(item1)
+
+    # Assert
+    assert item1.uid not in repo_collection.indexes["uid"]
+
+
+def test_update_indexes(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_update_indexes"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+    uid1_test = "test_uid"
+
+    # Act
+    item1.uid = uid1_test
+
+    # Assert
+    assert repo_collection.indexes["uid"][uid1_test] == name
+
+
+def test_find_by_indexes(
+    cobbler_api: CobblerAPI,
+    repo_collection: repos.Repos,
+):
+    # Arrange
+    name = "test_find_by_indexes"
+    item1 = repo.Repo(cobbler_api)
+    item1.name = name
+    repo_collection.add(item1)
+    kargs1 = {"uid": item1.uid}
+    kargs2 = {"uid": "fake_uid"}
+    kargs3 = {"fake_index": item1.uid}
+
+    # Act
+    result1 = repo_collection.find_by_indexes(kargs1)
+    result2 = repo_collection.find_by_indexes(kargs2)
+    result3 = repo_collection.find_by_indexes(kargs3)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == item1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1

--- a/tests/items/base_item_test.py
+++ b/tests/items/base_item_test.py
@@ -52,6 +52,26 @@ class MockItem(BaseItem):
 
         return attribute_value
 
+    @property
+    def uid(self) -> str:
+        """
+        The uid is the internal unique representation of a Cobbler object. It should never be used twice, even after an
+        object was deleted.
+
+        :getter: The uid for the item. Should be unique across a running Cobbler instance.
+        :setter: The new uid for the object. Should only be used by the Cobbler Item Factory.
+        """
+        return self._uid
+
+    @uid.setter
+    def uid(self, uid: str) -> None:
+        """
+        Setter for the uid of the item.
+
+        :param uid: The new uid.
+        """
+        self._uid = uid
+
 
 def test_uid(cobbler_api: CobblerAPI):
     """

--- a/tests/items/bootable_item_test.py
+++ b/tests/items/bootable_item_test.py
@@ -258,7 +258,7 @@ def test_dump_vars(cobbler_api: CobblerAPI):
     print(result)
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 169
+    assert len(result) == 170
 
 
 def test_to_dict(cobbler_api: CobblerAPI):

--- a/tests/items/inheritable_item_test.py
+++ b/tests/items/inheritable_item_test.py
@@ -188,6 +188,15 @@ def test_descendants(
     for x in range(len(cache_tests)):
         assert set(cache_tests[x]) == set(results[x])
 
+    # Cleanup
+    cobbler_api.remove_system(test_system1.name)
+    cobbler_api.remove_system(test_system2.name)
+    cobbler_api.remove_profile(test_profile3.name)
+    cobbler_api.remove_profile(test_profile2.name)
+    cobbler_api.remove_profile(test_profile1.name)
+    cobbler_api.remove_menu(test_menu2.name)
+    cobbler_api.remove_menu(test_menu1.name)
+
 
 def test_tree_walk(cobbler_api: CobblerAPI):
     """

--- a/tests/items/inmemory_test.py
+++ b/tests/items/inmemory_test.py
@@ -136,6 +136,13 @@ def test_inmemory(
     inmemory_api.menus().listing.pop(test_menu1.name)
     inmemory_api.repos().listing.pop(test_repo.name)
 
+    inmemory_api.systems().indexes = {}
+    inmemory_api.images().indexes = {}
+    inmemory_api.profiles().indexes = {}
+    inmemory_api.distros().indexes = {}
+    inmemory_api.menus().indexes = {}
+    inmemory_api.repos().indexes = {}
+
     inmemory_api.deserialize()
 
     test_repo: Repo = inmemory_api.find_repo("test_repo")  # type: ignore[reportAssignmentType]

--- a/tests/modules/managers/isc_test.py
+++ b/tests/modules/managers/isc_test.py
@@ -244,7 +244,6 @@ def test_manager_gen_full_config(mocker: "MockerFixture", api_isc_mock: CobblerA
     manager = isc.get_manager(api_isc_mock)
     mock_distro = Distro(api_isc_mock)
     mock_distro.redhat_management_key = ""
-    mock_distro.arch = "x86_64"
     mock_profile = Profile(api_isc_mock)
     mock_profile.autoinstall = ""
     mock_profile.proxy = ""
@@ -319,7 +318,6 @@ def test_manager_remove_single_system(
     manager = isc.get_manager(api_isc_mock)
     mock_distro = Distro(api_isc_mock)
     mock_distro.redhat_management_key = ""
-    mock_distro.arch = "x86_64"
     mock_profile = Profile(api_isc_mock)
     mock_profile.autoinstall = ""
     mock_profile.proxy = ""
@@ -366,7 +364,6 @@ def test_manager_sync_single_system(mocker: "MockerFixture", api_isc_mock: Cobbl
     manager = isc.get_manager(api_isc_mock)
     mock_distro = Distro(api_isc_mock)
     mock_distro.redhat_management_key = ""
-    mock_distro.arch = "x86_64"
     mock_profile = Profile(api_isc_mock)
     mock_profile.autoinstall = ""
     mock_profile.proxy = ""

--- a/tests/modules/serializer/sqlite_test.py
+++ b/tests/modules/serializer/sqlite_test.py
@@ -27,6 +27,7 @@ def test_settings(mocker: MockerFixture, cobbler_api: CobblerAPI) -> Settings:
     settings.lazy_start = False
     settings.cache_enabled = False
     settings.serializer_pretty_json = False
+    settings.memory_indexes = {}
     return settings
 
 

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -3,12 +3,13 @@ Module that contains a helper class which supports the performance testsuite. Th
 rather related pytest-benchmark. Thus, the different style in usage.
 """
 
-from typing import Any, Callable
+from typing import Callable
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.image import Image
 from cobbler.items.menu import Menu
+from cobbler.items.network_interface import NetworkInterface
 from cobbler.items.profile import Profile
 from cobbler.items.repo import Repo
 from cobbler.items.system import System
@@ -19,108 +20,145 @@ class CobblerTree:
     Helper class that defines methods that can be used during benchmark testing.
     """
 
-    objs_count = 2
+    objs_default_count = 10
+    repos_count = objs_default_count
+    distros_count = objs_default_count
+    menus_count = objs_default_count
+    profiles_count = 300
+    images_count = objs_default_count
+    systems_count = 1000
     test_rounds = 1
     tree_levels = 3
 
     @staticmethod
-    def create_repos(api: CobblerAPI):
+    def create_repos(api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool):
         """
         Create a number of repos for benchmark testing.
         """
-        for i in range(CobblerTree.objs_count):
-            test_item = Repo(api)
+        for i in range(CobblerTree.repos_count):
+            test_item: Repo = Repo(api)
             test_item.name = f"test_repo_{i}"
-            api.add_repo(test_item)
+            api.repos().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
 
     @staticmethod
-    def create_distros(api: CobblerAPI, create_distro: Any):
+    def create_distros(
+        api: CobblerAPI,
+        create_distro: Callable[[str, bool], Distro],
+        save: bool,
+        with_triggers: bool,
+        with_sync: bool,
+    ):
         """
         Create a number of distros for benchmark testing. This pairs the distros with the repositories and mgmt classes.
         """
-        for i in range(CobblerTree.objs_count):
-            test_item: Distro = create_distro(name=f"test_distro_{i}")
-            test_item.source_repos = [f"test_repo_{i}"]
+        for i in range(CobblerTree.distros_count):
+            test_item = create_distro(f"test_distro_{i}", False)
+            test_item.source_repos = [f"test_repo_{i % CobblerTree.repos_count}"]
+            api.distros().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
 
     @staticmethod
-    def create_menus(api: CobblerAPI):
+    def create_menus(api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool):
         """
         Create a number of menus for benchmark testing. Depending on the menu depth this method also adds children for
         the menus.
         """
         for l in range(CobblerTree.tree_levels):
-            for i in range(CobblerTree.objs_count):
-                test_item = Menu(api)
+            for i in range(CobblerTree.menus_count):
+                test_item: Menu = Menu(api)
                 test_item.name = f"level_{l}_test_menu_{i}"
                 if l > 0:
                     test_item.parent = f"level_{l - 1}_test_menu_{i}"
                 else:
                     test_item.parent = ""
-                api.add_menu(test_item)
+                api.menus().add(
+                    test_item,
+                    save=save,
+                    with_triggers=with_triggers,
+                    with_sync=with_sync,
+                )
 
     @staticmethod
-    def create_profiles(api: CobblerAPI, create_profile: Any):
+    def create_profiles(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
         """
         Create a number of profiles for benchmark testing. Depending on the menu depth this method also pairs the
         profile with a menu.
         """
         for l in range(CobblerTree.tree_levels):
-            for i in range(CobblerTree.objs_count):
+            for i in range(CobblerTree.profiles_count):
+                test_item: Profile = Profile(api)
+                test_item.name = f"level_{l}_test_profile_{i}"
                 if l > 0:
-                    test_item: Profile = create_profile(
-                        profile_name=f"level_{l - 1}_test_profile_{i}",
-                        name=f"level_{l}_test_profile_{i}",
-                    )
+                    test_item.parent = f"level_{l - 1}_test_profile_{i}"
                 else:
-                    test_item: Profile = create_profile(
-                        distro_name=f"test_distro_{i}",
-                        name=f"level_{l}_test_profile_{i}",
-                    )
-                test_item.menu = f"level_{l}_test_menu_{i}"
+                    test_item.distro = f"test_distro_{i % CobblerTree.distros_count}"
+                test_item.menu = f"level_{l}_test_menu_{i % CobblerTree.menus_count}"
                 test_item.autoinstall = "sample.ks"
+                api.profiles().add(
+                    test_item,
+                    save=save,
+                    with_triggers=with_triggers,
+                    with_sync=with_sync,
+                )
 
     @staticmethod
-    def create_images(api: CobblerAPI, create_image: Any):
+    def create_images(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
         """
         Create a number of images for benchmark testing.
         """
-        for i in range(CobblerTree.objs_count):
-            test_item: Image = create_image(name=f"test_image_{i}")
-            test_item.menu = f"level_{CobblerTree.tree_levels - 1}_test_menu_{i}"
+        for i in range(CobblerTree.images_count):
+            test_item: Image = Image(api)
+            test_item.name = f"test_image_{i}"
+            test_item.menu = f"level_{CobblerTree.tree_levels - 1}_test_menu_{i % CobblerTree.menus_count}"
             test_item.autoinstall = "sample.ks"
+            api.images().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
 
     @staticmethod
-    def create_systems(api: CobblerAPI, create_system: Any):
+    def create_systems(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
         """
         Create a number of systems for benchmark testing. Depending on the strategy the system is paired with a profile
         or image.
         """
-        for i in range(CobblerTree.objs_count):
+        for i in range(CobblerTree.systems_count):
+            test_item: System = System(api)
+            test_item.name = f"test_system_{i}"
             if i % 2 == 0:
-                create_system(
-                    name=f"test_system_{i}",
-                    profile_name=f"level_{CobblerTree.tree_levels - 1}_test_profile_{i}",
-                )
+                test_item.profile = f"level_{CobblerTree.tree_levels - 1}_test_profile_{i % CobblerTree.profiles_count}"
             else:
-                create_system(name=f"test_system_{i}", image_name=f"test_image_{i}")
+                test_item.image = f"test_image_{i % CobblerTree.images_count}"
+            test_item.interfaces = {"default": NetworkInterface(api, test_item.name)}
+            api.systems().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
 
     @staticmethod
     def create_all_objs(
         api: CobblerAPI,
-        create_distro: Callable[[str], Distro],
-        create_profile: Callable[[str, str, str], Profile],
-        create_image: Callable[[str], Image],
-        create_system: Callable[[str, str, str], System],
+        create_distro: Callable[[str, bool], Distro],
+        save: bool,
+        with_triggers: bool,
+        with_sync: bool,
     ):
         """
         Method that collectively creates all items at the same time.
         """
-        CobblerTree.create_repos(api)
-        CobblerTree.create_distros(api, create_distro)
-        CobblerTree.create_menus(api)
-        CobblerTree.create_profiles(api, create_profile)
-        CobblerTree.create_images(api, create_image)
-        CobblerTree.create_systems(api, create_system)
+        CobblerTree.create_repos(api, save, with_triggers, with_sync)
+        CobblerTree.create_distros(api, create_distro, save, with_triggers, with_sync)
+        CobblerTree.create_menus(api, save, with_triggers, with_sync)
+        CobblerTree.create_profiles(api, save, with_triggers, with_sync)
+        CobblerTree.create_images(api, save, with_triggers, with_sync)
+        CobblerTree.create_systems(api, save, with_triggers, with_sync)
 
     @staticmethod
     def remove_repos(api: CobblerAPI):
@@ -128,7 +166,7 @@ class CobblerTree:
         Method that removes all repositories.
         """
         for test_item in api.repos():
-            api.remove_repo(test_item.name)
+            api.repos().remove(test_item.name, with_triggers=False, with_sync=False)
 
     @staticmethod
     def remove_distros(api: CobblerAPI):
@@ -136,7 +174,7 @@ class CobblerTree:
         Method that removes all distributions.
         """
         for test_item in api.distros():
-            api.remove_distro(test_item.name)
+            api.distros().remove(test_item.name, with_triggers=False, with_sync=False)
 
     @staticmethod
     def remove_menus(api: CobblerAPI):
@@ -144,7 +182,12 @@ class CobblerTree:
         Method that removes all menus.
         """
         while len(api.menus()) > 0:
-            api.remove_menu(list(api.menus())[0], recursive=True)
+            api.menus().remove(
+                list(api.menus())[0].name,
+                recursive=True,
+                with_triggers=False,
+                with_sync=False,
+            )
 
     @staticmethod
     def remove_profiles(api: CobblerAPI):
@@ -152,7 +195,12 @@ class CobblerTree:
         Method that removes all profiles.
         """
         while len(api.profiles()) > 0:
-            api.remove_profile(list(api.profiles())[0], recursive=True)
+            api.profiles().remove(
+                list(api.profiles())[0].name,
+                recursive=True,
+                with_triggers=False,
+                with_sync=False,
+            )
 
     @staticmethod
     def remove_images(api: CobblerAPI):
@@ -160,7 +208,7 @@ class CobblerTree:
         Method that removes all images.
         """
         for test_item in api.images():
-            api.remove_image(test_item.name)
+            api.images().remove(test_item.name, with_triggers=False, with_sync=False)
 
     @staticmethod
     def remove_systems(api: CobblerAPI):
@@ -168,7 +216,7 @@ class CobblerTree:
         Method that removes all systems.
         """
         for test_item in api.systems():
-            api.remove_system(test_item.name)
+            api.systems().remove(test_item.name, with_triggers=False, with_sync=False)
 
     @staticmethod
     def remove_all_objs(api: CobblerAPI):

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -11,9 +11,6 @@ from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs]
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
-from cobbler.items.image import Image
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
 
 from tests.performance import CobblerTree
 
@@ -34,7 +31,12 @@ def test_repos_create(
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         CobblerTree.remove_all_objs(cobbler_api)
-        return (cobbler_api,), {}
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
@@ -43,9 +45,6 @@ def test_repos_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_repos, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert
 
@@ -69,8 +68,14 @@ def test_distros_create(
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         CobblerTree.remove_all_objs(cobbler_api)
-        CobblerTree.create_repos(cobbler_api)
-        return (cobbler_api, create_distro), {}
+        CobblerTree.create_repos(cobbler_api, False, False, False)
+        return (
+            cobbler_api,
+            create_distro,
+            True,
+            True,
+            False,
+        ), {}
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
@@ -79,9 +84,6 @@ def test_distros_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_distros, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert
 
@@ -102,7 +104,12 @@ def test_menus_create(
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         CobblerTree.remove_all_objs(cobbler_api)
-        return (cobbler_api,), {}
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
@@ -111,9 +118,6 @@ def test_menus_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_menus, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert
 
@@ -142,8 +146,7 @@ def test_menus_create(
 def test_profiles_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_distro: Callable[[str], Distro],
-    create_profile: Callable[[str, str, str], Profile],
+    create_distro: Callable[[str, bool], Distro],
     cache_enabled: bool,
     enable_menu: bool,
 ):
@@ -153,10 +156,15 @@ def test_profiles_create(
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         CobblerTree.remove_all_objs(cobbler_api)
-        CobblerTree.create_repos(cobbler_api)
-        CobblerTree.create_distros(cobbler_api, create_distro)
-        CobblerTree.create_menus(cobbler_api)
-        return (cobbler_api, create_profile), {}
+        CobblerTree.create_repos(cobbler_api, False, False, False)
+        CobblerTree.create_distros(cobbler_api, create_distro, False, False, False)
+        CobblerTree.create_menus(cobbler_api, False, False, False)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
@@ -166,9 +174,6 @@ def test_profiles_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_profiles, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert
 
@@ -183,7 +188,6 @@ def test_profiles_create(
 def test_images_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_image: Callable[[str], Image],
     cache_enabled: bool,
 ):
     """
@@ -192,8 +196,13 @@ def test_images_create(
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         CobblerTree.remove_all_objs(cobbler_api)
-        CobblerTree.create_menus(cobbler_api)
-        return (cobbler_api, create_image), {}
+        CobblerTree.create_menus(cobbler_api, False, False, False)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
@@ -202,9 +211,6 @@ def test_images_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_images, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert
 
@@ -233,10 +239,7 @@ def test_images_create(
 def test_systems_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_distro: Callable[[str], Distro],
-    create_profile: Callable[[str, str, str], Profile],
-    create_image: Callable[[str], Image],
-    create_system: Callable[[str, str, str], System],
+    create_distro: Callable[[str, bool], Distro],
     cache_enabled: bool,
     enable_menu: bool,
 ):
@@ -246,12 +249,17 @@ def test_systems_create(
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
         CobblerTree.remove_all_objs(cobbler_api)
-        CobblerTree.create_repos(cobbler_api)
-        CobblerTree.create_distros(cobbler_api, create_distro)
-        CobblerTree.create_menus(cobbler_api)
-        CobblerTree.create_images(cobbler_api, create_image)
-        CobblerTree.create_profiles(cobbler_api, create_profile)
-        return (cobbler_api, create_system), {}
+        CobblerTree.create_repos(cobbler_api, False, False, False)
+        CobblerTree.create_distros(cobbler_api, create_distro, False, False, False)
+        CobblerTree.create_menus(cobbler_api, False, False, False)
+        CobblerTree.create_images(cobbler_api, False, False, False)
+        CobblerTree.create_profiles(cobbler_api, False, False, False)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
@@ -261,9 +269,6 @@ def test_systems_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_systems, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert
 
@@ -292,10 +297,7 @@ def test_systems_create(
 def test_all_items_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_distro: Callable[[str], Distro],
-    create_profile: Callable[[str, str, str], Profile],
-    create_image: Callable[[str], Image],
-    create_system: Callable[[str, str, str], System],
+    create_distro: Callable[[str, bool], Distro],
     cache_enabled: bool,
     enable_menu: bool,
 ):
@@ -308,9 +310,9 @@ def test_all_items_create(
         return (
             cobbler_api,
             create_distro,
-            create_profile,
-            create_image,
-            create_system,
+            True,
+            True,
+            False,
         ), {}
 
     # Arrange
@@ -321,8 +323,5 @@ def test_all_items_create(
     result = benchmark.pedantic(  # type: ignore
         CobblerTree.create_all_objs, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -11,9 +11,6 @@ from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs]
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
-from cobbler.items.image import Image
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
 
 from tests.performance import CobblerTree
 
@@ -60,10 +57,7 @@ from tests.performance import CobblerTree
 def test_item_edit(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_distro: Callable[[str], Distro],
-    create_profile: Callable[[str, str, str], Profile],
-    create_image: Callable[[str], Image],
-    create_system: Callable[[str, str, str], System],
+    create_distro: Callable[[str, bool], Distro],
     cache_enabled: bool,
     enable_menu: bool,
     inherit_property: bool,
@@ -74,10 +68,6 @@ def test_item_edit(
     """
 
     def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
-        CobblerTree.remove_all_objs(cobbler_api)
-        CobblerTree.create_all_objs(
-            cobbler_api, create_distro, create_profile, create_image, create_system
-        )
         return (cobbler_api, what), {}
 
     def item_edit(api: CobblerAPI, what: str):
@@ -90,13 +80,11 @@ def test_item_edit(
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
     cobbler_api.settings().enable_menu = enable_menu
+    CobblerTree.create_all_objs(cobbler_api, create_distro, False, False, False)
 
     # Act
     result = benchmark.pedantic(  # type: ignore
         item_edit, setup=setup_func, rounds=CobblerTree.test_rounds
     )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
 
     # Assert

--- a/tests/performance/make_pxe_menu_test.py
+++ b/tests/performance/make_pxe_menu_test.py
@@ -2,7 +2,7 @@
 Test module to assert the performance of creating the PXE menu.
 """
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Callable
 
 import pytest
 from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs]
@@ -11,9 +11,6 @@ from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs]
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
-from cobbler.items.image import Image
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
 
 from tests.performance import CobblerTree
 
@@ -42,10 +39,7 @@ from tests.performance import CobblerTree
 def test_make_pxe_menu(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_distro: Callable[[str], Distro],
-    create_profile: Callable[[str, str, str], Profile],
-    create_image: Callable[[str], Image],
-    create_system: Callable[[str, str, str], System],
+    create_distro: Callable[[str, bool], Distro],
     cache_enabled: bool,
     enable_menu: bool,
 ):
@@ -53,28 +47,15 @@ def test_make_pxe_menu(
     Test that asserts if creating the PXE menu is running wihtout a performance decrease.
     """
 
-    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
-        api = cobbler_api
-        CobblerTree.remove_all_objs(api)
-        CobblerTree.create_all_objs(
-            api, create_distro, create_profile, create_image, create_system
-        )
-        del api
-        return (cobbler_api,), {}
-
-    def make_pxe_menu(api: CobblerAPI):
-        api.tftpgen.make_pxe_menu()
+    def make_pxe_menu():
+        cobbler_api.tftpgen.make_pxe_menu()
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
     cobbler_api.settings().enable_menu = enable_menu
+    CobblerTree.create_all_objs(cobbler_api, create_distro, False, False, False)
 
     # Act
-    result = benchmark.pedantic(  # type: ignore
-        make_pxe_menu, setup=setup_func, rounds=CobblerTree.test_rounds
-    )
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
+    result = benchmark.pedantic(make_pxe_menu, rounds=CobblerTree.test_rounds)  # type: ignore
 
     # Assert

--- a/tests/performance/sync_test.py
+++ b/tests/performance/sync_test.py
@@ -2,7 +2,7 @@
 Test module to assert the performance of "cobbler sync".
 """
 
-from typing import Any, Callable, Dict, Tuple
+from typing import Callable
 
 import pytest
 from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs]
@@ -11,9 +11,6 @@ from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs]
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
-from cobbler.items.image import Image
-from cobbler.items.profile import Profile
-from cobbler.items.system import System
 
 from tests.performance import CobblerTree
 
@@ -42,10 +39,7 @@ from tests.performance import CobblerTree
 def test_sync(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,
-    create_distro: Callable[[str], Distro],
-    create_profile: Callable[[str, str, str], Profile],
-    create_image: Callable[[str], Image],
-    create_system: Callable[[str, str, str], System],
+    create_distro: Callable[[str, bool], Distro],
     cache_enabled: bool,
     enable_menu: bool,
 ):
@@ -53,26 +47,15 @@ def test_sync(
     Test that asserts if "cobbler sync" without arguments is running without a performance decrease.
     """
 
-    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
-        api = cobbler_api
-        CobblerTree.remove_all_objs(api)
-        CobblerTree.create_all_objs(
-            api, create_distro, create_profile, create_image, create_system
-        )
-        del api
-        return (cobbler_api,), {}
-
-    def sync(api: CobblerAPI):
-        api.sync()
+    def sync():
+        cobbler_api.sync()
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled
     cobbler_api.settings().enable_menu = enable_menu
+    CobblerTree.create_all_objs(cobbler_api, create_distro, False, False, False)
 
     # Act
-    result = benchmark.pedantic(sync, setup=setup_func, rounds=CobblerTree.test_rounds)  # type: ignore
-
-    # Cleanup
-    CobblerTree.remove_all_objs(cobbler_api)
+    result = benchmark.pedantic(sync, rounds=CobblerTree.test_rounds)  # type: ignore
 
     # Assert

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -212,7 +212,7 @@ def test_blender(cobbler_api):  # type: ignore
     result = utils.blender(cobbler_api, False, root_item)  # type: ignore
 
     # Assert
-    assert len(result) == 169
+    assert len(result) == 170
     # Must be present because the settings have it
     assert "server" in result
     # Must be present because it is a field of distro


### PR DESCRIPTION
## Linked Items

Fixes #3720, #3817, #3816

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

PR adds the ability to create non-unique collection indexes and set their properties in the settings..

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->
- only unique indexes are supported
- indexes are hard-coded, there is no way to set their properties

New: <!-- This is the new way Cobbler behaves -->
- supports unique and non-unique indexes on arbitrary attributes
- the necessary indexes and their properties are set in the settings

## Category

This is related to a:

- [ ] Bugfix
- [X] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
