### PR TITLE
Add SUSE bootloader to default config

### DIFF
--- a/cobbler/data/config/cobbler/settings.yaml
+++ b/cobbler/data/config/cobbler/settings.yaml
@@ -71,6 +71,10 @@ bootloaders_formats:
     extra_modules:
       - chain
       - efinet
+  # Necessary for secure boot to work by default on x86_64 with SUSE-based distros
+  default-suse-efi:
+    binary_name: grub.efi
+    use_secure_boot_grub: true
 bootloaders_modules:
   - btrfs
   - ext2


### PR DESCRIPTION
## Description

On x86_64, we provide `shim.efi`, which expects `grub.efi`. However, by default, `grub.efi` gets copied as `grubx86.efi`, which means that secure boot doesn't work without modifying the config.

## Behaviour changes

Old: `grub.efi` was missing so secure boot does not work for openSUSE/SUSE distros

New:  `grub.efi` is also synchronised so secure boot works for openSUSE/SUSE distros

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [X] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
