### PR TITLE
Exclude disabled profiles from buildiso gen

### DIFF
--- a/changelog.d/3895.fixed
+++ b/changelog.d/3895.fixed
@@ -1,0 +1,1 @@
+Cobbler buildiso excludes disabled profiles

--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -216,7 +216,11 @@ class BuildIso:
         """
         if selected_items is None:
             selected_items = []
-        return self.filter_items(self.api.profiles(), selected_items)
+        return [
+            profile
+            for profile in self.filter_items(self.api.profiles(), selected_items)
+            if profile.enable_menu
+        ]
 
     def filter_items(
         self, all_objs: "Collection[ITEM]", selected_items: List[str]

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -279,6 +279,26 @@ def test_filter_profile(
     assert expected_result == result
 
 
+def test_filter_profile_disabled(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.name)
+    test_profile.enable_menu = False
+    itemlist = [test_profile.name]
+    build_iso = buildiso.BuildIso(cobbler_api)
+    expected_result = []  # No enabled profiles
+
+    # Act
+    result = build_iso.filter_profiles(itemlist)
+
+    # Assert
+    assert expected_result == result
+
+
 def test_netboot_run(
     cobbler_api: CobblerAPI,
     create_distro: Callable[[], Distro],


### PR DESCRIPTION
## Description

Currently, all profiles are taken into consideration when using `cobbler buildiso` - even if a user explicitly disabled a profile.

With this change, we only use enabled profiles when generating an ISO.

Porting https://github.com/openSUSE/cobbler/pull/120

## Behaviour changes

Old: `cobbler buildiso` doesn't distinguish between enabled and disabled profiles.

New: `cobbler buildiso` doesn't include profiles that users explicitly disabled.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
