### PR TITLE
Network Interface: Allow empty str for interface type

### DIFF
--- a/changelog.d/3774.fixed
+++ b/changelog.d/3774.fixed
@@ -1,0 +1,1 @@
+Network Interface: Allow empty str for interface type

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -436,6 +436,8 @@ class NetworkInterface:
                 raise ValueError("intf_type with number \"%s\" was not a valid interface type!" % intf_type) \
                     from value_error
         elif isinstance(intf_type, str):
+            if not intf_type:
+                intf_type = "na"
             try:
                 intf_type = enums.NetworkInterfaceType[intf_type.upper()]
             except KeyError as key_error:

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -297,29 +297,43 @@ def test_virt_bridge(
 
 
 @pytest.mark.parametrize(
-    "input_interface_type,expected_result,expected_exception",
+    "value,expected_exception,expected_result",
     [
-        ([], enums.NetworkInterfaceType.NA, pytest.raises(TypeError)),
-        (0, enums.NetworkInterfaceType.NA, does_not_raise()),
-        (100, enums.NetworkInterfaceType.NA, pytest.raises(ValueError)),
-        ("INVALID", enums.NetworkInterfaceType.NA, pytest.raises(ValueError)),
-        # TODO: Create test for last ValueError
-        ("NA", enums.NetworkInterfaceType.NA, does_not_raise()),
-        ("na", enums.NetworkInterfaceType.NA, does_not_raise()),
+        ("foobar_not_existing", pytest.raises(ValueError), None),
+        ("", does_not_raise(), enums.NetworkInterfaceType.NA),
+        ("na", does_not_raise(), enums.NetworkInterfaceType.NA),
+        ("bond", does_not_raise(), enums.NetworkInterfaceType.BOND),
+        ("bond_slave", does_not_raise(), enums.NetworkInterfaceType.BOND_SLAVE),
+        ("bridge", does_not_raise(), enums.NetworkInterfaceType.BRIDGE),
+        ("bridge_slave", does_not_raise(), enums.NetworkInterfaceType.BRIDGE_SLAVE),
+        (
+            "bonded_bridge_slave",
+            does_not_raise(),
+            enums.NetworkInterfaceType.BONDED_BRIDGE_SLAVE,
+        ),
+        ("bmc", does_not_raise(), enums.NetworkInterfaceType.BMC),
+        ("infiniband", does_not_raise(), enums.NetworkInterfaceType.INFINIBAND),
+        (0, does_not_raise(), enums.NetworkInterfaceType.NA),
+        (1, does_not_raise(), enums.NetworkInterfaceType.BOND),
+        (2, does_not_raise(), enums.NetworkInterfaceType.BOND_SLAVE),
+        (3, does_not_raise(), enums.NetworkInterfaceType.BRIDGE),
+        (4, does_not_raise(), enums.NetworkInterfaceType.BRIDGE_SLAVE),
+        (5, does_not_raise(), enums.NetworkInterfaceType.BONDED_BRIDGE_SLAVE),
+        (6, does_not_raise(), enums.NetworkInterfaceType.BMC),
+        (7, does_not_raise(), enums.NetworkInterfaceType.INFINIBAND),
     ],
 )
-def test_interface_type(
-    cobbler_api: CobblerAPI, input_interface_type, expected_result, expected_exception
+def test_network_interface_type(
+    cobbler_api, value, expected_exception, expected_result
 ):
     # Arrange
     interface = NetworkInterface(cobbler_api, "")
 
     # Act
     with expected_exception:
-        interface.interface_type = input_interface_type
+        interface.interface_type = value
 
         # Assert
-        assert isinstance(interface.interface_type, enums.NetworkInterfaceType)
         assert interface.interface_type == expected_result
 
 


### PR DESCRIPTION
## Linked Items

Fixes #3774

## Description

Backports a subset of the bugfix that enables Cobbler to accept empty str values as valid for the `interface_type` for the `NetworkInterface` type. An older version of Cobbler allowed this value to be present under some circumstances.

## Behaviour changes

Old: Cobbler may refuse to start due to an empty str in the `interface_type` attribute for network interfaces.

New: Cobbler is able to automatically convert an empty str to the correct internal enum value.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

