### PR TITLE
Fix: Missing dependencies in the installation-guide

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - name: Build a openSUSE Leap 15.3 Package
+      - name: Build a openSUSE Leap 15 Package
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          ./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+          ./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
   build-opensuse-tumbleweed-rpms:
     runs-on: ubuntu-20.04
     steps:

--- a/changelog.d/3845.fixed
+++ b/changelog.d/3845.fixed
@@ -1,0 +1,1 @@
+Docs: Add missing dependencies for source installation

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -40,12 +40,16 @@ met prior to installing Cobbler or any of its components.
 First and foremost, Cobbler requires Python. Since 3.0.0 you will need Python 3. Cobbler also requires the installation
 of the following packages:
 
+- wget and/or curl
 - createrepo_c
 - httpd / apache2
 - xorriso
 - mod_wsgi / libapache2-mod-wsgi
 - mod_ssl / libapache2-mod-ssl
 - python-cheetah
+- python-distro
+- python-dns
+- python-file-magic
 - python-netaddr
 - python-librepo
 - python-schema
@@ -54,10 +58,30 @@ of the following packages:
 - syslinux
 - tftp-server / atftpd
 - dnf-plugins-core
+- dosfstools
+
+If you decide to use the power management, please also install manually:
+
+- fence-agents / fence-agents-all
 
 If you decide to use the LDAP authentication, please also install manually in any case:
 
 - python3-ldap (or via PyPi: ldap)
+
+If you decide to use the MongoDB storage backend, please also install manually:
+
+- python-pymongo
+
+If you decide to write your templates in Jinja2 instead of Cheetah, please also install manually:
+
+- python-jinja2
+
+If you decide to require Windows auto-installation support, please also install manually:
+
+- python-hivex
+- python-pefile
+
+If you are on an apt-based system our operation may be better for mirror detection if the ``aptsources`` Python module is available.
 
 Koan can be installed apart from Cobbler. Please visit the `Koan documentation <https://koan.readthedocs.io/en/latest/>`_ for details.
 


### PR DESCRIPTION
## Linked Items

Fixes #3845

## Description

This expands the installation guide with dependencies that were added to the codebase but not mentioned in the installation guide.

## Behaviour changes

Old: Installation from source is not succeeding due to missing required dependencies.

New: Installation from source succeeds thanks to added dependencies.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [x] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
