### PR TITLE
Make the CNAME rendering to actually be aligned.

### DIFF
--- a/changelog.d/4070.fixed
+++ b/changelog.d/4070.fixed
@@ -1,0 +1,1 @@
+Aligned CNAME records in generated BIND zone files into columns, matching the existing A/AAAA/PTR record formatting.

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -461,15 +461,17 @@ zone "%(arpa)s." {
                 s += "%s  %s  %s  %s;\n" % (my_name, rclass, my_rectype, my_host)
         return s
 
-    def __pretty_print_cname_records(self, hosts, rectype: str = 'CNAME'):
+    def __pretty_print_cname_records(self, hosts, rectype: str = 'CNAME', rclass: str = 'IN'):
         """
         Format CNAMEs and with consistent indentation
 
         :param hosts: This parameter is currently unused.
         :param rectype: The type of record which shall be pretty printed.
+        :param rclass: The record class.
         :return: The pretty printed version of the cname records.
         """
         s = ""
+        zone_alliases = {}
 
         # This loop warns and skips the host without dns_name instead of outright exiting
         # Which results in empty records without any warning to the users
@@ -482,13 +484,24 @@ zone "%(arpa)s." {
                     if interface.dns_name != "":
                         dnsname = interface.dns_name.split('.')[0]
                         for cname in cnames:
-                            s += "%s  %s  %s;\n" % (cname.split('.')[0], rectype, dnsname)
+                            zone_alliases[cname.split('.')[0]] = dnsname
                     else:
                         self.logger.info("Warning: dns_name unspecified in the system: %s, Skipped!, while writing "
                                          "cname records", system.name)
                         continue
                 except:
                     pass
+
+        aliases = [ k for k, v in zone_alliases.items() ]
+        aliases.sort()
+        if not aliases:
+            return s
+        max_alias = max([ len(i) for i in aliases ])
+
+        for alias in aliases:
+            spacing = " " * (max_alias - len(alias))
+            my_alias = "%s%s" % (alias, spacing)
+            s += "%s  %s  %s  %s;\n" % (my_alias, rclass, rectype, zone_alliases[alias])
 
         return s
 

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 import pytest
 
 from cobbler.api import CobblerAPI
+from cobbler.items.system import NetworkInterface, System
 from cobbler.modules.managers import bind
 
 if TYPE_CHECKING:
@@ -122,3 +123,51 @@ def test_manager_restart_service(mocker: "MockerFixture", cobbler_api: CobblerAP
     assert mocked_service_name.call_count == 1
     mock_service_restart.assert_called_with(["service", "named", "restart"], shell=False)
     assert result == 0
+
+
+def test_pretty_print_cname_records_without_any_cnames_does_not_crash(
+    cobbler_api: CobblerAPI,
+):
+    """
+    Regression test: a DNS-managed zone with zero CNAME records used to crash cobbler sync with
+    "ValueError: max() arg is an empty sequence" (#4070).
+    """
+    # Arrange
+    manager = bind.get_manager(cobbler_api)
+    mock_system = System(cobbler_api)
+    mock_system.name = "test_pretty_print_cname_records_without_any_cnames"
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
+    mock_system.interfaces["default"].dns_name = "host1.example.com"
+    manager.systems = [mock_system]
+
+    # Act
+    result = manager._BindManager__pretty_print_cname_records([])
+
+    # Assert
+    assert result == ""
+
+
+def test_pretty_print_cname_records_aligns_columns(cobbler_api: CobblerAPI):
+    # Arrange
+    manager = bind.get_manager(cobbler_api)
+    mock_system = System(cobbler_api)
+    mock_system.name = "test_pretty_print_cname_records_aligns_columns"
+    mock_system.interfaces = {
+        "default": NetworkInterface(cobbler_api, mock_system.name)
+    }
+    mock_system.interfaces["default"].dns_name = "host1.example.com"
+    mock_system.interfaces["default"].cnames = [
+        "aaaaaaalongalias.example.com",
+        "b.example.com",
+    ]
+    manager.systems = [mock_system]
+
+    # Act
+    result = manager._BindManager__pretty_print_cname_records([])
+
+    # Assert
+    assert result == (
+        "aaaaaaalongalias  IN  CNAME  host1;\n" "b                 IN  CNAME  host1;\n"
+    )


### PR DESCRIPTION
## Linked Items

Fixes #4070

## Description

This is purely a cosmetic change, in how the CNAME aliases are aligned in the zone files.

## Behaviour changes

Old: A fixed number of spaces was inserted between the tokens in the zone-file, making it look unappealing.

New: The same logic that is used for the A, AAAA and PTR records as been applied to the CNAME section.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
