### PR TITLE
Fix OBS devel image build

### DIFF
--- a/changelog.d/3910.fixed
+++ b/changelog.d/3910.fixed
@@ -1,0 +1,1 @@
+Docker: Remove openssl 1.1 requirement

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -98,7 +98,6 @@ RUN zypper install --no-recommends -y \
 
 # Required for ldap tests
 RUN zypper install --no-recommends -y \
-    openssl-1_1                       \
     openldap2                         \
     openldap2-client                  \
     hostname                          \

--- a/docker/develop/scripts/setup-mongodb.sh
+++ b/docker/develop/scripts/setup-mongodb.sh
@@ -2,5 +2,9 @@
 
 rpm --import https://www.mongodb.org/static/pgp/server-6.0.asc
 zypper addrepo --gpgcheck "https://repo.mongodb.org/zypper/suse/15/mongodb-org/6.0/x86_64/" mongodb
+# Work around broken MongoDB packaging
+zypper download mongodb-org-database-tools-extra
+rpm -i --nodeps /var/cache/zypp/packages/mongodb/RPMS/*
+# Continue as normal
 zypper -n install mongodb-org
 mkdir -p /data/db


### PR DESCRIPTION
## Linked Items

Fixes #3910

## Description

This PR is a split-out of #3912 to enable the `main` branch to build again in OBS.

The PR addressed the issue that MongoDB is not set up as desired, and OpenSSL 1.1 is unavailable anymore.

## Behaviour changes

Old: The CI-Testing image doesn't successfully build in the openSUSE Build Service due to OpenSSL 1.1.

New: The OpenSSL 1.1 issue is solved.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
