### PR TITLE
Drop Requires: /sbin/service from spec

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -215,8 +215,6 @@ Recommends:     %{grub2_ia32_efi_pkg}
 Recommends:     logrotate
 Recommends:     python%{python3_pkgversion}-librepo
 %endif
-# https://github.com/cobbler/cobbler/issues/1685
-Requires:       /sbin/service
 # No point in having this split out...
 Obsoletes:      cobbler-nsupdate < 3.0.99
 Provides:       cobbler-nsupdate = %{version}-%{release}


### PR DESCRIPTION
## Description

#1685 has been fixed for a while, so this can be removed.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous