### PR TITLE
Let users specify ESP for buildiso

### DIFF
--- a/changelog.d/3834.added
+++ b/changelog.d/3834.added
@@ -1,0 +1,1 @@
+Add the `esp` parameter in the `buildiso` command to allow users to specify the ESP partition for built ISOs

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -678,6 +678,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         distro_name: str = "",
         systems: Optional[List[str]] = None,
         exclude_dns: bool = False,
+        esp: Optional[str] = None,
         **kwargs: Any,
     ):
         """
@@ -726,15 +727,19 @@ class NetbootBuildiso(buildiso.BuildIso):
 
             # fill temporary directory with arch-specific binaries
             self._copy_isolinux_files()
-            try:
-                filesource = self._find_distro_source(
-                    distro_obj.kernel, str(distro_mirrordir)
-                )
-                self.logger.info("filesource=%s", filesource)
-                distro_esp = self._find_esp(pathlib.Path(filesource))
-                self.logger.info("esp=%s", distro_esp)
-            except ValueError:
-                distro_esp = None
+            if esp:
+                self.logger.info("esp=%s", esp)
+                distro_esp = esp
+            else:
+                try:
+                    filesource = self._find_distro_source(
+                        distro_obj.kernel, str(distro_mirrordir)
+                    )
+                    self.logger.info("filesource=%s", filesource)
+                    distro_esp = self._find_esp(pathlib.Path(filesource))
+                    self.logger.info("esp=%s", distro_esp)
+                except ValueError:
+                    distro_esp = None
 
             if distro_esp is not None:
                 self._copy_esp(distro_esp, buildisodir)
@@ -776,4 +781,4 @@ class NetbootBuildiso(buildiso.BuildIso):
                 copyset.new_filename,
             )
 
-        xorriso_func(xorrisofs_opts, iso, buildisodir, esp_location)
+        xorriso_func(xorrisofs_opts, iso, buildisodir, buildisodir + "/efi")

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -246,6 +246,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         distro_name: str = "",
         airgapped: bool = False,
         source: str = "",
+        esp: Optional[str] = None,
         **kwargs: Any,
     ):
         """
@@ -314,7 +315,11 @@ class StandaloneBuildiso(buildiso.BuildIso):
             self._copy_isolinux_files()
             # create EFI system partition (ESP) if needed, uses the ESP from the
             # distro if it was copied
-            esp_location = self._find_esp(buildiso_dirs.root)
+            if esp:
+                esp_location = esp
+            else:
+                esp_location = self._find_esp(buildiso_dirs.root)
+
             if esp_location is None:
                 esp_location = self._create_esp_image_file(buildisodir)
                 self._copy_grub_into_esp(esp_location, distro_obj.arch)
@@ -367,4 +372,4 @@ class StandaloneBuildiso(buildiso.BuildIso):
             )
 
         self._write_autoinstall_cfg(autoinstall_data, buildiso_dirs.autoinstall)
-        xorriso_func(xorrisofs_opts, iso, buildisodir, esp_location)
+        xorriso_func(xorrisofs_opts, iso, buildisodir, buildisodir + "/efi")

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2161,6 +2161,7 @@ class CobblerAPI:
         source: str = "",
         exclude_dns: bool = False,
         xorrisofs_opts: str = "",
+        esp: Optional[str] = None,
     ) -> None:
         r"""
         Build an iso image which may be network bootable or not.
@@ -2176,11 +2177,14 @@ class CobblerAPI:
         :param source: If the iso should be offline available this is the path to the sources of the image.
         :param exclude_dns: Whether the repositories have to be locally available or the internet is reachable.
         :param xorrisofs_opts: ``xorrisofs`` options to include additionally.
+        :param esp: location of the ESP partition, e.g. for secure boot.
         """
         if not isinstance(standalone, bool):  # type: ignore
             raise TypeError('Argument "standalone" needs to be of type bool!')
         if not isinstance(airgapped, bool):  # type: ignore
             raise TypeError('Argument "airgapped" needs to be of type bool!')
+        if esp and not Path(esp).exists():
+            raise TypeError(f"Specified ESP partition does not exist: {esp}")
         if airgapped:
             standalone = True
         Builder = StandaloneBuildiso if standalone else NetbootBuildiso
@@ -2194,6 +2198,7 @@ class CobblerAPI:
             source=source,
             systems=systems,
             exclude_dns=exclude_dns,
+            esp=esp,
         )
 
     # ==========================================================================

