### PR TITLE
Fix: setuptools 70+ compatibility

### DIFF
--- a/changelog.d/3692.fixed
+++ b/changelog.d/3692.fixed
@@ -1,0 +1,1 @@
+Fix compatibility with setuptools 70+

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -714,7 +714,8 @@ class Item:
     @LazyProperty
     def template_files(self) -> Dict[Any, Any]:
         """
-        File mappings for built-in configuration management
+        File mappings for built-in configuration management. The keys are the template source files and the value is the
+        destination. The destination must be inside the bootloc (most of the time TFTP server directory).
 
         :getter: The dictionary with name-path key-value pairs.
         :setter: A dict. If not a dict must be a str which is split by
@@ -740,7 +741,8 @@ class Item:
     @LazyProperty
     def boot_files(self) -> Dict[Any, Any]:
         """
-        Files copied into tftpboot beyond the kernel/initrd
+        Files copied into tftpboot beyond the kernel/initrd. These get rendered via Cheetah/Jinja and must be text
+        based.
 
         :getter: The dictionary with name-path key-value pairs.
         :setter: A dict. If not a dict must be a str which is split by

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,16 @@ from typing import Any, Dict, List
 
 from setuptools import Command
 from setuptools import Distribution as _Distribution
-from setuptools import dep_util, find_packages, setup
+from setuptools import find_packages, setup
 from setuptools.command.build_py import build_py as _build_py
 from setuptools.command.install import install as _install
+
+try:
+    # Setuptools compatibility 70+
+    # https://github.com/cobbler/cobbler/issues/3692
+    from setuptools import modified
+except ImportError:
+    from setuptools import dep_util as modified
 
 VERSION = "3.4.0"
 OUTPUT_DIR = "config"
@@ -290,7 +297,7 @@ class BuildCfg(Command):
             # We copy the files to build/
             outfile = os.path.join(self.build_dir, infile)  # type: ignore
             # check if the file is out of date
-            if self.force or dep_util.newer_group([infile, "setup.py"], outfile, mode):  # type: ignore
+            if self.force or modified.newer_group([infile, "setup.py"], outfile, mode):  # type: ignore
                 # It is. Configure it
                 self.configure_one_file(infile, outfile)  # type: ignore
 


### PR DESCRIPTION
## Linked Items

Fixes #3692

## Description

Cobbler is still used in distros that default to Python 3.6 on the system-wide level. As such the installer needs to be compatible with both setuptools 70+ and lower.

## Behaviour changes

Old: Cobbler fails to successfully install on setuptools 70+

New: Cobbler installs successfully on both setuptools 70+ and lower

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
