### PR TITLE
Increase start timeout for cobblerd unit

### DIFF
--- a/changelog.d/3821.changed
+++ b/changelog.d/3821.changed
@@ -1,0 +1,1 @@
+Increase start timeout for cobblerd unit to 180 seconds

--- a/config/service/cobblerd.service
+++ b/config/service/cobblerd.service
@@ -8,6 +8,7 @@ ExecStart=/usr/bin/cobblerd -F
 PrivateTmp=yes
 KillMode=process
 Type=notify
+TimeoutStartSec=180
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Description

The default timeout when starting the `systemd` unit is 90s. In this PR, we double it in case users have large number of systems managed by Cobbler.

## Behaviour changes

Old: The timeout for the `cobblerd` service is 90 seconds.

New: The timeout for the `cobblerd` service is 180 seconds.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [X] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [X] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
