### PR TITLE
re-delocalize verb participle

### DIFF
--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -866,7 +866,7 @@ default: ``"--newest-only --delete --refresh --remote-time"``
 
 reposync_rsync_flags
 ####################
-Flags to use for rysync's reposync. If archive mode (-a,--archive) is used then createrepo is not ran after the rsync as
+Flags to use for rysync's reposync. If archive mode (-a,--archive) is used then createrepo is not run after the rsync as
 it pulls down the repodata as well. This allows older OS's to mirror modular repos using rsync.
 
 default: ``"-rltDv --copy-unsafe-links"``


### PR DESCRIPTION
PetPeeve - Outside certain regions, 'would run', 'did run', 'had run' and 'could run', all use the same global default.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [x] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous
- [x] trivial
