### PR TITLE
Backport collection indicies

### DIFF
--- a/changelog.d/3725.added
+++ b/changelog.d/3725.added
@@ -1,0 +1,1 @@
+Add collection indices for UUID's, MAC's, IP addresses and hostnames

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -56,8 +56,6 @@ class Distros(collection.Collection):
         :raises CX: In case any subitem (profiles or systems) would be orphaned. If the option ``recursive`` is set then
                     the orphaned items would be removed automatically.
         """
-        name = name.lower()
-
         obj = self.find(name=name)
 
         if obj is None:
@@ -66,7 +64,7 @@ class Distros(collection.Collection):
         # first see if any Groups use this distro
         if not recursive:
             for profile in self.api.profiles():
-                if profile.distro and profile.distro.name.lower() == name:
+                if profile.distro and profile.distro.name == name:
                     raise CX("removal would orphan profile: %s" % profile.name)
 
         kernel = obj.kernel
@@ -83,6 +81,7 @@ class Distros(collection.Collection):
                 lite_sync.remove_single_distro(name)
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -52,7 +52,6 @@ class Files(collection.Collection):
 
         :raises CX: In case a non existent object should be deleted.
         """
-        name = name.lower()
         obj = self.find(name=name)
 
         if obj is None:
@@ -64,6 +63,7 @@ class Files(collection.Collection):
 
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -47,7 +47,6 @@ class Images(collection.Collection):
         :raises CX: In case object does not exist or it would orhan a system.
         """
         # NOTE: with_delete isn't currently meaningful for repos but is left in for consistency in the API. Unused.
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX("cannot delete an object that does not exist: %s" % name)
@@ -55,7 +54,7 @@ class Images(collection.Collection):
         # first see if any Groups use this distro
         if not recursive:
             for v in self.api.systems():
-                if v.image is not None and v.image.lower() == name:
+                if v.image is not None and v.image == name:
                     raise CX("removal would orphan system: %s" % v.name)
 
         if recursive:
@@ -72,6 +71,7 @@ class Images(collection.Collection):
 
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -91,6 +91,7 @@ class Menus(collection.Collection):
                 utils.run_triggers(self.api, obj, "/var/lib/cobbler/triggers/delete/menu/pre/*", [])
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -56,7 +56,6 @@ class Mgmtclasses(collection.Collection):
 
         :raises CX: In case the object does not exist.
         """
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX("cannot delete an object that does not exist: %s" % name)
@@ -67,6 +66,7 @@ class Mgmtclasses(collection.Collection):
 
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -52,7 +52,6 @@ class Packages(collection.Collection):
 
         :raises CX: In case the object does not exist.
         """
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX("cannot delete an object that does not exist: %s" % name)
@@ -63,6 +62,7 @@ class Packages(collection.Collection):
 
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -52,10 +52,9 @@ class Profiles(collection.Collection):
 
         :raises CX: In case the name of the object was not given or any other descendant would be orphaned.
         """
-        name = name.lower()
         if not recursive:
             for v in self.api.systems():
-                if v.profile is not None and v.profile.lower() == name:
+                if v.profile is not None and v.profile == name:
                     raise CX("removal would orphan system: %s" % v.name)
 
         obj = self.find(name=name)
