### PR TITLE
Document detail for buildiso exclude-dns param

### DIFF
--- a/docs/user-guide/building-isos.rst
+++ b/docs/user-guide/building-isos.rst
@@ -77,7 +77,7 @@ You have to provide the following parameters:
 
 * ``--systems``: Filter the systems you want to build the ISO for.
 * ``--exclude-dns``: Flag to add the nameservers (and other DNS information) to the append line or not. This only has
-  an effect in case you supply ``--systems``.
+  an effect in case you supply ``--systems`` and the system contains the ``--name-servers`` configuration.
 
 Examples
 ########


### PR DESCRIPTION
## Description

Document that systems must have the name server config when using `exclude-dns` param to generate buildiso.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [x] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
