### PR TITLE
[XMLRPC-API] Add support for querying and removing unsaved items 

### DIFF
--- a/changelog.d/3799.changed
+++ b/changelog.d/3799.changed
@@ -1,0 +1,1 @@
+XMLRPC-API: Added support for deleting and querying unsaved items

--- a/tests/xmlrpcapi/item_test.py
+++ b/tests/xmlrpcapi/item_test.py
@@ -1,5 +1,9 @@
 import pytest
 
+from cobbler.api import CobblerAPI
+from cobbler.items.menu import Menu
+from cobbler.remote import CobblerXMLRPCInterface
+
 
 @pytest.mark.usefixtures("create_testdistro", "remove_testdistro")
 def test_get_item_resolved(remote, fk_initrd, fk_kernel):
@@ -16,3 +20,30 @@ def test_get_item_resolved(remote, fk_initrd, fk_kernel):
     assert distro.get("redhat_management_key") == ""
     assert fk_initrd in distro.get("initrd")
     assert fk_kernel in distro.get("kernel")
+
+
+def test_remove_item(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: remove item object (in this case menu).
+    """
+    # Arrange
+    test_menu = remote.new_menu(token)  # type: ignore
+    remote.modify_menu(test_menu, "name", "testmenu0", token)
+    remote.modify_menu(test_menu, "display_name", "testmenu0", token)
+
+    # Act
+    result = remote.remove_menu("testmenu0", token, True)  # type: ignore
+
+    # Assert
+    assert result
+    assert not test_menu in remote.unsaved_items
+
+
+def test_create_unsaved_item(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: create unsaved item (in this case menu)
+    """
+    test_menu = remote.new_menu(token)
+    remote.modify_menu(test_menu, "name", "testmenu0", token)
+    remote.modify_menu(test_menu, "display_name", "testmenu", token)
+    assert test_menu in remote.unsaved_items


### PR DESCRIPTION
## Linked Items

Fixes #3799 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Relace all calls of `self.api.get_item()` with `self.__get_object(self.get_item_handle())`.

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [x] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
