### PR TITLE
CI: Limit number of branches for coverage upload

### DIFF
--- a/.github/workflows/coverage-upload.yml
+++ b/.github/workflows/coverage-upload.yml
@@ -5,6 +5,8 @@ on:
     workflows: [Testing Cobbler]
     types:
       - completed
+    # This needs to be adjusted to match all branches that use this double-boxed approached.
+    branches: [main]
 
 jobs:
   run_tests:
@@ -13,7 +15,7 @@ jobs:
       # https://github.com/dawidd6/action-download-artifact
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@v3
+        uses: dawidd6/action-download-artifact@v6
         with:
           name: coverage-report
           workflow: testing.yml


### PR DESCRIPTION
## Linked Items

No issue.

## Description

This limits the upload coverage action to branches that actually are using the split coverage upload report method. This is needed to access the token that is needed to upload to Codacy.

## Behaviour changes

Old: The "Uploading coverage" action triggered on every finish of the "Testing Cobbler" workflow.

New: The action now only attempts to upload reports that are generated on specific branches.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
