### PR TITLE
Forward port 3.3.4 and 3.3.5 migrations

### DIFF
--- a/changelog.d/3628.changed
+++ b/changelog.d/3628.changed
@@ -1,0 +1,1 @@
+Forward ported settings migrations from 3.3.4 and 3.3.5

--- a/changelog/v3.3.4.md
+++ b/changelog/v3.3.4.md
@@ -1,0 +1,82 @@
+# Cobbler [3.3.4](https://github.com/cobbler/cobbler/tree/v3.3.4) - 2024-02-26
+
+This release is containing a lot of backports from `main` to make Cobbler more stable for the community.
+
+Milestone: <https://github.com/cobbler/cobbler/milestone/21>
+
+Diff to last release: [`v3.3.3...v3.3.4`](https://github.com/cobbler/cobbler/compare/v3.3.3...v3.3.4)
+
+## Added
+
+- SPEC: Add "cobbler-tests-containers" subpackage
+  [#3368](https://github.com/cobbler/cobbler/issues/3368)
+- Tests: Add integration tests for "cobbler-settings"
+  [#3382](https://github.com/cobbler/cobbler/issues/3382)
+- SPEC: Add support for Cobbler running on Ubuntu 22.04
+  [#3413](https://github.com/cobbler/cobbler/issues/3413)
+- Add build of debs for Debian 12 Bookworm
+  [#3566](https://github.com/cobbler/cobbler/issues/3566)
+- Add various openSUSE, SLES and SLE Micro signatures
+  [#3589](https://github.com/cobbler/cobbler/issues/3589)
+- Settings: Added settings migration for Cobbler 3.3.4
+  [#3592](https://github.com/cobbler/cobbler/issues/3592)
+
+
+## Changed
+
+- Distros: Enhance error message when a kernel doesn't match our regex
+  requirements [#3194](https://github.com/cobbler/cobbler/issues/3194)
+- CI: Use Fedora Rawhide for tests to stabalize reposync tests
+  [#3468](https://github.com/cobbler/cobbler/issues/3468)
+
+
+## Fixed
+
+- XML-RPC API: Systems - Re-enable the modify_interface call
+  [#2896](https://github.com/cobbler/cobbler/issues/2896)
+- XML-RPC API: Fix an issue where "get_item_resolved_value()" would return
+  unserializable types [#3173](https://github.com/cobbler/cobbler/issues/3173)
+- "grab_tree" is not spamming the logfile anymore
+  [#3176](https://github.com/cobbler/cobbler/issues/3176)
+- Systems: Don't create interface "default" when not needed
+  [#3190](https://github.com/cobbler/cobbler/issues/3190)
+- Buildiso: The action doesn't fail anymore if a system is based on an image
+  [#3238](https://github.com/cobbler/cobbler/issues/3238)
+- DHCP: The main config file doesn't contain "<<inherit>>" anymore for the
+  filename option [#3367](https://github.com/cobbler/cobbler/issues/3367)
+- Anamon: Fix uploading of logfiles from the installer
+  [#3420](https://github.com/cobbler/cobbler/issues/3420)
+- SELinux: Fix daemon startup error caused by incorrect ownership of
+  /var/lib/cobbler/web.ss
+  [#3446](https://github.com/cobbler/cobbler/issues/3446)
+- CLI: Fixed an error that mangled the types of certain flags for Cobbler items
+  [#3450](https://github.com/cobbler/cobbler/issues/3450)
+- Docs: The documentation builds with Sphinx 7.x now
+  [#3455](https://github.com/cobbler/cobbler/issues/3455)
+- Windows Support: Fixed issues that prevented Windows from being able to be
+  installed [#3473](https://github.com/cobbler/cobbler/issues/3473)
+- Re-Added "tree" variable to "autoinstall_meta"
+  [#3498](https://github.com/cobbler/cobbler/issues/3498)
+- Add EFI chainloader for Ubuntu to menu local
+  [#3524](https://github.com/cobbler/cobbler/issues/3524)
+- Fix path to linux.c32 for symlink in mkloaders
+  [#3580](https://github.com/cobbler/cobbler/issues/3580)
+- SPEC: Add guard for Fedora to ensure that an incorrect /etc/os-release
+  doesn't fail the build
+  [#3584](https://github.com/cobbler/cobbler/issues/3584)
+- sync: Fix KeyError with enabled DNS management due to missing context in the
+  template lookup mapping data structure
+  [#3588](https://github.com/cobbler/cobbler/issues/3588)
+- scm_track: Fix error that commits didn't work due to pathspec errors
+  [#3591](https://github.com/cobbler/cobbler/issues/3591)
+- Fixed infinite recursion of bash completion
+  [#3604](https://github.com/cobbler/cobbler/issues/3604)
+- Removed from Python 3.12 SafeConfigParser replaced with ConfigParser
+  [#3606](https://github.com/cobbler/cobbler/issues/3606)
+- Settings: Clarify leftover settings and group them according to their
+  respective topics [#3612](https://github.com/cobbler/cobbler/issues/3612)
+- scm_track: Pushing to remote repositories via the "scm_push_script" settings
+  works again [#3621](https://github.com/cobbler/cobbler/issues/3621)
+- mkloaders: The default name for grub2-efi changed to grubx64.efi to match the
+  expected name in the DHCPv4 template.
+  [#3623](https://github.com/cobbler/cobbler/issues/3623)

--- a/changelog/v3.3.5.md
+++ b/changelog/v3.3.5.md
@@ -1,0 +1,25 @@
+# Cobbler [3.3.5](https://github.com/cobbler/cobbler/tree/v3.3.5) - 2024-07-01
+
+
+## Added
+
+- Added lazy loading of collections during application startup
+  [#3596](https://github.com/cobbler/cobbler/issues/3596)
+- DNS: Add support for cnames with dnsmasq module (Backport release33)
+  [#3666](https://github.com/cobbler/cobbler/issues/3666)
+- Add compatibility with the file binary version below 5.37
+  [#3680](https://github.com/cobbler/cobbler/issues/3680)
+- Add function Item.to_dict() caching
+  [#3702](https://github.com/cobbler/cobbler/issues/3702)
+- Add collection indices for UUID's, MAC's, IP addresses and hostnames
+  [#3725](https://github.com/cobbler/cobbler/issues/3725)
+
+
+## Fixed
+
+- "get_event_log" endpoint didn't output any data even thought the event id is
+  valid. [#3708](https://github.com/cobbler/cobbler/issues/3708)
+- Fix inheritance behavior of non-string properties
+  [#3715](https://github.com/cobbler/cobbler/issues/3715)
+- Fix compatibility with setuptools 70+
+  [#3724](https://github.com/cobbler/cobbler/issues/3724)

--- a/cobbler/settings/migrations/V3_3_4.py
+++ b/cobbler/settings/migrations/V3_3_4.py
@@ -1,0 +1,55 @@
+"""
+Migration from V3.3.3 to V3.3.4
+"""
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com
+# SPDX-FileCopyrightText: Copyright SUSE LLC
+
+from schema import SchemaError  # type: ignore
+
+from cobbler.settings.migrations import V3_3_3
+
+# schema identical to V3_3_3
+schema = V3_3_3.schema
+
+
+def validate(settings: dict) -> bool:
+    """
+    Checks that a given settings dict is valid according to the reference V3.3.1 schema ``schema``.
+
+    :param settings: The settings dict to validate.
+    :return: True if valid settings dict otherwise False.
+    """
+    try:
+        schema.validate(settings)  # type: ignore
+    except SchemaError:
+        return False
+    return True
+
+
+def normalize(settings: dict) -> dict:
+    """
+    If data in ``settings`` is valid the validated data is returned.
+
+    :param settings: The settings dict to validate.
+    :return: The validated dict.
+    """
+    return schema.validate(settings)  # type: ignore
+
+
+def migrate(settings: dict) -> dict:
+    """
+    Migration of the settings ``settings`` to version V3.3.4 settings
+
+    :param settings: The settings dict to migrate
+    :return: The migrated dict
+    """
+
+    if not V3_3_3.validate(settings):
+        raise SchemaError("V3.3.3: Schema error while validating")
+
+    # rename keys and update their value
+    # add missing keys
+    # name - value pairs
+
+    return normalize(settings)

--- a/cobbler/settings/migrations/V3_3_5.py
+++ b/cobbler/settings/migrations/V3_3_5.py
@@ -1,0 +1,277 @@
+"""
+Migration from V3.3.4 to V3.3.5
+"""
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com
+# SPDX-FileCopyrightText: Copyright SUSE LLC
+
+from schema import Optional, Schema, SchemaError  # type: ignore
+
+from cobbler.settings.migrations import V3_3_4
+
+schema = Schema(
+    {
+        "auto_migrate_settings": bool,
+        "allow_duplicate_hostnames": bool,
+        "allow_duplicate_ips": bool,
+        "allow_duplicate_macs": bool,
+        "allow_dynamic_settings": bool,
+        "always_write_dhcp_entries": bool,
+        "anamon_enabled": bool,
+        "auth_token_expiration": int,
+        "authn_pam_service": str,
+        "autoinstall_snippets_dir": str,
+        "autoinstall_templates_dir": str,
+        "bind_chroot_path": str,
+        "bind_zonefile_path": str,
+        "bind_master": str,
+        "boot_loader_conf_template_dir": str,
+        Optional("bootloaders_dir", default="/var/lib/cobbler/loaders"): str,
+        Optional(
+            "bootloaders_formats",
+            default={
+                "aarch64": {"binary_name": "grubaa64.efi"},
+                "arm": {"binary_name": "bootarm.efi"},
+                "arm64-efi": {
+                    "binary_name": "grubaa64.efi",
+                    "extra_modules": ["efinet"],
+                },
+                "i386": {"binary_name": "bootia32.efi"},
+                "i386-pc-pxe": {
+                    "binary_name": "grub.0",
+                    "mod_dir": "i386-pc",
+                    "extra_modules": ["chain", "pxe", "biosdisk"],
+                },
+                "i686": {"binary_name": "bootia32.efi"},
+                "IA64": {"binary_name": "bootia64.efi"},
+                "powerpc-ieee1275": {
+                    "binary_name": "grub.ppc64le",
+                    "extra_modules": ["net", "ofnet"],
+                },
+                "x86_64-efi": {
+                    "binary_name": "grubx86.efi",
+                    "extra_modules": ["chain", "efinet"],
+                },
+            },
+        ): dict,
+        Optional(
+            "bootloaders_modules",
+            default=[
+                "btrfs",
+                "ext2",
+                "xfs",
+                "jfs",
+                "reiserfs",
+                "all_video",
+                "boot",
+                "cat",
+                "configfile",
+                "echo",
+                "fat",
+                "font",
+                "gfxmenu",
+                "gfxterm",
+                "gzio",
+                "halt",
+                "iso9660",
+                "jpeg",
+                "linux",
+                "loadenv",
+                "minicmd",
+                "normal",
+                "part_apple",
+                "part_gpt",
+                "part_msdos",
+                "password_pbkdf2",
+                "png",
+                "reboot",
+                "search",
+                "search_fs_file",
+                "search_fs_uuid",
+                "search_label",
+                "sleep",
+                "test",
+                "true",
+                "video",
+                "mdraid09",
+                "mdraid1x",
+                "lvm",
+                "serial",
+                "regexp",
+                "tr",
+                "tftp",
+                "http",
+                "luks",
+                "gcry_rijndael",
+                "gcry_sha1",
+                "gcry_sha256",
+            ],
+        ): list,
+        Optional("bootloaders_shim_folder", default="/usr/share/efi/*/"): str,
+        Optional("bootloaders_shim_file", default=r"shim\.efi"): str,
+        Optional("bootloaders_ipxe_folder", default="/usr/share/ipxe/"): str,
+        Optional("syslinux_dir", default="/usr/share/syslinux"): str,
+        Optional("syslinux_memdisk_folder", default="/usr/share/syslinux"): str,
+        Optional("syslinux_pxelinux_folder", default="/usr/share/syslinux"): str,
+        Optional("grub2_mod_dir", default="/usr/share/grub"): str,
+        Optional("grubconfig_dir", default="/var/lib/cobbler/grub_config"): str,
+        "build_reporting_enabled": bool,
+        "build_reporting_email": [str],
+        "build_reporting_ignorelist": [str],
+        "build_reporting_sender": str,
+        "build_reporting_smtp_server": str,
+        "build_reporting_subject": str,
+        Optional("buildisodir", default="/var/cache/cobbler/buildiso"): str,
+        "cheetah_import_whitelist": [str],
+        "client_use_https": bool,
+        "client_use_localhost": bool,
+        Optional("cobbler_master", default=""): str,
+        Optional("convert_server_to_ip", default=False): bool,
+        "createrepo_flags": str,
+        "autoinstall": str,
+        "default_name_servers": [str],
+        "default_name_servers_search": [str],
+        "default_ownership": [str],
+        "default_password_crypted": str,
+        "default_template_type": str,
+        "default_virt_bridge": str,
+        Optional("default_virt_disk_driver", default="raw"): str,
+        "default_virt_file_size": float,
+        "default_virt_ram": int,
+        "default_virt_type": str,
+        "enable_ipxe": bool,
+        "enable_menu": bool,
+        "http_port": int,
+        "include": [str],
+        Optional("iso_template_dir", default="/etc/cobbler/iso"): str,
+        Optional("jinja2_includedir", default="/var/lib/cobbler/jinja2"): str,
+        "kernel_options": dict,
+        Optional("ldap_anonymous_bind", default=True): bool,
+        Optional("ldap_base_dn", default="DC=devel,DC=redhat,DC=com"): str,
+        Optional("ldap_port", default=389): int,
+        Optional("ldap_search_bind_dn", default=""): str,
+        Optional("ldap_search_passwd", default=""): str,
+        Optional("ldap_search_prefix", default="uid="): str,
+        Optional("ldap_server", default="grimlock.devel.redhat.com"): str,
+        Optional("ldap_tls", default=True): bool,
+        Optional("ldap_tls_cacertdir", default=""): str,
+        Optional("ldap_tls_cacertfile", default=""): str,
+        Optional("ldap_tls_certfile", default=""): str,
+        Optional("ldap_tls_keyfile", default=""): str,
+        Optional("ldap_tls_reqcert", default=""): str,
+        Optional("ldap_tls_cipher_suite", default=""): str,
+        Optional("bind_manage_ipmi", default=False): bool,
+        # TODO: Remove following line
+        "manage_dhcp": bool,
+        "manage_dhcp_v4": bool,
+        "manage_dhcp_v6": bool,
+        "manage_dns": bool,
+        "manage_forward_zones": [str],
+        "manage_reverse_zones": [str],
+        Optional("manage_genders", False): bool,
+        "manage_rsync": bool,
+        "manage_tftpd": bool,
+        "mgmt_classes": [str],
+        # TODO: Validate Subdict
+        "mgmt_parameters": dict,
+        "next_server_v4": str,
+        "next_server_v6": str,
+        Optional("nsupdate_enabled", False): bool,
+        Optional("nsupdate_log", default="/var/log/cobbler/nsupdate.log"): str,
+        Optional("nsupdate_tsig_algorithm", default="hmac-sha512"): str,
+        Optional("nsupdate_tsig_key", default=[]): [str],
+        "power_management_default_type": str,
+        Optional("proxies", default=[]): [str],
+        "proxy_url_ext": str,
+        "proxy_url_int": str,
+        "puppet_auto_setup": bool,
+        Optional("puppet_parameterized_classes", default=True): bool,
+        Optional("puppet_server", default="puppet"): str,
+        Optional("puppet_version", default=2): int,
+        "puppetca_path": str,
+        "pxe_just_once": bool,
+        "nopxe_with_triggers": bool,
+        "redhat_management_permissive": bool,
+        "redhat_management_server": str,
+        "redhat_management_key": str,
+        "register_new_installs": bool,
+        "remove_old_puppet_certs_automatically": bool,
+        "replicate_repo_rsync_options": str,
+        "replicate_rsync_options": str,
+        "reposync_flags": str,
+        "reposync_rsync_flags": str,
+        "restart_dhcp": bool,
+        "restart_dns": bool,
+        "run_install_triggers": bool,
+        "scm_track_enabled": bool,
+        "scm_track_mode": str,
+        "scm_track_author": str,
+        "scm_push_script": str,
+        "serializer_pretty_json": bool,
+        "server": str,
+        "sign_puppet_certs_automatically": bool,
+        Optional(
+            "signature_path", default="/var/lib/cobbler/distro_signatures.json"
+        ): str,
+        Optional(
+            "signature_url",
+            default="https://cobbler.github.io/signatures/3.0.x/latest.json",
+        ): str,
+        "tftpboot_location": str,
+        "virt_auto_boot": bool,
+        "webdir": str,
+        "webdir_whitelist": [str],
+        "xmlrpc_port": int,
+        "yum_distro_priority": int,
+        "yum_post_install_mirror": bool,
+        "yumdownloader_flags": str,
+        Optional("windows_enabled", default=False): bool,
+        Optional("windows_template_dir", default="/etc/cobbler/windows"): str,
+        Optional("samba_distro_share", default="DISTRO"): str,
+        Optional("cache_enabled"): bool,
+        Optional("lazy_start", default=False): bool,
+    },
+    ignore_extra_keys=False,
+)
+
+
+def validate(settings: dict) -> bool:
+    """
+    Checks that a given settings dict is valid according to the reference V3.3.1 schema ``schema``.
+
+    :param settings: The settings dict to validate.
+    :return: True if valid settings dict otherwise False.
+    """
+    try:
+        schema.validate(settings)  # type: ignore
+    except SchemaError:
+        return False
+    return True
+
+
+def normalize(settings: dict) -> dict:
+    """
+    If data in ``settings`` is valid the validated data is returned.
+
+    :param settings: The settings dict to validate.
+    :return: The validated dict.
+    """
+    return schema.validate(settings)  # type: ignore
+
+
+def migrate(settings: dict) -> dict:
+    """
+    Migration of the settings ``settings`` to version V3.3.4 settings
+
+    :param settings: The settings dict to migrate
+    :return: The migrated dict
+    """
+
+    if not V3_3_4.validate(settings):
+        raise SchemaError("V3.3.3: Schema error while validating")
+
+    # rename keys and update their value
+    # add missing keys
+    # name - value pairs
+
+    return normalize(settings)

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -16,7 +16,7 @@ from typing import Any, Dict
 
 from schema import Optional, Schema, SchemaError  # type: ignore
 
-from cobbler.settings.migrations import V3_3_3, helper
+from cobbler.settings.migrations import V3_3_5, helper
 
 schema = Schema(
     {
@@ -211,8 +211,8 @@ def migrate(settings: Dict[str, Any]) -> Dict[str, Any]:
     :return: The migrated dict
     """
 
-    if not V3_3_3.validate(settings):
-        raise SchemaError("V3.3.3: Schema error while validating")
+    if not V3_3_5.validate(settings):
+        raise SchemaError("V3.3.5: Schema error while validating")
 
     # rename keys and update their value if needed
     include = settings.pop("include")

--- a/tests/settings/migrations/migrations_test.py
+++ b/tests/settings/migrations/migrations_test.py
@@ -25,6 +25,8 @@ from cobbler.settings.migrations import (
     V3_3_1,
     V3_3_2,
     V3_3_3,
+    V3_3_4,
+    V3_3_5,
     V3_4_0,
 )
 
@@ -250,13 +252,47 @@ def test_migrate_v3_3_3():
     assert isinstance(new_settings.get("default_virt_file_size", None), float)
 
 
+def test_migrate_v3_3_4():
+    """
+    Test to validate that a migrations of the settings from Cobbler 3.3.3 to 3.3.4 is working as expected.
+    """
+    # Arrange
+    with open(
+        "/code/tests/test_data/V3_3_3/settings.yaml", encoding="UTF-8"
+    ) as old_settings:
+        old_settings_dict = yaml.safe_load(old_settings.read())
+
+    # Act
+    new_settings = V3_3_4.migrate(old_settings_dict)
+
+    # Assert
+    assert V3_3_4.validate(new_settings)
+
+
+def test_migrate_v3_3_5():
+    """
+    Test to validate that a migrations of the settings from Cobbler 3.3.4 to 3.3.5 is working as expected.
+    """
+    # Arrange
+    with open(
+        "/code/tests/test_data/V3_3_4/settings.yaml", encoding="UTF-8"
+    ) as old_settings:
+        old_settings_dict = yaml.safe_load(old_settings.read())
+
+    # Act
+    new_settings = V3_3_5.migrate(old_settings_dict)
+
+    # Assert
+    assert V3_3_5.validate(new_settings)
+
+
 def test_migrate_v3_4_0():
     # Arrange
-    with open("/code/tests/test_data/V3_3_3/settings.yaml") as old_settings:
+    with open("/code/tests/test_data/V3_3_5/settings.yaml") as old_settings:
         old_settings_dict = yaml.safe_load(old_settings.read())
-    shutil.copy("/code/tests/test_data/V3_3_3/modules.conf", modules_conf_location)
+    shutil.copy("/code/tests/test_data/V3_3_5/modules.conf", modules_conf_location)
     shutil.copy(
-        "/code/tests/test_data/V3_3_3/mongodb.conf", "/etc/cobbler/mongodb.conf"
+        "/code/tests/test_data/V3_3_5/mongodb.conf", "/etc/cobbler/mongodb.conf"
     )
 
     # Act

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -20,6 +20,8 @@ from cobbler.settings.migrations import (
     V3_3_1,
     V3_3_2,
     V3_3_3,
+    V3_3_4,
+    V3_3_5,
     V3_4_0,
 )
 
@@ -156,6 +158,30 @@ def test_normalize_v3_3_3():
     assert len(new_settings) == 131
     # Migration of default_virt_file_size to float is working
     assert isinstance(new_settings.get("default_virt_file_size", None), float)
+
+
+def test_normalize_v3_3_4():
+    # Arrange
+    with open("/code/tests/test_data/V3_3_4/settings.yaml") as old_settings:
+        old_settings_dict = yaml.safe_load(old_settings.read())
+
+    # Act
+    new_settings = V3_3_4.normalize(old_settings_dict)
+
+    # Assert
+    assert len(new_settings) == 131
+
+
+def test_normalize_v3_3_5():
+    # Arrange
+    with open("/code/tests/test_data/V3_3_4/settings.yaml") as old_settings:
+        old_settings_dict = yaml.safe_load(old_settings.read())
+
+    # Act
+    new_settings = V3_3_5.normalize(old_settings_dict)
+
+    # Assert
+    assert len(new_settings) == 131
 
 
 def test_normalize_v3_4_0_empty():

--- a/tests/test_data/V3_3_4/modules.conf
+++ b/tests/test_data/V3_3_4/modules.conf
@@ -1,0 +1,19 @@
+# cobbler module configuration file
+#
+# Documentation: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html#modules-conf
+
+[authentication]
+module = authentication.configfile
+hash_algorithm = sha3_512
+
+[authorization]
+module = authorization.allowall
+
+[dns]
+module = managers.bind
+
+[dhcp]
+module = managers.isc
+
+[tftpd]
+module = managers.in_tftpd

--- a/tests/test_data/V3_3_4/mongodb.conf
+++ b/tests/test_data/V3_3_4/mongodb.conf
@@ -1,0 +1,3 @@
+[connection]
+host = localhost
+port = 27017

--- a/tests/test_data/V3_3_4/settings.d/bind_manage_ipmi.settings
+++ b/tests/test_data/V3_3_4/settings.d/bind_manage_ipmi.settings
@@ -1,0 +1,3 @@
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind
+# is set.
+bind_manage_ipmi: true

--- a/tests/test_data/V3_3_4/settings.d/manage_genders.settings
+++ b/tests/test_data/V3_3_4/settings.d/manage_genders.settings
@@ -1,0 +1,2 @@
+# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
+manage_genders: false

--- a/tests/test_data/V3_3_4/settings.d/nsupdate.settings
+++ b/tests/test_data/V3_3_4/settings.d/nsupdate.settings
@@ -1,0 +1,12 @@
+# Set to "true" to enable Cobbler's dynamic DNS updates.
+nsupdate_enabled: false
+
+# define tsig key
+# please don't use this one, instead generate your own:
+#   dnssec-keygen -a HMAC-SHA512 -b 512 -n USER cobbler_update_key
+nsupdate_tsig_algorithm: "hmac-sha512"
+nsupdate_tsig_key: [ "cobbler_update_key.", "hvnK54HFJXFasHjzjEn09ASIkCOGYSnofRq4ejsiBHz3udVyGiuebFGAswSjKUxNuhmllPrkI0HRSSmM2qvZug==" ]
+
+# if set, enables logging to that file
+nsupdate_log: "/var/log/cobbler/nsupdate.log"
+

--- a/tests/test_data/V3_3_4/settings.d/windows.settings
+++ b/tests/test_data/V3_3_4/settings.d/windows.settings
@@ -1,0 +1,8 @@
+# Set to true to enable the generation of Windows boot files in Cobbler.
+windows_enabled: false
+
+# Location of templates used for Windows
+windows_template_dir: "/etc/cobbler/windows"
+
+# Samba share name for distros
+samba_distro_share: "DISTRO"

--- a/tests/test_data/V3_3_4/settings.yaml
+++ b/tests/test_data/V3_3_4/settings.yaml
@@ -1,0 +1,571 @@
+# Cobbler settings file
+
+# Restart cobblerd and run "cobbler sync" after making changes.
+# This config file is in YAML 1.2 format; see "http://yaml.org".
+
+# if "true" Cobbler will auto migrate the settings file after upgrading from older versions. The current settings
+# are backed up in the same folder before the upgrade.
+auto_migrate_settings: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the "--dns-name" information of other system
+# records. In general, this is undesirable and should be left "false".
+allow_duplicate_hostnames: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the ip address information of other system
+# records. In general, this is undesirable and should be left "false".
+allow_duplicate_ips: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the MAC address information of other system
+# records. In general, this is undesirable.
+allow_duplicate_macs: false
+
+# If "true", Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can
+# only change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
+allow_dynamic_settings: false
+
+# By default, installs are *not* set to send installation logs to the Cobbler server. With "anamon_enabled", automatic
+# installation templates may use the "pre_anamon" snippet to allow remote live monitoring of their installations from
+# the Cobbler server. Installation logs will be stored under "/var/log/cobbler/anamon/".
+# NOTE: This does allow an xmlrpc call to send logs to this directory, without authentication, so enable only if you are
+# ok with this limitation.
+anamon_enabled: false
+
+# If using "authn_pam" in the "modules.conf", this can be configured to change the PAM service authentication will be
+# tested against.
+# The default value is "login".
+authn_pam_service: "login"
+
+# How long the authentication token is valid for, in seconds.
+auth_token_expiration: 3600
+
+# This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information.  Changing
+# this directory should not be required.
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+
+# location of templates used for boot loader config generation
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx64.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '/usr/share/syslinux'
+syslinux_memdisk_folder: '/usr/share/syslinux'
+syslinux_pxelinux_folder: '/usr/share/syslinux'
+grub2_mod_dir: '/usr/share/grub2'
+bootloaders_shim_folder: '/usr/share/efi/*/'
+bootloaders_shim_file: 'shim\.efi'
+bootloaders_ipxe_folder: '/usr/share/ipxe/'
+
+# Email out a report when Cobbler finishes installing a system.
+# enabled: set to true to turn this feature on
+# sender: optional
+# email: which addresses to email
+# smtp_server: used to specify another server for an MTA
+# subject: use the default subject unless overridden
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+
+# Cheetah-language autoinstall templates can import Python modules. While this is a useful feature, it is not safe to
+# allow them to import anything they want. This whitelists which modules can be imported through Cheetah. Users can
+# expand this as needed but should never allow modules such as subprocess or those that allow access to the filesystem
+# as Cheetah templates are evaluated by cobblerd as code.
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+
+# Default "createrepo_flags" to use for new repositories. If you have createrepo >= 0.4.10, consider
+# "-c cache --update -C", which can dramatically improve your "cobbler reposync" time. "-s sha" enables working with
+# Fedora repos from F11/F12 from EL-4 or EL-5 without python-hashlib installed (which is not available on EL-4)
+createrepo_flags: "-c cache -s sha"
+
+# if no autoinstall template is specified to profile add, use this template (path is relative to template root)
+autoinstall: "default.ks"
+
+# configure all installed systems to use these nameservers by default
+# unless defined differently in the profile.  For DHCP configurations
+# you probably do /not/ want to supply this.
+default_name_servers: []
+default_name_servers_search: []
+
+# if using the authz_ownership module (see the Wiki), objects
+# created without specifying an owner are assigned to this
+# owner and/or group.  Can be a comma seperated list.
+default_ownership:
+ - "admin"
+
+# Cobbler has various sample automatic installation templates stored
+# in /var/lib/cobbler/templates/.  This controls
+# what install (root) password is set up for those
+# systems that reference this variable.  The factory
+# default is "cobbler" and Cobbler check will warn if
+# this is not changed.
+# The simplest way to change the password is to run
+# openssl passwd -1
+# and put the output between the "" below.
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+
+# the default template type to use in the absence of any
+# other detected template. If you do not specify the template
+# with '#template=<template_type>' on the first line of your
+# templates/snippets, Cobbler will assume try to use the
+# following template engine to parse the templates.
+#
+# Current valid values are: cheetah, jinja2
+default_template_type: "cheetah"
+
+# for libvirt based installs in koan, if no virt bridge
+# is specified, which bridge do we try?  For EL 4/5 hosts
+# this should be xenbr0, for all versions of Fedora, try
+# "virbr0".  This can be overriden on a per-profile
+# basis or at the koan command line though this saves
+# typing to just set it here to the most common option.
+default_virt_bridge: xenbr0
+
+# use this as the default disk size for virt guests (GB)
+default_virt_file_size: 5.0
+
+# use this as the default memory size for virt guests (MB)
+default_virt_ram: 512
+
+# if koan is invoked without --virt-type and no virt-type
+# is set on the profile/system, what virtualization type
+# should be assumed?  Values: xenpv, xenfv, qemu, vmware
+# (NOTE: this does not change what virt_type is chosen by import)
+default_virt_type: xenpv
+
+# enable iPXE booting? Enabling this option will cause Cobbler
+# to copy the undionly.kpxe file to the tftp root directory,
+# and if a profile/system is configured to boot via iPXE it will
+# chain load off pxelinux.0.
+# Default: false
+enable_ipxe: false
+
+# controls whether Cobbler will add each new profile entry to the default
+# PXE boot menu.  This can be over-ridden on a per-profile
+# basis when adding/editing profiles with --enable-menu=false/true.  Users
+# should ordinarily leave this setting enabled unless they are concerned
+# with accidental reinstalls from users who select an entry at the PXE
+# boot menu.  Adding a password to the boot menus templates
+# may also be a good solution to prevent unwanted reinstallations
+enable_menu: true
+
+# change this port if Apache is not running plaintext on port
+# 80.  Most people can leave this alone.
+http_port: 80
+
+# kernel options that should be present in every Cobbler installation.
+# kernel options can also be applied at the distro/profile/system
+# level.
+kernel_options: {}
+
+# configuration options if using the authn_ldap module. See the
+# the Wiki for details.  This can be ignored if you are not using
+# LDAP for WebUI/XMLRPC authentication.
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+
+# Cobbler has a feature that allows for integration with config management
+# systems such as Puppet.  The following parameters work in conjunction with
+# --mgmt-classes  and are described in further detail at:
+# https://github.com/cobbler/cobbler/wiki/Using-cobbler-with-a-configuration-management-system
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+
+# if enabled, this setting ensures that puppet is installed during
+# machine provision, a client certificate is generated and a
+# certificate signing request is made with the puppet master server
+puppet_auto_setup: false
+
+# when puppet starts on a system after installation it needs to have
+# its certificate signed by the puppet master server. Enabling the
+# following feature will ensure that the puppet server signs the
+# certificate after installation if the puppet master server is
+# running on the same machine as Cobbler. This requires
+# puppet_auto_setup above to be enabled
+sign_puppet_certs_automatically: false
+
+# location of the puppet executable, used for revoking certificates
+puppetca_path: "/usr/bin/puppet"
+
+# when a puppet managed machine is reinstalled it is necessary to
+# remove the puppet certificate from the puppet master server before a
+# new certificate is signed (see above). Enabling the following
+# feature will ensure that the certificate for the machine to be
+# installed is removed from the puppet master server if the puppet
+# master server is running on the same machine as Cobbler. This
+# requires puppet_auto_setup above to be enabled
+remove_old_puppet_certs_automatically: false
+
+# choose a --server argument when running puppetd/puppet agent during autoinstall
+puppet_server: 'puppet'
+
+# let Cobbler know that you're using a newer version of puppet
+# choose version 3 to use: 'puppet agent'; version 2 uses status quo: 'puppetd'
+puppet_version: 2
+
+# choose whether to enable puppet parameterized classes or not.
+# puppet versions prior to 2.6.5 do not support parameters
+puppet_parameterized_classes: true
+
+# set to true to enable Cobbler's DHCP management features.
+# the choice of DHCP management engine is in /etc/cobbler/modules.conf
+# See the docs (https://cobbler.readthedocs.io/en/latest/user-guide.html#dhcp-management) for more info
+manage_dhcp: false
+
+# set to true to enable DHCP IPv6 address configuration generation.
+# This currently only works with manager.isc DHCP module (isc dhcpd6 daemon)
+# See /etc/cobbler/modules.conf whether this isc module is chosen for dhcp
+# generation.
+manage_dhcp_v6: false
+
+# set to true to enable DHCP IPv4 address configuration generation.
+# This currently only works with manager.isc DHCP module
+# Other dhcp modules ignore this and above settings
+manage_dhcp_v4: false
+
+# if using Cobbler with manage_dhcp, put the IP address
+# of the Cobbler server here so that PXE booting guests can find it
+# if you do not set this correctly, this will be manifested in TFTP open timeouts.
+next_server_v4: 127.0.0.1
+
+# And the same if you set manage_dhcp_v6 to true.
+# Set the cobbler IPv6 address here so that PXE booting guests can find it
+next_server_v6: "::1"
+
+# set to true to enable Cobbler's DNS management features.
+# the choice of DNS management engine is in /etc/cobbler/modules.conf
+# needs manage_forward_zones and manage_reverse_zones to be set, too.
+manage_dns: false
+
+# set to path of bind chroot to create bind-chroot compatible bind
+# configuration files.
+bind_chroot_path: ""
+
+# set to path where zonefiles of bind/named server are located.
+bind_zonefile_path: "/var/lib/named"
+
+# set to the ip address of the master bind DNS server for creating secondary
+# bind configuration files
+bind_master: 127.0.0.1
+
+# if using BIND (named) for DNS management in /etc/cobbler/modules.conf
+# and manage_dns is enabled (above), this lists which zones are managed
+# See the docs (https://cobbler.readthedocs.io/en/latest/user-guide.html#dns-configuration-management) for more info
+manage_forward_zones: []
+manage_reverse_zones: []
+
+# set to true to enable Cobbler's TFTP management features.
+# the choice of TFTP management engine is in /etc/cobbler/modules.conf
+manage_tftpd: true
+
+# This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not
+# start.
+# Default: "/var/lib/tftpboot"
+tftpboot_location: "/var/lib/tftpboot"
+
+# set to true to enable Cobbler's RSYNC management features.
+manage_rsync: false
+
+# settings for power management features.  optional.
+# see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
+# choices (refer to codes.py):
+#    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
+#    ipmilan ipmilanplus lpar rsa virsh wti
+power_management_default_type: 'ipmilanplus'
+
+# if this setting is set to true, Cobbler systems that pxe boot
+# will request at the end of their installation to toggle the
+# --netboot-enabled record in the Cobbler system record.  This eliminates
+# the potential for a PXE boot loop if the system is set to PXE
+# first in it's BIOS order.  Enable this if PXE is first in your BIOS
+# boot order, otherwise leave this disabled.   See the manpage
+# for --netboot-enabled.
+pxe_just_once: true
+
+# if this setting is set to one, triggers will be executed when systems
+# will request to toggle the --netboot-enabled record at the end of their installation.
+nopxe_with_triggers: true
+
+# This setting is only used by the code that supports using Spacewalk/Satellite
+# authentication within Cobbler Web and Cobbler XMLRPC.
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+
+# if using authn_spacewalk in modules.conf to let Cobbler authenticate
+# against Satellite/Spacewalk's auth system, by default it will not allow per user
+# access into Cobbler Web and Cobbler XMLRPC.
+# in order to permit this, the following setting must be enabled HOWEVER
+# doing so will permit all Spacewalk/Satellite users of certain types to edit all
+# of Cobbler's configuration.
+# these roles are:  config_admin and org_admin
+# users should turn this on only if they want this behavior and
+# do not have a cross-multi-org seperation concern.  If you have
+# a single org in your satellite, it's probably safe to turn this
+# on and then you can use CobblerWeb alongside a Satellite install.
+redhat_management_permissive: false
+
+# specify the default Red Hat authorization key to use to register
+# system.  If left blank, no registration will be attempted.  Similarly
+# you can set the --redhat-management-key to blank on any system to
+# keep it from trying to register.
+redhat_management_key: ""
+
+# if set to true, allows /usr/bin/cobbler-register (part of the koan package)
+# to be used to remotely add new Cobbler system records to Cobbler.
+# this effectively allows for registration of new hardware from system
+# records.
+register_new_installs: false
+
+# Flags to use for dnf's reposync. You can exclude some packages by adding --exclude.
+# For example exclude source packages: --exclude=\\*.src
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+
+# Flags to use for rysync's reposync. If flag 'a' is used then createrepo
+# is not ran after the rsync
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+
+# when DHCP and DNS management are enabled, Cobbler sync can automatically
+# restart those services to apply changes.  The exception for this is
+# if using ISC for DHCP, then omapi eliminates the need for a restart.
+# omapi, however, is experimental and not recommended for most configurations.
+# If DHCP and DNS are going to be managed, but hosted on a box that
+# is not on this server, disable restarts here and write some other
+# script to ensure that the config files get copied/rsynced to the destination
+# box.  This can be done by modifying the restart services trigger.
+# Note that if manage_dhcp and manage_dns are disabled, the respective
+# parameter will have no effect.  Most users should not need to change
+# this.
+restart_dns: true
+restart_dhcp: true
+
+# install triggers are scripts in /var/lib/cobbler/triggers/install
+# that are triggered in autoinstall pre and post sections.  Any
+# executable script in those directories is run.  They can be used
+# to send email or perform other actions.  They are currently
+# run as root so if you do not need this functionality you can
+# disable it, though this will also disable "cobbler status" which
+# uses a logging trigger to audit install progress.
+run_install_triggers: true
+
+# enables a trigger which version controls all changes to /var/lib/cobbler
+# when add, edit, or sync events are performed.  This can be used
+# to revert to previous database versions, generate RSS feeds, or for
+# other auditing or backup purposes. "git" and "hg" are currently suported,
+# but git is the recommend SCM for use with this feature.
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+
+# this is the address of the Cobbler server -- as it is used
+# by systems during the install process, it must be the address
+# or hostname of the system as those systems can see the server.
+# if you have a server that appears differently to different subnets
+# (dual homed, etc), you need to read the --server-override section
+# of the manpage for how that works.
+server: 127.0.0.1
+
+# If set to true, all commands will be forced to use the localhost address
+# instead of using the above value which can force commands like
+# cobbler sync to open a connection to a remote address if one is in the
+# configuration and would traceback.
+client_use_localhost: false
+
+# If set to "true", all commands to the API (not directly to the XMLRPC server) will go over HTTPS instead of plaintext.
+# Be sure to change the "http_port" setting to the correct value for the web server.
+client_use_https: false
+
+# Should new profiles for virtual machines default to auto booting with the physical host when the physical host
+# reboots? This can be overridden on each profile or system object.
+virt_auto_boot: true
+
+# Cobbler's web directory. Don't change this setting -- see the Wiki on "Relocating your Cobbler install" if your "/var"
+# partition is not large enough.
+webdir: "/var/www/cobbler"
+
+# Directories that will not get wiped and recreated on a "cobbler sync".
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+
+# Cobbler's public XMLRPC listens on this port.  Change this only
+# if absolutely needed, as you'll have to start supplying a new
+# port option to koan if it is not the default.
+xmlrpc_port: 25151
+
+# "cobbler repo add" commands set Cobbler up with repository
+# information that can be used during autoinstall and is automatically
+# set up in the Cobbler autoinstall templates.  By default, these
+# are only available at install time.  To make these repositories
+# usable on installed systems (since Cobbler makes a very convenient
+# mirror) set this to true.  Most users can safely set this to true.  Users
+# who have a dual homed Cobbler server, or are installing laptops that
+# will not always have access to the Cobbler server may wish to leave
+# this as false.  In that case, the Cobbler mirrored yum repos are still
+# accessable at http://cobbler.example.org/cblr/repo_mirror and yum
+# configuration can still be done manually.  This is just a shortcut.
+yum_post_install_mirror: true
+
+# the default yum priority for all the distros. This is only used if yum-priorities plugin is used.
+# 1=maximum
+# Tweak with caution!
+yum_distro_priority: 1
+
+# Flags to use for yumdownloader.  Not all versions may support
+# --resolve.
+yumdownloader_flags: "--resolve"
+
+# sort and indent JSON output to make it more human-readable
+serializer_pretty_json: false
+
+# replication rsync options for distros, autoinstalls, snippets set to override default value of "-avzH"
+replicate_rsync_options: "-avzH"
+
+# replication rsync options for repos set to override default value of "-avzH"
+replicate_repo_rsync_options: "-avzH"
+
+# always write DHCP entries, regardless if netboot is enabled
+always_write_dhcp_entries: false
+
+# External proxy - used by: reposync", "signature update"
+# Eg: "http://192.168.1.1:8080" (HTTP), "https://192.168.1.1:8443" (HTTPS)
+proxy_url_ext: ""
+
+# Internal proxy - used by systems to reach Cobbler for templates
+# Eg: proxy_url_int: "http://10.0.0.1:8080"
+proxy_url_int: ""
+
+# This is a directory of files that Cobbler uses to include
+# files into Jinja2 templates
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+
+# Up to now, cobblerd used $server's IP address instead of the DNS name in autoinstallation
+# file settings (pxelinux.cfg files) to save bytes, which seemed required for S/390 systems.
+# This behavior can have negative impact on installs with multi-homed Cobbler servers, because
+# not all of the IP addresses may be reachable during system install.
+# This behavior was now made conditional, with default being "off".
+convert_server_to_ip: false
+
+# Leftover settings
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+
+# Signatures
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+
+# Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
+# this file.
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]

--- a/tests/test_data/V3_3_5/modules.conf
+++ b/tests/test_data/V3_3_5/modules.conf
@@ -1,0 +1,19 @@
+# cobbler module configuration file
+#
+# Documentation: https://cobbler.readthedocs.io/en/latest/cobbler-conf.html#modules-conf
+
+[authentication]
+module = authentication.configfile
+hash_algorithm = sha3_512
+
+[authorization]
+module = authorization.allowall
+
+[dns]
+module = managers.bind
+
+[dhcp]
+module = managers.isc
+
+[tftpd]
+module = managers.in_tftpd

--- a/tests/test_data/V3_3_5/mongodb.conf
+++ b/tests/test_data/V3_3_5/mongodb.conf
@@ -1,0 +1,3 @@
+[connection]
+host = localhost
+port = 27017

--- a/tests/test_data/V3_3_5/settings.d/bind_manage_ipmi.settings
+++ b/tests/test_data/V3_3_5/settings.d/bind_manage_ipmi.settings
@@ -1,0 +1,3 @@
+# bind_manage_ipmi - used to let bind manage IPMI addresses if the power management address is an IP and if manage_bind
+# is set.
+bind_manage_ipmi: true

--- a/tests/test_data/V3_3_5/settings.d/manage_genders.settings
+++ b/tests/test_data/V3_3_5/settings.d/manage_genders.settings
@@ -1,0 +1,2 @@
+# manage_genders - Bool to enable/disable managing an /etc/genders file for use with pdsh and others.
+manage_genders: false

--- a/tests/test_data/V3_3_5/settings.d/nsupdate.settings
+++ b/tests/test_data/V3_3_5/settings.d/nsupdate.settings
@@ -1,0 +1,12 @@
+# Set to "true" to enable Cobbler's dynamic DNS updates.
+nsupdate_enabled: false
+
+# define tsig key
+# please don't use this one, instead generate your own:
+#   dnssec-keygen -a HMAC-SHA512 -b 512 -n USER cobbler_update_key
+nsupdate_tsig_algorithm: "hmac-sha512"
+nsupdate_tsig_key: [ "cobbler_update_key.", "hvnK54HFJXFasHjzjEn09ASIkCOGYSnofRq4ejsiBHz3udVyGiuebFGAswSjKUxNuhmllPrkI0HRSSmM2qvZug==" ]
+
+# if set, enables logging to that file
+nsupdate_log: "/var/log/cobbler/nsupdate.log"
+

--- a/tests/test_data/V3_3_5/settings.d/windows.settings
+++ b/tests/test_data/V3_3_5/settings.d/windows.settings
@@ -1,0 +1,8 @@
+# Set to true to enable the generation of Windows boot files in Cobbler.
+windows_enabled: false
+
+# Location of templates used for Windows
+windows_template_dir: "/etc/cobbler/windows"
+
+# Samba share name for distros
+samba_distro_share: "DISTRO"

--- a/tests/test_data/V3_3_5/settings.yaml
+++ b/tests/test_data/V3_3_5/settings.yaml
@@ -1,0 +1,584 @@
+# Cobbler settings file
+
+# Restart cobblerd and run "cobbler sync" after making changes.
+# This config file is in YAML 1.2 format; see "http://yaml.org".
+
+# if "true" Cobbler will auto migrate the settings file after upgrading from older versions. The current settings
+# are backed up in the same folder before the upgrade.
+auto_migrate_settings: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the "--dns-name" information of other system
+# records. In general, this is undesirable and should be left "false".
+allow_duplicate_hostnames: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the ip address information of other system
+# records. In general, this is undesirable and should be left "false".
+allow_duplicate_ips: false
+
+# If "true", Cobbler will allow insertions of system records that duplicate the MAC address information of other system
+# records. In general, this is undesirable.
+allow_duplicate_macs: false
+
+# If "true", Cobbler will allow settings to be changed dynamically without a restart of the cobblerd daemon. You can
+# only change this variable by manually editing the settings file, and you MUST restart cobblerd after changing it.
+allow_dynamic_settings: false
+
+# By default, installs are *not* set to send installation logs to the Cobbler server. With "anamon_enabled", automatic
+# installation templates may use the "pre_anamon" snippet to allow remote live monitoring of their installations from
+# the Cobbler server. Installation logs will be stored under "/var/log/cobbler/anamon/".
+# NOTE: This does allow an xmlrpc call to send logs to this directory, without authentication, so enable only if you are
+# ok with this limitation.
+anamon_enabled: false
+
+# If using "authn_pam" in the "modules.conf", this can be configured to change the PAM service authentication will be
+# tested against.
+# The default value is "login".
+authn_pam_service: "login"
+
+# How long the authentication token is valid for, in seconds.
+auth_token_expiration: 3600
+
+# This is a directory of files that Cobbler uses to make templating easier. See the Wiki for more information.  Changing
+# this directory should not be required.
+autoinstall_snippets_dir: /var/lib/cobbler/snippets
+autoinstall_templates_dir: /var/lib/cobbler/templates
+
+# location of templates used for boot loader config generation
+boot_loader_conf_template_dir: "/etc/cobbler/boot_loader_conf"
+bootloaders_dir: "/var/lib/cobbler/loaders"
+bootloaders_formats:
+  aarch64:
+    binary_name: grubaa64.efi
+  arm:
+    binary_name: bootarm.efi
+  arm64-efi:
+    binary_name: grubaa64.efi
+    extra_modules:
+      - efinet
+  i386-efi:
+    binary_name: bootia32.efi
+  i386-pc-pxe:
+    binary_name: grub.0
+    mod_dir: i386-pc
+    extra_modules:
+      - chain
+      - pxe
+      - biosdisk
+  i686:
+    binary_name: bootia32.efi
+  IA64:
+    binary_name: bootia64.efi
+  powerpc-ieee1275:
+    binary_name: grub.ppc64le
+    extra_modules:
+      - net
+      - ofnet
+  x86_64-efi:
+    binary_name: grubx64.efi
+    extra_modules:
+      - chain
+      - efinet
+bootloaders_modules:
+  - btrfs
+  - ext2
+  - xfs
+  - jfs
+  - reiserfs
+  - all_video
+  - boot
+  - cat
+  - configfile
+  - echo
+  - fat
+  - font
+  - gfxmenu
+  - gfxterm
+  - gzio
+  - halt
+  - iso9660
+  - jpeg
+  - linux
+  - loadenv
+  - minicmd
+  - normal
+  - part_apple
+  - part_gpt
+  - part_msdos
+  - password_pbkdf2
+  - png
+  - reboot
+  - search
+  - search_fs_file
+  - search_fs_uuid
+  - search_label
+  - sleep
+  - test
+  - "true"
+  - video
+  - mdraid09
+  - mdraid1x
+  - lvm
+  - serial
+  - regexp
+  - tr
+  - tftp
+  - http
+  - luks
+  - gcry_rijndael
+  - gcry_sha1
+  - gcry_sha256
+syslinux_dir: '/usr/share/syslinux'
+syslinux_memdisk_folder: '/usr/share/syslinux'
+syslinux_pxelinux_folder: '/usr/share/syslinux'
+grub2_mod_dir: '/usr/share/grub2'
+bootloaders_shim_folder: '/usr/share/efi/*/'
+bootloaders_shim_file: 'shim\.efi'
+bootloaders_ipxe_folder: '/usr/share/ipxe/'
+
+# Email out a report when Cobbler finishes installing a system.
+# enabled: set to true to turn this feature on
+# sender: optional
+# email: which addresses to email
+# smtp_server: used to specify another server for an MTA
+# subject: use the default subject unless overridden
+build_reporting_enabled: false
+build_reporting_sender: ""
+build_reporting_email: [ 'root@localhost' ]
+build_reporting_smtp_server: "localhost"
+build_reporting_subject: ""
+build_reporting_ignorelist: []
+
+# Cheetah-language autoinstall templates can import Python modules. While this is a useful feature, it is not safe to
+# allow them to import anything they want. This whitelists which modules can be imported through Cheetah. Users can
+# expand this as needed but should never allow modules such as subprocess or those that allow access to the filesystem
+# as Cheetah templates are evaluated by cobblerd as code.
+cheetah_import_whitelist:
+ - "random"
+ - "re"
+ - "time"
+ - "netaddr"
+
+# Default "createrepo_flags" to use for new repositories. If you have createrepo >= 0.4.10, consider
+# "-c cache --update -C", which can dramatically improve your "cobbler reposync" time. "-s sha" enables working with
+# Fedora repos from F11/F12 from EL-4 or EL-5 without python-hashlib installed (which is not available on EL-4)
+createrepo_flags: "-c cache -s sha"
+
+# if no autoinstall template is specified to profile add, use this template (path is relative to template root)
+autoinstall: "default.ks"
+
+# configure all installed systems to use these nameservers by default
+# unless defined differently in the profile.  For DHCP configurations
+# you probably do /not/ want to supply this.
+default_name_servers: []
+default_name_servers_search: []
+
+# if using the authz_ownership module (see the Wiki), objects
+# created without specifying an owner are assigned to this
+# owner and/or group.  Can be a comma seperated list.
+default_ownership:
+ - "admin"
+
+# Cobbler has various sample automatic installation templates stored
+# in /var/lib/cobbler/templates/.  This controls
+# what install (root) password is set up for those
+# systems that reference this variable.  The factory
+# default is "cobbler" and Cobbler check will warn if
+# this is not changed.
+# The simplest way to change the password is to run
+# openssl passwd -1
+# and put the output between the "" below.
+default_password_crypted: "$1$mF86/UHC$WvcIcX2t6crBz2onWxyac."
+
+# the default template type to use in the absence of any
+# other detected template. If you do not specify the template
+# with '#template=<template_type>' on the first line of your
+# templates/snippets, Cobbler will assume try to use the
+# following template engine to parse the templates.
+#
+# Current valid values are: cheetah, jinja2
+default_template_type: "cheetah"
+
+# for libvirt based installs in koan, if no virt bridge
+# is specified, which bridge do we try?  For EL 4/5 hosts
+# this should be xenbr0, for all versions of Fedora, try
+# "virbr0".  This can be overriden on a per-profile
+# basis or at the koan command line though this saves
+# typing to just set it here to the most common option.
+default_virt_bridge: xenbr0
+
+# use this as the default disk size for virt guests (GB)
+default_virt_file_size: 5.0
+
+# use this as the default memory size for virt guests (MB)
+default_virt_ram: 512
+
+# if koan is invoked without --virt-type and no virt-type
+# is set on the profile/system, what virtualization type
+# should be assumed?  Values: xenpv, xenfv, qemu, vmware
+# (NOTE: this does not change what virt_type is chosen by import)
+default_virt_type: xenpv
+
+# enable iPXE booting? Enabling this option will cause Cobbler
+# to copy the undionly.kpxe file to the tftp root directory,
+# and if a profile/system is configured to boot via iPXE it will
+# chain load off pxelinux.0.
+# Default: false
+enable_ipxe: false
+
+# controls whether Cobbler will add each new profile entry to the default
+# PXE boot menu.  This can be over-ridden on a per-profile
+# basis when adding/editing profiles with --enable-menu=false/true.  Users
+# should ordinarily leave this setting enabled unless they are concerned
+# with accidental reinstalls from users who select an entry at the PXE
+# boot menu.  Adding a password to the boot menus templates
+# may also be a good solution to prevent unwanted reinstallations
+enable_menu: true
+
+# change this port if Apache is not running plaintext on port
+# 80.  Most people can leave this alone.
+http_port: 80
+
+# kernel options that should be present in every Cobbler installation.
+# kernel options can also be applied at the distro/profile/system
+# level.
+kernel_options: {}
+
+# configuration options if using the authn_ldap module. See the
+# the Wiki for details.  This can be ignored if you are not using
+# LDAP for WebUI/XMLRPC authentication.
+ldap_server: "ldap.example.com"
+ldap_base_dn: "DC=example,DC=com"
+ldap_port: 389
+ldap_tls: true
+ldap_anonymous_bind: true
+ldap_search_bind_dn: ''
+ldap_search_passwd: ''
+ldap_search_prefix: 'uid='
+ldap_tls_cacertfile: ''
+ldap_tls_keyfile: ''
+ldap_tls_certfile: ''
+ldap_tls_cacertdir: ''
+ldap_tls_cipher_suite: ''
+ldap_tls_reqcert: ''
+
+# Cobbler has a feature that allows for integration with config management
+# systems such as Puppet.  The following parameters work in conjunction with
+# --mgmt-classes  and are described in further detail at:
+# https://github.com/cobbler/cobbler/wiki/Using-cobbler-with-a-configuration-management-system
+mgmt_classes: []
+mgmt_parameters:
+ from_cobbler: true
+
+# if enabled, this setting ensures that puppet is installed during
+# machine provision, a client certificate is generated and a
+# certificate signing request is made with the puppet master server
+puppet_auto_setup: false
+
+# when puppet starts on a system after installation it needs to have
+# its certificate signed by the puppet master server. Enabling the
+# following feature will ensure that the puppet server signs the
+# certificate after installation if the puppet master server is
+# running on the same machine as Cobbler. This requires
+# puppet_auto_setup above to be enabled
+sign_puppet_certs_automatically: false
+
+# location of the puppet executable, used for revoking certificates
+puppetca_path: "/usr/bin/puppet"
+
+# when a puppet managed machine is reinstalled it is necessary to
+# remove the puppet certificate from the puppet master server before a
+# new certificate is signed (see above). Enabling the following
+# feature will ensure that the certificate for the machine to be
+# installed is removed from the puppet master server if the puppet
+# master server is running on the same machine as Cobbler. This
+# requires puppet_auto_setup above to be enabled
+remove_old_puppet_certs_automatically: false
+
+# choose a --server argument when running puppetd/puppet agent during autoinstall
+puppet_server: 'puppet'
+
+# let Cobbler know that you're using a newer version of puppet
+# choose version 3 to use: 'puppet agent'; version 2 uses status quo: 'puppetd'
+puppet_version: 2
+
+# choose whether to enable puppet parameterized classes or not.
+# puppet versions prior to 2.6.5 do not support parameters
+puppet_parameterized_classes: true
+
+# set to true to enable Cobbler's DHCP management features.
+# the choice of DHCP management engine is in /etc/cobbler/modules.conf
+# See the docs (https://cobbler.readthedocs.io/en/latest/user-guide.html#dhcp-management) for more info
+manage_dhcp: false
+
+# set to true to enable DHCP IPv6 address configuration generation.
+# This currently only works with manager.isc DHCP module (isc dhcpd6 daemon)
+# See /etc/cobbler/modules.conf whether this isc module is chosen for dhcp
+# generation.
+manage_dhcp_v6: false
+
+# set to true to enable DHCP IPv4 address configuration generation.
+# This currently only works with manager.isc DHCP module
+# Other dhcp modules ignore this and above settings
+manage_dhcp_v4: false
+
+# if using Cobbler with manage_dhcp, put the IP address
+# of the Cobbler server here so that PXE booting guests can find it
+# if you do not set this correctly, this will be manifested in TFTP open timeouts.
+next_server_v4: 127.0.0.1
+
+# And the same if you set manage_dhcp_v6 to true.
+# Set the cobbler IPv6 address here so that PXE booting guests can find it
+next_server_v6: "::1"
+
+# set to true to enable Cobbler's DNS management features.
+# the choice of DNS management engine is in /etc/cobbler/modules.conf
+# needs manage_forward_zones and manage_reverse_zones to be set, too.
+manage_dns: false
+
+# set to path of bind chroot to create bind-chroot compatible bind
+# configuration files.
+bind_chroot_path: ""
+
+# set to path where zonefiles of bind/named server are located.
+bind_zonefile_path: "/var/lib/named"
+
+# set to the ip address of the master bind DNS server for creating secondary
+# bind configuration files
+bind_master: 127.0.0.1
+
+# if using BIND (named) for DNS management in /etc/cobbler/modules.conf
+# and manage_dns is enabled (above), this lists which zones are managed
+# See the docs (https://cobbler.readthedocs.io/en/latest/user-guide.html#dns-configuration-management) for more info
+manage_forward_zones: []
+manage_reverse_zones: []
+
+# set to true to enable Cobbler's TFTP management features.
+# the choice of TFTP management engine is in /etc/cobbler/modules.conf
+manage_tftpd: true
+
+# This variable contains the location of the tftpboot directory. If this directory is not present Cobbler does not
+# start.
+# Default: "/var/lib/tftpboot"
+tftpboot_location: "/var/lib/tftpboot"
+
+# set to true to enable Cobbler's RSYNC management features.
+manage_rsync: false
+
+# settings for power management features.  optional.
+# see https://github.com/cobbler/cobbler/wiki/Power-management to learn more
+# choices (refer to codes.py):
+#    apc_snmp bladecenter bullpap drac ether_wake ilo integrity
+#    ipmilan ipmilanplus lpar rsa virsh wti
+power_management_default_type: 'ipmilanplus'
+
+# if this setting is set to true, Cobbler systems that pxe boot
+# will request at the end of their installation to toggle the
+# --netboot-enabled record in the Cobbler system record.  This eliminates
+# the potential for a PXE boot loop if the system is set to PXE
+# first in it's BIOS order.  Enable this if PXE is first in your BIOS
+# boot order, otherwise leave this disabled.   See the manpage
+# for --netboot-enabled.
+pxe_just_once: true
+
+# if this setting is set to one, triggers will be executed when systems
+# will request to toggle the --netboot-enabled record at the end of their installation.
+nopxe_with_triggers: true
+
+# This setting is only used by the code that supports using Spacewalk/Satellite
+# authentication within Cobbler Web and Cobbler XMLRPC.
+redhat_management_server: "xmlrpc.rhn.redhat.com"
+
+# if using authn_spacewalk in modules.conf to let Cobbler authenticate
+# against Satellite/Spacewalk's auth system, by default it will not allow per user
+# access into Cobbler Web and Cobbler XMLRPC.
+# in order to permit this, the following setting must be enabled HOWEVER
+# doing so will permit all Spacewalk/Satellite users of certain types to edit all
+# of Cobbler's configuration.
+# these roles are:  config_admin and org_admin
+# users should turn this on only if they want this behavior and
+# do not have a cross-multi-org seperation concern.  If you have
+# a single org in your satellite, it's probably safe to turn this
+# on and then you can use CobblerWeb alongside a Satellite install.
+redhat_management_permissive: false
+
+# specify the default Red Hat authorization key to use to register
+# system.  If left blank, no registration will be attempted.  Similarly
+# you can set the --redhat-management-key to blank on any system to
+# keep it from trying to register.
+redhat_management_key: ""
+
+# if set to true, allows /usr/bin/cobbler-register (part of the koan package)
+# to be used to remotely add new Cobbler system records to Cobbler.
+# this effectively allows for registration of new hardware from system
+# records.
+register_new_installs: false
+
+# Flags to use for dnf's reposync. You can exclude some packages by adding --exclude.
+# For example exclude source packages: --exclude=\\*.src
+reposync_flags: "--newest-only --delete --refresh --remote-time"
+
+# Flags to use for rysync's reposync. If flag 'a' is used then createrepo
+# is not ran after the rsync
+reposync_rsync_flags: "-rltDv --copy-unsafe-links"
+
+# when DHCP and DNS management are enabled, Cobbler sync can automatically
+# restart those services to apply changes.  The exception for this is
+# if using ISC for DHCP, then omapi eliminates the need for a restart.
+# omapi, however, is experimental and not recommended for most configurations.
+# If DHCP and DNS are going to be managed, but hosted on a box that
+# is not on this server, disable restarts here and write some other
+# script to ensure that the config files get copied/rsynced to the destination
+# box.  This can be done by modifying the restart services trigger.
+# Note that if manage_dhcp and manage_dns are disabled, the respective
+# parameter will have no effect.  Most users should not need to change
+# this.
+restart_dns: true
+restart_dhcp: true
+
+# install triggers are scripts in /var/lib/cobbler/triggers/install
+# that are triggered in autoinstall pre and post sections.  Any
+# executable script in those directories is run.  They can be used
+# to send email or perform other actions.  They are currently
+# run as root so if you do not need this functionality you can
+# disable it, though this will also disable "cobbler status" which
+# uses a logging trigger to audit install progress.
+run_install_triggers: true
+
+# enables a trigger which version controls all changes to /var/lib/cobbler
+# when add, edit, or sync events are performed.  This can be used
+# to revert to previous database versions, generate RSS feeds, or for
+# other auditing or backup purposes. "git" and "hg" are currently suported,
+# but git is the recommend SCM for use with this feature.
+scm_track_enabled: false
+scm_track_mode: "git"
+scm_track_author: "cobbler <cobbler@localhost>"
+scm_push_script: "/bin/true"
+
+# this is the address of the Cobbler server -- as it is used
+# by systems during the install process, it must be the address
+# or hostname of the system as those systems can see the server.
+# if you have a server that appears differently to different subnets
+# (dual homed, etc), you need to read the --server-override section
+# of the manpage for how that works.
+server: 127.0.0.1
+
+# If set to true, all commands will be forced to use the localhost address
+# instead of using the above value which can force commands like
+# cobbler sync to open a connection to a remote address if one is in the
+# configuration and would traceback.
+client_use_localhost: false
+
+# If set to "true", all commands to the API (not directly to the XMLRPC server) will go over HTTPS instead of plaintext.
+# Be sure to change the "http_port" setting to the correct value for the web server.
+client_use_https: false
+
+# Should new profiles for virtual machines default to auto booting with the physical host when the physical host
+# reboots? This can be overridden on each profile or system object.
+virt_auto_boot: true
+
+# Cobbler's web directory. Don't change this setting -- see the Wiki on "Relocating your Cobbler install" if your "/var"
+# partition is not large enough.
+webdir: "/var/www/cobbler"
+
+# Directories that will not get wiped and recreated on a "cobbler sync".
+webdir_whitelist:
+  - misc
+  - web
+  - webui
+  - localmirror
+  - repo_mirror
+  - distro_mirror
+  - images
+  - links
+  - pub
+  - repo_profile
+  - repo_system
+  - svc
+  - rendered
+  - .link_cache
+
+# Cobbler's public XMLRPC listens on this port.  Change this only
+# if absolutely needed, as you'll have to start supplying a new
+# port option to koan if it is not the default.
+xmlrpc_port: 25151
+
+# "cobbler repo add" commands set Cobbler up with repository
+# information that can be used during autoinstall and is automatically
+# set up in the Cobbler autoinstall templates.  By default, these
+# are only available at install time.  To make these repositories
+# usable on installed systems (since Cobbler makes a very convenient
+# mirror) set this to true.  Most users can safely set this to true.  Users
+# who have a dual homed Cobbler server, or are installing laptops that
+# will not always have access to the Cobbler server may wish to leave
+# this as false.  In that case, the Cobbler mirrored yum repos are still
+# accessable at http://cobbler.example.org/cblr/repo_mirror and yum
+# configuration can still be done manually.  This is just a shortcut.
+yum_post_install_mirror: true
+
+# the default yum priority for all the distros. This is only used if yum-priorities plugin is used.
+# 1=maximum
+# Tweak with caution!
+yum_distro_priority: 1
+
+# Flags to use for yumdownloader.  Not all versions may support
+# --resolve.
+yumdownloader_flags: "--resolve"
+
+# sort and indent JSON output to make it more human-readable
+serializer_pretty_json: false
+
+# replication rsync options for distros, autoinstalls, snippets set to override default value of "-avzH"
+replicate_rsync_options: "-avzH"
+
+# replication rsync options for repos set to override default value of "-avzH"
+replicate_repo_rsync_options: "-avzH"
+
+# always write DHCP entries, regardless if netboot is enabled
+always_write_dhcp_entries: false
+
+# External proxy - used by: reposync", "signature update"
+# Eg: "http://192.168.1.1:8080" (HTTP), "https://192.168.1.1:8443" (HTTPS)
+proxy_url_ext: ""
+
+# Internal proxy - used by systems to reach Cobbler for templates
+# Eg: proxy_url_int: "http://10.0.0.1:8080"
+proxy_url_int: ""
+
+# This is a directory of files that Cobbler uses to include
+# files into Jinja2 templates
+jinja2_includedir: "/var/lib/cobbler/jinja2"
+
+# Up to now, cobblerd used $server's IP address instead of the DNS name in autoinstallation
+# file settings (pxelinux.cfg files) to save bytes, which seemed required for S/390 systems.
+# This behavior can have negative impact on installs with multi-homed Cobbler servers, because
+# not all of the IP addresses may be reachable during system install.
+# This behavior was now made conditional, with default being "off".
+convert_server_to_ip: false
+
+# Leftover settings
+buildisodir: "/var/cache/cobbler/buildiso"
+cobbler_master: ""
+default_virt_disk_driver: "raw"
+grubconfig_dir: "/var/lib/cobbler/grub_config"
+iso_template_dir: "/etc/cobbler/iso"
+
+# Signatures
+signature_path: "/var/lib/cobbler/distro_signatures.json"
+signature_url: "https://cobbler.github.io/signatures/3.0.x/latest.json"
+
+# Set to true to cache of some internal operations can speed up their execution, but can slow down
+# editing objects.
+cache_enabled: false
+
+# Set to true to speed up the start of the Cobbler. When storing collections as files, the directory with the names
+# of the collection elements will be scanned without reading and parsing the files themselves. In the case of storing
+# collections in the database, a projection query is made that includes only the names of the collection elements.
+# The first time an attribute of an element other than a name is accessed, a full read of all other attributes will be
+# performed, and a recursive full read of all elements on which this element depends. At startup, a background task is
+# also launched, which, when idle, fills in all the properties of the elements of the collections.
+# Suitable for configurations with a large number of elements placed on a slow device (HDD, network).
+lazy_start: false
+
+# Include other configuration snippets. Overwriting a key from this file in a childfile will overwrite the value from
+# this file.
+include: [ "/code/tests/test_data/V3_3_3/settings.d/*.settings" ]


### PR DESCRIPTION
## Linked Items

Fixes #3628

## Description

This PR forward-ports the settings tests and migrations for 3.3.4 and 3.3.5 to the current development version. This is required to ensure order of operation during migrations.

## Behaviour changes

Old: Migrations executed in existing Cobbler instances were not part of the development branch.

New: All migrations are executed in the correct sequence again.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
