### PR TITLE
Introduce `BaseItem` class

### DIFF
--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -550,9 +550,7 @@ class CobblerAPI:
 
     # =======================================================================
 
-    def __item_resolved_helper(
-        self, item_uuid: str, attribute: str
-    ) -> "item_base.Item":
+    def __item_resolved_helper(self, item_uuid: str, attribute: str) -> "ITEM":
         """
         This helper validates the common data for ``*_item_resolved_value``.
 
@@ -1661,7 +1659,7 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    def get_repo_config_for_profile(self, obj: "item_base.Item") -> str:
+    def get_repo_config_for_profile(self, obj: "ITEM") -> str:
         """
         Get the repository configuration for the specified profile
 
@@ -1670,7 +1668,7 @@ class CobblerAPI:
         """
         return self.yumgen.get_yum_config(obj, True)
 
-    def get_repo_config_for_system(self, obj: "item_base.Item") -> str:
+    def get_repo_config_for_system(self, obj: "ITEM") -> str:
         """
         Get the repository configuration for the specified system.
 
@@ -2030,7 +2028,7 @@ class CobblerAPI:
         """
         return self._collection_mgr.deserialize()
 
-    def deserialize_item(self, obj: "item_base.Item") -> Dict[str, Any]:
+    def deserialize_item(self, obj: "ITEM") -> Dict[str, Any]:
         """
         Load cobbler item from disk.
         Cobbler internal use only.

--- a/cobbler/autoinstall_manager.py
+++ b/cobbler/autoinstall_manager.py
@@ -12,7 +12,7 @@ from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
-    from cobbler.items.item import Item
+    from cobbler.items.abstract.base_item import ITEM
 
 
 TEMPLATING_ERROR = 1
@@ -314,7 +314,7 @@ class AutoInstallationManager:
         elif errors_type == KICKSTART_ERROR:
             self.logger.warning("Kickstart validation errors: %s", errors[0])
 
-    def validate_autoinstall_file(self, obj: "Item", is_profile: bool) -> List[Any]:
+    def validate_autoinstall_file(self, obj: "ITEM", is_profile: bool) -> List[Any]:
         """
         Validate automatic installation file used by a system/profile.
 

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -28,6 +28,7 @@ from cobbler.cexceptions import CX
 from cobbler.items import distro, image
 from cobbler.items import item as item_base
 from cobbler.items import menu, profile, repo, system
+from cobbler.items.abstract.base_item import BaseItem
 
 if TYPE_CHECKING:
     from cobbler.actions.sync import CobblerSync
@@ -35,7 +36,7 @@ if TYPE_CHECKING:
     from cobbler.cobbler_collections.manager import CollectionManager
 
 
-ITEM = TypeVar("ITEM", bound=item_base.Item)
+ITEM = TypeVar("ITEM", bound=BaseItem)
 FIND_KWARGS = Union[  # pylint: disable=invalid-name
     str, int, bool, Dict[Any, Any], List[Any]
 ]
@@ -164,7 +165,7 @@ class Collection(Generic[ITEM]):
         :returns: NotImplementedError
         """
 
-    def get(self, name: str) -> Optional[item_base.Item]:
+    def get(self, name: str) -> Optional[ITEM]:
         """
         Return object with name in the collection
 
@@ -367,7 +368,7 @@ class Collection(Generic[ITEM]):
                 raise ValueError("Unexepcted return value from find_items!")
             for item in items:
                 attr = getattr(item, "_" + dep_type[1])
-                if isinstance(attr, (str, item_base.Item)):
+                if isinstance(attr, (str, BaseItem)):
                     setattr(item, dep_type[1], newname)
                 elif isinstance(attr, list):
                     for i, attr_val in enumerate(attr):  # type: ignore

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -17,12 +17,12 @@ from cobbler.cobbler_collections.menus import Menus
 from cobbler.cobbler_collections.profiles import Profiles
 from cobbler.cobbler_collections.repos import Repos
 from cobbler.cobbler_collections.systems import Systems
-from cobbler.items.item import Item
 from cobbler.settings import Settings
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.cobbler_collections.collection import ITEM, Collection
+    from cobbler.items.abstract.base_item import BaseItem
 
     COLLECTION_UNION = Union[Menus, Distros, Repos, Profiles, Images, Systems]
 
@@ -177,7 +177,7 @@ class CollectionManager:
                     f"Check your settings!"
                 ) from error
 
-    def deserialize_one_item(self, obj: Item) -> Dict[str, Any]:
+    def deserialize_one_item(self, obj: "BaseItem") -> Dict[str, Any]:
         """
         Load a collection item from disk
 

--- a/cobbler/decorator.py
+++ b/cobbler/decorator.py
@@ -5,7 +5,7 @@ This module provides decorators that are required for Cobbler to work as expecte
 
 from typing import Any, Optional
 
-from cobbler.items import item
+from cobbler.items.abstract import base_item
 
 
 class LazyProperty(property):
@@ -17,7 +17,7 @@ class LazyProperty(property):
         if obj is None:
             return self
         if (
-            isinstance(obj, item.Item)
+            isinstance(obj, base_item.BaseItem)
             and not obj.inmemory
             and obj._has_initialized  # pyright: ignore [reportPrivateUsage]
         ):

