### PR TITLE
fixed issue with profile and pxe menu

### DIFF
--- a/changelog.d/3779.fixed
+++ b/changelog.d/3779.fixed
@@ -1,0 +1,1 @@
+API: Fix issue where searching for a profile by arch wasn't possible

--- a/cobbler/cobbler_collections/distros.py
+++ b/cobbler/cobbler_collections/distros.py
@@ -44,9 +44,7 @@ class Distros(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_distro = distro.Distro(api, **item_dict)
-        new_distro.from_dict(item_dict)
-        return new_distro
+        return distro.Distro(api, **item_dict)
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/files.py
+++ b/cobbler/cobbler_collections/files.py
@@ -41,9 +41,7 @@ class Files(collection.Collection):
         """
         Return a File forged from item_dict
         """
-        new_file = file.File(api, **item_dict)
-        new_file.from_dict(item_dict)
-        return new_file
+        return file.File(api, **item_dict)
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -35,9 +35,7 @@ class Images(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_image = image.Image(api, **item_dict)
-        new_image.from_dict(item_dict)
-        return new_image
+        return image.Image(api, **item_dict)
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = True):

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -45,9 +45,7 @@ class Menus(collection.Collection):
         :param item_dict: The seed data.
         :return: A new menu instance.
         """
-        new_menu = menu.Menu(api, **item_dict)
-        new_menu.from_dict(item_dict)
-        return new_menu
+        return menu.Menu(api, **item_dict)
 
     def remove(self, name: str, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/mgmtclasses.py
+++ b/cobbler/cobbler_collections/mgmtclasses.py
@@ -45,9 +45,7 @@ class Mgmtclasses(collection.Collection):
         :param item_dict: TODO
         :returns: TODO
         """
-        new_mgmtclass = mgmtclass.Mgmtclass(api, **item_dict)
-        new_mgmtclass.from_dict(item_dict)
-        return new_mgmtclass
+        return mgmtclass.Mgmtclass(api, **item_dict)
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/packages.py
+++ b/cobbler/cobbler_collections/packages.py
@@ -41,9 +41,7 @@ class Packages(collection.Collection):
         """
         Return a Package forged from item_dict
         """
-        new_package = package.Package(api, **item_dict)
-        new_package.from_dict(item_dict)
-        return new_package
+        return package.Package(api, **item_dict)
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -41,9 +41,7 @@ class Profiles(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_profile = profile.Profile(api, **item_dict)
-        new_profile.from_dict(item_dict)
-        return new_profile
+        return profile.Profile(api, **item_dict)
 
     def remove(self, name: str, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/repos.py
+++ b/cobbler/cobbler_collections/repos.py
@@ -44,9 +44,7 @@ class Repos(collection.Collection):
         """
         Return a Distro forged from item_dict
         """
-        new_repo = repo.Repo(api, **item_dict)
-        new_repo.from_dict(item_dict)
-        return new_repo
+        return repo.Repo(api, **item_dict)
 
     def remove(self, name, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/cobbler_collections/systems.py
+++ b/cobbler/cobbler_collections/systems.py
@@ -71,9 +71,7 @@ class Systems(collection.Collection):
         :param item_dict: TODO
         :returns: TODO
         """
-        new_system = system.System(api, **item_dict)
-        new_system.from_dict(item_dict)
-        return new_system
+        return system.System(api, **item_dict)
 
     def remove(self, name: str, with_delete: bool = True, with_sync: bool = True, with_triggers: bool = True,
                recursive: bool = False):

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -46,7 +46,7 @@ class Distro(item.Item):
         :param args: Place for extra parameters in this distro object.
         :param kwargs: Place for extra parameters in this distro object.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -67,6 +67,8 @@ class Distro(item.Item):
         self._remote_grub_initrd = ""
         self._supported_boot_loaders = []
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/file.py
+++ b/cobbler/items/file.py
@@ -42,12 +42,14 @@ class File(resource.Resource):
         :param args: The arguments which should be passed additionally to a Resource.
         :param kwargs: The keyword arguments which should be passed additionally to a Resource.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
         self._is_dir = False
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/image.py
+++ b/cobbler/items/image.py
@@ -42,7 +42,7 @@ class Image(item.Item):
         :param args: The arguments which should be passed additionally to the base Item class constructor.
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -65,6 +65,8 @@ class Image(item.Item):
         self._virt_type: Union[str, enums.VirtType] = enums.VirtType.INHERITED
         self._supported_boot_loaders = []
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/item.py
+++ b/cobbler/items/item.py
@@ -288,8 +288,12 @@ class Item:
 
         self.logger = logging.getLogger()
         self.api = api
-        if not self._has_initialized:
-            self._has_initialized = True
+
+        if len(kwargs) > 0:
+            kwargs.update({"is_subobject": is_subobject})
+            Item.from_dict(self, kwargs)
+        if self._uid == "":
+            self._uid = uuid.uuid4().hex
 
         if not self._has_initialized:
             self._has_initialized = True
@@ -1135,6 +1139,7 @@ class Item:
                     raise AttributeError("Attribute \"%s\" could not be set!" % lowered_key) from error
                 result.pop(key)
         self._has_initialized = old_has_initialized
+        self.clean_cache()
         if len(result) > 0:
             raise KeyError("The following keys supplied could not be set: %s" % result.keys())
 

--- a/cobbler/items/menu.py
+++ b/cobbler/items/menu.py
@@ -37,12 +37,14 @@ class Menu(item.Item):
         """
         Constructor
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
         self._display_name = ""
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/mgmtclass.py
+++ b/cobbler/items/mgmtclass.py
@@ -41,7 +41,7 @@ class Mgmtclass(item.Item):
         :param args: The arguments which should be passed additionally to the base Item class constructor.
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -51,6 +51,8 @@ class Mgmtclass(item.Item):
         self._files = []
         self._packages = []
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/package.py
+++ b/cobbler/items/package.py
@@ -39,13 +39,15 @@ class Package(resource.Resource):
         :param args: The arguments which should be passed additionally to a Resource.
         :param kwargs: The keyword arguments which should be passed additionally to a Resource.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
         self._installer = ""
         self._version = ""
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -42,7 +42,7 @@ class Profile(item.Item):
         :param args:
         :param kwargs:
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -85,6 +85,8 @@ class Profile(item.Item):
         self.virt_disk_driver = api.settings().default_virt_disk_driver
         self.virt_type = api.settings().default_virt_type
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -147,6 +147,26 @@ class Profile(item.Item):
         self._has_initialized = old_has_initialized
         super().from_dict(dictionary)
 
+    def find_match_single_key(
+        self, data: Dict[str, Any], key: str, value: Any, no_errors: bool = False
+    ) -> bool:
+        """
+        Look if the data matches or not. This is an alternative for ``find_match()``.
+
+        :param data: The data to search through.
+        :param key: The key to look for int the item.
+        :param value: The value for the key.
+        :param no_errors: How strict this matching is.
+        :return: Whether the data matches or not.
+        """
+        # special case for profile, since arch is a derived property from the parent distro
+        if key == "arch":
+            if self.arch:
+                return self.arch.value == value
+            return value is None
+
+        return super().find_match_single_key(data, key, value, no_errors)
+
     #
     # specific methods for item.Profile
     #

--- a/cobbler/items/repo.py
+++ b/cobbler/items/repo.py
@@ -42,7 +42,7 @@ class Repo(item.Item):
         :param args: The arguments which should be passed additionally to the base Item class constructor.
         :param kwargs: The keyword arguments which should be passed additionally to the base Item class constructor.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -63,6 +63,8 @@ class Repo(item.Item):
         self._rpm_list = []
         self._os_version = ""
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/resource.py
+++ b/cobbler/items/resource.py
@@ -32,7 +32,7 @@ class Resource(item.Item):
         """
         Constructor.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -43,6 +43,8 @@ class Resource(item.Item):
         self._path = ""
         self._template = ""
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -795,7 +795,7 @@ class System(Item):
 
         :param api: The Cobbler API
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
         # Prevent attempts to clear the to_dict cache before the object is initialized.
         self._has_initialized = False
 
@@ -848,6 +848,8 @@ class System(Item):
         self._mgmt_parameters = enums.VALUE_INHERITED
         self._mgmt_classes = enums.VALUE_INHERITED
 
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
         if not self._has_initialized:
             self._has_initialized = True
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,7 @@ from cobbler.items.distro import Distro
 from cobbler.items.profile import Profile
 from cobbler.items.system import NetworkInterface, System
 from cobbler.items.image import Image
+from cobbler.items.menu import Menu
 
 
 @contextmanager
@@ -175,6 +176,31 @@ def create_system(request, cobbler_api):
         return test_system
 
     return _create_system
+
+
+@pytest.fixture(scope="function")
+def create_menu(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Returns a function which has the profile name as an argument. The function returns a system object. The system is
+    already added to the CobblerAPI.
+    """
+
+    def _create_menu(name: str = "", display_name: str = "") -> Menu:
+        test_menu = cobbler_api.new_menu()
+
+        if name == "":
+            test_menu.name = (
+                request.node.originalname  # type: ignore
+                if request.node.originalname  # type: ignore
+                else request.node.name
+            )
+
+        test_menu.display_name = display_name
+
+        cobbler_api.add_menu(test_menu)
+        return test_menu
+
+    return _create_menu
 
 
 @pytest.fixture(scope="function", autouse=True)

--- a/tests/items/item_test.py
+++ b/tests/items/item_test.py
@@ -1,4 +1,5 @@
 import os
+from typing import Dict, Any
 
 import pytest
 
@@ -432,28 +433,62 @@ def test_sort_key(request, cobbler_api):
     assert result == [item_name]
 
 
-@pytest.mark.skip("Test not yet implemented")
-def test_find_match(cobbler_api: CobblerAPI):
+@pytest.mark.parametrize(
+    "in_keys, check_keys, expect_match",
+    [
+        ({"uid": "test-uid"}, {"uid": "test-uid"}, True),
+        ({"name": "test-object"}, {"name": "test-object"}, True),
+        ({"comment": "test-comment"}, {"comment": "test-comment"}, True),
+        ({"uid": "test-uid"}, {"uid": ""}, False),
+    ],
+)
+def test_find_match(
+    cobbler_api: CobblerAPI,
+    in_keys: Dict[str, Any],
+    check_keys: Dict[str, Any],
+    expect_match: bool,
+):
+    """
+    Assert that given a desired amount of key-value pairs is matching the item or not.
+    """
+    # Arrange
+    titem = Item(cobbler_api, **in_keys)
+
+    # Act
+    result = titem.find_match(check_keys)
+
+    # Assert
+    assert expect_match == result
+
+
+@pytest.mark.parametrize(
+    "data_keys, check_key, check_value, expect_match",
+    [
+        ({"uid": "test-uid"}, "uid", "test-uid", True),
+        ({"menu": "testmenu0"}, "menu", "testmenu0", True),
+        ({"uid": "test", "name": "test-name"}, "uid", "test", True),
+        ({"depth": "1"}, "name", "test", False),
+        ({"uid": "test", "name": "test-name"}, "menu", "testmenu0", False),
+    ],
+)
+def test_find_match_single_key(
+    cobbler_api: CobblerAPI,
+    data_keys: Dict[str, Any],
+    check_key: str,
+    check_value: Any,
+    expect_match: bool,
+):
+    """
+    Assert that a single given key and value match the object or not.
+    """
     # Arrange
     titem = Item(cobbler_api)
 
     # Act
-    titem.find_match()
+    result = titem.find_match_single_key(data_keys, check_key, check_value)
 
     # Assert
-    assert False
-
-
-@pytest.mark.skip("Test not yet implemented")
-def test_find_match_single_key(cobbler_api: CobblerAPI):
-    # Arrange
-    titem = Item(cobbler_api)
-
-    # Act
-    titem.find_match_single_key()
-
-    # Assert
-    assert False
+    assert expect_match == result
 
 
 def test_dump_vars(cobbler_api: CobblerAPI):


### PR DESCRIPTION
## Linked Items

Fixes #3779

## Description

Due to the special property `arch` on the `Profile` object, it is required to overwrite the `find_match_key` method of the class to resolve as expected during a search.

Without this, the different boot menus could not be correctly generated.

## Behaviour changes

Old: Missing boot menus due to incorrectly functioning search.

New: Boot menus show up as expected.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
