### PR TITLE
Fix param-file for s390 systems when long parameters

### DIFF
--- a/changelog.d/3750.fixed
+++ b/changelog.d/3750.fixed
@@ -1,0 +1,1 @@
+S390X: Add linebreaks for param files longer then 80 characters

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -151,6 +151,37 @@ class TFTPGen:
         Writes all files for tftp for a given system with the menu items handed to this method. The system must have a
         profile attached. Otherwise this method throws an error.
 
+        Directory structure:
+
+        .. code-block::
+
+           TFTP Directory/
+               pxelinux.cfg/
+                   01-aa-bb-cc-dd-ee-ff
+               grub/
+                   system/
+                       aa:bb:cc:dd:ee:ff
+                   system_link/
+                       <system_name>
+
+        Directory structure for netboot enabled S390X systems:
+
+        .. code-block::
+
+           TFTP Directory/
+               S390X/
+                   s_<system_name>
+                   s_<system_name>_conf
+                   s_<system_name>_parm
+
+        Directory structure for netboot disabled S390X systems:
+
+        .. code-block::
+
+           TFTP Directory/
+               S390X/
+                   s_<system_name>_conf
+
         :param system: The system to generate files for.
         :param menu_items: TODO
         """
@@ -178,7 +209,7 @@ class TFTPGen:
             s390_name = 'linux' + short_name[7:10]
             self.logger.info("Writing s390x pxe config for %s", short_name)
             # Always write a system specific _conf and _parm file
-            pxe_f = os.path.join(self.bootloc, enums.Archs.S390X, "s_%s" % s390_name)
+            pxe_f = os.path.join(self.bootloc, enums.Archs.S390X.value, "s_%s" % s390_name)
             conf_f = "%s_conf" % pxe_f
             parm_f = "%s_parm" % pxe_f
 
@@ -187,22 +218,30 @@ class TFTPGen:
             # FIXME: profiles also need this data!
             # gather default kernel_options and default kernel_options_s390x
             kernel_options = self.build_kernel_options(system, profile, distro,
-                                                       image, "s390x", blended.get("autoinstall", ""))
+                                                       image, enums.Archs.S390X.value, blended.get("autoinstall", ""))
+            # parm file format is fixed to 80 chars per line.
+            # All the lines are concatenated without spaces when being passed to the kernel.
+            #
+            # Recommendation: one parameter per line (ending with whitespace)
+            #
+            # NOTE: If a parameter is too long to fit into the 80 characters limit it can simply
+            # be continued in the first column of the next line.
+            #
+            # https://www.debian.org/releases/stable/s390x/ch05s01.en.html
+            # https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-zseries.html#sec-appdendix-parm-examples
+            # https://wiki.ubuntu.com/S390X/InstallationGuide
+            _parmfile_fixed_line_len = 79
             kopts_aligned = ""
-            column = 0
-            for option in kernel_options.split():
-                opt_len = len(option)
-                if opt_len > 78:
-                    kopts_aligned += '\n' + option + ' '
-                    column = opt_len + 1
-                    self.logger.error("Kernel paramer [%s] too long %s" % (option, opt_len))
-                    continue
-                if column + opt_len > 78:
-                    kopts_aligned += '\n' + option + ' '
-                    column = opt_len + 1
-                else:
-                    kopts_aligned += option + ' '
-                    column += opt_len + 1
+            kopts = kernel_options.strip()
+            # Only in case we have kernel options
+            if kopts:
+                for option in [
+                    kopts[i: i + _parmfile_fixed_line_len]
+                    for i in range(0, len(kopts), _parmfile_fixed_line_len)
+                ]:
+                    # If chunk contains multiple parameters (separated by whitespaces)
+                    # then we put them in separated lines followed by whitespace
+                    kopts_aligned += option.replace(" ", " \n") + "\n"
 
             # Write system specific zPXE file
             if system.is_management_supported():

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -1,11 +1,20 @@
 import glob
 import os
 import shutil
+from typing import TYPE_CHECKING, Any, Callable, List, Tuple
 
 import pytest
 
+from cobbler import enums
 from cobbler import tftpgen
+from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
+from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 def test_copy_bootloaders(tmpdir, cobbler_api):
@@ -62,7 +71,13 @@ def cleanup_copy_single_distro_files(cobbler_api):
     cobbler_api.remove_distro("test_copy_single_distro_files")
 
 
-def test_copy_single_distro_files(create_kernel_initrd, fk_initrd, fk_kernel, cobbler_api, cleanup_copy_single_distro_files):
+def test_copy_single_distro_files(
+    create_kernel_initrd,
+    fk_initrd,
+    fk_kernel,
+    cobbler_api,
+    cleanup_copy_single_distro_files,
+):
     # Arrange
     # Create fake files
     directory = create_kernel_initrd(fk_kernel, fk_initrd)
@@ -84,3 +99,120 @@ def test_copy_single_distro_files(create_kernel_initrd, fk_initrd, fk_kernel, co
     result_initrd = os.path.join(directory, "images", test_distro.name, fk_initrd)
     assert os.path.exists(result_kernel)
     assert os.path.exists(result_initrd)
+
+
+@pytest.fixture()
+def setup_test_write_all_system_files(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str, str, str], System],
+):
+    """
+    Setup fixture for "test_write_all_system_files".
+    """
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_system: System = create_system(profile_name=test_profile.name)  # type: ignore
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    return test_system, test_gen
+
+
+@pytest.mark.parametrize(
+    "mock_is_management_supported,mock_get_config_filename,expected_pxe_file,expected_rmfile,expected_mkdir,expected_symlink",
+    [
+        (True, ["A", "B"], 2, 1, 1, 1),
+        (True, ["A", None], 1, 0, 0, 0),
+        (True, [None, "B"], 1, 1, 1, 1),
+        # TODO: Add image based scenario
+        (False, ["A", "B"], 0, 2, 0, 0),
+        (False, ["A", None], 0, 1, 0, 0),
+    ],
+)
+def test_write_all_system_files(
+    mocker: "MockerFixture",
+    setup_test_write_all_system_files: Tuple[System, tftpgen.TFTPGen],
+    mock_is_management_supported: bool,
+    mock_get_config_filename: List[Any],
+    expected_pxe_file: int,
+    expected_rmfile: int,
+    expected_mkdir: int,
+    expected_symlink: int,
+):
+    """
+    Test that asserts if the "write_all_system_files" subroutine is working as intended.
+
+    Two main scenarios must be tested for
+
+    * normal hardware and
+    * S390(X) hardware
+
+    as they generate a different set of files. This method handles only GRUB and pxelinux.
+
+    ESXI bootloader and iPXE generation is handled in a different test.
+    """
+    # Arrange
+    test_system, test_gen = setup_test_write_all_system_files
+    result = {}
+    mocker.patch.object(
+        test_system,
+        "is_management_supported",
+        return_value=mock_is_management_supported,
+    )
+    mocker.patch.object(
+        test_system, "get_config_filename", side_effect=mock_get_config_filename
+    )
+    mock_write_pxe_file = mocker.patch.object(test_gen, "write_pxe_file")
+    mock_fs_helpers_rmfile = mocker.patch("cobbler.utils.rmfile")
+    mock_fs_helpers_mkdir = mocker.patch("cobbler.utils.mkdir")
+    mock_os_symlink = mocker.patch("os.symlink")
+
+    # Act
+    test_gen.write_all_system_files(test_system, result)
+
+    # Assert
+    assert mock_write_pxe_file.call_count == expected_pxe_file
+    assert mock_fs_helpers_rmfile.call_count == expected_rmfile
+    assert mock_fs_helpers_mkdir.call_count == expected_mkdir
+    assert mock_os_symlink.call_count == expected_symlink
+
+
+def test_write_all_system_files_s390(
+    mocker: "MockerFixture",
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str, str, str], System],
+    create_image: Callable[[], Image],
+):
+    """
+    Test that asserts if the generated kernel options are longer then 79 character we insert a newline for S390X.
+    """
+    # Arrange
+    result = {}
+    test_distro = create_distro()
+    test_distro.arch = enums.Archs.S390X
+    test_distro.kernel_options = {
+        "foobar1": "whatever",
+        "autoyast": "http://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/this-is-a-long-string-that-need-to-be-splitted/zzzzzzzzzzzzzzzzz",
+        "foobar2": "woohooo",
+    }
+    test_profile = create_profile(test_distro.name)
+    test_system = create_system(profile_name=test_profile.name)
+    test_system.netboot_enabled = True
+    test_image = create_image()
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    mocker.patch.object(test_system, "is_management_supported", return_value=True)
+    open_mock = mocker.mock_open()
+    open_mock.write = mocker.MagicMock()
+    mocker.patch("builtins.open", open_mock)
+
+    # Act
+    test_gen.write_all_system_files(test_system, result)
+
+    # Assert - ensure generated parm file has fixed 80 characters format
+    open_mock().write.assert_called()
+    open_mock().write.assert_any_call(
+        "foobar1=whatever \nautoyast=http://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/this-is-a-\nlong-string-that-need-to-be-splitted/zzzzzzzzzzzzzzzzz \nfoobar2=woohooo\n"
+    )


### PR DESCRIPTION
## Linked Items

Fixes #3750

## Description

The previous code was not handling well the cases where kernel option is longer than 80 characters.

parm file format is fixed to 80 chars per line.
All the lines are concatenated without spaces when being passed to the kernel.

Recommendation: one parameter per line (ending with whitespace)

NOTE: If a parameter is too long to fit into the 80 characters limit it can simply be continued in the first column of the next line.

https://www.debian.org/releases/stable/s390x/ch05s01.en.html https://documentation.suse.com/sles/15-SP1/html/SLES-all/cha-zseries.html#sec-appdendix-parm-examples https://wiki.ubuntu.com/S390X/InstallationGuide

## Behaviour changes

Old: Param Files for S390(X) were incorrectly rendered

New: Param Files are now at maximum 80 characters long.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
