### PR TITLE
Fix rhel9 fences dependency

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -225,7 +225,11 @@ Requires(postun): systemd
 Requires:       %{apache_pkg}
 Requires:       %{tftpsrv_pkg}
 Requires:       %{createrepo_pkg}
+%if 0%{?rhel} && 0%{?rhel} < 9
 Requires:       fence-agents
+%else
+Requires:       fence-agents-all
+%endif
 Requires:       rsync
 Requires:       xorriso
 Requires:       dosfstools


### PR DESCRIPTION
## Linked Items

Fixes package dependency issue for RHEL9 due to `fence-agents` having been split into separate RPMs and renamed to
 `fence-agents-all` between RHEL7 and RHEL9.

## Description

Conditionally require either `fence-agents` or `fence-agents-all`, requiring the latter for RHEL 9 and later based distros.

## Behaviour changes

Old: Cobbler would fail to install via RPMs on RHEL9 based machines due to a broken dependency on `fence-agents`

New: Cobbler now installs `fence-agents-all`

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
