### PR TITLE
Update grub.cfg

### DIFF
--- a/config/grub/grub/grub.cfg
+++ b/config/grub/grub/grub.cfg
@@ -43,7 +43,7 @@ fi
 echo "Running on $arch CPU architecture"
 
 #-------------------------------------------------------------------------------
-# MAC address
+# Load MAC address or default architecture system
 #-------------------------------------------------------------------------------
 set mac=${net_default_mac}
 export mac
@@ -51,6 +51,9 @@ export mac
 if [ -s "$prefix/system/$mac" ]; then
   source "$prefix/system/$mac"
   echo "Machine specific grub config file $prefix/system/$mac for $system loaded"
+elif [ -s "$prefix/system/default-$arch" ]; then
+  source "$prefix/system/default-$arch"
+  echo "Machine specific grub config file $prefix/system/default-$arch for $system loaded"
 else
   echo "Could not find machine specific grub config file $prefix/system/$mac"
 fi


### PR DESCRIPTION
Add GRUB support for system named default-$arch as the default boot entry.

## Description

Provide the GRUB loader with the capability to offer a default system based on the architecture, similar to PXE and iPXE.

## Behaviour changes

Old: system named "default" will not be loaded in the GRUB loader.

New: system named default-$arch as the default boot entry

## Category

This is related to a:
- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous
