### PR TITLE
Settings: Add extra_settings_list

### DIFF
--- a/bin/cobbler-settings
+++ b/bin/cobbler-settings
@@ -5,6 +5,7 @@ Tool to manage the settings of Cobbler without the daemon running.
 # SPDX-License-Identifier: GPL-2.0-or-later
 # SPDX-FileCopyrightText: 2021 Dominik Gedon <dgedon@suse.de>
 # SPDX-FileCopyrightText: 2021 Enno Gotthold <egotthold@suse.de>
+# SPDX-FileCopyrightText: 2022 Pablo Suárez Hernández <psuarezhernandez@suse.de>
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
 
@@ -29,14 +30,14 @@ def __generate_version_choices() -> List[str]:
     return result
 
 
-def __check_settings(filepath: str) -> dict:
+def __check_settings(filepath: str, settings_to_preserve: List[str]) -> dict:
     try:
         result = settings.read_yaml_file(filepath)
     except (FileNotFoundError, yaml.YAMLError) as error:
         print(str(error))
         return {}
 
-    settings_version = migrations.get_settings_file_version(result)
+    settings_version = migrations.get_settings_file_version(result, settings_to_preserve)
     if settings_version == EMPTY_VERSION:
         print("Error detecting settings file version!")
         return {}
@@ -44,8 +45,8 @@ def __check_settings(filepath: str) -> dict:
     return result
 
 
-def __update_settings(yaml_dict: dict, filepath) -> int:
-    if not settings.update_settings_file(yaml_dict, filepath):
+def __update_settings(yaml_dict: dict, filepath, settings_to_preserve: List[str]) -> int:
+    if not settings.update_settings_file(yaml_dict, filepath, settings_to_preserve):
         print("Modification would make settings invalid!")
         return 1
     print("Updated settings file successfully!")
@@ -58,6 +59,9 @@ def validate(args: argparse.Namespace) -> int:
     except (FileNotFoundError, yaml.YAMLError) as error:
         print(str(error))
         return 1
+
+    # Exclude settings to preserve from the list of settings to migrate
+    result, data_to_exclude_from_validation = migrations.filter_settings_to_validate(result, args.preserve_settings)
 
     version_split = args.version.split(".")
     version = migrations.CobblerVersion(*version_split)
@@ -73,12 +77,12 @@ def validate(args: argparse.Namespace) -> int:
 
 
 def migrate(args: argparse.Namespace) -> int:
-    settings_dict = __check_settings(args.config)
+    settings_dict = __check_settings(args.config, args.preserve_settings)
     if not settings_dict:
         print("Settings file invalid!")
         return 1
 
-    old = migrations.get_settings_file_version(settings_dict)
+    old = migrations.get_settings_file_version(settings_dict, args.preserve_settings)
     if old == migrations.EMPTY_VERSION:
         print("Settings file version could not be discovered!")
         return 1
@@ -86,11 +90,11 @@ def migrate(args: argparse.Namespace) -> int:
     new_list = args.new.split(".")
     new = migrations.CobblerVersion(*new_list)
 
-    result_settings = migrations.migrate(settings_dict, args.config, old, new)
+    result_settings = migrations.migrate(settings_dict, args.config, old, new, args.preserve_settings)
 
     # only if --target supplied
     if args.target is not None:
-        return __update_settings(result_settings, args.target)
+        return __update_settings(result_settings, args.target, args.preserve_settings)
 
     # if --target not supplied
     print(yaml.dump(result_settings))
@@ -98,18 +102,18 @@ def migrate(args: argparse.Namespace) -> int:
 
 
 def automigrate(args: argparse.Namespace) -> int:
-    settings_dict = __check_settings(args.config)
+    settings_dict = __check_settings(args.config, args.preserve_settings)
     if not settings_dict:
         print("Settings file invalid!")
         return 1
     setting_obj = helper.Setting("auto_migrate_settings", args.enable_automigration)
     helper.key_set_value(setting_obj, settings_dict)
 
-    return __update_settings(settings_dict, args.config)
+    return __update_settings(settings_dict, args.config, args.preserve_settings)
 
 
 def modify(args: argparse.Namespace) -> int:
-    settings_dict = __check_settings(args.config)
+    settings_dict = __check_settings(args.config, args.preserve_settings)
     if not settings_dict:
         print("Settings file invalid!")
         return 1
@@ -159,7 +163,7 @@ def modify(args: argparse.Namespace) -> int:
         return 1
     helper.key_set_value(setting_obj, settings_dict)
 