--- a/cobbler/items/abstract/base_item.py
+++ b/cobbler/items/abstract/base_item.py
@@ -1,0 +1,467 @@
+"""
+"BaseItem" is the highest point in the object hierarchy of Cobbler. All concrete objects that can be generated should
+inherit from it or one of its derived classes.
+"""
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
+# SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
+
+import copy
+import enum
+import logging
+import re
+import uuid
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
+
+from cobbler import enums
+from cobbler.cexceptions import CX
+from cobbler.decorator import InheritableProperty, LazyProperty
+from cobbler.items.abstract.item_cache import ItemCache
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+    from cobbler.cobbler_collections.collection import ITEM
+
+
+RE_OBJECT_NAME = re.compile(r"[a-zA-Z0-9_\-.:]*$")
+
+
+class BaseItem(ABC):
+    """
+    Abstract base class to represent the common attributes that a concrete item needs to have at minimum.
+    """
+
+    # Constants
+    TYPE_NAME = "base"
+    COLLECTION_TYPE = "base"
+
+    @staticmethod
+    def _is_dict_key(name: str) -> bool:
+        """
+        Whether the attribute is part of the item's to_dict or not
+
+        :name: The attribute name.
+        """
+        return (
+            name[:1] == "_"
+            and "__" not in name
+            and name
+            not in {
+                "_last_cached_mtime",
+                "_cache",
+                "_supported_boot_loaders",
+                "_has_initialized",
+                "_inmemory",
+            }
+        )
+
+    def __init__(self, api: "CobblerAPI", *args: Any, **kwargs: Any):
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
+
+        # Attributes
+        self._ctime = 0.0
+        self._mtime = 0.0
+        self._uid = uuid.uuid4().hex
+        self._name = ""
+        self._comment = ""
+        self._owners: Union[List[str], str] = enums.VALUE_INHERITED
+        self._inmemory = (
+            False  # Set this to true after the last attribute has been initialized.
+        )
+
+        # Item Cache
+        self._cache: ItemCache = ItemCache(api)
+
+        # Global/Internal API
+        self.api = api
+        # Logger
+        self.logger = logging.getLogger()
+
+        # Bootstrap rest of the properties
+        if len(kwargs) > 0:
+            BaseItem.from_dict(self, kwargs)
+        if self._uid == "":
+            self._uid = uuid.uuid4().hex
+
+    def __eq__(self, other: Any) -> bool:
+        """
+        Comparison based on the uid for our items.
+
+        :param other: The other Item to compare.
+        :return: True if uid is equal, otherwise false.
+        """
+        if isinstance(other, BaseItem):
+            return self._uid == other.uid
+        return False
+
+    def __hash__(self):
+        """
+        Hash table for Items.
+        Requires special handling if the uid value changes and the Item
+        is present in set, frozenset, and dict types.
+
+        :return: hash(uid).
+        """
+        return hash(self._uid)
+
+    @property
+    def uid(self) -> str:
+        """
+        The uid is the internal unique representation of a Cobbler object. It should never be used twice, even after an
+        object was deleted.
+
+        :getter: The uid for the item. Should be unique across a running Cobbler instance.
+        :setter: The new uid for the object. Should only be used by the Cobbler Item Factory.
+        """
+        return self._uid
+
+    @uid.setter
+    def uid(self, uid: str) -> None:
+        """
+        Setter for the uid of the item.
+
+        :param uid: The new uid.
+        """
+        if self._uid != uid and self.COLLECTION_TYPE != BaseItem.COLLECTION_TYPE:
+            collection = self.api.get_items(self.COLLECTION_TYPE)
+            with collection.lock:
+                item = collection.get(self.name)
+                if item is not None and item.uid == self._uid:
+                    # Update uid index
+                    indx_dict = collection.indexes["uid"]
+                    del indx_dict[self._uid]
+                    indx_dict[uid] = self.name
+        self._uid = uid
+
+    @property
+    def ctime(self) -> float:
+        """
+        Property which represents the creation time of the object.
+
+        :getter: The float which can be passed to Python time stdlib.
+        :setter: Should only be used by the Cobbler Item Factory.
+        """
+        return self._ctime
+
+    @ctime.setter
+    def ctime(self, ctime: float) -> None:
+        """
+        Setter for the ctime property.
+
+        :param ctime: The time the object was created.
+        :raises TypeError: In case ``ctime`` was not of type float.
+        """
+        if not isinstance(ctime, float):  # type: ignore
+            raise TypeError("ctime needs to be of type float")
+        self._ctime = ctime
+
+    @property
+    def mtime(self) -> float:
+        """
+        Represents the last modification time of the object via the API. This is not updated automagically.
+
+        :getter: The float which can be fed into a Python time object.
+        :setter: The new time something was edited via the API.
+        """
+        return self._mtime
+
+    @mtime.setter
+    def mtime(self, mtime: float) -> None:
+        """
+        Setter for the modification time of the object.
+
+        :param mtime: The new modification time.
+        """
+        if not isinstance(mtime, float):  # type: ignore
+            raise TypeError("mtime needs to be of type float")
+        self._mtime = mtime
+
+    @property
+    def name(self) -> str:
+        """
+        Property which represents the objects name.
+
+        :getter: The name of the object.
+        :setter: Updating this has broad implications. Please try to use the ``rename()`` functionality from the
+                 corresponding collection.
+        """
+        return self._name
+
+    @name.setter
+    def name(self, name: str) -> None:
+        """
+        The objects name.
+
+        :param name: object name string
+        :raises TypeError: In case ``name`` was not of type str.
+        :raises ValueError: In case there were disallowed characters in the name.
+        """
+        if not isinstance(name, str):  # type: ignore
+            raise TypeError("name must of be type str")
+        if not RE_OBJECT_NAME.match(name):
+            raise ValueError(f"Invalid characters in name: '{name}'")
+        self._name = name
+
+    @LazyProperty
+    def comment(self) -> str:
+        """
+        For every object you are able to set a unique comment which will be persisted on the object.
+
+        :getter: The comment or an emtpy string.
+        :setter: The new comment for the item.
+        """
+        return self._comment
+
+    @comment.setter
+    def comment(self, comment: str) -> None:
+        """
+        Setter for the comment of the item.
+
+        :param comment: The new comment. If ``None`` the comment will be set to an emtpy string.
+        """
+        self._comment = comment
+
+    @InheritableProperty
+    def owners(self) -> List[Any]:
+        """
+        This is a feature which is related to the ownership module of Cobbler which gives only specific people access
+        to specific records. Otherwise this is just a cosmetic feature to allow assigning records to specific users.
+
+        .. warning:: This is never validated against a list of existing users. Thus you can lock yourself out of a
+                     record.
+
+        .. note:: This property can be set to ``<<inherit>>``.
+
+        :getter: Return the list of users which are currently assigned to the record.
+        :setter: The list of people which should be new owners. May lock you out if you are using the ownership
+                 authorization module.
+        """
+        return self._resolve("owners")
+
+    @owners.setter  # type: ignore[no-redef]
+    def owners(self, owners: Union[str, List[Any]]):
+        """
+        Setter for the ``owners`` property.
+
+        :param owners: The new list of owners. Will not be validated for existence.
+        """
+        if not isinstance(owners, (str, list)):  # type: ignore
+            raise TypeError("owners must be str or list!")
+        self._owners = self.api.input_string_or_list(owners)
+
+    @property
+    def inmemory(self) -> bool:
+        r"""
+        If set to ``false``, only the Item name is in memory. The rest of the Item's properties can be retrieved
+        either on demand or as a result of the ``load_items`` background task.
+
+        :getter: The inmemory for the item.
+        :setter: The new inmemory value for the object. Should only be used by the Cobbler serializers.
+        """
+        return self._inmemory
+
+    @inmemory.setter
+    def inmemory(self, inmemory: bool):
+        """
+        Setter for the inmemory of the item.
+
+        :param inmemory: The new inmemory value.
+        """
+        self._inmemory = inmemory
+
+    @property
+    def cache(self) -> ItemCache:
+        """
+        Getting the ItemCache object.
+
+        .. note:: This is a read only property.
+
+        :getter: This is the ItemCache object.
+        """
+        return self._cache
+
+    def check_if_valid(self) -> None:
+        """
+        Raise exceptions if the object state is inconsistent.
+
+        :raises CX: In case the name of the item is not set.
+        """
+        if not self.name:
+            raise CX("Name is required")
+
+    @abstractmethod
+    def make_clone(self) -> "ITEM":
+        """
+        Must be defined in any subclass
+        """
+
+    @abstractmethod
+    def _resolve(self, property_name: str) -> Any:
+        """
+        Resolve the ``property_name`` value in the object tree. This function traverses the tree from the object to its
+        topmost parent and returns the first value that is not inherited. If the tree does not contain a value the
+        settings are consulted.
+
+        Items that don't have the concept of Inheritance via parent objects may still inherit from the settings. It is
+        the responsibility of the concrete class to implement the correct behavior.
+
+        :param property_name: The property name to resolve.
+        :raises AttributeError: In case one of the objects try to inherit from a parent that does not have
+                                ``property_name``.
+        :return: The resolved value.
+        """
+        raise NotImplementedError("Must be implemented in a specific Item")
+
+    @classmethod
+    def _remove_depreacted_dict_keys(cls, dictionary: Dict[Any, Any]) -> None:
+        """
+        This method does remove keys which should not be deserialized and are only there for API compatibility in
+        :meth:`~cobbler.items.item.Item.to_dict`.
+
+        :param dictionary: The dict to update
+        """
+        if "ks_meta" in dictionary:
+            dictionary.pop("ks_meta")
+        if "kickstart" in dictionary:
+            dictionary.pop("kickstart")
+        if "children" in dictionary:
+            dictionary.pop("children")
+
+    def serialize(self) -> Dict[str, Any]:
+        """
+        This method is a proxy for :meth:`~cobbler.items.item.Item.to_dict` and contains additional logic for
+        serialization to a persistent location.
+
+        :return: The dictionary with the information for serialization.
+        """
+        keys_to_drop = [
+            "kickstart",
+            "ks_meta",
+            "remote_grub_kernel",
+            "remote_grub_initrd",
+        ]
+        result = self.to_dict()
+        for key in keys_to_drop:
+            result.pop(key, "")
+        return result
+
+    def deserialize(self) -> None:
+        """
+        Deserializes the object itself and, if necessary, recursively all the objects it depends on.
+        """
+        if not self._has_initialized:
+            return
+
+        item_dict = self.api.deserialize_item(self)
+        self.from_dict(item_dict)
+
+    def from_dict(self, dictionary: Dict[Any, Any]) -> None:
+        """
+        Modify this object to take on values in ``dictionary``.
+
+        :param dictionary: This should contain all values which should be updated.
+        :raises AttributeError: In case during the process of setting a value for an attribute an error occurred.
+        :raises KeyError: In case there were keys which could not be set in the item dictionary.
+        """
+        self._remove_depreacted_dict_keys(dictionary)
+        if len(dictionary) == 0:
+            return
+        old_has_initialized = self._has_initialized
+        self._has_initialized = False
+        result = copy.deepcopy(dictionary)
+        for key in dictionary:
+            lowered_key = key.lower()
+            # The following also works for child classes because self is a child class at this point and not only an
+            # Item.
+            if hasattr(self, "_" + lowered_key):
+                try:
+                    setattr(self, lowered_key, dictionary[key])
+                except AttributeError as error:
+                    raise AttributeError(
+                        f'Attribute "{lowered_key}" could not be set!'
+                    ) from error
+                result.pop(key)
+        self._has_initialized = old_has_initialized
+        self.clean_cache()
+        if len(result) > 0:
+            raise KeyError(
+                f"The following keys supplied could not be set: {result.keys()}"
+            )
+
+    def to_dict(self, resolved: bool = False) -> Dict[Any, Any]:
+        """
+        This converts everything in this object to a dictionary.
+
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                     objects raw value.
+        :return: A dictionary with all values present in this object.
+        """
+        if not self.inmemory:
+            self.deserialize()
+        cached_result = self.cache.get_dict_cache(resolved)
+        if cached_result is not None:
+            return cached_result
+
+        value: Dict[str, Any] = {}
+        for key, key_value in self.__dict__.items():
+            if BaseItem._is_dict_key(key):
+                new_key = key[1:].lower()
+                if isinstance(key_value, enum.Enum):
+                    if resolved:
+                        value[new_key] = getattr(self, new_key).value
+                    else:
+                        value[new_key] = key_value.value
+                elif new_key == "interfaces":
+                    # This is the special interfaces dict. Let's fix it before it gets to the normal process.
+                    serialized_interfaces = {}
+                    interfaces = key_value
+                    for interface_key in interfaces:
+                        serialized_interfaces[interface_key] = interfaces[
+                            interface_key
+                        ].to_dict(resolved)
+                    value[new_key] = serialized_interfaces
+                elif isinstance(key_value, list):
+                    value[new_key] = copy.deepcopy(key_value)  # type: ignore
+                elif isinstance(key_value, dict):
+                    if resolved:
+                        value[new_key] = getattr(self, new_key)
+                    else:
+                        value[new_key] = copy.deepcopy(key_value)  # type: ignore
+                elif (
+                    isinstance(key_value, str)
+                    and key_value == enums.VALUE_INHERITED
+                    and resolved
+                ):
+                    value[new_key] = getattr(self, key[1:])
+                else:
+                    value[new_key] = key_value
+        if "autoinstall" in value:
+            value.update({"kickstart": value["autoinstall"]})  # type: ignore
+        if "autoinstall_meta" in value:
+            value.update({"ks_meta": value["autoinstall_meta"]})
+        self.cache.set_dict_cache(value, resolved)
+        return value
+
+    def _clean_dict_cache(self, name: Optional[str]):
+        """
+        Clearing the Item dict cache.
+
+        :param name: The name of Item attribute or None.
+        """
+        if not self.api.settings().cache_enabled:
+            return
+
+        # Invalidating the cache of the object itself.
+        self.cache.clean_dict_cache()
+
+    def clean_cache(self, name: Optional[str] = None):
+        """
+        Clearing the Item cache.
+
+        :param name: The name of Item attribute or None.
+        """
+        if self._inmemory:
+            self._clean_dict_cache(name)

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -203,7 +203,7 @@ class Distro(item.Item):
     @classmethod
     def _remove_depreacted_dict_keys(cls, dictionary: Dict[Any, Any]):
         r"""
-        See :meth:`~cobbler.items.item.Item._remove_depreacted_dict_keys`.
+        See :meth:`~cobbler.items.item.Item._remove_deprecated_dict_keys`.
 
         :param dictionary: The dict to update
         """

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -100,27 +100,22 @@ V2.8.5:
 # SPDX-FileCopyrightText: Copyright 2006-2009, Red Hat, Inc and Others
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 
-import copy
-import enum
 import fnmatch
