### PR TITLE
CI: Add repo execution condition on release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,7 @@ env:
 
 jobs:
   build-n-publish:
+    if: github.repository == 'cobbler/cobbler'
     name: Build and publish Python distributions to PyPI and TestPyPI
     runs-on: ubuntu-latest
     steps:

--- a/changelog.d/3743.added
+++ b/changelog.d/3743.added
@@ -1,0 +1,1 @@
+CI: Add repository filter condition for release workflow


### PR DESCRIPTION
## Linked Items

Fixes #3743 

## Description

Forks of our repository have issues that their CI fails on the `main` branch since the release workflow cannot work successfully.

## Behaviour changes

Old: The overall CI status failed in CIs due to the release workflow.

New: CI runs may now pass fully.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
