### PR TITLE
Fix: release33 login test errors

### DIFF
--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import pytest
 
+from cobbler.cexceptions import CX
 from cobbler.remote import CobblerXMLRPCInterface
 from cobbler.utils import get_shared_secret
 
@@ -543,8 +544,8 @@ class TestMiscellaneous:
         "input_username,input_password,expected_result,expected_exception,web_ss_exists",
         [
             ("cobbler", "cobbler", True, does_not_raise(), True),
-            ("cobbler", "incorrect-password", True, pytest.raises(ValueError), True),
-            ("", "doesnt-matter", True, pytest.raises(ValueError), True),
+            ("cobbler", "incorrect-password", True, pytest.raises(CX), True),
+            ("", "doesnt-matter", True, pytest.raises(CX), True),
             ("", "my-random-web-ss", True, does_not_raise(), True),
             ("", "my-random-web-ss", True, pytest.raises(ValueError), False),
         ],


### PR DESCRIPTION
## Linked Items

No tracker issue

## Description

No change to the application. The backport of the CVE fix had an error in the test assertions.

## Behaviour changes

Old: None

New: None

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
