### PR TITLE
Fix: Inheriting some non-string properties

### DIFF
--- a/changelog.d/3715.fixed
+++ b/changelog.d/3715.fixed
@@ -1,0 +1,1 @@
+Fix inheritance behavior of non-string properties

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -57,7 +57,7 @@ class Image(item.Item):
         self._menu = ""
         self._virt_auto_boot = False
         self._virt_bridge = ""
-        self._virt_cpus = 0
+        self._virt_cpus = 1
         self._virt_disk_driver = enums.VirtDiskDrivers.RAW
         self._virt_file_size = enums.VALUE_INHERITED
         self._virt_path = ""
@@ -146,7 +146,7 @@ class Image(item.Item):
         :getter: The path relative to the template directory.
         :setter: The location of the template relative to the template base directory.
         """
-        return self._autoinstall
+        return self._resolve("autoinstall")
 
     @autoinstall.setter
     def autoinstall(self, autoinstall: str):
@@ -355,7 +355,7 @@ class Image(item.Item):
         return self._virt_auto_boot
 
     @virt_auto_boot.setter
-    def virt_auto_boot(self, num: bool):
+    def virt_auto_boot(self, num: Union[str, bool]):
         """
         Setter for the virtual automatic boot option.
 
@@ -413,7 +413,7 @@ class Image(item.Item):
         :getter: The amount of RAM currently assigned to the image.
         :setter: The new amount of ram. Must be an integer.
         """
-        return self._virt_ram
+        return self._resolve("virt_ram")
 
     @virt_ram.setter
     def virt_ram(self, num: int):
@@ -514,13 +514,11 @@ class Image(item.Item):
 
         :getter: The bootloaders which are available for being set.
         """
