### PR TITLE
Tests: Switch to tftpd for supervisorctl tests

### DIFF
--- a/changelog.d/3749.fixed
+++ b/changelog.d/3749.fixed
@@ -1,0 +1,1 @@
+Tests: Switch to tftpd for supervisorctl tests

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -934,7 +934,7 @@ def test_service_restart_supervisord(mocker):
     # TODO Mock supervisor API and return value
 
     # Act
-    result = utils.service_restart("dhcpd")
+    result = utils.service_restart("tftpd")
 
     # Assert
     assert result == 0


### PR DESCRIPTION
## Linked Items

Fixes #3749

## Description

Since dhpcd require special configuration in some environments and it may not be desired to start a dhcpd server, this PR switches to tftpd which is much easier to restart from an environmental perspective.

## Behaviour changes

Old: `dhcpd` was used to evaluate the supervisor service restart.

New: `tftpd` is used to evaluate the supervisor service restart.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