-import logging
 import pprint
-import re
 import uuid
-from abc import abstractmethod
+from abc import ABC
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Type, TypeVar, Union
-
-import yaml
 
 from cobbler import enums, utils
 from cobbler.cexceptions import CX
 from cobbler.decorator import InheritableDictProperty, InheritableProperty, LazyProperty
-from cobbler.items.abstract.item_cache import ItemCache
+from cobbler.items.abstract.base_item import BaseItem
 from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
-    from cobbler.cobbler_collections.collection import ITEM, ITEM_UNION
+    from cobbler.cobbler_collections.collection import ITEM_UNION
+    from cobbler.items.abstract.base_item import ITEM
     from cobbler.items.distro import Distro
     from cobbler.items.menu import Menu
     from cobbler.items.profile import Profile
@@ -128,11 +123,10 @@ if TYPE_CHECKING:
     from cobbler.settings import Settings
 
 
-RE_OBJECT_NAME = re.compile(r"[a-zA-Z0-9_\-.:]*$")
 T = TypeVar("T")
 
 
-class Item:
+class Item(BaseItem, ABC):
     """
     An Item is a serializable thing that can appear in a Collection
     """
@@ -252,27 +246,9 @@ class Item:
 
         raise TypeError(f"find cannot compare type: {type(from_obj)}")
 
