### PR TITLE
Actions: Buildiso - Fix DNS append line generation

### DIFF
--- a/changelog.d/3747.fixed
+++ b/changelog.d/3747.fixed
@@ -1,0 +1,1 @@
+Fix DNS append line generation of "cobbler buildiso"

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -92,7 +92,7 @@ class AppendLineBuilder:
         This generates the DNS configuration for the system to boot for the append line.
         :param exclude_dns: If this flag is set to True, the DNS configuration is skipped.
         """
-        if not exclude_dns or self.system_dns is not None:
+        if not exclude_dns and self.system_dns is not None:
             if self.dist.breed == "suse":
                 nameserver_key = "nameserver"
             elif self.dist.breed == "redhat":
@@ -194,7 +194,6 @@ class AppendLineBuilder:
         """
         Try to add static ip boot options to avoid DHCP (interface/ip/netmask/gw/dns)
         Check for overrides first and clear them from kernel_options
-        :return: The Tuple with the interface, IP, Netmask, Gateway and DNS information.
         """
         self._generate_static_ip_boot_interface()
         self._generate_static_ip_boot_ip()

--- a/docs/user-guide/building-isos.rst
+++ b/docs/user-guide/building-isos.rst
@@ -74,7 +74,9 @@ Building net-installer ISOs
 You have to provide the following parameters:
 
 * ``--systems``: Filter the systems you want to build the ISO for.
-* ``--exclude-dns``: Flag to add the nameservers (and other DNS information) to the append line or not.
+* ``--exclude-dns``: Flag to add the nameservers (and other DNS information) to the append line or not. This only has
+                     an effect in case you supply ``--systems``and the system contains the ``--name-servers``
+                     configuration.
 
 Examples
 ########

--- a/tests/actions/buildiso/append_line_test.py
+++ b/tests/actions/buildiso/append_line_test.py
@@ -1,0 +1,51 @@
+from cobbler.actions.buildiso.netboot import AppendLineBuilder
+from cobbler import utils
+
+
+def test_init():
+    assert isinstance(AppendLineBuilder("", {}), AppendLineBuilder)
+
+
+def test_generate_system(
+    request, cobbler_api, create_distro, create_profile, create_system
+):
+    # Arrange
+    test_distro = create_distro()
+    test_distro.breed = "suse"
+    cobbler_api.add_distro(test_distro)
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(profile_name=test_profile.name)
+    blendered_data = utils.blender(cobbler_api, False, test_system)
+    test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+    # Act
+    result = test_builder.generate_system(test_distro, test_system, False)
+
+    # Assert
+    # Very basic test yes but this is the expected result atm
+    # TODO: Make tests more sophisticated
+    assert (
+        result
+        == "  APPEND initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
+        % (test_distro.name, test_distro.name)
+    )
+
+
+def test_generate_profile(request, cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    blendered_data = utils.blender(cobbler_api, False, test_profile)
+    test_builder = AppendLineBuilder(test_distro.name, blendered_data)
+
+    # Act
+    result = test_builder.generate_profile("suse")
+
+    # Assert
+    # Very basic test yes but this is the expected result atm
+    # TODO: Make tests more sophisticated
+    assert (
+        result
+        == "  APPEND initrd=%s.img install=http://192.168.1.1:80/cblr/links/%s autoyast=default.ks"
+        % (test_distro.name, test_distro.name)
+    )

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -1,0 +1,164 @@
+import os
+
+import pytest
+
+from cobbler import enums
+from cobbler.actions import buildiso
+from cobbler.actions.buildiso.netboot import NetbootBuildiso
+from cobbler.actions.buildiso.standalone import StandaloneBuildiso
+from tests.conftest import does_not_raise
+
+
+@pytest.mark.parametrize(
+    "input_arch,result_binary_name,expected_exception",
+    [
+        (enums.Archs.X86_64, "grubx64.efi", does_not_raise()),
+        (enums.Archs.PPC, "grub.ppc64le", does_not_raise()),
+        (enums.Archs.PPC64, "grub.ppc64le", does_not_raise()),
+        (enums.Archs.PPC64EL, "grub.ppc64le", does_not_raise()),
+        (enums.Archs.PPC64LE, "grub.ppc64le", does_not_raise()),
+        (enums.Archs.AARCH64, "grubaa64.efi", does_not_raise()),
+        (enums.Archs.ARM, "bootarm.efi", does_not_raise()),
+        (enums.Archs.I386, "bootia32.efi", does_not_raise()),
+        (enums.Archs.IA64, "bootia64.efi", does_not_raise()),
+    ],
+)
+def test_calculate_grub_name(
+    input_arch,
+    result_binary_name,
+    expected_exception,
+    cobbler_api,
+    create_distro,
+):
+    # Arrange
+    test_builder = buildiso.BuildIso(cobbler_api)
+    test_distro = create_distro()
+    test_distro.arch = input_arch
+    cobbler_api.add_distro(test_distro)
+
+    # Act
+    with expected_exception:
+        result = test_builder.calculate_grub_name(test_distro)
+
+        # Assert
+        assert result == result_binary_name
+
+
+@pytest.mark.parametrize(
+    "input_kopts_dict,exepcted_output",
+    [
+        ({}, ""),
+        ({"test": 1}, " test=1"),
+        ({"test": None}, " test"),
+        ({"test": '"test"'}, ' test="test"'),
+        ({"test": "test test test"}, ' test="test test test"'),
+        ({"test": 'test "test" test'}, ' test="test "test" test"'),
+        ({"test": ['"test"']}, ' test="test"'),
+        ({"test": ['"test"', "test"]}, ' test="test" test=test'),
+    ],
+)
+def test_add_remaining_kopts(input_kopts_dict, exepcted_output):
+    # Arrange (missing)
+    # Act
+    output = buildiso.add_remaining_kopts(input_kopts_dict)
+
+    # Assert
+    assert output == exepcted_output
+
+
+def test_make_shorter(cobbler_api):
+    # Arrange
+    build_iso = NetbootBuildiso(cobbler_api)
+    distroname = "Testdistro"
+
+    # Act
+    result = build_iso.make_shorter(distroname)
+
+    # Assert
+    assert type(result) == str
+    assert distroname in build_iso.distmap
+    assert result == "1"
+
+
+def test_copy_boot_files(cobbler_api, create_distro, tmpdir):
+    # Arrange
+    target_folder = tmpdir.mkdir("target")
+    build_iso = buildiso.BuildIso(cobbler_api)
+    testdistro = create_distro()
+
+    # Act
+    build_iso.copy_boot_files(testdistro, target_folder)
+
+    # Assert
+    assert len(os.listdir(target_folder)) == 2
+
+
+def test_filter_system(cobbler_api, create_distro, create_profile, create_system):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(profile_name=test_profile.name)
+    itemlist = [test_system.name]
+    build_iso = NetbootBuildiso(cobbler_api)
+    expected_result = [test_system]
+
+    # Act
+    result = build_iso.filter_systems(itemlist)
+
+    # Assert
+    assert expected_result == result
+
+
+def test_filter_profile(cobbler_api, create_distro, create_profile):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    itemlist = [test_profile.name]
+    build_iso = buildiso.BuildIso(cobbler_api)
+    expected_result = [test_profile]
+
+    # Act
+    result = build_iso.filter_profiles(itemlist)
+
+    # Assert
+    assert expected_result == result
+
+
+def test_netboot_run(
+    cobbler_api,
+    create_distro,
+    create_loaders,
+    tmpdir,
+):
+    # Arrange
+    test_distro = create_distro()
+    build_iso = NetbootBuildiso(cobbler_api)
+    iso_location = tmpdir.join("autoinst.iso")
+
+    # Act
+    build_iso.run(iso=str(iso_location), distro_name=test_distro.name)
+
+    # Assert
+    assert iso_location.exists()
+
+
+def test_standalone_run(
+    cobbler_api,
+    create_distro,
+    create_loaders,
+    tmpdir_factory,
+):
+    # Arrange
+    iso_directory = tmpdir_factory.mktemp("isodir")
+    iso_source = tmpdir_factory.mktemp("isosource")
+    iso_location = iso_directory.join("autoinst.iso")
+    test_distro = create_distro()
+    build_iso = StandaloneBuildiso(cobbler_api)
+
+    # Act
+    build_iso.run(
+        iso=str(iso_location), distro_name=test_distro.name, source=str(iso_source)
+    )
+
+    # Assert
+    assert iso_location.exists()

--- a/tests/actions/buildiso/conftest.py
+++ b/tests/actions/buildiso/conftest.py
@@ -1,0 +1,9 @@
+import pytest
+
+from cobbler.actions import mkloaders
+
+
+@pytest.fixture(scope="function", autouse=True)
+def create_loaders(cobbler_api):
+    loaders = mkloaders.MkLoaders(cobbler_api)
+    loaders.run()


### PR DESCRIPTION
## Linked Items

Fixes #3747

## Description

`cobbler buildiso`: Fix DNS append line generation

This commit also cleans up the raw usage of the distro class in favor of the API fixtures provided by conftest.py in the root test folder.

## Behaviour changes

Old: The flag `--exclude-dns` had no effect

New: The flags for `cobbler buildiso` are now working as expected.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