-        try:
-            # If we have already loaded the supported boot loaders from the signature, use that data
-            return self._supported_boot_loaders
-        except:
-            # otherwise, refresh from the signatures / defaults
-            self._supported_boot_loaders = utils.get_supported_distro_boot_loaders(self)
-            return self._supported_boot_loaders
+        if len(self._supported_boot_loaders) == 0:
+            self._supported_boot_loaders = utils.get_supported_distro_boot_loaders(
+                self
+            )
+        return self._supported_boot_loaders
 
     @InheritableProperty
     def boot_loaders(self) -> list:

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -1230,6 +1230,8 @@ class System(Item):
         :getter: Returns the value for ``proxy``.
         :setter: Sets the value for the property ``proxy``.
         """
+        if self.profile != "":
+            return self._resolve("proxy")
         return self._resolve("proxy_url_int")
 
     @proxy.setter
@@ -1468,13 +1470,17 @@ class System(Item):
         return self._resolve("enable_ipxe")
 
     @enable_ipxe.setter
-    def enable_ipxe(self, enable_ipxe: bool):
+    def enable_ipxe(self, enable_ipxe: Union[str, bool]):
         """
         Sets whether the system will use iPXE for booting.
 
         :param enable_ipxe: If ipxe should be enabled or not.
         :raises TypeError: In case enable_ipxe is not a boolean.
         """
+        if enable_ipxe == enums.VALUE_INHERITED:
+            self._enable_ipxe = enums.VALUE_INHERITED
+            return
+
         enable_ipxe = utils.input_boolean(enable_ipxe)
         if not isinstance(enable_ipxe, bool):
             raise TypeError("enable_ipxe needs to be of type bool")
@@ -1567,12 +1573,16 @@ class System(Item):
         return self._resolve("virt_cpus")
 
     @virt_cpus.setter
-    def virt_cpus(self, num: int):
+    def virt_cpus(self, num: Union[int, str]):
         """
         Setter for the virt_cpus of the System class.
 
         :param num: The new value for the number of CPU cores.
         """
+        if num == enums.VALUE_INHERITED:
+            self._virt_cpus = enums.VALUE_INHERITED
+            return
+
         self._virt_cpus = validate.validate_virt_cpus(num)
 
     @InheritableProperty

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -343,13 +343,15 @@ def validate_virt_file_size(num: Union[str, int, float]) -> Union[str, float]:
     return num
 
 
-def validate_virt_auto_boot(value: bool) -> bool:
+def validate_virt_auto_boot(value: Union[str, bool, int]) -> Union[bool, str]:
     """
     For Virt only.
     Specifies whether the VM should automatically boot upon host reboot 0 tells Koan not to auto_boot virtuals.
 
     :param value: May be True or False.
     """
+    if value == enums.VALUE_INHERITED:
+        return enums.VALUE_INHERITED
     value = utils.input_boolean(value)
     if not isinstance(value, bool):
         raise TypeError("virt_auto_boot needs to be of type bool.")

--- a/tests/items/distro_test.py
+++ b/tests/items/distro_test.py
@@ -3,8 +3,18 @@ import os
 import pytest
 
 from cobbler import enums, utils
+from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from tests.conftest import does_not_raise
+
+
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="distro_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
 
 
 def test_object_creation(cobbler_api):
@@ -384,3 +394,46 @@ def test_supported_boot_loaders(cobbler_api):
     # Assert
     assert isinstance(distro.supported_boot_loaders, list)
     assert distro.supported_boot_loaders == ["grub", "pxe", "ipxe"]
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    distro = Distro(cobbler_api)
+
+    # Act
+    for key, key_value in distro.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(distro, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(distro, new_key)
+            setattr(distro, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(distro, new_key)

--- a/tests/items/file_test.py
+++ b/tests/items/file_test.py
@@ -1,10 +1,21 @@
 import pytest
 
+from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.file import File
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="file_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -14,7 +25,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(distro, File)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     file = File(cobbler_api)
 
@@ -31,7 +42,7 @@ def test_make_clone(cobbler_api):
 @pytest.mark.parametrize("value,expected_exception", [
     (False, does_not_raise())
 ])
-def test_is_dir(cobbler_api, value, expected_exception):
+def test_is_dir(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     file = File(cobbler_api)
 
@@ -41,3 +52,46 @@ def test_is_dir(cobbler_api, value, expected_exception):
 
         # Assert
         assert file.is_dir is value
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    file = File(cobbler_api)
+
+    # Act
+    for key, key_value in file.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(file, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(file, new_key)
+            setattr(file, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(file, new_key)

--- a/tests/items/image_test.py
+++ b/tests/items/image_test.py
@@ -1,11 +1,21 @@
 import pytest
 
 from cobbler import enums, utils
+from cobbler.api import CobblerAPI
 from cobbler.items.image import Image
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="image_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -15,7 +25,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(image, Image)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -26,7 +36,7 @@ def test_make_clone(cobbler_api):
     assert image != result
 
 
-def test_arch(cobbler_api):
+def test_arch(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -37,7 +47,7 @@ def test_arch(cobbler_api):
     assert image.arch == enums.Archs.X86_64
 
 
-def test_autoinstall(cobbler_api):
+def test_autoinstall(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -48,7 +58,7 @@ def test_autoinstall(cobbler_api):
     assert image.autoinstall == ""
 
 
-def test_file(cobbler_api):
+def test_file(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -59,7 +69,7 @@ def test_file(cobbler_api):
     assert image.file == "/tmp/test"
 
 
-def test_os_version(cobbler_api):
+def test_os_version(cobbler_api: CobblerAPI):
     # Arrange
     utils.load_signatures("/var/lib/cobbler/distro_signatures.json")
     image = Image(cobbler_api)
@@ -72,7 +82,7 @@ def test_os_version(cobbler_api):
     assert image.os_version == "sles15generic"
 
 
-def test_breed(cobbler_api):
+def test_breed(cobbler_api: CobblerAPI):
     # Arrange
     utils.load_signatures("/var/lib/cobbler/distro_signatures.json")
     image = Image(cobbler_api)
@@ -84,7 +94,7 @@ def test_breed(cobbler_api):
     assert image.breed == "suse"
 
 
-def test_image_type(cobbler_api):
+def test_image_type(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -95,7 +105,7 @@ def test_image_type(cobbler_api):
     assert image.image_type == enums.ImageTypes.DIRECT
 
 
-def test_virt_cpus(cobbler_api):
+def test_virt_cpus(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -106,7 +116,7 @@ def test_virt_cpus(cobbler_api):
     assert image.virt_cpus == 5
 
 
-def test_network_count(cobbler_api):
+def test_network_count(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -117,7 +127,7 @@ def test_network_count(cobbler_api):
     assert image.network_count == 2
 
 
-def test_virt_auto_boot(cobbler_api):
+def test_virt_auto_boot(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -151,7 +161,7 @@ def test_virt_file_size(
         assert image.virt_file_size == expected_result
 
 
-def test_virt_disk_driver(cobbler_api):
+def test_virt_disk_driver(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -162,7 +172,7 @@ def test_virt_disk_driver(cobbler_api):
     assert image.virt_disk_driver == enums.VirtDiskDrivers.RAW
 
 
-def test_virt_ram(cobbler_api):
+def test_virt_ram(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -173,7 +183,7 @@ def test_virt_ram(cobbler_api):
     assert image.virt_ram == 5
 
 
-def test_virt_type(cobbler_api):
+def test_virt_type(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -184,7 +194,7 @@ def test_virt_type(cobbler_api):
     assert image.virt_type == enums.VirtType.AUTO
 
 
-def test_virt_bridge(cobbler_api):
+def test_virt_bridge(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -195,7 +205,7 @@ def test_virt_bridge(cobbler_api):
     assert image.virt_bridge == "testbridge"
 
 
-def test_virt_path(cobbler_api):
+def test_virt_path(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -206,7 +216,7 @@ def test_virt_path(cobbler_api):
     assert image.virt_path == ""
 
 
-def test_menu(cobbler_api):
+def test_menu(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -217,15 +227,15 @@ def test_menu(cobbler_api):
     assert image.menu == ""
 
 
-def test_supported_boot_loaders(cobbler_api):
+def test_supported_boot_loaders(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
     # Act & Assert
-    assert image.supported_boot_loaders == []
+    assert image.supported_boot_loaders == ["grub", "pxe", "ipxe"]
 
 
-def test_boot_loaders(cobbler_api):
+def test_boot_loaders(cobbler_api: CobblerAPI):
     # Arrange
     image = Image(cobbler_api)
 
@@ -234,3 +244,47 @@ def test_boot_loaders(cobbler_api):
 
     # Assert
     assert image.boot_loaders == []
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    image = Image(cobbler_api)
+
+    # Act
+    for key, key_value in image.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(image, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(image, new_key)
+            setattr(image, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(image, new_key)
+

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.package import Package
 from cobbler.items.file import File
 from cobbler.items.mgmtclass import Mgmtclass
@@ -10,12 +11,21 @@ from cobbler.items.repo import Repo
 from cobbler.items.distro import Distro
 from cobbler.items.menu import Menu
 from cobbler.items.profile import Profile
-from cobbler.items.system import System
 from cobbler.items.item import Item
+
 from tests.conftest import does_not_raise
 
 
-def test_item_create(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="item_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_item_create(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -25,7 +35,7 @@ def test_item_create(cobbler_api):
     assert isinstance(titem, Item)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -34,7 +44,7 @@ def test_make_clone(cobbler_api):
         titem.make_clone()
 
 
-def test_from_dict(cobbler_api, create_kernel_initrd, fk_kernel, fk_initrd):
+def test_from_dict(cobbler_api: CobblerAPI, create_kernel_initrd, fk_kernel, fk_initrd):
     # Arrange
     folder = create_kernel_initrd(fk_kernel, fk_initrd)
     name = "test_from_dict"
@@ -52,7 +62,7 @@ def test_from_dict(cobbler_api, create_kernel_initrd, fk_kernel, fk_initrd):
     assert titem.initrd == initrd_path
 
 
-def test_uid(cobbler_api):
+def test_uid(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -63,7 +73,7 @@ def test_uid(cobbler_api):
     assert titem.uid == "uid"
 
 
-def test_children(cobbler_api):
+def test_children(cobbler_api: CobblerAPI):
     # Arrange
     titem = Distro(cobbler_api)
 
@@ -73,7 +83,7 @@ def test_children(cobbler_api):
     assert titem.children == []
 
 
-def test_tree_walk(cobbler_api):
+def test_tree_walk(cobbler_api: CobblerAPI):
     # Arrange
     titem = Distro(cobbler_api)
 
@@ -84,7 +94,7 @@ def test_tree_walk(cobbler_api):
     assert result == []
 
 
-def test_item_descendants(cobbler_api):
+def test_item_descendants(cobbler_api: CobblerAPI):
     # Arrange
     titem = Distro(cobbler_api)
 
@@ -96,7 +106,7 @@ def test_item_descendants(cobbler_api):
 
 
 def test_descendants(
-    cobbler_api, create_distro, create_image, create_profile, create_system
+    cobbler_api: CobblerAPI, create_distro, create_image, create_profile, create_system
 ):
     # Arrange
     test_package = Package(cobbler_api)
@@ -197,7 +207,7 @@ def test_descendants(
         assert set(cache_tests[x]) == set(results[x])
 
 
-def test_get_conceptual_parent(request, cobbler_api, create_distro, create_profile):
+def test_get_conceptual_parent(request, cobbler_api: CobblerAPI, create_distro, create_profile):
     # Arrange
     tmp_distro = create_distro()
     tmp_profile = create_profile(tmp_distro.name)
@@ -216,7 +226,7 @@ def test_get_conceptual_parent(request, cobbler_api, create_distro, create_profi
     assert result.name == tmp_distro.name
 
 
-def test_name(cobbler_api):
+def test_name(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -227,7 +237,7 @@ def test_name(cobbler_api):
     assert titem.name == "testname"
 
 
-def test_comment(cobbler_api):
+def test_comment(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -248,7 +258,7 @@ def test_comment(cobbler_api):
         (False, pytest.raises(TypeError), None),
     ],
 )
-def test_owners(cobbler_api, input_owners, expected_exception, expected_result):
+def test_owners(cobbler_api: CobblerAPI, input_owners, expected_exception, expected_result):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -268,7 +278,7 @@ def test_owners(cobbler_api, input_owners, expected_exception, expected_result):
     ],
 )
 def test_kernel_options(
-    cobbler_api, input_kernel_options, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_kernel_options, expected_exception, expected_result
 ):
     # Arrange
     titem = Item(cobbler_api)
@@ -289,7 +299,7 @@ def test_kernel_options(
     ],
 )
 def test_kernel_options_post(
-    cobbler_api, input_kernel_options, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_kernel_options, expected_exception, expected_result
 ):
     # Arrange
     titem = Item(cobbler_api)
@@ -310,7 +320,7 @@ def test_kernel_options_post(
     ],
 )
 def test_autoinstall_meta(
-    cobbler_api, input_autoinstall_meta, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_autoinstall_meta, expected_exception, expected_result
 ):
     # Arrange
     titem = Item(cobbler_api)
@@ -359,7 +369,7 @@ def test_mgmt_classes(
     ],
 )
 def test_mgmt_parameters(
-    cobbler_api, input_mgmt_parameters, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_mgmt_parameters, expected_exception, expected_result
 ):
     # Arrange
     titem = Item(cobbler_api)
@@ -372,7 +382,7 @@ def test_mgmt_parameters(
         assert titem.mgmt_parameters == expected_result
 
 
-def test_template_files(cobbler_api):
+def test_template_files(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -383,7 +393,7 @@ def test_template_files(cobbler_api):
     assert titem.template_files == {}
 
 
-def test_boot_files(cobbler_api):
+def test_boot_files(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -394,7 +404,7 @@ def test_boot_files(cobbler_api):
     assert titem.boot_files == {}
 
 
-def test_fetchable_files(cobbler_api):
+def test_fetchable_files(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -423,7 +433,7 @@ def test_sort_key(request, cobbler_api):
 
 
 @pytest.mark.skip("Test not yet implemented")
-def test_find_match(cobbler_api):
+def test_find_match(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -435,7 +445,7 @@ def test_find_match(cobbler_api):
 
 
 @pytest.mark.skip("Test not yet implemented")
-def test_find_match_single_key(cobbler_api):
+def test_find_match_single_key(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -446,7 +456,7 @@ def test_find_match_single_key(cobbler_api):
     assert False
 
 
-def test_dump_vars(cobbler_api):
+def test_dump_vars(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -466,7 +476,7 @@ def test_dump_vars(cobbler_api):
         (5, does_not_raise(), 5),
     ],
 )
-def test_depth(cobbler_api, input_depth, expected_exception, expected_result):
+def test_depth(cobbler_api: CobblerAPI, input_depth, expected_exception, expected_result):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -482,7 +492,7 @@ def test_depth(cobbler_api, input_depth, expected_exception, expected_result):
     "input_ctime,expected_exception,expected_result",
     [("", pytest.raises(TypeError), None), (0.0, does_not_raise(), 0.0)],
 )
-def test_ctime(cobbler_api, input_ctime, expected_exception, expected_result):
+def test_ctime(cobbler_api: CobblerAPI, input_ctime, expected_exception, expected_result):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -499,7 +509,7 @@ def test_ctime(cobbler_api, input_ctime, expected_exception, expected_result):
     (0, pytest.raises(TypeError)),
     ("", pytest.raises(TypeError))
 ])
-def test_mtime(cobbler_api, value, expected_exception):
+def test_mtime(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -511,7 +521,7 @@ def test_mtime(cobbler_api, value, expected_exception):
         assert titem.mtime == value
 
 
-def test_parent(cobbler_api):
+def test_parent(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -538,7 +548,7 @@ def test_check_if_valid(request, cobbler_api):
     assert True  # This test passes if there is no exception raised
 
 
-def test_to_dict(cobbler_api):
+def test_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -550,7 +560,7 @@ def test_to_dict(cobbler_api):
     assert result.get("owners") == enums.VALUE_INHERITED
 
 
-def test_to_dict_resolved(cobbler_api):
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
     # Arrange
     titem = Item(cobbler_api)
 
@@ -562,7 +572,7 @@ def test_to_dict_resolved(cobbler_api):
     assert result.get("owners") == ["admin"]
 
 
-def test_to_dict_resolved_dict(cobbler_api, create_distro):
+def test_to_dict_resolved_dict(cobbler_api: CobblerAPI, create_distro):
     # Arrange
     test_distro = create_distro()
     test_distro.kernel_options = {"test": True}
@@ -581,7 +591,7 @@ def test_to_dict_resolved_dict(cobbler_api, create_distro):
     assert result.get("kernel_options") == {"test": True, "my_value": 5}
 
 
-def test_serialize(cobbler_api):
+def test_serialize(cobbler_api: CobblerAPI):
     # Arrange
     kernel_url = "http://10.0.0.1/custom-kernels-are-awesome"
     titem = Distro(cobbler_api)
@@ -596,7 +606,7 @@ def test_serialize(cobbler_api):
     assert "remote_grub_kernel" not in result
 
 
-def test_grab_tree(cobbler_api):
+def test_grab_tree(cobbler_api: CobblerAPI):
     # Arrange
     object_to_check = Distro(cobbler_api)
     # TODO: Create some objects and give them some inheritance.
@@ -607,3 +617,46 @@ def test_grab_tree(cobbler_api):
     # Assert
     assert isinstance(result, list)
     assert result[-1].server == "192.168.1.1"
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    item = Item(cobbler_api)
+
+    # Act
+    for key, key_value in item.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(item, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(item, new_key)
+            setattr(item, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(item, new_key)

--- a/tests/items/menu_test.py
+++ b/tests/items/menu_test.py
@@ -1,7 +1,20 @@
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.menu import Menu
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="menu_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -11,7 +24,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(distro, Menu)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     menu = Menu(cobbler_api)
 
@@ -22,7 +35,7 @@ def test_make_clone(cobbler_api):
     assert menu != result
 
 
-def test_display_name(cobbler_api):
+def test_display_name(cobbler_api: CobblerAPI):
     # Arrange
     menu = Menu(cobbler_api)
 
@@ -31,3 +44,46 @@ def test_display_name(cobbler_api):
 
     # Assert
     assert menu.display_name == ""
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    menu = Menu(cobbler_api)
+
+    # Act
+    for key, key_value in menu.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(menu, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(menu, new_key)
+            setattr(menu, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(menu, new_key)

--- a/tests/items/mgmtclass_test.py
+++ b/tests/items/mgmtclass_test.py
@@ -1,7 +1,22 @@
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.mgmtclass import Mgmtclass
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="mgmtclass_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -11,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(mgmtclass, Mgmtclass)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
 
@@ -22,7 +37,7 @@ def test_make_clone(cobbler_api):
     assert result != mgmtclass
 
 
-def test_check_if_valid(cobbler_api):
+def test_check_if_valid(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
     mgmtclass.name = "unittest_mgmtclass"
@@ -34,7 +49,7 @@ def test_check_if_valid(cobbler_api):
     assert True
 
 
-def test_packages(cobbler_api):
+def test_packages(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
 
@@ -45,7 +60,7 @@ def test_packages(cobbler_api):
     assert mgmtclass.packages == []
 
 
-def test_files(cobbler_api):
+def test_files(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
 
@@ -56,7 +71,7 @@ def test_files(cobbler_api):
     assert mgmtclass.files == []
 
 
-def test_params(cobbler_api):
+def test_params(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
 
@@ -67,7 +82,7 @@ def test_params(cobbler_api):
     assert mgmtclass.params == {}
 
 
-def test_is_definition(cobbler_api):
+def test_is_definition(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
 
@@ -78,7 +93,7 @@ def test_is_definition(cobbler_api):
     assert not mgmtclass.is_definition
 
 
-def test_class_name(cobbler_api):
+def test_class_name(cobbler_api: CobblerAPI):
     # Arrange
     mgmtclass = Mgmtclass(cobbler_api)
 
@@ -87,3 +102,46 @@ def test_class_name(cobbler_api):
 
     # Assert
     assert mgmtclass.class_name == ""
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    titem = Mgmtclass(cobbler_api)
+
+    # Act
+    for key, key_value in titem.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(titem, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(titem, new_key)
+            setattr(titem, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(titem, new_key)

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -4,11 +4,23 @@ from ipaddress import AddressValueError
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.system import NetworkInterface
 from tests.conftest import does_not_raise
 
 
-def test_network_interface_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="interface_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_network_interface_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -18,7 +30,7 @@ def test_network_interface_object_creation(cobbler_api):
     assert isinstance(interface, NetworkInterface)
 
 
-def test_network_interface_to_dict(cobbler_api):
+def test_network_interface_to_dict(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -41,7 +53,7 @@ def test_network_interface_to_dict(cobbler_api):
 )
 def test_network_interface_from_dict(
     caplog,
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     input_dict,
     modified_field,
     expected_result,
@@ -78,7 +90,7 @@ def test_deserialize():
         (0, "", pytest.raises(TypeError)),
     ],
 )
-def test_dhcp_tag(cobbler_api, input_dhcp_tag, expected_result, expected_exception):
+def test_dhcp_tag(cobbler_api: CobblerAPI, input_dhcp_tag, expected_result, expected_exception):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -91,7 +103,7 @@ def test_dhcp_tag(cobbler_api, input_dhcp_tag, expected_result, expected_excepti
         assert interface.dhcp_tag == expected_result
 
 
-def test_cnames(cobbler_api):
+def test_cnames(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -103,7 +115,7 @@ def test_cnames(cobbler_api):
     assert interface.cnames == []
 
 
-def test_static_routes(cobbler_api):
+def test_static_routes(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -124,7 +136,7 @@ def test_static_routes(cobbler_api):
         ([], "", pytest.raises(TypeError)),
     ],
 )
-def test_static(cobbler_api, input_static, expected_result, expected_exception):
+def test_static(cobbler_api: CobblerAPI, input_static, expected_result, expected_exception):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -146,7 +158,7 @@ def test_static(cobbler_api, input_static, expected_result, expected_exception):
         ([], "", pytest.raises(TypeError)),
     ],
 )
-def test_management(cobbler_api, input_management, expected_result, expected_exception):
+def test_management(cobbler_api: CobblerAPI, input_management, expected_result, expected_exception):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -168,7 +180,7 @@ def test_management(cobbler_api, input_management, expected_result, expected_exc
     ],
 )
 def test_dns_name(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -206,7 +218,7 @@ def test_dns_name(
 )
 def test_mac_address(
     mocker,
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -236,7 +248,7 @@ def test_mac_address(
         assert interface.mac_address == expected_result
 
 
-def test_netmask(cobbler_api):
+def test_netmask(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -248,7 +260,7 @@ def test_netmask(cobbler_api):
     assert interface.netmask == ""
 
 
-def test_if_gateway(cobbler_api):
+def test_if_gateway(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -270,7 +282,7 @@ def test_if_gateway(cobbler_api):
     ],
 )
 def test_virt_bridge(
-    cobbler_api, input_virt_bridge, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_virt_bridge, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -297,7 +309,7 @@ def test_virt_bridge(
     ],
 )
 def test_interface_type(
-    cobbler_api, input_interface_type, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_interface_type, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -319,7 +331,7 @@ def test_interface_type(
     ],
 )
 def test_interface_master(
-    cobbler_api, input_interface_master, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_interface_master, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -341,7 +353,7 @@ def test_interface_master(
     ],
 )
 def test_bonding_opts(
-    cobbler_api, input_bonding_opts, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_bonding_opts, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -363,7 +375,7 @@ def test_bonding_opts(
     ],
 )
 def test_bridge_opts(
-    cobbler_api, input_bridge_opts, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_bridge_opts, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -386,7 +398,7 @@ def test_bridge_opts(
     ],
 )
 def test_ip_address(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -421,7 +433,7 @@ def test_ip_address(
     ],
 )
 def test_ipv6_address(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     create_system,
@@ -455,7 +467,7 @@ def test_ipv6_address(
     ],
 )
 def test_ipv6_prefix(
-    cobbler_api, input_ipv6_prefix, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_ipv6_prefix, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -478,7 +490,7 @@ def test_ipv6_prefix(
     ],
 )
 def test_ipv6_secondaries(
-    cobbler_api, input_secondaries, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_secondaries, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -502,7 +514,7 @@ def test_ipv6_secondaries(
     ],
 )
 def test_ipv6_default_gateway(
-    cobbler_api, input_address, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_address, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -516,7 +528,7 @@ def test_ipv6_default_gateway(
         assert interface.ipv6_default_gateway == expected_result
 
 
-def test_ipv6_static_routes(cobbler_api):
+def test_ipv6_static_routes(cobbler_api: CobblerAPI):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -535,7 +547,7 @@ def test_ipv6_static_routes(cobbler_api):
         (0, "", pytest.raises(TypeError)),
     ],
 )
-def test_ipv6_mtu(cobbler_api, input_ipv6_mtu, expected_result, expected_exception):
+def test_ipv6_mtu(cobbler_api: CobblerAPI, input_ipv6_mtu, expected_result, expected_exception):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -555,7 +567,7 @@ def test_ipv6_mtu(cobbler_api, input_ipv6_mtu, expected_result, expected_excepti
         (0, "", pytest.raises(TypeError)),
     ],
 )
-def test_mtu(cobbler_api, input_mtu, expected_result, expected_exception):
+def test_mtu(cobbler_api: CobblerAPI, input_mtu, expected_result, expected_exception):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
@@ -578,7 +590,7 @@ def test_mtu(cobbler_api, input_mtu, expected_result, expected_exception):
     ],
 )
 def test_connected_mode(
-    cobbler_api, input_connected_mode, expected_result, expected_exception
+    cobbler_api: CobblerAPI, input_connected_mode, expected_result, expected_exception
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
@@ -600,7 +612,7 @@ def test_connected_mode(
     ],
 )
 def test_modify_interface(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     input_modify_interface,
     expected_modified_field,
     expected_value,
@@ -615,3 +627,46 @@ def test_modify_interface(
 
         # Assert
         assert getattr(interface, expected_modified_field) == expected_value
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    interface = NetworkInterface(cobbler_api, "")
+
+    # Act
+    for key, key_value in interface.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(interface, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(interface, new_key)
+            setattr(interface, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(interface, new_key)

--- a/tests/items/package_test.py
+++ b/tests/items/package_test.py
@@ -1,7 +1,22 @@
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.package import Package
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="package_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # & Act
@@ -11,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(package, Package)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     package = Package(cobbler_api)
 
@@ -22,7 +37,7 @@ def test_make_clone(cobbler_api):
     assert package != result
 
 
-def test_installer(cobbler_api):
+def test_installer(cobbler_api: CobblerAPI):
     # Arrange
     package = Package(cobbler_api)
 
@@ -33,7 +48,7 @@ def test_installer(cobbler_api):
     assert package.installer == ""
 
 
-def test_version(cobbler_api):
+def test_version(cobbler_api: CobblerAPI):
     # Arrange
     package = Package(cobbler_api)
 
@@ -42,3 +57,46 @@ def test_version(cobbler_api):
 
     # Assert
     assert package.version == ""
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    titem = Package(cobbler_api)
+
+    # Act
+    for key, key_value in titem.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(titem, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(titem, new_key)
+            setattr(titem, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(titem, new_key)

--- a/tests/items/profile_test.py
+++ b/tests/items/profile_test.py
@@ -1,13 +1,27 @@
+from typing import Callable
+
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="profile_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -17,7 +31,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(profile, Profile)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -29,12 +43,12 @@ def test_make_clone(cobbler_api):
 
 
 @pytest.fixture(autouse=True)
-def cleanup_to_dict(cobbler_api):
+def cleanup_to_dict(cobbler_api: CobblerAPI):
     yield
     cobbler_api.remove_distro("test_to_dict_distro")
 
 
-def test_to_dict(cobbler_api, cleanup_to_dict):
+def test_to_dict(cobbler_api: CobblerAPI, cleanup_to_dict):
     # Arrange
     distro = Distro(cobbler_api)
     distro.name = "test_to_dict_distro"
@@ -54,7 +68,7 @@ def test_to_dict(cobbler_api, cleanup_to_dict):
 # Properties Tests
 
 
-def test_parent_empty(cobbler_api):
+def test_parent_empty(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -65,7 +79,7 @@ def test_parent_empty(cobbler_api):
     assert profile.parent is None
 
 
-def test_parent_profile(cobbler_api, create_distro, create_profile):
+def test_parent_profile(cobbler_api: CobblerAPI, create_distro, create_profile):
     # Arrange
     test_dist = create_distro()
     test_profile = create_profile(test_dist.name)
@@ -78,7 +92,7 @@ def test_parent_profile(cobbler_api, create_distro, create_profile):
     assert profile.parent is test_profile
 
 
-def test_parent_other_object_type(cobbler_api, create_image):
+def test_parent_other_object_type(cobbler_api: CobblerAPI, create_image):
     # Arrange
     test_image = create_image()
     profile = Profile(cobbler_api)
@@ -88,7 +102,7 @@ def test_parent_other_object_type(cobbler_api, create_image):
         profile.parent = test_image.name
 
 
-def test_parent_invalid_type(cobbler_api):
+def test_parent_invalid_type(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -97,7 +111,7 @@ def test_parent_invalid_type(cobbler_api):
         profile.parent = 0
 
 
-def test_parent_self(cobbler_api):
+def test_parent_self(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
     profile.name = "testname"
@@ -107,7 +121,7 @@ def test_parent_self(cobbler_api):
         profile.parent = profile.name
 
 
-def test_distro(cobbler_api):
+def test_distro(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -118,7 +132,7 @@ def test_distro(cobbler_api):
     assert profile.distro is None
 
 
-def test_name_servers(cobbler_api):
+def test_name_servers(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -129,7 +143,7 @@ def test_name_servers(cobbler_api):
     assert profile.name_servers == []
 
 
-def test_name_servers_search(cobbler_api):
+def test_name_servers_search(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -140,7 +154,7 @@ def test_name_servers_search(cobbler_api):
     assert profile.name_servers_search == ""
 
 
-def test_proxy(cobbler_api):
+def test_proxy(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -152,7 +166,7 @@ def test_proxy(cobbler_api):
 
 
 @pytest.mark.parametrize("value,expected_exception", [(False, does_not_raise())])
-def test_enable_ipxe(cobbler_api, value, expected_exception):
+def test_enable_ipxe(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -173,7 +187,7 @@ def test_enable_ipxe(cobbler_api, value, expected_exception):
         (0, does_not_raise()),
     ],
 )
-def test_enable_menu(cobbler_api, value, expected_exception):
+def test_enable_menu(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -186,7 +200,7 @@ def test_enable_menu(cobbler_api, value, expected_exception):
         assert profile.enable_menu or not profile.enable_menu
 
 
-def test_dhcp_tag(cobbler_api):
+def test_dhcp_tag(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -205,7 +219,7 @@ def test_dhcp_tag(cobbler_api):
         (False, pytest.raises(TypeError), ""),
     ],
 )
-def test_server(cobbler_api, input_server, expected_exception, expected_result):
+def test_server(cobbler_api: CobblerAPI, input_server, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -217,7 +231,7 @@ def test_server(cobbler_api, input_server, expected_exception, expected_result):
         assert profile.server == expected_result
 
 
-def test_next_server_v4(cobbler_api):
+def test_next_server_v4(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -228,7 +242,7 @@ def test_next_server_v4(cobbler_api):
     assert profile.next_server_v4 == ""
 
 
-def test_next_server_v6(cobbler_api):
+def test_next_server_v6(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -252,7 +266,7 @@ def test_next_server_v6(cobbler_api):
     ],
 )
 def test_filename(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     input_filename,
@@ -293,7 +307,7 @@ def test_filename(
     ],
 )
 def test_filename(
-    cobbler_api,
+    cobbler_api: CobblerAPI,
     create_distro,
     create_profile,
     input_filename,
@@ -318,7 +332,7 @@ def test_filename(
         assert profile.filename == expected_result
 
 
-def test_autoinstall(cobbler_api):
+def test_autoinstall(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -338,7 +352,7 @@ def test_autoinstall(cobbler_api):
         (True, does_not_raise(), True),
     ],
 )
-def test_virt_auto_boot(cobbler_api, value, expected_exception, expected_result):
+def test_virt_auto_boot(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -361,7 +375,7 @@ def test_virt_auto_boot(cobbler_api, value, expected_exception, expected_result)
         (5, does_not_raise(), 5),
     ],
 )
-def test_virt_cpus(cobbler_api, value, expected_exception, expected_result):
+def test_virt_cpus(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -384,7 +398,7 @@ def test_virt_cpus(cobbler_api, value, expected_exception, expected_result):
         (5, does_not_raise(), 5.0),
     ],
 )
-def test_virt_file_size(cobbler_api, value, expected_exception, expected_result):
+def test_virt_file_size(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -406,7 +420,7 @@ def test_virt_file_size(cobbler_api, value, expected_exception, expected_result)
         ("", pytest.raises(ValueError), None),
     ],
 )
-def test_virt_disk_driver(cobbler_api, value, expected_exception, expected_result):
+def test_virt_disk_driver(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -427,7 +441,7 @@ def test_virt_disk_driver(cobbler_api, value, expected_exception, expected_resul
         (0.0, pytest.raises(TypeError), 0),
     ],
 )
-def test_virt_ram(cobbler_api, value, expected_exception, expected_result):
+def test_virt_ram(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -449,7 +463,7 @@ def test_virt_ram(cobbler_api, value, expected_exception, expected_result):
         (False, pytest.raises(TypeError), None),
     ],
 )
-def test_virt_type(cobbler_api, value, expected_exception, expected_result):
+def test_virt_type(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -470,7 +484,7 @@ def test_virt_type(cobbler_api, value, expected_exception, expected_result):
         (False, pytest.raises(TypeError), None),
     ],
 )
-def test_virt_bridge(cobbler_api, value, expected_exception, expected_result):
+def test_virt_bridge(cobbler_api: CobblerAPI, value, expected_exception, expected_result):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -482,7 +496,7 @@ def test_virt_bridge(cobbler_api, value, expected_exception, expected_result):
     assert profile.virt_bridge == "xenbr0"
 
 
-def test_virt_path(cobbler_api):
+def test_virt_path(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -493,7 +507,7 @@ def test_virt_path(cobbler_api):
     assert profile.virt_path == ""
 
 
-def test_repos(cobbler_api):
+def test_repos(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -504,7 +518,7 @@ def test_repos(cobbler_api):
     assert profile.repos == []
 
 
-def test_redhat_management_key(cobbler_api):
+def test_redhat_management_key(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -515,7 +529,7 @@ def test_redhat_management_key(cobbler_api):
     assert profile.redhat_management_key == ""
 
 
-def test_boot_loaders(cobbler_api):
+def test_boot_loaders(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -526,7 +540,7 @@ def test_boot_loaders(cobbler_api):
     assert profile.boot_loaders == []
 
 
-def test_menu(cobbler_api):
+def test_menu(cobbler_api: CobblerAPI):
     # Arrange
     profile = Profile(cobbler_api)
 
@@ -535,3 +549,63 @@ def test_menu(cobbler_api):
 
     # Assert
     assert profile.menu == ""
+
+
+def test_distro_inherit(mocker, test_settings, create_distro: Callable[[], Distro]):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    distro = create_distro()
+    api = distro.api
+    mocker.patch.object(api, "settings", return_value=test_settings)
+    distro.arch = enums.Archs.X86_64
+    profile = Profile(api)
+    profile.distro = distro.name
+
+    # Act
+    for key, key_value in profile.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(profile, new_key)
+            settings_name = new_key
+            parent_obj = None
+            if hasattr(distro, settings_name):
+                parent_obj = distro
+            else:
+                if new_key == "owners":
+                    settings_name = "default_ownership"
+                elif new_key == "proxy":
+                    settings_name = "proxy_url_int"
+
+                if hasattr(test_settings, f"default_{settings_name}"):
+                    settings_name = f"default_{settings_name}"
+                if hasattr(test_settings, settings_name):
+                    parent_obj = test_settings
+
+            if parent_obj is not None:
+                setting = getattr(parent_obj, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value.update({"test_inheritance": "test_inheritance"})
+                elif isinstance(setting, list):
+                    if new_key == "boot_loaders":
+                        new_value = ["grub"]
+                    else:
+                        new_value = ["test_inheritance"]
+                setattr(parent_obj, settings_name, new_value)
+
+            prev_value = getattr(profile, new_key)
+            setattr(profile, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(profile, new_key)

--- a/tests/items/repo_test.py
+++ b/tests/items/repo_test.py
@@ -1,11 +1,22 @@
-from cobbler import enums
-from cobbler.items.repo import Repo
 import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.items.repo import Repo
 
 from tests.conftest import does_not_raise
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(name="repo_setting_mock", spec=cobbler_api.settings())
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -15,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(repo, Repo)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -29,7 +40,7 @@ def test_make_clone(cobbler_api):
 # Properties Tests
 
 
-def test_mirror(cobbler_api):
+def test_mirror(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -40,7 +51,7 @@ def test_mirror(cobbler_api):
     assert repo.mirror == "https://mymirror.com"
 
 
-def test_mirror_type(cobbler_api):
+def test_mirror_type(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -51,7 +62,7 @@ def test_mirror_type(cobbler_api):
     assert repo.mirror_type == enums.MirrorType.BASEURL
 
 
-def test_keep_updated(cobbler_api):
+def test_keep_updated(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -62,7 +73,7 @@ def test_keep_updated(cobbler_api):
     assert not repo.keep_updated
 
 
-def test_yumopts(cobbler_api):
+def test_yumopts(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -73,7 +84,7 @@ def test_yumopts(cobbler_api):
     assert testrepo.yumopts == {}
 
 
-def test_rsyncopts(cobbler_api):
+def test_rsyncopts(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -84,7 +95,7 @@ def test_rsyncopts(cobbler_api):
     assert testrepo.rsyncopts == {}
 
 
-def test_environment(cobbler_api):
+def test_environment(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -95,7 +106,7 @@ def test_environment(cobbler_api):
     assert testrepo.environment == {}
 
 
-def test_priority(cobbler_api):
+def test_priority(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -106,7 +117,7 @@ def test_priority(cobbler_api):
     assert testrepo.priority == 5
 
 
-def test_rpm_list(cobbler_api):
+def test_rpm_list(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -130,7 +141,7 @@ def test_rpm_list(cobbler_api):
     ],
 )
 def test_createrepo_flags(
-    cobbler_api, input_flags, expected_exception, expected_result
+    cobbler_api: CobblerAPI, input_flags, expected_exception, expected_result
 ):
     # Arrange
     testrepo = Repo(cobbler_api)
@@ -143,7 +154,7 @@ def test_createrepo_flags(
         assert testrepo.createrepo_flags == expected_result
 
 
-def test_breed(cobbler_api):
+def test_breed(cobbler_api: CobblerAPI):
     # Arrange
     repo = Repo(cobbler_api)
 
@@ -154,7 +165,7 @@ def test_breed(cobbler_api):
     assert repo.breed == enums.RepoBreeds.YUM
 
 
-def test_os_version(cobbler_api):
+def test_os_version(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
     testrepo.breed = "yum"
@@ -174,7 +185,7 @@ def test_os_version(cobbler_api):
     (False, pytest.raises(TypeError)),
     ("", pytest.raises(ValueError))
 ])
-def test_arch(cobbler_api, value, expected_exception):
+def test_arch(cobbler_api: CobblerAPI, value, expected_exception):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -189,7 +200,7 @@ def test_arch(cobbler_api, value, expected_exception):
             assert testrepo.arch == value
 
 
-def test_mirror_locally(cobbler_api):
+def test_mirror_locally(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -200,7 +211,7 @@ def test_mirror_locally(cobbler_api):
     assert not testrepo.mirror_locally
 
 
-def test_apt_components(cobbler_api):
+def test_apt_components(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -211,7 +222,7 @@ def test_apt_components(cobbler_api):
     assert testrepo.apt_components == []
 
 
-def test_apt_dists(cobbler_api):
+def test_apt_dists(cobbler_api: CobblerAPI):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -230,7 +241,7 @@ def test_apt_dists(cobbler_api):
         (0, pytest.raises(TypeError), ""),
     ],
 )
-def test_proxy(cobbler_api, input_proxy, expected_exception, expected_result):
+def test_proxy(cobbler_api: CobblerAPI, input_proxy, expected_exception, expected_result):
     # Arrange
     testrepo = Repo(cobbler_api)
 
@@ -240,3 +251,48 @@ def test_proxy(cobbler_api, input_proxy, expected_exception, expected_result):
 
         # Assert
         assert testrepo.proxy == expected_result
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    testrepo = Repo(cobbler_api)
+
+    # Act
+    for key, key_value in testrepo.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(testrepo, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            elif new_key == "proxy":
+                settings_name = "proxy_url_ext"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(testrepo, new_key)
+            setattr(testrepo, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(testrepo, new_key)

--- a/tests/items/resource_test.py
+++ b/tests/items/resource_test.py
@@ -1,8 +1,22 @@
+import pytest
+
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.resource import Resource
 
 
-def test_object_creation(cobbler_api):
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="resource_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
@@ -12,7 +26,7 @@ def test_object_creation(cobbler_api):
     assert isinstance(distro, Resource)
 
 
-def test_make_clone(cobbler_api):
+def test_make_clone(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -25,7 +39,7 @@ def test_make_clone(cobbler_api):
 # Properties Tests
 
 
-def test_action(cobbler_api):
+def test_action(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -36,7 +50,7 @@ def test_action(cobbler_api):
     assert resource.action == enums.ResourceAction.CREATE
 
 
-def test_group(cobbler_api):
+def test_group(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -47,7 +61,7 @@ def test_group(cobbler_api):
     assert resource.group == "test"
 
 
-def test_mode(cobbler_api):
+def test_mode(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -58,7 +72,7 @@ def test_mode(cobbler_api):
     assert resource.mode == "test"
 
 
-def test_owner(cobbler_api):
+def test_owner(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -69,7 +83,7 @@ def test_owner(cobbler_api):
     assert resource.owner == "test"
 
 
-def test_path(cobbler_api):
+def test_path(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -80,7 +94,7 @@ def test_path(cobbler_api):
     assert resource.path == "test"
 
 
-def test_template(cobbler_api):
+def test_template(cobbler_api: CobblerAPI):
     # Arrange
     resource = Resource(cobbler_api)
 
@@ -89,3 +103,46 @@ def test_template(cobbler_api):
 
     # Assert
     assert resource.template == "test"
+
+
+def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    resource = Resource(cobbler_api)
+
+    # Act
+    for key, key_value in resource.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(resource, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(resource, new_key)
+            setattr(resource, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(resource, new_key)

--- a/tests/items/system_test.py
+++ b/tests/items/system_test.py
@@ -1,9 +1,26 @@
+from typing import Callable
+
 import pytest
 
+from cobbler.api import CobblerAPI
 from cobbler import enums
 from cobbler.cexceptions import CX
 from cobbler.items.system import NetworkInterface, System
+from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
 from tests.conftest import does_not_raise
+
+
+@pytest.fixture()
+def test_settings(mocker, cobbler_api: CobblerAPI):
+    settings = mocker.MagicMock(
+        name="profile_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
 
 
 def test_object_creation(cobbler_api):
@@ -677,3 +694,138 @@ def test_is_management_supported(cobbler_api, input_mac, input_ipv4, input_ipv6,
 
     # Assert
     assert result is expected_result
+
+
+def test_profile_inherit(mocker, test_settings, create_distro: Callable[[], Distro]):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    distro = create_distro()
+    api = distro.api
+    mocker.patch.object(api, "settings", return_value=test_settings)
+    distro.arch = enums.Archs.X86_64
+    profile = Profile(api)
+    profile.name = "test_profile_inherit"
+    profile.distro = distro.name
+    api.add_profile(profile)
+    system = System(api)
+    system.profile = profile.name
+
+    # Act
+    for key, key_value in system.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(system, new_key)
+            settings_name = new_key
+            parent_obj = None
+            if hasattr(profile, settings_name):
+                parent_obj = profile
+            elif hasattr(distro, settings_name):
+                parent_obj = distro
+            else:
+                if new_key == "owners":
+                    settings_name = "default_ownership"
+                elif new_key == "proxy":
+                    settings_name = "proxy_url_int"
+
+                if hasattr(test_settings, f"default_{settings_name}"):
+                    settings_name = f"default_{settings_name}"
+                if hasattr(test_settings, settings_name):
+                    parent_obj = test_settings
+
+            if parent_obj is not None:
+                setting = getattr(parent_obj, settings_name)
+                if new_key == "autoinstall":
+                    new_value = "default.ks"
+                elif new_key == "boot_loaders":
+                    new_value = ["grub"]
+                elif new_key == "next_server_v4":
+                    new_value = "10.10.10.10"
+                elif new_key == "next_server_v6":
+                    new_value = "fd00::"
+                elif isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value.update({"test_inheritance": "test_inheritance"})
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(parent_obj, settings_name, new_value)
+
+            prev_value = getattr(system, new_key)
+            setattr(system, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(system, new_key)
+
+
+def test_image_inherit(mocker, test_settings, create_image: Callable[[], Image]):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    image = create_image()
+    api = image.api
+    mocker.patch.object(api, "settings", return_value=test_settings)
+    system = System(api)
+    system.image = image.name
+
+    # Act
+    for key, key_value in system.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(system, new_key)
+            settings_name = new_key
+            parent_obj = None
+            if hasattr(image, settings_name):
+                parent_obj = image
+            else:
+                if new_key == "owners":
+                    settings_name = "default_ownership"
+                elif new_key == "proxy":
+                    settings_name = "proxy_url_int"
+
+                if hasattr(test_settings, f"default_{settings_name}"):
+                    settings_name = f"default_{settings_name}"
+                if hasattr(test_settings, settings_name):
+                    parent_obj = test_settings
+
+            if parent_obj is not None:
+                setting = getattr(parent_obj, settings_name)
+                if new_key == "autoinstall":
+                    new_value = "default.ks"
+                elif new_key == "boot_loaders":
+                    new_value = ["grub"]
+                elif new_key == "next_server_v4":
+                    new_value = "10.10.10.10"
+                elif new_key == "next_server_v6":
+                    new_value = "fd00::"
+                elif isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value.update({"test_inheritance": "test_inheritance"})
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(parent_obj, settings_name, new_value)
+
+            prev_value = getattr(system, new_key)
+            setattr(system, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(system, new_key)


### PR DESCRIPTION
## Linked Items

Fixes #3715

## Description

This PR fixes the issue that some properties had broken inheritance behaviour after the conversion to properties. This is yet another try to improve the situation.

P.S.: I am aware that this PR will not fix all issues with inheritance that are present but it should fix the most important ones for now. In the `main` branch all properties should be fixed at the moment, as such with 3.4.0 the situation will hopefully be considered stable.

## Behaviour changes

Old: Some core properties had broken inheritance behaviour.

New: Inheritance behaviour should be improved.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
