### PR TITLE
Update Cobbler version to 3.2.4 (release32)

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -3,31 +3,50 @@ name: Building Cobbler Packages
 on:
   push:
     branches: [ main, release* ]
+    tags: [ 'v*' ]
   pull_request:
     branches: [ main, release* ]
 
 jobs:
   build-rockylinux8-rpms:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Build a Rocky Linux 8 Package
         shell: 'script -q -e -c "bash {0}"'
         run: |
           ./tests/build-and-install-rpms.sh rl8 docker/Rocky_Linux_8.dockerfile
+      - name: Archive RPMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-rockylinux-8
+          path: |
+            rpm-build/*.rpm
   build-fedora33-rpms:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Build a Fedora 33 Package
         shell: 'script -q -e -c "bash {0}"'
         run: |
           ./tests/build-and-install-rpms.sh fc33 docker/Fedora33.dockerfile
+      - name: Archive RPMs
+        uses: actions/upload-artifact@v4
+        with:
+          name: rpms-fedora-33
+          path: |
+            rpm-build/*.rpm
   build-debian-debs:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Build a Debian 10 Package
         shell: 'script -q -e -c "bash {0}"'
         run: |
           ./tests/build-and-install-debs.sh deb10 docker/Debian10.dockerfile
+      - name: Archive DEBs
+        uses: actions/upload-artifact@v4
+        with:
+          name: debs-debian10
+          path: |
+            deb-build/DEBS/all/*.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,15 @@ name: Publish Python distributions to PyPI
 
 on:
   push:
+    branches:
+      - main
+      - release*
     tags:
       - 'v*'
+  pull_request:
+    branches:
+      - main,
+      - release*
 
 env:
   DATAPATH: "/usr/share/cobbler"

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include COPYING AUTHORS
 include cobbler.spec config/service/cobblerd.service
 include AUTHORS.in README.md
 include distro_build_configs.sh
+include Makefile
 recursive-include misc *
 recursive-include bin *
 recursive-include config *

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ doc: ## Creates the documentation with sphinx in html form.
 	@echo "creating: documentation"
 	@cd docs; make html > /dev/null 2>&1
 
+man: ## Creates documentation and man pages using Sphinx
+	@${PYTHON} -m sphinx -b man -j auto ./docs ./build/sphinx/man
+
 qa: ## If pyflakes and/or pycodestyle is found then they are run.
 ifeq ($(strip $(PYFLAKES)),)
 	@echo "No pyflakes found"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,18 +2,18 @@
 
 ## Supported Versions
 
-| Version   | Supported                   |
-| --------- | --------------------------- |
-| 4.0.X     | Next API breaking Release   |
-| 3.3.x     | Current Release             |
-| 3.2.x     | Current Version: 3.2.2      |
-| 3.1.x     | EOL                         |
-| 3.0.x     | EOL                         |
-| 2.8.x     | EOL                         |
-| 2.6.x     | EOL                         |
-| 2.4.x     | EOL                         |
-| 2.2.x     | EOL                         |
-| < 2.x.x   | EOL                         |
+| Version | Supported                 |
+|---------|---------------------------|
+| 4.0.X   | Next API breaking Release |
+| 3.3.x   | Current Release series    |
+| 3.2.x   | Current Version: 3.2.4    |
+| 3.1.x   | EOL                       |
+| 3.0.x   | EOL                       |
+| 2.8.x   | EOL                       |
+| 2.6.x   | EOL                       |
+| 2.4.x   | EOL                       |
+| 2.2.x   | EOL                       |
+| < 2.x.x | EOL                       |
 
 Due to the amount of maintainers we have, we can only support the most current version. Old versions won't be actively
 maintained.

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -137,7 +137,7 @@
 %endif
 
 Name:           cobbler
-Version:        3.2.2
+Version:        3.2.4
 Release:        1%{?dist}
 Summary:        Boot server configurator
 URL:            https://cobbler.github.io/

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -290,7 +290,7 @@ Unit test files from the Cobbler project
 
 
 %prep
-%setup
+%autosetup -p1
 
 %if 0%{?suse_version}
 # Set tftpboot location correctly for SUSE distributions
@@ -298,6 +298,9 @@ sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i cobbler/settings.py config/cob
 %endif
 
 %build
+if [ -d "%{_sourcedir}/%{name}-%{version}/.git" ]; then
+    cp -r %{_sourcedir}/%{name}-%{version}/.git %{_builddir}/%{name}-%{version}
+fi
 . distro_build_configs.sh
 
 # Check distro specific variables for consistency

--- a/cobbler.spec
+++ b/cobbler.spec
@@ -314,6 +314,7 @@ sed -e "s|/var/lib/tftpboot|%{tftpboot_dir}|g" -i cobbler/settings.py config/cob
 [ "${TFTPROOT}" != %{tftpboot_dir} ] && echo "ERROR: TFTPROOT: ${TFTPROOT} does not match %{tftpboot_dir}"
 
 %py3_build
+make man
 
 %install
 . distro_build_configs.sh

--- a/docker/openSUSE_Leap.dockerfile
+++ b/docker/openSUSE_Leap.dockerfile
@@ -12,7 +12,7 @@ RUN ["zypper", "-n", "update"]
 RUN ["zypper", "-n", "in", "python3", "python3-devel", "python3-pip", "python3-setuptools", "python3-wheel", \
     "python3-distro", "python3-coverage", "python3-schema", "apache2", "apache2-devel", "acl", "ipmitool", \
     "rsync", "fence-agents", "genders", "xorriso", "python3-ldap", "tftp", "python3-Sphinx", "hardlink", "supervisor", \
-    "apache2-mod_wsgi-python3"]
+    "apache2-mod_wsgi-python3", "python3-sphinx_rtd_theme"]
 RUN ["pip3", "install", "pykickstart"]
 
 # Packages for building & installing cobbler from sourceless

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ author = 'Enno Gotthold'
 # The short X.Y version
 version = '3.2'
 # The full version, including alpha/beta/rc tags
-release = '3.2.2'
+release = '3.2.4'
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ import shutil
 import subprocess
 
 
-VERSION = "3.2.2"
+VERSION = "3.2.4"
 OUTPUT_DIR = "config"
 
 log = logging.getLogger("setup.py")

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ from setuptools import dep_util
 from distutils.command.build import build as _build
 from configparser import ConfigParser
 from setuptools import find_packages
-from sphinx.setup_command import BuildDoc
 
 import codecs
 from coverage import Coverage
@@ -147,15 +146,6 @@ class build(_build):
     def run(self):
         _build.run(self)
 
-#####################################################################
-# # Build man pages using Sphinx  ###################################
-#####################################################################
-
-
-class build_man(BuildDoc):
-    def initialize_options(self):
-        BuildDoc.initialize_options(self)
-        self.builder = 'man'
 
 #####################################################################
 # # Configure files ##################################################
@@ -283,15 +273,7 @@ def has_configure_files(build):
     return bool(build.distribution.configure_files)
 
 
-def has_man_pages(build):
-    """Check if the distribution has configuration files to work on."""
-    return bool(build.distribution.man_pages)
-
-
-build.sub_commands.extend((
-    ('build_man', has_man_pages),
-    ('build_cfg', has_configure_files)
-))
+build.sub_commands.extend((('build_cfg', has_configure_files),))
 
 
 #####################################################################
@@ -494,7 +476,6 @@ if __name__ == "__main__":
             'savestate': savestate,
             'restorestate': restorestate,
             'build_cfg': build_cfg,
-            'build_man': build_man
         },
         name="cobbler",
         version=VERSION,

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -78,7 +78,7 @@ class TestMiscellaneous:
         #                       '3.1.2', 'version_tuple': [3, 1, 2]}
         assert type(result) == dict
         assert type(result.get("version_tuple")) == list
-        assert [3, 2, 2] == result.get("version_tuple")
+        assert [3, 2, 4] == result.get("version_tuple")
 
     def test_find_items_paged(self, remote, token, create_distro, remove_distro):
         # Arrange
@@ -516,7 +516,7 @@ class TestMiscellaneous:
 
         # Assert
         # Will fail if the version is adjusted in the setup.py
-        assert result == 3.202
+        assert result == 3.204
 
     def test_xapi_object_edit(self, remote, token, remove_distro):
         # Arrange


### PR DESCRIPTION
## Linked Items

Fixes #3855

Fixes #3856 

## Description

Due to me running out of time yesterday evening when making the release a few things went wrong. This PR is attempting to prepare the `release32` branch for a fixup release. As the CVE is fixed with 3.2.3 and the release in principle is installable (especially with a patch provided by a downstream packager), there is no rush in getting 3.2.4 out.

## Behaviour changes

Old: Releases in the series of 3.2.x are failing to be uploaded to PyPi

New: Releases in the series of 3.2.x should successfully upload to PyPi in theory (emphasis on should)

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
