### PR TITLE
Fix for updating profile.arch memory index

### DIFF
--- a/changelog.d/3875.fixed
+++ b/changelog.d/3875.fixed
@@ -1,0 +1,1 @@
+Fix for updating profile.arch memory index

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -339,9 +339,15 @@ class Profile(BootableItem):
             raise TypeError("distro_name needs to be of type str")
         items = self.api.profiles()
         old_distro = self._distro
+        old_arch = self.arch
         if not distro_name:
             self._distro = ""
             items.update_index_value(self, "distro", old_distro, "")
+            items.update_index_value(self, "arch", old_arch, self.arch)
+            for child in self.tree_walk():
+                items.update_index_value(
+                    child, "arch", old_arch, self.arch  # type: ignore[reportArgumentType]
+                )
             return
         distro = self.api.distros().find(name=distro_name)
         if distro is None or isinstance(distro, list):
@@ -351,6 +357,11 @@ class Profile(BootableItem):
             distro.depth + 1
         )  # reset depth if previously a subprofile and now top-level
         items.update_index_value(self, "distro", old_distro, distro_name)
+        items.update_index_value(self, "arch", old_arch, distro.arch)
+        for child in self.tree_walk():
+            items.update_index_value(
+                child, "arch", old_arch, self.arch  # type: ignore[reportArgumentType]
+            )
 
     @InheritableProperty
     def name_servers(self) -> List[str]:


### PR DESCRIPTION
## Linked Items

Fixes #3874

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Updating `profile.arch` index when distro or parent profile changes.

## Behaviour changes

Old: None

New: None

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