-    @staticmethod
-    def __is_dict_key(name: str) -> bool:
-        """
-        Whether the attribute is part of the item's to_dict or not
-
-        :name: The attribute name.
-        """
-        return (
-            name[:1] == "_"
-            and "__" not in name
-            and name
-            not in {
-                "_last_cached_mtime",
-                "_cache",
-                "_supported_boot_loaders",
-                "_has_initialized",
-                "_inmemory",
-            }
-        )
-
-    def __init__(self, api: "CobblerAPI", is_subobject: bool = False, **kwargs: Any):
+    def __init__(
+        self, api: "CobblerAPI", *args: Any, is_subobject: bool = False, **kwargs: Any
+    ):
         """
         Constructor.  Requires a back reference to the CobblerAPI object.
 
@@ -303,17 +279,11 @@ class Item:
         :param api: The Cobbler API object which is used for resolving information.
         :param is_subobject: See above extensive description.
         """
-        # Prevent attempts to clear the to_dict cache before the object is initialized.
-        self._has_initialized = False
+        super().__init__(api, *args, **kwargs)
 
         self._parent = ""
         self._depth = 0
         self._children: List[str] = []
-        self._ctime = 0.0
-        self._mtime = 0.0
-        self._uid = uuid.uuid4().hex
-        self._name = ""
-        self._comment = ""
         self._kernel_options: Union[Dict[Any, Any], str] = {}
         self._kernel_options_post: Union[Dict[Any, Any], str] = {}
         self._autoinstall_meta: Union[Dict[Any, Any], str] = {}
@@ -321,13 +291,8 @@ class Item:
         self._boot_files: Union[Dict[Any, Any], str] = {}
         self._template_files: Dict[str, Any] = {}
         self._last_cached_mtime = 0
-        self._owners: Union[List[Any], str] = enums.VALUE_INHERITED
-        self._cache: ItemCache = ItemCache(api)
         self._is_subobject = is_subobject
         self._inmemory = True
-
-        self.logger = logging.getLogger()
-        self.api = api
 
         if len(kwargs) > 0:
             kwargs.update({"is_subobject": is_subobject})
@@ -338,27 +303,6 @@ class Item:
         if not self._has_initialized:
             self._has_initialized = True
 
-    def __eq__(self, other: Any) -> bool:
-        """
-        Comparison based on the uid for our items.
-
-        :param other: The other Item to compare.
-        :return: True if uid is equal, otherwise false.
-        """
-        if isinstance(other, Item):
-            return self._uid == other.uid
-        return False
-
-    def __hash__(self):
-        """
-        Hash table for Items.
-        Requires special handling if the uid value changes and the Item
-        is present in set, frozenset, and dict types.
-
-        :return: hash(uid).
-        """
-        return hash(self._uid)
-
     def __setattr__(self, name: str, value: Any):
         """
         Intercepting an attempt to assign a value to an attribute.
@@ -366,7 +310,7 @@ class Item:
         :name: The attribute name.
         :value: The attribute value.
         """
-        if Item.__is_dict_key(name) and self._has_initialized:
+        if Item._is_dict_key(name) and self._has_initialized:
             self.clean_cache(name)
         super().__setattr__(name, value)
 
@@ -501,130 +445,6 @@ class Item:
                 value.pop(key)  # type: ignore
 
         return value
-
-    @property
-    def uid(self) -> str:
-        """
-        The uid is the internal unique representation of a Cobbler object. It should never be used twice, even after an
-        object was deleted.
-
-        :getter: The uid for the item. Should be unique across a running Cobbler instance.
-        :setter: The new uid for the object. Should only be used by the Cobbler Item Factory.
-        """
-        return self._uid
-
-    @uid.setter
-    def uid(self, uid: str) -> None:
-        """
-        Setter for the uid of the item.
-
-        :param uid: The new uid.
-        """
-        if self._uid != uid and self.COLLECTION_TYPE != Item.COLLECTION_TYPE:
-            collection = self.api.get_items(self.COLLECTION_TYPE)
-            with collection.lock:
-                item = collection.get(self.name)
-                if item is not None and item.uid == self._uid:
-                    # Update uid index
-                    indx_dict = collection.indexes["uid"]
-                    del indx_dict[self._uid]
-                    indx_dict[uid] = self.name
-        self._uid = uid
-
-    @property
-    def ctime(self) -> float:
-        """
-        Property which represents the creation time of the object.
-
-        :getter: The float which can be passed to Python time stdlib.
-        :setter: Should only be used by the Cobbler Item Factory.
-        """
-        return self._ctime
-
-    @ctime.setter
-    def ctime(self, ctime: float) -> None:
-        """
-        Setter for the ctime property.
-
-        :param ctime: The time the object was created.
-        :raises TypeError: In case ``ctime`` was not of type float.
-        """
-        if not isinstance(ctime, float):  # type: ignore
-            raise TypeError("ctime needs to be of type float")
-        self._ctime = ctime
-
-    @property
-    def name(self) -> str:
-        """
-        Property which represents the objects name.
-
-        :getter: The name of the object.
-        :setter: Updating this has broad implications. Please try to use the ``rename()`` functionality from the
-                 corresponding collection.
-        """
-        return self._name
-
-    @name.setter
-    def name(self, name: str) -> None:
-        """
-        The objects name.
-
-        :param name: object name string
-        :raises TypeError: In case ``name`` was not of type str.
-        :raises ValueError: In case there were disallowed characters in the name.
-        """
-        if not isinstance(name, str):  # type: ignore
-            raise TypeError("name must of be type str")
-        if not RE_OBJECT_NAME.match(name):
-            raise ValueError(f"Invalid characters in name: '{name}'")
-        self._name = name
-
-    @LazyProperty
-    def comment(self) -> str:
-        """
-        For every object you are able to set a unique comment which will be persisted on the object.
-
-        :getter: The comment or an emtpy string.
-        :setter: The new comment for the item.
-        """
-        return self._comment
-
-    @comment.setter
-    def comment(self, comment: str) -> None:
-        """
-        Setter for the comment of the item.
-
-        :param comment: The new comment. If ``None`` the comment will be set to an emtpy string.
-        """
-        self._comment = comment
-
-    @InheritableProperty
-    def owners(self) -> List[Any]:
-        """
-        This is a feature which is related to the ownership module of Cobbler which gives only specific people access
-        to specific records. Otherwise this is just a cosmetic feature to allow assigning records to specific users.
-
-        .. warning:: This is never validated against a list of existing users. Thus you can lock yourself out of a
-                     record.
-
-        .. note:: This property can be set to ``<<inherit>>``.
-
-        :getter: Return the list of users which are currently assigned to the record.
-        :setter: The list of people which should be new owners. May lock you out if you are using the ownership
-                 authorization module.
-        """
-        return self._resolve("owners")
-
-    @owners.setter  # type: ignore[no-redef]
-    def owners(self, owners: Union[str, List[Any]]):
-        """
-        Setter for the ``owners`` property.
-
-        :param owners: The new list of owners. Will not be validated for existence.
-        """
-        if not isinstance(owners, (str, list)):  # type: ignore
-            raise TypeError("owners must be str or list!")
-        self._owners = input_converters.input_string_or_list(owners)
 
     @InheritableDictProperty
     def kernel_options(self) -> Dict[Any, Any]:
@@ -814,27 +634,6 @@ class Item:
         if not isinstance(depth, int):  # type: ignore
             raise TypeError("depth needs to be of type int")
         self._depth = depth
