### PR TITLE
Settings: Fix 3.3.0 migration

### DIFF
--- a/changelog.d/3776.fixed
+++ b/changelog.d/3776.fixed
@@ -1,0 +1,1 @@
+Settings: Correct multiple missing migration points for 3.3.0


### PR DESCRIPTION
## Linked Items

Fixes #3776

## Description

With version 3.3.0 a few changes weren't correctly migrated. This PR addresses these issues:

- The setting "power_management_default_type" is now set to the value "ipmilanplus"
- The data item attribute "boot_loader" is now named "boot_loaders".
- The setting and data item attribute "next_server" was split into a v4 and v6 setting.
- The setting and data item attribute "enable_gpxe" was renamed to "enable_ipxe".
- The data item attributes "serial_device" and "serial_baud_rate" are now having the default value "-1" instead of an empty str.

## Behaviour changes

Old: When upgrading from <3.3.0 to 3.3.0 both data items and the settings had missing migrations leading to errors.

New: Migrations from <3.3.0 to 3.3.6 should be possible without errors.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