--- a/cobbler/cli.py
+++ b/cobbler/cli.py
@@ -2180,6 +2180,12 @@ class CobblerCLI:
                 help="(OPTIONAL) extra options for xorrisofs",
             )
 
+            self.parser.add_option(
+                "--esp",
+                dest="esp",
+                help="(OPTIONAL) location of ESP partition, e.g. for secure boot",
+            )
+
             (options, _) = self.parser.parse_args(self.args)
             task_id = self.start_task("buildiso", options)
 

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -238,6 +238,7 @@ class CobblerXMLRPCInterface:
                 self.options.get("source", ""),
                 self.options.get("exclude_dns", False),
                 self.options.get("xorrisofs_opts", ""),
+                self.options.get("esp", None),
             )
 
         def on_done(self: CobblerThread):

--- a/docs/user-guide/building-isos.rst
+++ b/docs/user-guide/building-isos.rst
@@ -59,6 +59,8 @@ Common options for building ISOs
   you should really consider using a tmpfs for performance.
 * ``--profiles``: Modify the profiles Cobbler builds ISOs for. If this is omitted, ISOs for all profiles will be built.
 * ``--xorrisofs-opts``: The options which are passed to xorriso additionally to the above shown.
+* ``--esp``: Explicitly specify the EFI System Partition (ESP). The default is to attempt to search for ESP, and
+  generate one if an ESP cannot be found.
 
 Building standalone ISOs
 ########################
@@ -78,6 +80,23 @@ You have to provide the following parameters:
 * ``--systems``: Filter the systems you want to build the ISO for.
 * ``--exclude-dns``: Flag to add the nameservers (and other DNS information) to the append line or not. This only has
   an effect in case you supply ``--systems`` and the system contains the ``--name-servers`` configuration.
+
+Building ISOs for Secure Boot
+#############################
+
+When you build an ISO from a distribution that is stored in the Cobbler Web directory, e.g.
+ ``/srv/www/cobbler/distro_mirror/``, Cobbler looks for the EFI System Partition (ESP) of the provided distribution
+ automatically. This is the default behavior, for example, when you use the ``cobbler import`` command to
+ create a distribution.
+
+If you create a distribution that references files stored outside of the Cobbler Web directory, e.g.
+``/usr/share/tftpboot-installation/SLE-15-SP6-x86_64``, use the ``--esp`` parameter to specify the location of
+the ESP, for example:
+
+.. code-block:: shell
+
+   cobbler buildiso --esp="/usr/share/tftpboot-installation/SLE-15-SP6-x86_64/boot/x86_64/efi" \
+     --iso=/tmp/out.iso --distro=sles15-sp6
 
 Examples
 ########


### PR DESCRIPTION
## Linked Items

Related to: https://github.com/SUSE/spacewalk/issues/25277 (downstream issue)

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

In this PR, there are two notable changes:

1. (main PR change) We allow users to specify the `esp` partition when building an ISO. Currently, for Cobbler to find the ESP, [0] needs to be true. We call that function e.g. from [1], where we hardcode the mirror_dir to [2]. This makes sense, because when users import distros, Cobbler copies it to the webroot. However, when we create a distro manually, this means that the buildiso command never finds and includes the ESP even when present.

This poses an issue where we cannot know for sure what the webroot is. I chose the approach where if users create distributions manually, they should know where the ESP for that distribution is. This allows the ESP to be within the distro root, or in a completely unrelated location.

2. (bugfix?) I noticed that both the `netboot` and `standalone` buildiso commands ended with `xorriso_func(xorrisofs_opts, iso, buildisodir, esp_location)`. Note the use of `esp_location` variable. This variable referred to the location in the distro root, not in the temporary directory where the esp is copied. I noticed that previously, this used to be `buildisodir + "/efi"`, which is where the EFI is either copied, or generated. Without this change, I couldn't make generating ISOs with secure boot work. Generating ISOs without secure boot worked because of [3] (which does not happen when the ESP is copied).

[0] https://github.com/cobbler/cobbler/blob/main/cobbler/actions/buildiso/__init__.py#L143
[1] https://github.com/cobbler/cobbler/blob/main/cobbler/actions/buildiso/netboot.py#L730
[2] https://github.com/cobbler/cobbler/blob/main/cobbler/actions/buildiso/netboot.py#L719
[3] https://github.com/cobbler/cobbler/blob/main/cobbler/actions/buildiso/netboot.py#L742

## Behaviour changes

Old: Users that generated ISOs from distros outside of Cobbler's webroot couldn't include ESP in the built ISOs. 

New: Users can now specify the ESP explicitly when building ISOs.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