-
-    @property
-    def mtime(self) -> float:
-        """
-        Represents the last modification time of the object via the API. This is not updated automagically.
-
-        :getter: The float which can be fed into a Python time object.
-        :setter: The new time something was edited via the API.
-        """
-        return self._mtime
-
-    @mtime.setter
-    def mtime(self, mtime: float) -> None:
-        """
-        Setter for the modification time of the object.
-
-        :param mtime: The new modification time.
-        """
-        if not isinstance(mtime, float):  # type: ignore
-            raise TypeError("mtime needs to be of type float")
-        self._mtime = mtime
 
     @LazyProperty
     def parent(self) -> Optional[Union["System", "Profile", "Distro", "Menu"]]:
@@ -1104,142 +903,6 @@ class Item:
             return pprint.pformat(raw)
         return raw
 
-    def check_if_valid(self) -> None:
-        """
-        Raise exceptions if the object state is inconsistent.
-
-        :raises CX: In case the name of the item is not set.
-        """
-        if not self.name:
-            raise CX("Name is required")
-
-    @abstractmethod
-    def make_clone(self) -> "ITEM":  # type: ignore
-        """
-        Must be defined in any subclass
-        """
-        raise NotImplementedError("Must be implemented in a specific Item")
-
-    @classmethod
-    def _remove_depreacted_dict_keys(cls, dictionary: Dict[Any, Any]) -> None:
-        """
-        This method does remove keys which should not be deserialized and are only there for API compatibility in
-        :meth:`~cobbler.items.item.Item.to_dict`.
-
-        :param dictionary: The dict to update
-        """
-        if "ks_meta" in dictionary:
-            dictionary.pop("ks_meta")
-        if "kickstart" in dictionary:
-            dictionary.pop("kickstart")
-        if "children" in dictionary:
-            dictionary.pop("children")
-
-    def from_dict(self, dictionary: Dict[Any, Any]) -> None:
-        """
-        Modify this object to take on values in ``dictionary``.
-
-        :param dictionary: This should contain all values which should be updated.
-        :raises AttributeError: In case during the process of setting a value for an attribute an error occurred.
-        :raises KeyError: In case there were keys which could not be set in the item dictionary.
-        """
-        self._remove_depreacted_dict_keys(dictionary)
-        if len(dictionary) == 0:
-            return
-        old_has_initialized = self._has_initialized
-        self._has_initialized = False
-        result = copy.deepcopy(dictionary)
-        for key in dictionary:
-            lowered_key = key.lower()
-            # The following also works for child classes because self is a child class at this point and not only an
-            # Item.
-            if hasattr(self, "_" + lowered_key):
-                try:
-                    setattr(self, lowered_key, dictionary[key])
-                except AttributeError as error:
-                    raise AttributeError(
-                        f'Attribute "{lowered_key}" could not be set!'
-                    ) from error
-                result.pop(key)
-        self._has_initialized = old_has_initialized
-        self.clean_cache()
-        if len(result) > 0:
-            raise KeyError(
-                f"The following keys supplied could not be set: {result.keys()}"
-            )
-
-    def to_dict(self, resolved: bool = False) -> Dict[Any, Any]:
-        """
-        This converts everything in this object to a dictionary.
-
-        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
-                     objects raw value.
-        :return: A dictionary with all values present in this object.
-        """
-        if not self.inmemory:
-            self.deserialize()
-        cached_result = self.cache.get_dict_cache(resolved)
-        if cached_result is not None:
-            return cached_result
-
-        value: Dict[str, Any] = {}
-        for key, key_value in self.__dict__.items():
-            if self.__is_dict_key(key):
-                new_key = key[1:].lower()
-                if isinstance(key_value, enum.Enum):
-                    if resolved:
-                        value[new_key] = getattr(self, new_key).value
-                    else:
-                        value[new_key] = key_value.value
-                elif new_key == "interfaces":
-                    # This is the special interfaces dict. Lets fix it before it gets to the normal process.
-                    serialized_interfaces = {}
-                    interfaces = key_value
-                    for interface_key in interfaces:
-                        serialized_interfaces[interface_key] = interfaces[
-                            interface_key
-                        ].to_dict(resolved)
-                    value[new_key] = serialized_interfaces
-                elif isinstance(key_value, list):
-                    value[new_key] = copy.deepcopy(key_value)  # type: ignore
-                elif isinstance(key_value, dict):
-                    if resolved:
-                        value[new_key] = getattr(self, new_key)
-                    else:
-                        value[new_key] = copy.deepcopy(key_value)  # type: ignore
-                elif (
-                    isinstance(key_value, str)
-                    and key_value == enums.VALUE_INHERITED
-                    and resolved
-                ):
-                    value[new_key] = getattr(self, key[1:])
-                else:
-                    value[new_key] = key_value
-        if "autoinstall" in value:
-            value.update({"kickstart": value["autoinstall"]})  # type: ignore
-        if "autoinstall_meta" in value:
-            value.update({"ks_meta": value["autoinstall_meta"]})
-        self.cache.set_dict_cache(value, resolved)
-        return value
-
-    def serialize(self) -> Dict[str, Any]:
-        """
-        This method is a proxy for :meth:`~cobbler.items.item.Item.to_dict` and contains additional logic for
-        serialization to a persistent location.
-
-        :return: The dictionary with the information for serialization.
-        """
-        keys_to_drop = [
-            "kickstart",
-            "ks_meta",
-            "remote_grub_kernel",
-            "remote_grub_initrd",
-        ]
-        result = self.to_dict()
-        for key in keys_to_drop:
-            result.pop(key, "")
-        return result
-
     def deserialize(self) -> None:
         """
         Deserializes the object itself and, if necessary, recursively all the objects it depends on.
@@ -1271,14 +934,14 @@ class Item:
                                 deserialize_ancestor(ancestor_item_type, ancestor_name)
         self.from_dict(item_dict)
 
-    def grab_tree(self) -> List[Union["Item", "Settings"]]:
+    def grab_tree(self) -> List[Union["ITEM", "Settings"]]:
         """
         Climb the tree and get every node.
 
         :return: The list of items with all parents from that object upwards the tree. Contains at least the item
                  itself and the settings of Cobbler.
         """
-        results: List[Union["Item", "Settings"]] = [self]
+        results: List[Union["ITEM", "Settings"]] = [self]
         parent = self.logical_parent
         while parent is not None:
             results.append(parent)
@@ -1291,23 +954,10 @@ class Item:
         )
         return results
 
-    @property
-    def cache(self) -> ItemCache:
-        """
-        Gettinging the ItemCache oject.
-
-        .. note:: This is a read only property.
-
-        :getter: This is the ItemCache oject.
-        """
-        return self._cache
-
     def _clean_dict_cache(self, name: Optional[str]):
         """
         Clearing the Item dict cache.
 
