### PR TITLE
XML-RPC API: Fix querying and removing items

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -959,7 +959,7 @@ class CobblerXMLRPCInterface:
         requested_item = requested_item.to_dict(resolved=resolved)
         if flatten:
             requested_item = utils.flatten(requested_item)
-        return requested_item
+        return self.xmlrpc_hacks(requested_item)
 
     def get_distro(
         self,
@@ -1450,7 +1450,7 @@ class CobblerXMLRPCInterface:
 
         found_saved = self.api.find_items(what, name=name, return_list=True)
         if len(found_saved) > 1:  # type: ignore
-            raise CX(f"ambigous match for given collection and name")
+            raise CX(f"ambiguous match for given collection and name")
         elif len(found_saved) == 1:  # type: ignore
             return found_saved[0].uid  # type: ignore
         # Check if in cache
@@ -2115,7 +2115,7 @@ class CobblerXMLRPCInterface:
                 handle = self.get_item_handle(object_type, tmp_name)
             except CX:
                 pass
-            if handle:
+            if handle and handle != "~":
                 raise CX(
                     "It seems unwise to overwrite the object %s, try 'edit'", tmp_name
                 )


### PR DESCRIPTION
## Linked Items

Fixes PR #3801 

## Description

This adds our xmlrpc_hacks wrapper for `get_item` and does an additional check for `xapi_object_edit` since the return type changed.

## Behaviour changes

Old: Using the CLI fails in many different scenarios

New: CLI works as expected again.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
