### PR TITLE
Add EFI chainloader for Centos to menu local

### DIFF
--- a/config/grub/grub/local_efi.cfg
+++ b/config/grub/grub/local_efi.cfg
@@ -29,6 +29,8 @@ menuentry "local" --class gnu-linux --class gnu --class os {
       chainloader (${root})/efi/grub/grub.efi
     elif [ -f (${root})/efi/ubuntu/grubx64.efi ] ; then
       chainloader (${root})/efi/ubuntu/grubx64.efi
+    elif [ -f (${root})/efi/centos/grubx64.efi ] ; then
+      chainloader (${root})/efi/centos/grubx64.efi
     else
       chainloader (${root})/efi/boot/bootx64.efi
     fi


### PR DESCRIPTION
## Linked Items

Fixes #3788

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Add support of CentOS 9 Stream to the local_efi chainload file

## Behaviour changes

Old: `/efi/boot/bootx64.efi` will be chainloaded after CentOS 9 Stream is installed, resulting in booting failure

New: The correct file `/efi/centos/grubx64.efi` will be chainloaded.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [X] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