-        :param obj: The object whose modification invalidates the dict cache.
-                    Can be Item, Settings or SIGNATURE_CACHE.
         :param name: The name of Item attribute or None.
         """
         if not self.api.settings().cache_enabled:
@@ -1326,34 +976,3 @@ class Item:
 
         # Invalidating the cache of the object itself.
         self.cache.clean_dict_cache()
-
-    def clean_cache(self, name: Optional[str] = None):
-        """
-        Clearing the Item cache.
-
-        :param obj: The object whose modification invalidates the dict cache.
-                    Can be Item, Settings or SIGNATURE_CACHE.
-        :param name: The name of Item attribute or None.
-        """
-        if self._inmemory:
-            self._clean_dict_cache(name)
-
-    @property
-    def inmemory(self) -> bool:
-        r"""
-        If set to ``false``, only the Item name is in memory. The rest of the Item's properties can be retrieved
-        either on demand or as a result of the ``load_items`` background task.
-
-        :getter: The inmemory for the item.
-        :setter: The new inmemory value for the object. Should only be used by the Cobbler serializers.
-        """
-        return self._inmemory
-
-    @inmemory.setter
-    def inmemory(self, inmemory: bool):
-        """
-        Setter for the inmemory of the item.
-
-        :param inmemory: The new inmemory value.
-        """
-        self._inmemory = inmemory

--- a/cobbler/modules/authorization/ownership.py
+++ b/cobbler/modules/authorization/ownership.py
@@ -15,7 +15,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
-    from cobbler.items.item import Item
+    from cobbler.items.abstract.base_item import ITEM
     from cobbler.items.profile import Profile
     from cobbler.items.system import System
 
@@ -116,7 +116,7 @@ def __authorize_snippet(
 
 
 def __is_user_allowed(
-    obj: "Item", groups: List[str], user: str, resource: Any, arg1: Any, arg2: Any
+    obj: "ITEM", groups: List[str], user: str, resource: Any, arg1: Any, arg2: Any
 ) -> int:
     """
     Check if a user is allowed to access the resource in question.

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -150,6 +150,7 @@ from xmlrpc.server import SimpleXMLRPCRequestHandler
 from cobbler import autoinstall_manager, configgen, enums, tftpgen, utils
 from cobbler.cexceptions import CX
 from cobbler.items import item, network_interface, system
+from cobbler.items.abstract import base_item
 from cobbler.utils import signatures
 from cobbler.utils.event import CobblerEvent
 from cobbler.utils.thread import CobblerThread
@@ -2963,7 +2964,7 @@ class CobblerXMLRPCInterface:
             )
             return False
         # Validate sys_name with item regex
-        if not re.fullmatch(item.RE_OBJECT_NAME, sys_name):
+        if not re.fullmatch(base_item.RE_OBJECT_NAME, sys_name):
             self.logger.warning(
                 "upload_log_data - The provided sys_name contained invalid characters!"
             )

--- a/cobbler/settings/migrations/V3_3_4.py
+++ b/cobbler/settings/migrations/V3_3_4.py
@@ -5,6 +5,8 @@ Migration from V3.3.3 to V3.3.4
 # SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
+from typing import Any, Dict
+
 from schema import SchemaError  # type: ignore
 
 from cobbler.settings.migrations import V3_3_3
@@ -13,7 +15,7 @@ from cobbler.settings.migrations import V3_3_3
 schema = V3_3_3.schema
 
 
-def validate(settings: dict) -> bool:
+def validate(settings: Dict[str, Any]) -> bool:
     """
     Checks that a given settings dict is valid according to the reference V3.3.1 schema ``schema``.
 
@@ -27,7 +29,7 @@ def validate(settings: dict) -> bool:
     return True
 
 
-def normalize(settings: dict) -> dict:
+def normalize(settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     If data in ``settings`` is valid the validated data is returned.
 
@@ -37,7 +39,7 @@ def normalize(settings: dict) -> dict:
     return schema.validate(settings)  # type: ignore
 
 
-def migrate(settings: dict) -> dict:
+def migrate(settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     Migration of the settings ``settings`` to version V3.3.4 settings
 

--- a/cobbler/settings/migrations/V3_3_5.py
+++ b/cobbler/settings/migrations/V3_3_5.py
@@ -5,6 +5,8 @@ Migration from V3.3.4 to V3.3.5
 # SPDX-FileCopyrightText: 2024 Enno Gotthold <egotthold@suse.com
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
+from typing import Any, Dict
+
 from schema import Optional, Schema, SchemaError  # type: ignore
 
 from cobbler.settings.migrations import V3_3_4
@@ -235,7 +237,7 @@ schema = Schema(
 )
 
 
-def validate(settings: dict) -> bool:
+def validate(settings: Dict[str, Any]) -> bool:
     """
     Checks that a given settings dict is valid according to the reference V3.3.1 schema ``schema``.
 
@@ -249,7 +251,7 @@ def validate(settings: dict) -> bool:
     return True
 
 
