### PR TITLE
Prevent crash during Cobbler startup on NFS environments

### DIFF
--- a/changelog.d/3905.fixed
+++ b/changelog.d/3905.fixed
@@ -1,0 +1,1 @@
+Prevent crash during Cobbler startup on NFS environments

--- a/cobbler/serializer.py
+++ b/cobbler/serializer.py
@@ -51,6 +51,7 @@ class Serializer:
                     pathlib.Path(self.lock_file_location).touch()
                 # exclusive lock requires writtable mode (r+) on NFS
                 # https://man7.org/linux/man-pages/man2/flock.2.html
+                # pylint: disable-next=consider-using-with
                 self.lock_handle = open(self.lock_file_location, "r+", encoding="UTF-8")
                 fcntl.flock(self.lock_handle.fileno(), fcntl.LOCK_EX)
         except Exception as exception:
@@ -73,6 +74,7 @@ class Serializer:
         if self.lock_enabled:
             # exclusive lock requires writtable mode (r+) on NFS
             # https://man7.org/linux/man-pages/man2/flock.2.html
+            # pylint: disable-next=consider-using-with
             self.lock_handle = open(self.lock_file_location, "r+", encoding="UTF-8")
             fcntl.flock(self.lock_handle.fileno(), fcntl.LOCK_UN)
             self.lock_handle.close()

--- a/cobbler/serializer.py
+++ b/cobbler/serializer.py
@@ -49,7 +49,9 @@ class Serializer:
             if self.lock_enabled:
                 if not os.path.exists(self.lock_file_location):
                     pathlib.Path(self.lock_file_location).touch()
-                self.lock_handle = open(self.lock_file_location, "r", encoding="UTF-8")
+                # exclusive lock requires writtable mode (r+) on NFS
+                # https://man7.org/linux/man-pages/man2/flock.2.html
+                self.lock_handle = open(self.lock_file_location, "r+", encoding="UTF-8")
                 fcntl.flock(self.lock_handle.fileno(), fcntl.LOCK_EX)
         except Exception as exception:
             # this is pretty much FATAL, avoid corruption and quit now.
@@ -69,7 +71,9 @@ class Serializer:
             with open(self.api.mtime_location, "w", encoding="UTF-8") as mtime_fd:
                 mtime_fd.write(f"{time.time():f}")
         if self.lock_enabled:
-            self.lock_handle = open(self.lock_file_location, "r", encoding="UTF-8")
+            # exclusive lock requires writtable mode (r+) on NFS
+            # https://man7.org/linux/man-pages/man2/flock.2.html
+            self.lock_handle = open(self.lock_file_location, "r+", encoding="UTF-8")
             fcntl.flock(self.lock_handle.fileno(), fcntl.LOCK_UN)
             self.lock_handle.close()
 


### PR DESCRIPTION
The current `flock` mechanism used by Cobbler serializer is not working on NFS enviroments, leading to a crash during Cobbler startup.

This PR fixes the `flock` mechanism to work in NFS environments on Linux kernel >= 2.6.12.

## Linked Items

Fixes https://github.com/cobbler/cobbler/issues/3905

## Description

As mentioned at https://man7.org/linux/man-pages/man2/flock.2.html:

_Since Linux 2.6.12, NFS clients support flock() locks by emulating them as [fcntl(2)](https://man7.org/linux/man-pages/man2/fcntl.2.html) byte-range locks on the entire file.  This means that [fcntl(2)](https://man7.org/linux/man-pages/man2/fcntl.2.html) and flock() locks do interact with one another over NFS.  **It also means that in order to place an exclusive lock, the file must be opened for writing.**_

## Behaviour changes

Old: cobbler is not able to start.

New: cobbler starts successfully.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
