### PR TITLE
Add changelog for 3.3.5

### DIFF
--- a/changelog.d/3596.added
+++ b/changelog.d/3596.added
@@ -1,1 +1,0 @@
-Added lazy loading of collections during application startup

--- a/changelog.d/3666.added
+++ b/changelog.d/3666.added
@@ -1,1 +1,0 @@
-DNS: Add support for cnames with dnsmasq module (Backport release33)

--- a/changelog.d/3680.added
+++ b/changelog.d/3680.added
@@ -1,1 +1,0 @@
-Add compatibility with the file binary version below 5.37

--- a/changelog.d/3702.added
+++ b/changelog.d/3702.added
@@ -1,1 +1,0 @@
-Add function Item.to_dict() caching

--- a/changelog.d/3708.fixed
+++ b/changelog.d/3708.fixed
@@ -1,1 +1,0 @@
-"get_event_log" endpoint didn't output any data even thought the event id is valid.

--- a/changelog.d/3715.fixed
+++ b/changelog.d/3715.fixed
@@ -1,1 +1,0 @@
-Fix inheritance behavior of non-string properties

--- a/changelog.d/3724.fixed
+++ b/changelog.d/3724.fixed
@@ -1,1 +1,0 @@
-Fix compatibility with setuptools 70+

--- a/changelog.d/3725.added
+++ b/changelog.d/3725.added
@@ -1,1 +1,0 @@
-Add collection indices for UUID's, MAC's, IP addresses and hostnames

--- a/changelog/v3.3.5.md
+++ b/changelog/v3.3.5.md
@@ -1,0 +1,25 @@
+# Cobbler [3.3.5](https://github.com/cobbler/cobbler/tree/v3.3.5) - 2024-07-01
+
+
+## Added
+
+- Added lazy loading of collections during application startup
+  [#3596](https://github.com/cobbler/cobbler/issues/3596)
+- DNS: Add support for cnames with dnsmasq module (Backport release33)
+  [#3666](https://github.com/cobbler/cobbler/issues/3666)
+- Add compatibility with the file binary version below 5.37
+  [#3680](https://github.com/cobbler/cobbler/issues/3680)
+- Add function Item.to_dict() caching
+  [#3702](https://github.com/cobbler/cobbler/issues/3702)
+- Add collection indices for UUID's, MAC's, IP addresses and hostnames
+  [#3725](https://github.com/cobbler/cobbler/issues/3725)
+
+
+## Fixed
+
+- "get_event_log" endpoint didn't output any data even thought the event id is
+  valid. [#3708](https://github.com/cobbler/cobbler/issues/3708)
+- Fix inheritance behavior of non-string properties
+  [#3715](https://github.com/cobbler/cobbler/issues/3715)
+- Fix compatibility with setuptools 70+
+  [#3724](https://github.com/cobbler/cobbler/issues/3724)


### PR DESCRIPTION
## Linked Items

Fixes #3736

## Description

Adds the rendered changelog and removes the individual fragments. Once this PR is merged the plan is to tag 3.3.5, push it and create the release on GitHub.

## Behaviour changes

Old: None

New: None

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