-def normalize(settings: dict) -> dict:
+def normalize(settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     If data in ``settings`` is valid the validated data is returned.
 
@@ -259,7 +261,7 @@ def normalize(settings: dict) -> dict:
     return schema.validate(settings)  # type: ignore
 
 
-def migrate(settings: dict) -> dict:
+def migrate(settings: Dict[str, Any]) -> Dict[str, Any]:
     """
     Migration of the settings ``settings`` to version V3.3.4 settings
 

--- a/cobbler/settings/migrations/V3_3_5.py
+++ b/cobbler/settings/migrations/V3_3_5.py
@@ -143,6 +143,7 @@ schema = Schema(
         "default_virt_type": str,
         "enable_ipxe": bool,
         "enable_menu": bool,
+        Optional("extra_settings_list", default=[]): [str],
         "http_port": int,
         "include": [str],
         Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -44,7 +44,6 @@ from cobbler.utils import process_management
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.cobbler_collections.collection import ITEM, ITEM_UNION
-    from cobbler.items.item import Item
     from cobbler.settings import Settings
 
 CHEETAH_ERROR_DISCLAIMER = """
@@ -775,7 +774,7 @@ def rsync_files(src: str, dst: str, args: str, quiet: bool = True) -> bool:
 
 def run_triggers(
     api: "CobblerAPI",
-    ref: Optional["Item"] = None,
+    ref: Optional["ITEM"] = None,
     globber: str = "",
     additional: Optional[List[Any]] = None,
 ) -> None:

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -15,7 +15,7 @@ from uuid import UUID
 import netaddr
 
 from cobbler import enums, utils
-from cobbler.items import item
+from cobbler.items.abstract import base_item
 from cobbler.utils import input_converters, signatures
 
 if TYPE_CHECKING:
@@ -628,4 +628,4 @@ def validate_obj_name(object_name: str) -> bool:
     """
     if not isinstance(object_name, str):  # type: ignore
         return False
-    return bool(re.fullmatch(item.RE_OBJECT_NAME, object_name))
+    return bool(re.fullmatch(base_item.RE_OBJECT_NAME, object_name))

--- a/cobbler/yumgen.py
+++ b/cobbler/yumgen.py
@@ -14,7 +14,7 @@ from cobbler import templar, utils
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
-    from cobbler.items.item import Item
+    from cobbler.items.abstract.base_item import ITEM
 
 
 class YumGen:
@@ -32,7 +32,7 @@ class YumGen:
         self.settings = api.settings()
         self.templar = templar.Templar(self.api)
 
-    def get_yum_config(self, obj: "Item", is_profile: bool) -> str:
+    def get_yum_config(self, obj: "ITEM", is_profile: bool) -> str:
         """
         Return one large yum repo config blob suitable for use by any target system that requests it.
 

--- a/system-tests/tests/settings-cli-migrate
+++ b/system-tests/tests/settings-cli-migrate
@@ -253,6 +253,8 @@ cheetah_import_whitelist:
 - netaddr
 createrepo_flags: --cachedir=cache --update
 default_password_crypted: /UHC.
+default_virt_bridge: xenbr0
+default_virt_type: xenpv
 grub2_mod_dir: '@@grub_mod_folder@@'
 ldap_base_dn: DC=example,DC=com
 ldap_server: ldap.example.com

--- a/tests/items/base_item_test.py
+++ b/tests/items/base_item_test.py
@@ -1,0 +1,186 @@
+import copy
+from typing import Any, List, Optional
+
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.cobbler_collections.collection import ITEM
+from cobbler.items.abstract.base_item import BaseItem
+
+from tests.conftest import does_not_raise
+
+
+class MockItem(BaseItem):
+    def __init__(self, api: "CobblerAPI", *args: Any, **kwargs: Any):
+        super().__init__(api, *args, **kwargs)
+        self._inmemory = True
+
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
+        if not self._has_initialized:
+            self._has_initialized = True
+
+    def make_clone(self) -> ITEM:
+        _dict = copy.deepcopy(self.to_dict())
+        # Drop attributes which are computed from other attributes
+        computed_properties = ["uid"]
+        for property_name in computed_properties:
+            _dict.pop(property_name, None)
+        return MockItem(self.api, **_dict)
+
+    def _resolve(self, property_name: str) -> Any:
+        settings_name = property_name
+        if property_name == "owners":
+            settings_name = "default_ownership"
+        attribute = "_" + property_name
+        attribute_value = getattr(self, attribute)
+
+        if attribute_value == enums.VALUE_INHERITED:
+            settings = self.api.settings()
+            possible_return = None
+            if hasattr(settings, settings_name):
+                possible_return = getattr(settings, settings_name)
+            elif hasattr(settings, f"default_{settings_name}"):
+                possible_return = getattr(settings, f"default_{settings_name}")
+
+            if possible_return is not None:
+                return possible_return
+
+        return attribute_value
+
+
+def test_uid(cobbler_api: CobblerAPI):
+    """
+    Assert that an abstract Cobbler Item can use the Getter and Setter of the uid property correctly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+
+    # Act
+    titem.uid = "uid"
+
+    # Assert
+    assert titem.uid == "uid"
+
+
+@pytest.mark.parametrize(
+    "input_ctime,expected_exception,expected_result",
+    [("", pytest.raises(TypeError), None), (0.0, does_not_raise(), 0.0)],
+)
+def test_ctime(
+    cobbler_api: CobblerAPI,
+    input_ctime: Any,
+    expected_exception: Any,
+    expected_result: float,
+):
+    """
+    Assert that an abstract Cobbler Item can use the Getter and Setter of the ctime property correctly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+
+    # Act
+    with expected_exception:
+        titem.ctime = input_ctime
+
+        # Assert
+        assert titem.ctime == expected_result
+
+
+@pytest.mark.parametrize(
+    "value,expected_exception",
+    [
+        (0.0, does_not_raise()),
+        (0, pytest.raises(TypeError)),
+        ("", pytest.raises(TypeError)),
+    ],
+)
+def test_mtime(cobbler_api: CobblerAPI, value: Any, expected_exception: Any):
+    """
+    Assert that an abstract Cobbler Item can use the Getter and Setter of the mtime property correctly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+
+    # Act
+    with expected_exception:
+        titem.mtime = value
+
+        # Assert
+        assert titem.mtime == value
+
+
+def test_name(cobbler_api: CobblerAPI):
+    """
+    Assert that an abstract Cobbler Item can use the Getter and Setter of the name property correctly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+
+    # Act
+    titem.name = "testname"
+
+    # Assert
+    assert titem.name == "testname"
+
+
+def test_comment(cobbler_api: CobblerAPI):
+    """
+    Assert that an abstract Cobbler Item can use the Getter and Setter of the comment property correctly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+
+    # Act
+    titem.comment = "my comment"
+
+    # Assert
+    assert titem.comment == "my comment"
+
+
+@pytest.mark.parametrize(
+    "input_owners,expected_exception,expected_result",
+    [
+        ("", does_not_raise(), []),
+        (enums.VALUE_INHERITED, does_not_raise(), ["admin"]),
+        ("Test1 Test2", does_not_raise(), ["Test1", "Test2"]),
+        (["Test1", "Test2"], does_not_raise(), ["Test1", "Test2"]),
+        (False, pytest.raises(TypeError), None),
+    ],
+)
+def test_owners(
+    cobbler_api: CobblerAPI,
+    input_owners: Any,
+    expected_exception: Any,
+    expected_result: Optional[List[str]],
+):
+    """
+    Assert that an abstract Cobbler Item can use the Getter and Setter of the owners property correctly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+
+    # Act
+    with expected_exception:
+        titem.owners = input_owners
+
+        # Assert
+        assert titem.owners == expected_result
+
+
+def test_check_if_valid(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Asserts that the check for a valid item is performed successfuly.
+    """
+    # Arrange
+    titem = MockItem(cobbler_api)
+    titem.name = (
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+
+    # Act
+    titem.check_if_valid()
+
+    # Assert
+    assert True  # This test passes if there is no exception raised

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -1,8 +1,8 @@
 """
-Test module that asserts that generic Cobbler Item functionallity is working as expected.
+Test module that asserts that generic Cobbler Item functionality is working as expected.
 """
 import os
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 
 import pytest
 
@@ -35,22 +35,10 @@ def test_item_create(cobbler_api: CobblerAPI):
     # Arrange
 
     # Act
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Assert
     assert isinstance(titem, Item)
-
-
-def test_make_clone(cobbler_api: CobblerAPI):
-    """
-    Assert that an abstract Cobbler Item cannot be cloned and raises the expected NotImplementedError.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act & Assert
-    with pytest.raises(NotImplementedError):
-        titem.make_clone()
 
 
 def test_from_dict(
@@ -77,20 +65,6 @@ def test_from_dict(
     assert titem.name == name
     assert titem.kernel == kernel_path
     assert titem.initrd == initrd_path
-
-
-def test_uid(cobbler_api: CobblerAPI):
-    """
-    Assert that an abstract Cobbler Item can use the Getter and Setter of the uid property correctly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    titem.uid = "uid"
-
-    # Assert
-    assert titem.uid == "uid"
 
 
 def test_children(cobbler_api: CobblerAPI):
@@ -231,64 +205,6 @@ def test_get_conceptual_parent(
     assert result.name == tmp_distro.name
 
 
-def test_name(cobbler_api: CobblerAPI):
-    """
-    Assert that an abstract Cobbler Item can use the Getter and Setter of the name property correctly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    titem.name = "testname"
-
-    # Assert
-    assert titem.name == "testname"
-
-
-def test_comment(cobbler_api: CobblerAPI):
-    """
-    Assert that an abstract Cobbler Item can use the Getter and Setter of the comment property correctly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    titem.comment = "my comment"
-
-    # Assert
-    assert titem.comment == "my comment"
-
-
-@pytest.mark.parametrize(
-    "input_owners,expected_exception,expected_result",
-    [
-        ("", does_not_raise(), []),
-        (enums.VALUE_INHERITED, does_not_raise(), ["admin"]),
-        ("Test1 Test2", does_not_raise(), ["Test1", "Test2"]),
-        (["Test1", "Test2"], does_not_raise(), ["Test1", "Test2"]),
-        (False, pytest.raises(TypeError), None),
-    ],
-)
-def test_owners(
-    cobbler_api: CobblerAPI,
-    input_owners: Any,
-    expected_exception: Any,
-    expected_result: Optional[List[str]],
-):
-    """
-    Assert that an abstract Cobbler Item can use the Getter and Setter of the owners property correctly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    with expected_exception:
-        titem.owners = input_owners
-
-        # Assert
-        assert titem.owners == expected_result
-
-
 @pytest.mark.parametrize(
     "input_kernel_options,expected_exception,expected_result",
     [
@@ -306,7 +222,7 @@ def test_kernel_options(
     Assert that an abstract Cobbler Item can use the Getter and Setter of the kernel_options property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     with expected_exception:
@@ -333,7 +249,7 @@ def test_kernel_options_post(
     Assert that an abstract Cobbler Item can use the Getter and Setter of the kernel_options_post property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     with expected_exception:
@@ -360,7 +276,7 @@ def test_autoinstall_meta(
     Assert that an abstract Cobbler Item can use the Getter and Setter of the autoinstall_meta property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     with expected_exception:
@@ -375,7 +291,7 @@ def test_template_files(cobbler_api: CobblerAPI):
     Assert that an abstract Cobbler Item can use the Getter and Setter of the template_files property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     titem.template_files = {}
@@ -389,7 +305,7 @@ def test_boot_files(cobbler_api: CobblerAPI):
     Assert that an abstract Cobbler Item can use the Getter and Setter of the boot_files property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     titem.boot_files = {}
@@ -403,7 +319,7 @@ def test_fetchable_files(cobbler_api: CobblerAPI):
     Assert that an abstract Cobbler Item can use the Getter and Setter of the fetchable_files property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     titem.fetchable_files = {}
@@ -417,7 +333,7 @@ def test_sort_key(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     Assert that the exported dict contains only the fields given in the argument.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
     titem.name = (
         request.node.originalname if request.node.originalname else request.node.name  # type: ignore
     )
@@ -450,7 +366,7 @@ def test_find_match(
     Assert that given a desired amount of key-value pairs is matching the item or not.
     """
     # Arrange
-    titem = Item(cobbler_api, **in_keys)
+    titem = Distro(cobbler_api, **in_keys)
 
     # Act
     result = titem.find_match(check_keys)
@@ -480,7 +396,7 @@ def test_find_match_single_key(
     Assert that a single given key and value match the object or not.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     result = titem.find_match_single_key(data_keys, check_key, check_value)
@@ -494,7 +410,7 @@ def test_dump_vars(cobbler_api: CobblerAPI):
     Assert that you can dump all variables of an item.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     result = titem.dump_vars(formatted_output=False)
@@ -503,7 +419,7 @@ def test_dump_vars(cobbler_api: CobblerAPI):
     print(result)
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 157
+    assert len(result) == 171
 
 
 @pytest.mark.parametrize(
@@ -523,7 +439,7 @@ def test_depth(
     Assert that an abstract Cobbler Item can use the Getter and Setter of the depth property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     with expected_exception:
@@ -533,59 +449,12 @@ def test_depth(
         assert titem.depth == expected_result
 
 
-@pytest.mark.parametrize(
-    "input_ctime,expected_exception,expected_result",
-    [("", pytest.raises(TypeError), None), (0.0, does_not_raise(), 0.0)],
-)
-def test_ctime(
-    cobbler_api: CobblerAPI,
-    input_ctime: Any,
-    expected_exception: Any,
-    expected_result: float,
-):
-    """
-    Assert that an abstract Cobbler Item can use the Getter and Setter of the ctime property correctly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    with expected_exception:
-        titem.ctime = input_ctime
-
-        # Assert
-        assert titem.ctime == expected_result
-
-
-@pytest.mark.parametrize(
-    "value,expected_exception",
-    [
-        (0.0, does_not_raise()),
-        (0, pytest.raises(TypeError)),
-        ("", pytest.raises(TypeError)),
-    ],
-)
-def test_mtime(cobbler_api: CobblerAPI, value: Any, expected_exception: Any):
-    """
-    Assert that an abstract Cobbler Item can use the Getter and Setter of the mtime property correctly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    with expected_exception:
-        titem.mtime = value
-
-        # Assert
-        assert titem.mtime == value
-
-
 def test_parent(cobbler_api: CobblerAPI):
     """
     Assert that an abstract Cobbler Item can use the Getter and Setter of the parent property correctly.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     titem.parent = ""
@@ -594,29 +463,12 @@ def test_parent(cobbler_api: CobblerAPI):
     assert titem.parent is None
 
 
-def test_check_if_valid(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
-    """
-    Asserts that the check for a valid item is performed successfuly.
-    """
-    # Arrange
-    titem = Item(cobbler_api)
-    titem.name = (
-        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
-    )
-
-    # Act
-    titem.check_if_valid()
-
-    # Assert
-    assert True  # This test passes if there is no exception raised
-
-
 def test_to_dict(cobbler_api: CobblerAPI):
     """
     Assert that a Cobbler Item can be converted to a dictionary.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     result = titem.to_dict()
@@ -631,7 +483,7 @@ def test_to_dict_resolved(cobbler_api: CobblerAPI):
     Assert that a Cobbler Item can be converted to a dictionary with resolved values.
     """
     # Arrange
-    titem = Item(cobbler_api)
+    titem = Distro(cobbler_api)
 
     # Act
     result = titem.to_dict(resolved=True)
@@ -684,7 +536,7 @@ def test_inheritance(mocker, cobbler_api: CobblerAPI, test_settings):
     """
     # Arrange
     mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
-    item = Item(cobbler_api)
+    item = Distro(cobbler_api)
 
     # Act
     for key, key_value in item.__dict__.items():

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -181,7 +181,7 @@ def test_normalize_v3_3_5():
     new_settings = V3_3_5.normalize(old_settings_dict)
 
     # Assert
-    assert len(new_settings) == 131
+    assert len(new_settings) == 132
 
 
 def test_normalize_v3_4_0_empty():


### PR DESCRIPTION
## Linked Items

This is a split-out of #3440

Changelog fragement will be added in the parent PR.

## Description

The status quo before opening this PR was that the `Item` class was the root of the object inheritance chain in Cobbler. The class contains a lot of attributes and methods that are actually not needed for many objects. As such I decided in the parent PR/feature to create a new base class that is abstract and doesn't change the existing object hierarchy to be able to base new item types of it.

The `BaseItem` class contains the generic caching logic and can inherit its properties from the settings if the concrete class implements the behaviour correctly. Lastly, the class can serialize and deserialize itself and inherited classes, specific quirks for the `System` type were kept since they can be removed once `NetworkInterface` is a dedicated collection.

## Behaviour changes

Old: Bloated abstract base item that contains a lot of unneeded logic.

New: Slimmed-down abstract item with the basics needed. Existing `Item` has the same number of properties as before this PR.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [x] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