@@ -81,6 +80,7 @@ class Profiles(collection.Collection):
 
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -57,7 +57,6 @@ class Repos(collection.Collection):
         """
         # NOTE: with_delete isn't currently meaningful for repos
         # but is left in for consistancy in the API.  Unused.
-        name = name.lower()
         obj = self.find(name=name)
         if obj is None:
             raise CX("cannot delete an object that does not exist: %s" % name)
@@ -68,6 +67,7 @@ class Repos(collection.Collection):
 
         self.lock.acquire()
         try:
+            self.remove_from_indexes(obj)
             del self.listing[name]
         finally:
             self.lock.release()

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -87,13 +87,13 @@ class Distro(item.Item):
         """
         # FIXME: Change unique base attributes
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         # Drop attributes which are computed from other attributes
         computed_properties = ["remote_grub_initrd", "remote_grub_kernel"]
         for property_name in computed_properties:
             _dict.pop(property_name, None)
         cloned = Distro(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     @classmethod

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -62,9 +62,9 @@ class File(resource.Resource):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = File(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     def check_if_valid(self):

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -84,6 +84,7 @@ class Image(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Image(self.api)
         cloned.from_dict(_dict)
         cloned.uid = uuid.uuid4().hex

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -451,6 +451,15 @@ class Item:
 
         :param uid: The new uid.
         """
+        if self._uid != uid and self.COLLECTION_TYPE != Item.COLLECTION_TYPE:
+            collection = self.api.get_items(self.COLLECTION_TYPE)
+            with collection.lock:
+                item = collection.get(self.name)
+                if item is not None and item.uid == self._uid:
+                    # Update uid index
+                    indx_dict = collection.indexes["uid"]
+                    del indx_dict[self._uid]
+                    indx_dict[uid] = self.name
         self._uid = uid
 
     @property

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -57,9 +57,9 @@ class Menu(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Menu(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     #

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -66,9 +66,9 @@ class Mgmtclass(item.Item):
         """
 
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Mgmtclass(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     #

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -60,9 +60,9 @@ class Package(resource.Resource):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Package(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     #

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -108,9 +108,9 @@ class Profile(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Profile(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     def check_if_valid(self):

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -77,9 +77,9 @@ class Repo(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Repo(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     def check_if_valid(self):

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -57,9 +57,9 @@ class Resource(item.Item):
         :return: The cloned instance of this object.
         """
         _dict = self.to_dict()
+        _dict.pop("uid", None)
         cloned = Resource(self.api)
         cloned.from_dict(_dict)
-        cloned.uid = uuid.uuid4().hex
         return cloned
 
     #

--- a/cobbler/modules/installation/post_report.py
+++ b/cobbler/modules/installation/post_report.py
@@ -97,7 +97,7 @@ def run(api, args) -> int:
 
         sendmail = True
         for prefix in settings.build_reporting_ignorelist:
-            if prefix != "" and name.lower().startswith(prefix):
+            if prefix != "" and name.startswith(prefix):
                 sendmail = False
 
         if sendmail:

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1978,7 +1978,7 @@ class CobblerXMLRPCInterface:
         if field_name in ("delete_interface", "rename_interface"):
             return True
 
-        interface = system.NetworkInterface(self.api)
+        interface = system.NetworkInterface(self.api, "")
         fields = []
         for attribute in interface.__dict__.keys():
             if attribute.startswith("_") and ("api" not in attribute or "logger" in attribute):
@@ -2129,7 +2129,7 @@ class CobblerXMLRPCInterface:
             interface = system_to_edit.interfaces.get(interface_name)
             if interface is None:
                 # If the interface is not existing, create a new one.
-                interface = system.NetworkInterface(self.api)
+                interface = system.NetworkInterface(self.api, system_to_edit.name)
             for attribute_key in attributes:
                 if self.__is_interface_field(attribute_key):
                     if hasattr(interface, attribute_key):

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -60,6 +60,7 @@ RUN zypper install --no-recommends -y \
     python3-pykickstart        \
     python3-netaddr            \
     python3-pymongo            \
+    python3-psutil             \
     rpm-build                  \
     rsync                      \
     supervisor                 \

--- a/tests/collections/system_collection_test.py
+++ b/tests/collections/system_collection_test.py
@@ -1,0 +1,774 @@
+"""
+TODO
+"""
+
+from typing import Callable
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import systems
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import distro, profile, system
+
+
+@pytest.fixture(name="system_collection")
+def fixture_system_collection(collection_mgr: CollectionManager):
+    """
+    Fixture to provide a concrete implementation (Systems) of a generic collection.
+    """
+    return systems.Systems(collection_mgr)
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    """
+    TODO
+    """
+    # Arrange & Act
+    test_system_collection = systems.Systems(collection_mgr)
+
+    # Assert
+    assert isinstance(test_system_collection, systems.Systems)
+
+
+def test_factory_produce(cobbler_api: CobblerAPI, system_collection: systems.Systems):
+    """
+    TODO
+    """
+    # Arrange & Act
+    result_system = system_collection.factory_produce(cobbler_api, {})
+
+    # Assert
+    assert isinstance(result_system, system.System)
+
+
+def test_get(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_get"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system_collection = cobbler_api.systems()
+
+    # Act
+    item = system_collection.get(name)
+    fake_item = system_collection.get("fake_name")
+
+    # Assert
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_find"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system_collection = cobbler_api.systems()
+
+    # Act
+    result = system_collection.find(name, True, True)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_to_list"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system_collection = cobbler_api.systems()
+
+    # Act
+    result = system_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_from_list"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system_collection = cobbler_api.systems()
+    item_list = [
+        {
+            "name": "test_from_list",
+            "profile": name,
+            "interfaces": {
+                "default": {
+                    "ip_address": "192.168.1.1",
+                    "ipv6_address": "::1",
+                    "dns_name": "example.org",
+                    "mac_address": "52:54:00:7d:81:f4",
+                }
+            },
+        }
+    ]
+
+    # Act
+    system_collection.from_list(item_list)
+
+    # Assert
+    assert len(system_collection.listing) == 1
+    for indx in system_collection.indexes.values():
+        assert len(indx) == 1
+
+
+def test_copy(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_copy"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+
+    # Act
+    test1 = {
+        x for y in system_collection.listing.values() for x in y.interfaces.values()
+    }
+    new_item_name = "test_copy_successful"
+    system_collection.copy(system1, new_item_name)
+    system2 = system_collection.find(new_item_name, False)
+
+    # Assert
+    assert len(system_collection.listing) == 2
+    assert name in system_collection.listing
+    assert new_item_name in system_collection.listing
+    for key, value in system_collection.indexes.items():
+        if key == "uid":
+            assert len(value) == 2
+            assert value[getattr(system1, key)] == name
+            assert value[getattr(system2, key)] == new_item_name
+        else:
+            assert len(value) == 1
+            assert value[getattr(system1.interfaces["default"], key)] == name
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+    input_new_name: str,
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_rename"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+
+    # Act
+    system_collection.rename(system1, input_new_name)
+
+    # Assert
+    assert input_new_name in system_collection.listing
+    assert system_collection.listing[input_new_name].name == input_new_name
+    for interface in system1.interfaces.values():
+        assert interface.system_name == input_new_name
+    for key, value in system_collection.indexes.items():
+        if key == "uid":
+            assert value[getattr(system1, key)] == input_new_name
+        else:
+            assert value[getattr(system1.interfaces["default"], key)] == input_new_name
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_collection_add"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = system.System(cobbler_api)
+    system1.name = name
+    system1.profile = profile1.name
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+
+    # Act
+    system_collection.add(system1)
+
+    # Assert
+    assert name in system_collection.listing
+    assert system_collection.listing[name].name == name
+    for interface in system1.interfaces.values():
+        assert interface.system_name == name
+    for key, value in system_collection.indexes.items():
+        if key == "uid":
+            assert value[getattr(system1, key)] == name
+        else:
+            assert value[getattr(system1.interfaces["default"], key)] == name
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_duplicate_add"
+    distro1 = create_distro(name="duplicate_add")
+    profile1 = create_profile(distro1.name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+    system2 = system.System(cobbler_api)
+    system2.name = name
+    system2.profile = name
+
+    # Act & Assert
+    assert len(system_collection.indexes["uid"]) == 1
+    with pytest.raises(CX):
+        system_collection.add(system2, check_for_duplicate_names=True)
+    for key, value in system_collection.indexes.items():
+        assert len(system_collection.indexes[key]) == 1
+
+
+def test_remove(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_remove"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+    assert name in system_collection.listing
+
+    # Pre-Assert to validate if the index is in its correct state
+    for key, value in system_collection.indexes.items():
+        assert len(system_collection.indexes[key]) == 1
+
+    # Act
+    system_collection.remove(name)
+
+    # Assert
+    assert name not in system_collection.listing
+    for key, value in system_collection.indexes.items():
+        assert len(system_collection.indexes[key]) == 0
+
+
+def test_indexes(
+    cobbler_api: CobblerAPI,
+    create_system: Callable[[str], system.System],
+    system_collection: systems.Systems,
+):
+    """
+    TODO
+    """
+    # Arrange
+
+    # Assert
+    assert len(system_collection.indexes) == 5
+    assert len(system_collection.indexes["uid"]) == 0
+    assert len(system_collection.indexes["mac_address"]) == 0
+    assert len(system_collection.indexes["ip_address"]) == 0
+    assert len(system_collection.indexes["ipv6_address"]) == 0
+    assert len(system_collection.indexes["dns_name"]) == 0
+
+    assert len(system_collection.disabled_indexes) == 4
+    assert not system_collection.disabled_indexes["mac_address"]
+    assert not system_collection.disabled_indexes["ip_address"]
+    assert not system_collection.disabled_indexes["ipv6_address"]
+    assert not system_collection.disabled_indexes["dns_name"]
+
+
+def test_add_to_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_add_to_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+    for key, value in system_collection.indexes.items():
+        if key == "uid":
+            del value[getattr(system1, key)]
+        else:
+            del value[getattr(system1.interfaces["default"], key)]
+
+    # Act
+    system_collection.add_to_indexes(system1)
+
+    # Assert
+    for key, value in system_collection.indexes.items():
+        if key == "uid":
+            assert {getattr(system1, key): system1.name} == value
+        else:
+            assert {getattr(system1.interfaces["default"], key): system1.name} == value
+
+
+def test_update_interfaces_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_update_interfaces_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "test1": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "test1.example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        },
+        "test2": {
+            "ip_address": "192.168.1.2",
+            "ipv6_address": "::2",
+            "dns_name": "test2.example.org",
+            "mac_address": "52:54:00:7d:81:f5",
+        },
+    }
+    system_collection = cobbler_api.systems()
+    interface1 = system.NetworkInterface(cobbler_api, system1.name)
+    interface1.from_dict(
+        {
+            "ip_address": "192.168.1.3",
+            "ipv6_address": "::3",
+            "dns_name": "",
+            "mac_address": "52:54:00:7d:81:f6",
+        }
+    )
+    interface2 = system.NetworkInterface(cobbler_api, system1.name)
+    interface2.from_dict(
+        {
+            "ip_address": "192.168.1.4",
+            "ipv6_address": "",
+            "dns_name": "test4.example.org",
+            "mac_address": "52:54:00:7d:81:f7",
+        }
+    )
+    new_interfaces = {
+        "test1": interface1,
+        "test2": interface2,
+        "test3": system1.interfaces["test2"],
+    }
+
+    # Act
+    system_collection.update_interfaces_indexes(system1, new_interfaces)
+
+    # Assert
+    assert set(system_collection.indexes["ip_address"].keys()) == {
+        "192.168.1.2",
+        "192.168.1.3",
+        "192.168.1.4",
+    }
+    assert set(system_collection.indexes["ipv6_address"].keys()) == {"::2", "::3"}
+    assert set(system_collection.indexes["dns_name"].keys()) == {
+        "test2.example.org",
+        "test4.example.org",
+    }
+    assert set(system_collection.indexes["mac_address"].keys()) == {
+        "52:54:00:7d:81:f5",
+        "52:54:00:7d:81:f6",
+        "52:54:00:7d:81:f7",
+    }
+
+    # Cleanup
+    for indx_key, indx_val in system_collection.indexes.items():
+        if indx_key == "uid":
+            continue
+        system_collection.indexes[indx_key] = {}
+
+
+def test_update_interface_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_update_interface_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "test1": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "test1.example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        },
+        "test2": {
+            "ip_address": "192.168.1.2",
+            "ipv6_address": "::2",
+            "dns_name": "test2.example.org",
+            "mac_address": "52:54:00:7d:81:f5",
+        },
+    }
+    system_collection = cobbler_api.systems()
+    interface1 = system.NetworkInterface(cobbler_api, system1.name)
+    interface1.from_dict(
+        {
+            "ip_address": "192.168.1.3",
+            "ipv6_address": "::3",
+            "dns_name": "",
+            "mac_address": "52:54:00:7d:81:f6",
+        }
+    )
+
+    # Act
+    system_collection.update_interface_indexes(system1, "test2", interface1)
+
+    # Assert
+    assert set(system_collection.indexes["ip_address"].keys()) == {
+        "192.168.1.1",
+        "192.168.1.3",
+    }
+    assert set(system_collection.indexes["ipv6_address"].keys()) == {"::1", "::3"}
+    assert set(system_collection.indexes["dns_name"].keys()) == {"test1.example.org"}
+    assert set(system_collection.indexes["mac_address"].keys()) == {
+        "52:54:00:7d:81:f4",
+        "52:54:00:7d:81:f6",
+    }
+
+    # Cleanup
+    for indx_key, indx_val in system_collection.indexes.items():
+        if indx_key == "uid":
+            continue
+        system_collection.indexes[indx_key] = {}
+
+
+def test_update_system_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_update_system_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "test1": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "test1.example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        },
+    }
+    system_collection = cobbler_api.systems()
+    interface1 = system.NetworkInterface(cobbler_api, system1.name)
+    interface1.from_dict(
+        {
+            "ip_address": "192.168.1.3",
+            "ipv6_address": "::3",
+            "dns_name": "",
+            "mac_address": "52:54:00:7d:81:f6",
+        }
+    )
+
+    # Act
+    original_uid = system1.uid
+    system1.uid = "test_uid"
+    system1.interfaces["test1"].ip_address = "192.168.1.2"
+    system1.interfaces["test1"].ipv6_address = "::2"
+    system1.interfaces["test1"].dns_name = "test2.example.org"
+    system1.interfaces["test1"].mac_address = "52:54:00:7d:81:f5"
+
+    interface1.ip_address = "192.168.1.4"
+    interface1.ipv6_address = "::4"
+    interface1.dns_name = "test4.example.org"
+    interface1.mac_address = "52:54:00:7d:81:f7"
+
+    # Assert
+    assert original_uid not in system_collection.indexes["uid"]
+    assert (system_collection.indexes["uid"])["test_uid"] == system1.name
+    assert "192.168.1.1" not in system_collection.indexes["ip_address"]
+    assert (system_collection.indexes["ip_address"])["192.168.1.2"] == system1.name
+    assert "::1" not in system_collection.indexes["ipv6_address"]
+    assert (system_collection.indexes["ipv6_address"])["::2"] == system1.name
+    assert "test1.example.org" not in system_collection.indexes["dns_name"]
+    assert (system_collection.indexes["dns_name"])["test2.example.org"] == system1.name
+    assert "52:54:00:7d:81:f4" not in system_collection.indexes["mac_address"]
+    assert (system_collection.indexes["mac_address"])[
+        "52:54:00:7d:81:f5"
+    ] == system1.name
+
+    assert interface1.ip_address not in system_collection.indexes["ip_address"]
+    assert interface1.ipv6_address not in system_collection.indexes["ipv6_address"]
+    assert interface1.dns_name not in system_collection.indexes["dns_name"]
+    assert interface1.mac_address not in system_collection.indexes["mac_address"]
+
+
+def test_remove_from_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_remove_from_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+    original_uid = system1.uid
+
+    # Act
+    system_collection.remove_from_indexes(system1)
+
+    # Assert
+    assert system1.uid not in system_collection.indexes["uid"]
+    assert (
+        system1.interfaces["default"].ip_address
+        not in system_collection.indexes["ip_address"]
+    )
+    assert (
+        system1.interfaces["default"].ipv6_address
+        not in system_collection.indexes["ipv6_address"]
+    )
+    assert (
+        system1.interfaces["default"].dns_name
+        not in system_collection.indexes["dns_name"]
+    )
+    assert (
+        system1.interfaces["default"].mac_address
+        not in system_collection.indexes["mac_address"]
+    )
+
+    # Cleanup
+    system1.uid = original_uid
+
+
+def test_find_by_indexes(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[[str], system.System],
+):
+    """
+    TODO
+    """
+    # Arrange
+    name = "test_find_by_indexes"
+    distro1 = create_distro()
+    profile1 = create_profile(name)
+    system1 = create_system(name)
+    system1.interfaces = {
+        "default": {
+            "ip_address": "192.168.1.1",
+            "ipv6_address": "::1",
+            "dns_name": "example.org",
+            "mac_address": "52:54:00:7d:81:f4",
+        }
+    }
+    system_collection = cobbler_api.systems()
+
+    kargs = {
+        "uid": [
+            {"uid": system1.uid},
+            {"uid": "fake_uid"},
+            {"fake_index": system1.uid},
+        ],
+        "ip_address": [
+            {"ip_address": system1.interfaces["default"].ip_address},
+            {"ip_address": "fake_ip_addres"},
+            {"fake_index": system1.interfaces["default"].ip_address},
+        ],
+        "ipv6_address": [
+            {"ipv6_address": system1.interfaces["default"].ipv6_address},
+            {"ipv6_address": "fake_ipv6_addres"},
+            {"fake_index": system1.interfaces["default"].ipv6_address},
+        ],
+        "dns_name": [
+            {"dns_name": system1.interfaces["default"].dns_name},
+            {"dns_name": "fake_dns_name"},
+            {"fake_index": system1.interfaces["default"].dns_name},
+        ],
+        "mac_address": [
+            {"mac_address": system1.interfaces["default"].mac_address},
+            {"mac_address": "fake_mac_address"},
+            {"fake_index": system1.interfaces["default"].mac_address},
+        ],
+    }
+    results = {}
+
+    # Act
+    for indx, args in kargs.items():
+        results[indx] = []
+        for arg in args:
+            results[indx].append(system_collection.find_by_indexes(arg))
+
+    # Assert
+    for indx, result in results.items():
+        assert isinstance(result[0], list)
+        assert len(result[0]) == 1
+        assert (result[0])[0] == system1
+        assert len((kargs[indx])[0]) == 0
+        assert result[1] is None
+        assert len((kargs[indx])[1]) == 0
+        assert result[2] is None
+        assert len((kargs[indx])[2]) == 1
+
+
+@pytest.mark.skip("Method which is under test is broken!")
+def test_to_string(cobbler_api: CobblerAPI, system_collection: systems.Systems):
+    """
+    TODO
+    """
+    # Arrange
+    name = "to_string"
+    item1 = system.System(cobbler_api)
+    item1.name = name
+    system_collection.add(item1)
+
+    # Act
+    result = system_collection.to_string()
+
+    # Assert
+    print(result)
+    assert False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,7 @@ def reset_settings_yaml(tmp_path):
 
 @pytest.fixture(scope="function", autouse=True)
 def reset_items(cobbler_api):
+    print(list(cobbler_api.systems().listing.keys()))
     for system in cobbler_api.systems():
         cobbler_api.remove_system(system.name)
     for image in cobbler_api.images():
@@ -167,7 +168,9 @@ def create_system(request, cobbler_api):
             test_system.profile = profile_name
         if image_name != "":
             test_system.image = image_name
-        test_system.interfaces = {"default": NetworkInterface(cobbler_api)}
+        test_system.interfaces = {
+            "default": NetworkInterface(cobbler_api, test_system.name)
+        }
         cobbler_api.add_system(test_system)
         return test_system
 

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -12,7 +12,7 @@ def test_network_interface_object_creation(cobbler_api):
     # Arrange
 
     # Act
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Assert
     assert isinstance(interface, NetworkInterface)
@@ -20,7 +20,7 @@ def test_network_interface_object_creation(cobbler_api):
 
 def test_network_interface_to_dict(cobbler_api):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     result = interface.to_dict()
@@ -49,7 +49,7 @@ def test_network_interface_from_dict(
 ):
     # Arrange
     caplog.set_level(logging.INFO)
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     interface.from_dict(input_dict)
@@ -80,7 +80,7 @@ def test_deserialize():
 )
 def test_dhcp_tag(cobbler_api, input_dhcp_tag, expected_result, expected_exception):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -93,7 +93,7 @@ def test_dhcp_tag(cobbler_api, input_dhcp_tag, expected_result, expected_excepti
 
 def test_cnames(cobbler_api):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     interface.cnames = []
@@ -105,7 +105,7 @@ def test_cnames(cobbler_api):
 
 def test_static_routes(cobbler_api):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     interface.static_routes = []
@@ -126,7 +126,7 @@ def test_static_routes(cobbler_api):
 )
 def test_static(cobbler_api, input_static, expected_result, expected_exception):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -148,7 +148,7 @@ def test_static(cobbler_api, input_static, expected_result, expected_exception):
 )
 def test_management(cobbler_api, input_management, expected_result, expected_exception):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -182,7 +182,7 @@ def test_dns_name(
     system = create_system(profile.name)
     system.interfaces["default"].dns_name = "duplicate.example.org"
     cobbler_api.add_system(system)
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, system.name)
 
     # Act
     with expected_exception:
@@ -224,7 +224,7 @@ def test_mac_address(
     system2.interfaces["default"].mac_address = "random"
     cobbler_api.add_system(system2)
     mocker.patch("cobbler.utils.get_random_mac", return_value="AA:BB:CC:DD:EE:FF")
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, system.name)
 
     # Act
     with expected_exception:
@@ -238,7 +238,7 @@ def test_mac_address(
 
 def test_netmask(cobbler_api):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     interface.netmask = ""
@@ -250,7 +250,7 @@ def test_netmask(cobbler_api):
 
 def test_if_gateway(cobbler_api):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     interface.if_gateway = ""
@@ -273,7 +273,7 @@ def test_virt_bridge(
     cobbler_api, input_virt_bridge, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -300,7 +300,7 @@ def test_interface_type(
     cobbler_api, input_interface_type, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -322,7 +322,7 @@ def test_interface_master(
     cobbler_api, input_interface_master, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -344,7 +344,7 @@ def test_bonding_opts(
     cobbler_api, input_bonding_opts, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -366,7 +366,7 @@ def test_bridge_opts(
     cobbler_api, input_bridge_opts, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -400,7 +400,7 @@ def test_ip_address(
     system = create_system(profile.name)
     system.interfaces["default"].ip_address = "172.30.0.2"
     cobbler_api.add_system(system)
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, system.name)
 
     # Act
     with expected_exception:
@@ -435,7 +435,7 @@ def test_ipv6_address(
     system = create_system(profile.name)
     system.interfaces["default"].ipv6_address = "2001:db8:3c4d::2"
     cobbler_api.add_system(system)
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, system.name)
 
     # Act
     with expected_exception:
@@ -458,7 +458,7 @@ def test_ipv6_prefix(
     cobbler_api, input_ipv6_prefix, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -481,7 +481,7 @@ def test_ipv6_secondaries(
     cobbler_api, input_secondaries, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -505,7 +505,7 @@ def test_ipv6_default_gateway(
     cobbler_api, input_address, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -518,7 +518,7 @@ def test_ipv6_default_gateway(
 
 def test_ipv6_static_routes(cobbler_api):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     interface.ipv6_static_routes = []
@@ -537,7 +537,7 @@ def test_ipv6_static_routes(cobbler_api):
 )
 def test_ipv6_mtu(cobbler_api, input_ipv6_mtu, expected_result, expected_exception):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -557,7 +557,7 @@ def test_ipv6_mtu(cobbler_api, input_ipv6_mtu, expected_result, expected_excepti
 )
 def test_mtu(cobbler_api, input_mtu, expected_result, expected_exception):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -581,7 +581,7 @@ def test_connected_mode(
     cobbler_api, input_connected_mode, expected_result, expected_exception
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
@@ -607,7 +607,7 @@ def test_modify_interface(
     expected_exception,
 ):
     # Arrange
-    interface = NetworkInterface(cobbler_api)
+    interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -1,5 +1,4 @@
 import pytest
-from docutils.nodes import error
 
 from cobbler import enums
 from cobbler.cexceptions import CX
@@ -648,7 +647,7 @@ def test_serial_baud_rate(cobbler_api, value, expected_exception):
 def test_from_dict_with_network_interface(cobbler_api):
     # Arrange
     system = System(cobbler_api)
-    system.interfaces = {"default": NetworkInterface(cobbler_api)}
+    system.interfaces = {"default": NetworkInterface(cobbler_api, system.name)}
     sys_dict = system.to_dict()
 
     # Act
@@ -668,7 +667,7 @@ def test_from_dict_with_network_interface(cobbler_api):
 def test_is_management_supported(cobbler_api, input_mac, input_ipv4, input_ipv6, expected_result):
     # Arrange
     system = System(cobbler_api)
-    system.interfaces = {"default": NetworkInterface(cobbler_api)}
+    system.interfaces = {"default": NetworkInterface(cobbler_api, system.name)}
     system.interfaces["default"].mac_address = input_mac
     system.interfaces["default"].ip_address = input_ipv4
     system.interfaces["default"].ipv6_address = input_ipv6

--- a/tests/modules/managers/dnsmasq_test.py
+++ b/tests/modules/managers/dnsmasq_test.py
@@ -41,7 +41,9 @@ def test_manager_write_configs(mocker, cobbler_api):
     mock_profile = Profile(cobbler_api)
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_hosts_system"
-    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"
@@ -75,7 +77,9 @@ def test_manager_regen_ethers(mocker, cobbler_api):
     mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_ethers_system"
-    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"
@@ -98,7 +102,9 @@ def test_manager_regen_hosts(mocker, cobbler_api):
     mock_builtins_open = mocker.patch("builtins.open", mocker.mock_open())
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_hosts_system"
-    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "AA:BB:CC:DD:EE:FF"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"

--- a/tests/modules/managers/ndjbdns_test.py
+++ b/tests/modules/managers/ndjbdns_test.py
@@ -36,7 +36,9 @@ def test_manager_write_configs(mocker, cobbler_api):
     mock_subproc_popen.return_value.returncode = 0
     mock_system = System(cobbler_api)
     mock_system.name = "test_manager_regen_hosts_system"
-    mock_system.interfaces = {"default": NetworkInterface(cobbler_api)}
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
     mock_system.interfaces["default"].dns_name = "host.example.org"
     mock_system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
     mock_system.interfaces["default"].ip_address = "192.168.1.2"


### PR DESCRIPTION
## Linked Items

Fixes #3725

## Description

Adds indexing of collections by non-key properties.

## Behaviour changes

Old: Quick search is supported only by item name.

New: A quick search can be performed using non-key properties.

There is additional overhead for updating indexes and allocating memory for them.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [x] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
