### PR TITLE
Fix: rename item

### DIFF
--- a/changelog.d/3745.fixed
+++ b/changelog.d/3745.fixed
@@ -1,0 +1,1 @@
+Fix item rename with uppercase letters

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -65,7 +65,7 @@ class Distros(collection.Collection):
         if not recursive:
             for profile in self.api.profiles():
                 if profile.distro and profile.distro.name == name:
-                    raise CX("removal would orphan profile: %s" % profile.name)
+                    raise CX(f"removal would orphan profile: {profile.name}")
 
         kernel = obj.kernel
         if recursive:

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -53,9 +53,9 @@ class Images(collection.Collection):
 
         # first see if any Groups use this distro
         if not recursive:
-            for v in self.api.systems():
-                if v.image is not None and v.image == name:
-                    raise CX("removal would orphan system: %s" % v.name)
+            for system in self.api.systems():
+                if system.image is not None and system.image == name:
+                    raise CX(f"removal would orphan system: {system.name}")
 
         if recursive:
             kids = self.api.find_items("system", {"image": obj.name})

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 """
 
 import weakref
-from typing import Union, Dict, Any
+from typing import TYPE_CHECKING, Union, Dict, Any
 
 from cobbler.cexceptions import CX
 from cobbler import serializer
@@ -38,6 +38,10 @@ from cobbler.cobbler_collections.systems import Systems
 from cobbler.cobbler_collections.menus import Menus
 
 
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
 class CollectionManager:
     """
     Manages a definitive copy of all data cobbler_collections with weakrefs pointing back into the class so they can
@@ -47,7 +51,7 @@ class CollectionManager:
     has_loaded = False
     __shared_state: Dict[str, Any] = {}
 
-    def __init__(self, api):
+    def __init__(self, api: "CobblerAPI"):
         """
         Constructor which loads all content if this action was not performed before.
         """
@@ -55,7 +59,7 @@ class CollectionManager:
         if not CollectionManager.has_loaded:
             self.__load(api)
 
-    def __load(self, api):
+    def __load(self, api: "CobblerAPI"):
         """
         Load all collections from the disk into Cobbler.
 

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -53,9 +53,9 @@ class Profiles(collection.Collection):
         :raises CX: In case the name of the object was not given or any other descendant would be orphaned.
         """
         if not recursive:
-            for v in self.api.systems():
-                if v.profile is not None and v.profile == name:
-                    raise CX("removal would orphan system: %s" % v.name)
+            for system in self.api.systems():
+                if system.profile is not None and system.profile == name:
+                    raise CX(f"removal would orphan system: {system.name}")
 
         obj = self.find(name=name)
         if obj is None:

--- a/tests/collections/conftest.py
+++ b/tests/collections/conftest.py
@@ -1,6 +1,17 @@
+"""
+Fixtures that are common for testing the cobbler collections.
+"""
+
 import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cobbler_collections.manager import CollectionManager
 
 
 @pytest.fixture()
-def collection_mgr(cobbler_api):
-    return cobbler_api._collection_mgr
+def collection_mgr(cobbler_api: CobblerAPI) -> CollectionManager:
+    """
+    Fixture that provides access to the collection manager instance for testing.
+    """
+    # pylint: disable=protected-access
+    return cobbler_api._collection_mgr  # pyright: ignore [reportPrivateUsage]

--- a/tests/collections/distro_collection_test.py
+++ b/tests/collections/distro_collection_test.py
@@ -2,19 +2,24 @@ import os.path
 from typing import Callable
 
 import pytest
+from cobbler.api import CobblerAPI
 
 from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import distros
+from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.items import distro
 
 
 @pytest.fixture
-def distro_collection(collection_mgr):
+def distro_collection(collection_mgr: CollectionManager):
+    """
+    Fixture to provide a concrete implementation (Distros) of a generic collection.
+    """
     return distros.Distros(collection_mgr)
 
 
-def test_obj_create(collection_mgr):
+def test_obj_create(collection_mgr: CollectionManager):
     # Arrange & Act
     distro_collection = distros.Distros(collection_mgr)
 
@@ -22,7 +27,7 @@ def test_obj_create(collection_mgr):
     assert isinstance(distro_collection, distros.Distros)
 
 
-def test_factory_produce(cobbler_api, distro_collection):
+def test_factory_produce(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange & Act
     result_distro = distro_collection.factory_produce(cobbler_api, {})
 
@@ -30,7 +35,7 @@ def test_factory_produce(cobbler_api, distro_collection):
     assert isinstance(result_distro, distro.Distro)
 
 
-def test_get(cobbler_api, distro_collection):
+def test_get(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "test_get"
     item1 = distro.Distro(cobbler_api)
@@ -47,7 +52,7 @@ def test_get(cobbler_api, distro_collection):
     assert fake_item is None
 
 
-def test_find(cobbler_api, distro_collection):
+def test_find(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "test_find"
     item1 = distro.Distro(cobbler_api)
@@ -63,7 +68,7 @@ def test_find(cobbler_api, distro_collection):
     assert result[0].name == name
 
 
-def test_to_list(cobbler_api, distro_collection):
+def test_to_list(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "test_to_list"
     item1 = distro.Distro(cobbler_api)
@@ -78,7 +83,7 @@ def test_to_list(cobbler_api, distro_collection):
     assert result[0].get("name") == name
 
 
-def test_from_list(distro_collection):
+def test_from_list(distro_collection: distros.Distros):
     # Arrange
     item_list = [{"name": "test_from_list"}]
 
@@ -90,7 +95,13 @@ def test_from_list(distro_collection):
     assert len(distro_collection.indexes["uid"]) == 1
 
 
-def test_copy(cobbler_api, distro_collection, create_kernel_initrd, fk_initrd, fk_kernel):
+def test_copy(
+    cobbler_api: CobblerAPI,
+    distro_collection: distros.Distros,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_initrd: str,
+    fk_kernel: str,
+):
     # Arrange
     folder = create_kernel_initrd(fk_kernel, fk_initrd)
     name = "test_copy"
@@ -156,7 +167,7 @@ def test_collection_add(
     assert item1.uid in distro_collection.indexes["uid"]
 
 
-def test_duplicate_add(cobbler_api, distro_collection):
+def test_duplicate_add(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "duplicate_name"
     item1 = distro.Distro(cobbler_api)
@@ -170,7 +181,7 @@ def test_duplicate_add(cobbler_api, distro_collection):
         distro_collection.add(item2, check_for_duplicate_names=True)
 
 
-def test_remove(cobbler_api, distro_collection):
+def test_remove(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "to_be_removed"
     item1 = distro.Distro(cobbler_api)
@@ -264,7 +275,7 @@ def test_find_by_indexes(
     assert len(kargs3) == 1
 
 @pytest.mark.skip("Method which is under test is broken!")
-def test_to_string(cobbler_api, distro_collection):
+def test_to_string(cobbler_api: CobblerAPI, distro_collection: distros.Distros):
     # Arrange
     name = "to_string"
     item1 = distro.Distro(cobbler_api)


### PR DESCRIPTION
## Linked Items

Fixes #3745

## Description

The current code to rename items in `collection.py` implicitly allowed only that lowercase item names were allowed. The PR addresses this regression.

## Behaviour changes

Old: Only lowercase item names could be renamed implicitly.

New: Renaming of items works independently of the casing.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
