### PR TITLE
Modules: bind - Fix cname generation bug

### DIFF
--- a/changelog.d/3812.fixed
+++ b/changelog.d/3812.fixed
@@ -1,0 +1,1 @@
+Modules: bind - Fix bug that prevents cname entries from being generated successfully

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -479,7 +479,7 @@ zone "%(arpa)s." {
                 cnames = interface.cnames
 
                 try:
-                    if interface.get("dns_name", "") != "":
+                    if interface.dns_name != "":
                         dnsname = interface.dns_name.split('.')[0]
                         for cname in cnames:
                             s += "%s  %s  %s;\n" % (cname.split('.')[0], rectype, dnsname)
@@ -503,21 +503,19 @@ zone "%(arpa)s." {
         # need a counter for new bind format
         serial = time.strftime("%Y%m%d00")
         try:
-            serialfd = open(serial_filename, "r")
-            old_serial = serialfd.readline()
-            # same date
-            if serial[0:8] == old_serial[0:8]:
-                if int(old_serial[8:10]) < 99:
-                    serial = "%s%.2i" % (serial[0:8], int(old_serial[8:10]) + 1)
-            else:
-                pass
-            serialfd.close()
+            with open(serial_filename, "r", encoding="UTF-8") as serialfd:
+                old_serial = serialfd.readline()
+                # same date
+                if serial[0:8] == old_serial[0:8]:
+                    if int(old_serial[8:10]) < 99:
+                        serial = "%s%.2i" % (serial[0:8], int(old_serial[8:10]) + 1)
+                else:
+                    pass
         except:
             pass
 
-        serialfd = open(serial_filename, "w")
-        serialfd.write(serial)
-        serialfd.close()
+        with open(serial_filename, "w", encoding="UTF-8") as serialfd:
+            serialfd.write(serial)
 
         forward = self.__forward_zones()
         reverse = self.__reverse_zones()

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -1,4 +1,45 @@
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from cobbler.api import CobblerAPI
 from cobbler.modules.managers import bind
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(scope="function")
+def named_template() -> str:
+    """
+    This provides a minmal test templated for named that is close to the real one.
+    """
+    return """options {
+          listen-on port 53 { 127.0.0.1; };
+          directory       "@@bind_zonefiles@@";
+          dump-file       "@@bind_zonefiles@@/data/cache_dump.db";
+          statistics-file "@@bind_zonefiles@@/data/named_stats.txt";
+          memstatistics-file "@@bind_zonefiles@@/data/named_mem_stats.txt";
+          allow-query     { localhost; };
+          recursion yes;
+};
+
+#for $zone in $forward_zones
+zone "${zone}." {
+    type master;
+    file "$zone";
+};
+
+#end for
+#for $zone, $arpa in $reverse_zones
+zone "${arpa}." {
+    type master;
+    file "$zone";
+};
+
+#end for
+"""
 
 
 def test_register():
@@ -14,9 +55,70 @@ def test_manager_what():
     assert bind._BindManager.what() == "bind"
 
 
-def test_get_manager(cobbler_api):
+def test_get_manager(cobbler_api: CobblerAPI):
     # Arrange & Act
     result = bind.get_manager(cobbler_api)
 
     # Assert
     isinstance(result, bind._BindManager)
+
+
+def test_manager_write_configs(mocker: "MockerFixture", cobbler_api: CobblerAPI, named_template: str):
+    # Arrange
+    open_mock = mocker.mock_open()
+    mock_named_template = mocker.mock_open(read_data=named_template)
+    mock_secondary_template = mocker.mock_open(read_data="garbage")
+    mock_zone_template = mocker.mock_open(read_data="garbage 2")
+    mock_bind_serial = mocker.mock_open()
+    mock_etc_named_conf = mocker.mock_open()
+    mock_etc_secondary_conf = mocker.mock_open()
+
+    def mock_open(*args: Any, **kwargs: Any):
+        if args[0] == "/etc/cobbler/named.template":
+            return mock_named_template(*args, **kwargs)
+        if args[0] == "/etc/cobbler/secondary.template":
+            return mock_secondary_template(*args, **kwargs)
+        if args[0] == "/etc/cobbler/zone.template":
+            return mock_zone_template(*args, **kwargs)
+        if args[0] == "/var/lib/cobbler/bind_serial":
+            return mock_bind_serial(*args, **kwargs)
+        if args[0] == "/etc/named.conf":
+            return mock_etc_named_conf(*args, **kwargs)
+        if args[0] == "/etc/secondary.conf":
+            return mock_etc_secondary_conf(*args, **kwargs)
+        return open_mock(*args, **kwargs)
+
+    mocker.patch("builtins.open", mock_open)
+    manager = bind.get_manager(cobbler_api)
+    # TODO Mock settings for manage_dns and forward/reverse zones
+
+    # Act
+    manager.write_configs()
+
+    # Assert
+    # TODO: Extend assertions
+    mock_bind_serial.assert_any_call(
+        "/var/lib/cobbler/bind_serial", "r", encoding="UTF-8"
+    )
+    mock_bind_serial_handle = mock_bind_serial()
+    mock_bind_serial_handle.write.assert_any_call(time.strftime("%Y%m%d00"))
+    open_mock.assert_not_called()
+
+
+def test_manager_restart_service(mocker: "MockerFixture", cobbler_api: CobblerAPI):
+    # Arrange
+    manager = bind.get_manager(cobbler_api)
+    mocked_service_name = mocker.patch(
+        "cobbler.utils.named_service_name", autospec=True, return_value="named"
+    )
+    mock_service_restart = mocker.patch(
+        "cobbler.utils.subprocess_call", return_value=0
+    )
+
+    # Act
+    result = manager.restart_service()
+
+    # Assert
+    assert mocked_service_name.call_count == 1
+    mock_service_restart.assert_called_with(["service", "named", "restart"], shell=False)
+    assert result == 0


### PR DESCRIPTION
## Linked Items

Fixes #3812

## Description

CNAME records for the bind DNS management weren't successfully generated due to on oversight when porting to Python Properties.

## Behaviour changes

Old: BIND CNAME records were missing

New: BIND CNAME records are present in the forward zone

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
