### PR TITLE
Fix: Python 3.13 support

### DIFF
--- a/changelog.d/3842.fixed
+++ b/changelog.d/3842.fixed
@@ -1,0 +1,1 @@
+Fix compatibility with Python 3.13

--- a/tests/actions/reposync_test.py
+++ b/tests/actions/reposync_test.py
@@ -92,8 +92,8 @@ def test_repo_walker(mocker: "MockerFixture", tmp_path: Path):
 @pytest.mark.parametrize(
     "input_has_librepo,input_path_exists_side_effect,expected_exception,expected_result",
     [
-        (True, [True, False], does_not_raise(), ["/usr/bin/dnf", "reposync"]),
-        (True, [False, True], does_not_raise(), ["/usr/bin/reposync"]),
+        (True, [False, True], does_not_raise(), ["/usr/bin/dnf", "reposync"]),
+        (True, [True, False], does_not_raise(), ["/usr/bin/reposync"]),
         (True, [False, False], pytest.raises(cexceptions.CX), ""),
         (False, [False, True], pytest.raises(cexceptions.CX), ""),
     ],


### PR DESCRIPTION
## Linked Items

Fixes #3826

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Replacement of modules deprecated in Python 3.13

## Behaviour changes

Old: Cobbler doesn't run on Fedora 41

New: Cobbler runs.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [X] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
