### PR TITLE
Add 3.3.6 changelog

### DIFF
--- a/changelog.d/3744.added
+++ b/changelog.d/3744.added
@@ -1,1 +1,0 @@
-EFI support for "cobbler buildiso"

--- a/changelog.d/3745.fixed
+++ b/changelog.d/3745.fixed
@@ -1,1 +1,0 @@
-Fix item rename with uppercase letters

--- a/changelog.d/3747.fixed
+++ b/changelog.d/3747.fixed
@@ -1,1 +1,0 @@
-Fix DNS append line generation of "cobbler buildiso"

--- a/changelog.d/3748.added
+++ b/changelog.d/3748.added
@@ -1,1 +1,0 @@
-Increase application version to 3.3.6

--- a/changelog.d/3749.fixed
+++ b/changelog.d/3749.fixed
@@ -1,1 +1,0 @@
-Tests: Switch to tftpd for supervisorctl tests

--- a/changelog.d/3750.fixed
+++ b/changelog.d/3750.fixed
@@ -1,1 +1,0 @@
-S390X: Add linebreaks for param files longer then 80 characters

--- a/changelog.d/3751.fixed
+++ b/changelog.d/3751.fixed
@@ -1,1 +1,0 @@
-Skip wrong/inconsistent collections

--- a/changelog.d/3753.fixed
+++ b/changelog.d/3753.fixed
@@ -1,1 +1,0 @@
-tftpgen: Always generate boot menus

--- a/changelog.d/3769.added
+++ b/changelog.d/3769.added
@@ -1,1 +1,0 @@
-CI: Add repository filter condition for release workflow

--- a/changelog.d/3771.added
+++ b/changelog.d/3771.added
@@ -1,1 +1,0 @@
-Settings: Allow definition of extra settings via "extra_settings_list"

--- a/changelog.d/3774.fixed
+++ b/changelog.d/3774.fixed
@@ -1,1 +1,0 @@
-Network Interface: Allow empty str for interface type

--- a/changelog.d/3776.fixed
+++ b/changelog.d/3776.fixed
@@ -1,1 +1,0 @@
-Settings: Correct multiple missing migration points for 3.3.0

--- a/changelog.d/3779.fixed
+++ b/changelog.d/3779.fixed
@@ -1,1 +1,0 @@
-API: Fix issue where searching for a profile by arch wasn't possible

--- a/changelog/v3.3.6.md
+++ b/changelog/v3.3.6.md
@@ -1,0 +1,40 @@
+# Cobbler [3.3.6](https://github.com/cobbler/cobbler/tree/v3.3.6) - 2024-07-16
+
+This release is containing again a lot of backports from `main` to make Cobbler more stable for the community.
+
+Milestone: <https://github.com/cobbler/cobbler/milestone/23>
+
+Diff to last release: [`v3.3.5...v3.3.6`](https://github.com/cobbler/cobbler/compare/v3.3.5...v3.3.6)
+
+## Added
+
+- EFI support for "cobbler buildiso"
+  [#3744](https://github.com/cobbler/cobbler/issues/3744)
+- Increase application version to 3.3.6
+  [#3748](https://github.com/cobbler/cobbler/issues/3748)
+- CI: Add repository filter condition for release workflow
+  [#3769](https://github.com/cobbler/cobbler/issues/3769)
+- Settings: Allow definition of extra settings via "extra_settings_list"
+  [#3771](https://github.com/cobbler/cobbler/issues/3771)
+
+
+## Fixed
+
+- Fix item rename with uppercase letters
+  [#3745](https://github.com/cobbler/cobbler/issues/3745)
+- Fix DNS append line generation of "cobbler buildiso"
+  [#3747](https://github.com/cobbler/cobbler/issues/3747)
+- Tests: Switch to tftpd for supervisorctl tests
+  [#3749](https://github.com/cobbler/cobbler/issues/3749)
+- S390X: Add linebreaks for param files longer then 80 characters
+  [#3750](https://github.com/cobbler/cobbler/issues/3750)
+- Skip wrong/inconsistent collections
+  [#3751](https://github.com/cobbler/cobbler/issues/3751)
+- tftpgen: Always generate boot menus
+  [#3753](https://github.com/cobbler/cobbler/issues/3753)
+- Network Interface: Allow empty str for interface type
+  [#3774](https://github.com/cobbler/cobbler/issues/3774)
+- Settings: Correct multiple missing migration points for 3.3.0
+  [#3776](https://github.com/cobbler/cobbler/issues/3776)
+- API: Fix issue where searching for a profile by arch wasn't possible
+  [#3779](https://github.com/cobbler/cobbler/issues/3779)


### PR DESCRIPTION
## Linked Items

Fixes #3778

## Description

This PR adds the changelog for Cobbler 3.3.6. After the PR has been merged its merge commit will receive the 3.3.6 tag.

## Behaviour changes

None

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