-    return __update_settings(settings_dict, args.config)
+    return __update_settings(settings_dict, args.config, args.preserve_settings)
 
 
 parser = argparse.ArgumentParser(
@@ -170,6 +174,13 @@ parser.add_argument(
     "--config",
     help="The location of the Cobbler configuration file.",
     default="/etc/cobbler/settings.yaml",
+)
+parser.add_argument(
+    "--preserve-settings",
+    help="Comma separated list of custom settings to preserve during migration",
+    dest="preserve_settings",
+    type=lambda arg: arg.split(','),
+    default=[]
 )
 subparsers = parser.add_subparsers(
     title="Subcommands", help="One of these commands is required."

--- a/changelog.d/3771.added
+++ b/changelog.d/3771.added
@@ -1,0 +1,1 @@
+Settings: Allow definition of extra settings via "extra_settings_list"

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -6,6 +6,7 @@ Cobbler app-wide settings
 # SPDX-FileCopyrightText: Michael DeHaan <michael.dehaan AT gmail>
 # SPDX-FileCopyrightText: 2021 Dominik Gedon <dgedon@suse.de>
 # SPDX-FileCopyrightText: 2021 Enno Gotthold <egotthold@suse.de>
+# SPDX-FileCopyrightText: 2022 Pablo Suárez Hernández <psuarezhernandez@suse.de>
 # SPDX-FileCopyrightText: Copyright SUSE LLC
 
 import datetime
@@ -16,7 +17,7 @@ import pathlib
 import shutil
 import traceback
 from pathlib import Path
-from typing import Any, Dict, Hashable
+from typing import Any, Dict, Hashable, List, Optional
 import yaml
 from schema import SchemaError, SchemaMissingKeyError, SchemaWrongKeyError
 
@@ -94,6 +95,7 @@ class Settings:
         self.default_virt_type = "auto"
         self.enable_ipxe = False
         self.enable_menu = True
+        self.extra_settings_list: List[str] = []
         self.http_port = 80
         self.include = ["/etc/cobbler/settings.d/*.settings"]
         self.iso_template_dir = "/etc/cobbler/iso"
@@ -264,33 +266,51 @@ class Settings:
             else:
                 raise AttributeError(f"no settings attribute named '{name}' found") from error
 
-    def save(self, filepath="/etc/cobbler/settings.yaml"):
+    def save(self, filepath="/etc/cobbler/settings.yaml", ignore_keys: Optional[List[str]] = None):
         """
         Saves the settings to the disk.
+
+        :param filepath: This sets the path of the settingsfile to write.
+        :param ignore_keys: The list of ignore keys to exclude from migration.
         """
-        update_settings_file(self.to_dict(), filepath)
+        if not ignore_keys:
+            ignore_keys = []
+
+        update_settings_file(self.to_dict(), filepath, ignore_keys=ignore_keys)
 
 
-def validate_settings(settings_content: dict) -> dict:
+def validate_settings(settings_content: dict, ignore_keys: Optional[List[str]] = None) -> dict:
     """
     This function performs logical validation of our loaded YAML files.
     This function will:
     - Perform type validation on all values of all keys.
     - Provide defaults for optional settings.
+
     :param settings_content: The dictionary content from the YAML file.
+    :param ignore_keys: The list of ignore keys to exclude from validation.
     :raises SchemaError: In case the data given is invalid.
     :return: The Settings of Cobbler which can be safely used inside this instance.
     """
-    return migrations.normalize(settings_content)
+    if not ignore_keys:
+        ignore_keys = []
+
+    # Extra settings and ignored keys are excluded from validation
+    data, data_to_exclude_from_validation = migrations.filter_settings_to_validate(
+        settings_content, ignore_keys
+    )
+
+    result = migrations.normalize(data)
+    result.update(data_to_exclude_from_validation)
+    return result
 
 
-def read_yaml_file(filepath="/ect/cobbler/settings.yaml") -> Dict[Hashable, Any]:
+def read_yaml_file(filepath="/etc/cobbler/settings.yaml") -> Dict[Hashable, Any]:
     """
     Reads settings files from ``filepath`` and all paths in `include` (which is read from the settings file) and saves
     the content in a dictionary.
     Any key may be overwritten in a later loaded settings file. The last loaded file wins.
 
-    :param filepath: Settings file path, defaults to "/ect/cobbler/settings.yaml"
+    :param filepath: Settings file path, defaults to "/etc/cobbler/settings.yaml"
     :raises FileNotFoundError: In case file does not exist or is a directory.
     :raises yaml.YAMLError: In case the file is not a valid YAML file.
     :return: The aggregated dict of all settings.
@@ -311,23 +331,30 @@ def read_yaml_file(filepath="/ect/cobbler/settings.yaml") -> Dict[Hashable, Any]
     return filecontent
 
 
-def read_settings_file(filepath="/etc/cobbler/settings.yaml") -> Dict[Hashable, Any]:
+def read_settings_file(
+    filepath="/etc/cobbler/settings.yaml",
+    ignore_keys: Optional[List[str]] = None,
+) -> Dict[Hashable, Any]:
     """
     Utilizes ``read_yaml_file()``. If the read settings file is invalid in the context of Cobbler we will return an
     empty dictionary.
 
     :param filepath: The path to the settings file.
-    :raises SchemaMissingKeyError: In case keys are minssing.
+    :param ignore_keys: The list of ignore keys to exclude from validation.
+    :raises SchemaMissingKeyError: In case keys are missing.
     :raises SchemaWrongKeyError: In case keys are not listed in the schema.
     :raises SchemaError: In case the schema is wrong.
     :return: A dictionary with the settings. As a word of caution: This may not represent a correct settings object, it
              will only contain a correct YAML representation.
     """
+    if not ignore_keys:
+        ignore_keys = []
+
     filecontent = read_yaml_file(filepath)
 
     # FIXME: Do not call validate_settings() because of chicken - egg problem
     try:
-        validate_settings(filecontent)
+        validate_settings(filecontent, ignore_keys=ignore_keys)
     except SchemaMissingKeyError:
         logging.exception("Settings file was not returned due to missing keys.")
         logging.debug('The settings to read were: "%s"', filecontent)
@@ -343,7 +370,11 @@ def read_settings_file(filepath="/etc/cobbler/settings.yaml") -> Dict[Hashable, 
     return filecontent
 
 
-def update_settings_file(data: dict, filepath="/etc/cobbler/settings.yaml") -> bool:
+def update_settings_file(
+    data: dict,
+    filepath="/etc/cobbler/settings.yaml",
+    ignore_keys: Optional[List[str]] = None,
+) -> bool:
     """
     Write data handed to this function into the settings file of Cobbler. This function overwrites the existing content.
     It will only write valid settings. If you are trying to save invalid data this will raise a SchemaException
@@ -351,8 +382,12 @@ def update_settings_file(data: dict, filepath="/etc/cobbler/settings.yaml") -> b
 
     :param data: The data to put into the settings file.
     :param filepath: This sets the path of the settingsfile to write.
-    :return: True if the action succeeded. Otherwise return False.
+    :param ignore_keys: The list of ignore keys to exclude from validation.
+    :return: True if the action succeeded. Otherwise, return False.
     """
+    if not ignore_keys:
+        ignore_keys = []
+
     # Backup old settings file
     path = pathlib.Path(filepath)
     if path.exists():
@@ -360,7 +395,32 @@ def update_settings_file(data: dict, filepath="/etc/cobbler/settings.yaml") -> b
         shutil.copy(path, path.parent.joinpath(f"{path.stem}_{timestamp}{path.suffix}"))
 
     try:
-        validated_data = validate_settings(data)
+        validated_data = validate_settings(data, ignore_keys)
+        version = migrations.get_installed_version()
+
+        # If "ignore_keys" was set during migration, we persist these keys as "extra_settings_list"
+        # in the final settings, so the migrated settings are able to validate later
+        if ignore_keys or "extra_settings_list" in validated_data:
+            if "extra_settings_list" in validated_data:
+                validated_data["extra_settings_list"].extend(ignore_keys)
+                # Remove items from "extra_settings_list" in case it is now a valid settings
+                current_schema = list(
+                    map(
+                        lambda x: getattr(x, "_schema", x),
+                        migrations.VERSION_LIST[version].schema._schema.keys(),
+                    )
+                )
+                validated_data["extra_settings_list"] = [
+                    x
+                    for x in validated_data["extra_settings_list"]
+                    if x not in current_schema
+                ]
+            else:
+                validated_data["extra_settings_list"] = ignore_keys
+            validated_data["extra_settings_list"] = list(
+                set(validated_data["extra_settings_list"])
+            )
+
         with open(filepath, "w") as settings_file:
             yaml_dump = yaml.safe_dump(validated_data)
             header = "# Cobbler settings file\n"
@@ -379,12 +439,23 @@ def update_settings_file(data: dict, filepath="/etc/cobbler/settings.yaml") -> b
         return False
 
 
-def migrate(yaml_dict: dict, settings_path: Path) -> dict:
+def migrate(yaml_dict: dict, settings_path: Path, ignore_keys: Optional[List[str]] = None) -> dict:
     """
     Migrates the current settings
 
     :param yaml_dict: The settings dict
     :param settings_path: The settings path
+    :param ignore_keys: The list of ignore keys to exclude from migration.
     :return: The migrated settings
     """
-    return migrations.migrate(yaml_dict, settings_path)
+    if not ignore_keys:
+        ignore_keys = []
+
+        # Extra settings and ignored keys are excluded from validation
+    data, data_to_exclude_from_validation = migrations.filter_settings_to_validate(
+        yaml_dict, ignore_keys
+    )
+
+    result = migrations.migrate(data, settings_path)
+    result.update(data_to_exclude_from_validation)
+    return result

--- a/cobbler/settings/migrations/V3_1_2.py
+++ b/cobbler/settings/migrations/V3_1_2.py
@@ -53,6 +53,7 @@ schema = Schema({
     "default_virt_type": str,
     "enable_gpxe": int,
     "enable_menu": int,
+    Optional("extra_settings_list", default=[]): [str],
     Optional("grubconfig_dir", default="/var/lib/cobbler/grub_config"): str,
     "http_port": int,
     "include": list,

--- a/cobbler/settings/migrations/V3_2_0.py
+++ b/cobbler/settings/migrations/V3_2_0.py
@@ -53,6 +53,7 @@ schema = Schema({
     "default_virt_type": str,
     "enable_gpxe": int,
     "enable_menu": int,
+    Optional("extra_settings_list", default=[]): [str],
     Optional("grubconfig_dir", default="/var/lib/cobbler/grub_config"): str,
     "http_port": int,
     "include": list,

--- a/cobbler/settings/migrations/V3_2_1.py
+++ b/cobbler/settings/migrations/V3_2_1.py
@@ -57,6 +57,7 @@ schema = Schema({
     "default_virt_type": str,
     "enable_gpxe": bool,
     "enable_menu": bool,
+    Optional("extra_settings_list", default=[]): [str],
     "http_port": int,
     "include": [str],
     Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/settings/migrations/V3_3_0.py
+++ b/cobbler/settings/migrations/V3_3_0.py
@@ -80,6 +80,7 @@ schema = Schema({
     "default_virt_type": str,
     "enable_ipxe": bool,
     "enable_menu": bool,
+    Optional("extra_settings_list", default=[]): [str],
     "http_port": int,
     "include": [str],
     Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/settings/migrations/V3_3_1.py
+++ b/cobbler/settings/migrations/V3_3_1.py
@@ -84,6 +84,7 @@ schema = Schema({
     "default_virt_type": str,
     "enable_ipxe": bool,
     "enable_menu": bool,
+    Optional("extra_settings_list", default=[]): [str],
     "http_port": int,
     "include": [str],
     Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/settings/migrations/V3_3_2.py
+++ b/cobbler/settings/migrations/V3_3_2.py
@@ -142,6 +142,7 @@ schema = Schema(
         "default_virt_type": str,
         "enable_ipxe": bool,
         "enable_menu": bool,
+        Optional("extra_settings_list", default=[]): [str],
         "http_port": int,
         "include": [str],
         Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/settings/migrations/V3_3_3.py
+++ b/cobbler/settings/migrations/V3_3_3.py
@@ -142,6 +142,7 @@ schema = Schema(
         "default_virt_type": str,
         "enable_ipxe": bool,
         "enable_menu": bool,
+        Optional("extra_settings_list", default=[]): [str],
         "http_port": int,
         "include": [str],
         Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/settings/migrations/V3_3_5.py
+++ b/cobbler/settings/migrations/V3_3_5.py
@@ -143,6 +143,7 @@ schema = Schema(
         "default_virt_type": str,
         "enable_ipxe": bool,
         "enable_menu": bool,
+        Optional("extra_settings_list", default=[]): [str],
         "http_port": int,
         "include": [str],
         Optional("iso_template_dir", default="/etc/cobbler/iso"): str,

--- a/cobbler/settings/migrations/__init__.py
+++ b/cobbler/settings/migrations/__init__.py
@@ -22,7 +22,7 @@ from importlib import import_module
 from inspect import signature
 from pathlib import Path
 from types import ModuleType
-from typing import Dict, List, Union
+from typing import Dict, List, Union, Optional, Tuple
 
 from schema import Schema
 
@@ -113,7 +113,6 @@ def __validate_module(name: ModuleType) -> bool:
         * those methods must have a certain signature
 
     :param name: The name of the module to validate.
-    :param version: The migration version as List.
     :return: True if every criteria is met otherwise False.
     """
     module_methods = {"validate": "(settings:dict)->bool",
@@ -143,15 +142,46 @@ def __load_migration_modules(name: str, version: List[str]):
         logger.warning('Exception raised when loading migrations module "%s"', name)
 
 
-def get_settings_file_version(yaml_dict: dict) -> CobblerVersion:
+def filter_settings_to_validate(settings: dict, ignore_keys: Optional[List[str]] = None) -> Tuple[dict, dict]:
     """
-    Return the correspondig version of the given settings dict.
+    Separate settings to validate from the ones to exclude from validation
+    according to "ignore_keys" parameter and "extra_settings_list" setting value.
+    :param settings: The settings dict to validate.
+    :param ignore_keys: The list of ignore keys to exclude from validation.
+    :return data: The filtered settings to validate
+    :return data_to_exclude: The settings that were excluded from the validation
+    """
+    if not ignore_keys:
+        ignore_keys = []
+
+    extra_settings = settings.get("extra_settings_list", [])
+    data_to_exclude = {
+        k: settings[k] for k in settings if k in ignore_keys or k in extra_settings
+    }
+    data = {
+        x: settings[x]
+        for x in settings
+        if x not in ignore_keys and x not in extra_settings
+    }
+    return data, data_to_exclude
+
+
+def get_settings_file_version(yaml_dict: dict, ignore_keys: Optional[List[str]] = None) -> CobblerVersion:
+    """
+    Return the corresponding version of the given settings dict.
 
     :param yaml_dict: The settings dict to get the version from.
+    :param ignore_keys: The list of ignore keys to exclude from validation.
     :return: The discovered Cobbler Version or ``EMPTY_VERSION``
     """
+    if not ignore_keys:
+        ignore_keys = []
+
+        # Extra settings and ignored keys are excluded from validation
+    data, _ = filter_settings_to_validate(yaml_dict, ignore_keys=ignore_keys)
+
     for (version, module_name) in VERSION_LIST.items():
-        if module_name.validate(yaml_dict):
+        if module_name.validate(data):
             return version
     return EMPTY_VERSION
 
@@ -211,17 +241,21 @@ def discover_migrations(path: str = migrations_path):
         __load_migration_modules(migration_name, version)
 
 
-def auto_migrate(yaml_dict: dict, settings_path: Path) -> dict:
+def auto_migrate(yaml_dict: dict, settings_path: Path, ignore_keys: Optional[List[str]] = None) -> dict:
     """
     Auto migration to the most recent version.
 
     :param yaml_dict: The settings dict to migrate.
     :param settings_path: The path of the settings dict.
+    :param ignore_keys: The list of ignore keys to exclude from auto migration.
     :return: The migrated dict.
     """
+    if not ignore_keys:
+        ignore_keys = []
+
     if not yaml_dict.get("auto_migrate_settings", True):
         raise RuntimeError("Settings automigration disabled but required for starting the daemon!")
-    settings_version = get_settings_file_version(yaml_dict)
+    settings_version = get_settings_file_version(yaml_dict, ignore_keys=ignore_keys)
     if settings_version == EMPTY_VERSION:
         raise RuntimeError("Automigration not possible due to undiscoverable settings!")
 
@@ -231,12 +265,23 @@ def auto_migrate(yaml_dict: dict, settings_path: Path) -> dict:
     for index in range(0, len(migrations) - 1):
         if index == len(migrations) - 1:
             break
-        yaml_dict = migrate(yaml_dict, settings_path, migrations[index], migrations[index + 1])
+        yaml_dict = migrate(
+            yaml_dict,
+            settings_path,
+            migrations[index],
+            migrations[index + 1],
+            ignore_keys,
+        )
     return yaml_dict
 
 
-def migrate(yaml_dict: dict, settings_path: Path,
-            old: CobblerVersion = EMPTY_VERSION, new: CobblerVersion = EMPTY_VERSION) -> dict:
+def migrate(
+    yaml_dict: dict,
+    settings_path: Path,
+    old: CobblerVersion = EMPTY_VERSION,
+    new: CobblerVersion = EMPTY_VERSION,
+    ignore_keys: Optional[List[str]] = None,
+) -> dict:
     """
     Migration to a specific version. If no old and new version is supplied it will call ``auto_migrate()``.
 
@@ -244,18 +289,30 @@ def migrate(yaml_dict: dict, settings_path: Path,
     :param settings_path: The path of the settings dict.
     :param old: The version to migrate from, defaults to EMPTY_VERSION.
     :param new: The version to migrate to, defaults to EMPTY_VERSION.
-    :raises ValueError: Raised if attempting to downgraade.
+    :param ignore_keys: The list of settings ot be excluded from migration.
+    :raises ValueError: Raised if attempting to downgrade.
     :return: The migrated dict.
     """
+    if not ignore_keys:
+        ignore_keys = []
+
     # If no version supplied do auto migrations
     if old == EMPTY_VERSION and new == EMPTY_VERSION:
-        return auto_migrate(yaml_dict, settings_path)
+        return auto_migrate(yaml_dict, settings_path, ignore_keys=ignore_keys)
 
     if old == EMPTY_VERSION or new == EMPTY_VERSION:
         raise ValueError("Either both or no versions must be specified for a migration!")
 
+    # Extra settings and ignored keys are excluded from validation
+    data, data_to_exclude_from_validation = filter_settings_to_validate(
+        yaml_dict, ignore_keys
+    )
+
     if old == new:
-        return VERSION_LIST[old].normalize(yaml_dict)
+        data = VERSION_LIST[old].normalize(data)
+        # Put back settings excluded form validation
+        data.update(data_to_exclude_from_validation)
+        return data
 
     # If both versions are present, check if old < new and then migrate the appropriate versions.
     if old > new:
@@ -263,32 +320,61 @@ def migrate(yaml_dict: dict, settings_path: Path,
 
     sorted_version_list = sorted(list(VERSION_LIST.keys()))
     migration_list = sorted_version_list[sorted_version_list.index(old) + 1:sorted_version_list.index(new) + 1]
+
     for key in migration_list:
         yaml_dict = VERSION_LIST[key].migrate(yaml_dict)
     return yaml_dict
 
 
-def validate(settings: dict, settings_path: Path = "") -> bool:
+def validate(settings: dict, settings_path: Path = "", ignore_keys: Optional[List[str]] = None) -> bool:
     """
     Wrapper function for the validate() methods of the individual migration modules.
 
     :param settings: The settings dict to validate.
     :param settings_path: TODO: not used at the moment
+    :param ignore_keys: The list of settings ot be excluded from validation.
     :return: True if settings are valid, otherwise False.
     """
+    if not ignore_keys:
+        ignore_keys = []
+
     version = get_installed_version()
-    return VERSION_LIST[version].validate(settings)
+
+    # Extra settings and ignored keys are excluded from validation
+    data, data_to_exclude_from_validation = filter_settings_to_validate(
+        settings, ignore_keys=ignore_keys
+    )
+
+    result = VERSION_LIST[version].validate(data)
+
+    # Put back settings excluded form validation
+    result.update(data_to_exclude_from_validation)
+    return result
 
 
-def normalize(settings: dict) -> dict:
+def normalize(settings: dict, ignore_keys: Optional[List[str]] = None) -> dict:
     """
     If data in ``settings`` is valid the validated data is returned.
 
     :param settings: The settings dict to validate.
+    :param ignore_keys: The list of settings ot be excluded from normalization.
     :return: The validated dict.
     """
+    if not ignore_keys:
+        ignore_keys = []
+
     version = get_installed_version()
-    return VERSION_LIST[version].normalize(settings)
+
+    # Extra settings and ignored keys are excluded from validation
+    data, data_to_exclude_from_validation = filter_settings_to_validate(
+        settings, ignore_keys
+    )
+
+    result = VERSION_LIST[version].normalize(data)
+
+    # Put back settings excluded form validation
+    result.update(data_to_exclude_from_validation)
+    return result
 
 
 discover_migrations()

--- a/docs/cobbler-conf.rst
+++ b/docs/cobbler-conf.rst
@@ -31,6 +31,9 @@ Starting with 3.3.6
 
 No changes to the settings.
 
+.. note:: We backported a PR that introduced a change that allows starting with the 3.2.1 schema the key
+          ``extra_settings_list`` which allows to define additional keys that are ignored during schema validation.
+
 Starting with 3.3.5
 ===================
 
@@ -531,6 +534,14 @@ setting enabled unless they are concerned with accidental reinstall from users w
 menu. Adding a password to the boot menus templates may also be a good solution to prevent unwanted reinstallations.
 
 default: ``True``
+
+extra_settings_list
+===================
+
+Allows the definition of additional keys that are not contained in the schema validation. During validation these keys
+are ignored. This is useful if you develop a plugin for Cobbler that adds additional settings.
+
+default: ``[]``
 
 http_port
 =========

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -466,7 +466,7 @@ def test_dump_vars(cobbler_api: CobblerAPI):
     # Assert
     assert "default_ownership" in result
     assert "owners" in result
-    assert len(result) == 150
+    assert len(result) == 151
 
 
 @pytest.mark.parametrize(

--- a/tests/settings/migrations/normalize_test.py
+++ b/tests/settings/migrations/normalize_test.py
@@ -83,7 +83,7 @@ def test_normalize_v3_1_2():
     new_settings = V3_1_2.normalize(old_settings_dict)
 
     # Assert
-    assert len(V3_1_2.normalize(new_settings)) == 110
+    assert len(V3_1_2.normalize(new_settings)) == 111
 
 
 def test_normalize_v3_2_0():
@@ -95,7 +95,7 @@ def test_normalize_v3_2_0():
     new_settings = V3_2_0.normalize(old_settings_dict)
 
     # Assert
-    assert len(V3_2_0.normalize(new_settings)) == 112
+    assert len(V3_2_0.normalize(new_settings)) == 113
 
 
 def test_normalize_v3_2_1():
@@ -107,7 +107,7 @@ def test_normalize_v3_2_1():
     new_settings = V3_2_1.normalize(old_settings_dict)
 
     # Assert
-    assert len(V3_2_1.normalize(new_settings)) == 111
+    assert len(V3_2_1.normalize(new_settings)) == 112
 
 
 def test_normalize_v3_3_0():
@@ -119,7 +119,7 @@ def test_normalize_v3_3_0():
     new_settings = V3_3_0.normalize(old_settings_dict)
 
     # Assert
-    assert len(V3_3_0.normalize(new_settings)) == 121
+    assert len(V3_3_0.normalize(new_settings)) == 122
 
 
 def test_normalize_v3_3_1():
@@ -131,7 +131,7 @@ def test_normalize_v3_3_1():
     new_settings = V3_3_1.normalize(old_settings_dict)
 
     # Assert
-    assert len(V3_3_1.normalize(new_settings)) == 129
+    assert len(V3_3_1.normalize(new_settings)) == 130
 
 
 def test_normalize_v3_3_2():
@@ -143,7 +143,7 @@ def test_normalize_v3_3_2():
     new_settings = V3_3_2.normalize(old_settings_dict)
 
     # Assert
-    assert len(V3_3_2.normalize(new_settings)) == 129
+    assert len(V3_3_2.normalize(new_settings)) == 130
 
 
 def test_normalize_v3_3_3():
@@ -155,7 +155,7 @@ def test_normalize_v3_3_3():
     new_settings = V3_3_3.normalize(old_settings_dict)
 
     # Assert
-    assert len(new_settings) == 130
+    assert len(new_settings) == 131
     # Migration of default_virt_file_size to float is working
     assert isinstance(new_settings.get("default_virt_file_size", None), float)
 
@@ -169,7 +169,7 @@ def test_normalize_v3_3_4():
     new_settings = V3_3_4.normalize(old_settings_dict)
 
     # Assert
-    assert len(new_settings) == 130
+    assert len(new_settings) == 131
 
 
 def test_normalize_v3_3_5():
@@ -181,7 +181,7 @@ def test_normalize_v3_3_5():
     new_settings = V3_3_5.normalize(old_settings_dict)
 
     # Assert
-    assert len(new_settings) == 132
+    assert len(new_settings) == 133
 
 
 def test_normalize_v3_3_6():
@@ -193,4 +193,4 @@ def test_normalize_v3_3_6():
     new_settings = V3_3_6.normalize(old_settings_dict)
 
     # Assert
-    assert len(new_settings) == 132
+    assert len(new_settings) == 133

--- a/tests/settings/settings_test.py
+++ b/tests/settings/settings_test.py
@@ -77,6 +77,52 @@ def test_read_settings_file():
     assert result.get("include")
 
 
+def test_read_settings_file_with_ignore_keys(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/etc/cobbler/settings.yaml"
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+    shutil.copyfile(src, settings_path)
+    with open(settings_path) as settings_file:
+        new_settings = yaml.safe_load(settings_file)
+        new_settings.update({"foobar": 1234})
+    with open(settings_path, "w") as new_settings_file:
+        new_settings_file.write(yaml.dump(new_settings))
+
+    # Act
+    result = settings.read_settings_file(settings_path, ignore_keys=["foobar"])
+
+    with open(settings_path, "w") as new_settings_file:
+        new_settings.pop("foobar")
+        new_settings_file.write(yaml.dump(new_settings))
+
+    # Assert
+    assert isinstance(result, dict)
+    assert result.get("server")
+    assert result.get("foobar")
+
+
+def test_read_settings_file_with_ignore_keys_failing(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/etc/cobbler/settings.yaml"
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+    shutil.copyfile(src, settings_path)
+    with open(settings_path) as settings_file:
+        new_settings = yaml.safe_load(settings_file)
+        new_settings.update({"foobar": 1234})
+    with open(settings_path, "w") as new_settings_file:
+        new_settings_file.write(yaml.dump(new_settings))
+
+    # Act
+    result = settings.read_settings_file(settings_path)
+
+    with open(settings_path, "w") as new_settings_file:
+        new_settings.pop("foobar")
+        new_settings_file.write(yaml.dump(new_settings))
+
+    # Assert
+    assert not result
+
+
 def test_update_settings_file(tmpdir: pathlib.Path):
     # Arrange
     src = "/etc/cobbler/settings.yaml"
@@ -107,3 +153,69 @@ def test_update_settings_file_emtpy_dict(tmpdir: pathlib.Path):
 
     # Assert
     assert not result
+
+
+def test_update_settings_file_ignore_keys_failing(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/etc/cobbler/settings.yaml"
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+    shutil.copyfile(src, settings_path)
+    with open(settings_path) as settings_file:
+        settings_read_pre = yaml.safe_load(settings_file)
+        settings_read_pre.update({"grub2_mod_dir": "/usr/share/grub2"})
+        settings_read_pre["foobar"] = 1234
+
+    # Act
+    result = settings.update_settings_file(settings_read_pre, filepath=settings_path)
+
+    # Assert
+    assert not result
+
+
+def test_update_settings_file_ignore_keys_success(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/etc/cobbler/settings.yaml"
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+    shutil.copyfile(src, settings_path)
+    with open(settings_path) as settings_file:
+        settings_read_pre = yaml.safe_load(settings_file)
+        settings_read_pre.update({"grub2_mod_dir": "/usr/share/grub2"})
+        settings_read_pre["foobar"] = 1234
+
+    # Act
+    result = settings.update_settings_file(
+        settings_read_pre, filepath=settings_path, ignore_keys=["foobar"]
+    )
+
+    # Assert
+    assert result
+    with open(settings_path) as settings_file:
+        settings_read_post = yaml.safe_load(settings_file)
+        assert "grub2_mod_dir" in settings_read_post
+        assert settings_read_post["grub2_mod_dir"] == "/usr/share/grub2"
+        assert "foobar" in settings_read_post
+        assert settings_read_post["foobar"] == 1234
+
+
+def test_update_settings_file_extra_settings_list(tmpdir: pathlib.Path):
+    # Arrange
+    src = "/etc/cobbler/settings.yaml"
+    settings_path = os.path.join(tmpdir, "settings.yaml")
+    shutil.copyfile(src, settings_path)
+    with open(settings_path) as settings_file:
+        settings_read_pre = yaml.safe_load(settings_file)
+        settings_read_pre.update({"grub2_mod_dir": "/usr/share/grub2"})
+        settings_read_pre["extra_settings_list"] = ["foobar"]
+        settings_read_pre["foobar"] = 1234
+
+    # Act
+    result = settings.update_settings_file(settings_read_pre, filepath=settings_path)
+
+    # Assert
+    assert result
+    with open(settings_path) as settings_file:
+        settings_read_post = yaml.safe_load(settings_file)
+        assert "grub2_mod_dir" in settings_read_post
+        assert settings_read_post["grub2_mod_dir"] == "/usr/share/grub2"
+        assert "foobar" in settings_read_post
+        assert settings_read_post["foobar"] == 1234

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -259,7 +259,7 @@ def test_blender(cobbler_api):
     result = utils.blender(cobbler_api, False, root_item)
 
     # Assert
-    assert len(result) == 163
+    assert len(result) == 164
     # Must be present because the settings have it
     assert "server" in result
     # Must be present because it is a field of distro


### PR DESCRIPTION
## Linked Items

Fixes #3771 

## Description

This commit introduces new logic that allows to preserve and exclude custom extra settings from validation and migration.

A new parameter has been introduced to cobbler-settings, "--preserve-settings" as well as a new settings named "extra_settings_list" to allow defining your own custom settings to be excluded from validation.

## Behaviour changes

Old: Settings not in the schema that are exposed by plugins crash the daemon.

New: Additional settings can be defined via `extra_settings_list` to not crash the daemon on startup.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
