### PR TITLE
SPEC: Add SUSE copyright

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -1,6 +1,7 @@
 #
 # spec file for package cobbler
 #
+# Copyright (c) 2023 SUSE LLC
 # Copyright (c) 2006 Michael DeHaan <mdehaan@redhat.com>
 #
 # All modifications and additions to the file contributed by third parties


### PR DESCRIPTION
## Linked Items

Fixes #3746

## Description

As in the issue stated: SUSE has contributed extensively to the SPEC in the past and as such the copyright should be added.

## Behaviour changes

None

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
