### PR TITLE
CI: Add self-hosted fireactions runner

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -181,7 +181,7 @@ jobs:
     ]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         name: Download all built artifacts
         with:
           path: artifacts

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Archive RPMs
         uses: actions/upload-artifact@v4
         with:
-          name: rpms-rockylinux-8
+          name: rpms-rockylinux-9
           path: |
             rpm-build/*.rpm
   build-fedora37-rpms:
@@ -170,6 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [
       build-rockylinux8-rpms,
+      build-rockylinux9-rpms,
       build-fedora37-rpms,
       build-opensuse-leap-rpms,
       build-opensuse-tumbleweed-rpms,
@@ -201,6 +202,7 @@ jobs:
             artifacts/rpms-opensuse-leap/*.rpm
             artifacts/rpms-opensuse-tumbleweed/*.rpm
             artifacts/rpms-rockylinux-8/*.rpm
+            artifacts/rpms-rockylinux-9/*.rpm
             artifacts/wheel/*.tar.gz
             artifacts/wheel/*.whl
           body_path: changelog/${{ env.RELEASE_VERSION }}.md

--- a/.github/workflows/performance_testing_automated.yml
+++ b/.github/workflows/performance_testing_automated.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   run_performance_tests:
-    runs-on: ubuntu-latest
+    runs-on: fireactions
     name: "Performance-Tests - ${{ matrix.test }}"
     strategy:
       fail-fast: false

--- a/.github/workflows/performance_testing_manual.yml
+++ b/.github/workflows/performance_testing_manual.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   run_performance_tests:
     name: Run Performance Tests
-    runs-on: ubuntu-latest
+    runs-on: fireactions
     timeout-minutes: 720
     steps:
       - uses: actions/checkout@v4

--- a/changelog.d/3908.added
+++ b/changelog.d/3908.added
@@ -1,0 +1,1 @@
+Run performance testsuite on top of self-hosted Fireactions based GH-runners


### PR DESCRIPTION
## Linked Items

Fixes #3908

## Description

Fix some smaller CI issues about Rocky Linux builds and download-artifact jobs.

The main change is the introduction of self-hosted runners for this repository.

## Behaviour changes

Old: The Cobbler performance testsuite is running on top of shared GitHub Runners.

New: The Cobbler performance testsuite is running on top of dedicated self-hosted GitHub Runners managed by https://fireactions.io/

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
