### PR TITLE
Docker: Include go for new CLI

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -63,6 +63,7 @@ RUN zypper install --no-recommends -y \
     python311-pytest-benchmark \
     python311-black            \
     python3-librepo            \
+    go                         \
     rpm-build                  \
     rsync                      \
     supervisor                 \

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -113,7 +113,6 @@ RUN zypper install --no-recommends -y \
 
 # Install packages and dependencies via pip
 RUN zypper install --no-recommends -y \
-    python311-codecov            \
     python311-magic              \
     python311-pycodestyle        \
     python311-pyflakes           \


### PR DESCRIPTION
## Linked Items

No linked items

## Description

This PR is a preparation to allow #3882 to integrate the new CLI for integration testing.

## Behaviour changes

Old: Golang wasn't included in the CI testing image

New: Golang is able to install the CLI

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
