### PR TITLE
Add dosfstools to dockerfiles

### DIFF
--- a/docker/debs/Debian_10/Debian10.dockerfile
+++ b/docker/debs/Debian_10/Debian10.dockerfile
@@ -60,7 +60,8 @@ RUN apt-get update -qq && \
     libapache2-mod-wsgi-py3 \
     iproute2 \
     systemd \
-    supervisor && \
+    supervisor \
+    dosfstools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make /bin/sh point to bash, not dash

--- a/docker/debs/Debian_11/Debian11.dockerfile
+++ b/docker/debs/Debian_11/Debian11.dockerfile
@@ -62,7 +62,8 @@ RUN apt-get update -qq && \
     iproute2 \
     systemd \
     systemd-sysv \
-    supervisor && \
+    supervisor \
+    dosfstools && \
     apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Make /bin/sh point to bash, not dash

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -41,7 +41,7 @@ RUN zypper install --no-recommends -y \
     gzip                       \
     ipmitool                   \
     make                       \
-    bind                       \    
+    bind                       \
     python3                    \
     python3-Sphinx             \
     python3-coverage           \
@@ -71,6 +71,7 @@ RUN zypper install --no-recommends -y \
     wget                       \
     which                      \
     xorriso                    \
+    dosfstools                 \
     && zypper clean
 
 # Add virtualization repository

--- a/docker/rpms/Fedora_34/Fedora34.dockerfile
+++ b/docker/rpms/Fedora_34/Fedora34.dockerfile
@@ -49,7 +49,8 @@ RUN yum install -y          \
     fence-agents            \
     openldap-servers        \
     openldap-clients        \
-    supervisor
+    supervisor              \
+    dosfstools
 
 # Dependencies for system tests
 RUN dnf install -y          \

--- a/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
+++ b/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
@@ -60,7 +60,8 @@ RUN touch /var/lib/rpm/* &&   \
     syslinux                  \
     tftp-server               \
     fence-agents              \
-    supervisor
+    supervisor                \
+    dosfstools
 
 # Dependencies for system tests
 RUN touch /var/lib/rpm/* &&   \

--- a/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
@@ -45,7 +45,8 @@ RUN zypper install -y          \
     python3-PyYAML             \
     python3-wheel              \
     rpm-build                  \
-    which
+    which                      \
+    dosfstools
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -46,7 +46,8 @@ RUN zypper install -y          \
     python3-PyYAML             \
     python3-wheel              \
     rpm-build                  \
-    which
+    which                      \
+    dosfstools
 
 # Add bootloader packages
 RUN zypper install --no-recommends -y \


### PR DESCRIPTION
## Linked Items

Related to #3744.

## Description

It's a dependency to create FAT formatted images, needed for buildiso

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
