### PR TITLE
setup.py: Fix compatibility with setuptools 70+

### DIFF
--- a/changelog.d/3724.fixed
+++ b/changelog.d/3724.fixed
@@ -1,0 +1,1 @@
+Fix compatibility with setuptools 70+

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ from setuptools import Command
 from setuptools.command.install import install as _install
 from setuptools import Distribution as _Distribution
 from setuptools.command.build_py import build_py as _build_py
-from setuptools import dep_util
 from distutils.command.build import build as _build
 from configparser import ConfigParser
 from setuptools import find_packages
@@ -21,6 +20,12 @@ import pwd
 import shutil
 import subprocess
 
+try:
+    # Setuptools compatibility 70+
+    # https://github.com/cobbler/cobbler/issues/3692
+    from setuptools import modified
+except ImportError:
+    from setuptools import dep_util as modified
 
 VERSION = "3.3.5"
 OUTPUT_DIR = "config"
@@ -241,7 +246,7 @@ class build_cfg(Command):
             # We copy the files to build/
             outfile = os.path.join(self.build_dir, infile)
             # check if the file is out of date
-            if self.force or dep_util.newer_group([infile, 'setup.py'], outfile, mode):
+            if self.force or modified.newer_group([infile, 'setup.py'], outfile, mode):
                 # It is. Configure it
                 self.configure_one_file(infile, outfile)
 


### PR DESCRIPTION
## Linked Items

Fixes #3724

## Description

Cobbler is still used in distros that default to Python 3.6 on the system-wide level. As such the installer needs to be compatible with both setuptools 70+ and lower.

## Behaviour changes

Old: Cobbler fails to successfully install on setuptools 70+

New: Cobbler installs successfully on both setuptools 70+ and lower

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
