### PR TITLE
WIP: Make passthru authentication work with XML-RPC

### DIFF
--- a/cobbler/modules/authentication/passthru.py
+++ b/cobbler/modules/authentication/passthru.py
@@ -28,11 +28,11 @@ def register() -> str:
 
 def authenticate(api_handle, username, password) -> bool:
     """
-    Validate a username/password combo. Uses cobbler_auth_helper
+    Validate a username/password combo.
 
     :param api_handle: This parameter is not used currently.
     :param username: This parameter is not used currently.
-    :param password: This should be the internal Cobbler secret.
-    :return: True if the password is the secret, otherwise false.
+    :param password: This parameter is not used currently.
+    :return: True always - authentication is handled by web server.
     """
-    return password == utils.get_shared_secret()
+    return True


### PR DESCRIPTION
## Linked Items

Fixes #3824 

## Description

Authentication is handled by web server and CLI access is handled by remote.login().

The next step though I think is to get the user information from the http request.


## Behaviour changes

Old: cobbler would only accept the shared web secret for login

New: cobbler allows other users to login via web auth and access xml-rpc

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

TODO