### PR TITLE
Added new autoinstall template for Ubuntu Autoinstall, accompanying s…

### DIFF
--- a/autoinstall_snippets/cloud_config_hostname
+++ b/autoinstall_snippets/cloud_config_hostname
@@ -1,0 +1,12 @@
+#if $getVar("system_name","") != ""
+    #if $hostname != ""
+    hostname: $hostname
+    #else
+    #set $myhostname = $getVar('name','').replace("_","-")
+    hostname: $myhostname
+    #end if
+#else
+## profile based install so just provide one interface for starters
+#set $myhostname = $getVar('hostname',$getVar('name','cobbler')).replace("_","-")
+    hostname: $myhostname
+#end if

--- a/autoinstall_snippets/cloud_config_network
+++ b/autoinstall_snippets/cloud_config_network
@@ -1,0 +1,76 @@
+#if $getVar("system_name","") != ""
+  network:
+    ethernets:
+    #set ikeys = $interfaces.keys()
+    #import re
+    #for $iname in $ikeys
+        #set $idata = $interfaces[$iname]
+        ## Ignore BMC interface
+        #if $idata["interface_type"].lower() == "bmc"
+            #continue
+        #end if
+    #end for
+    #for $iname in $ikeys
+        #set $idata    = $interfaces[$iname]
+        #set $mac      = $idata["mac_address"]
+        #set $static   = $idata["static"]
+        #set $ip       = $idata["ip_address"]
+        #set $netmask  = $idata["netmask"]
+        #set $type     = $idata["interface_type"]
+        #set $routes   = $idata["static_routes"]
+        ## Ignore BMC interface
+        #if $type == "bmc"
+            #continue
+        #end if
+      $iname:
+        match:
+          macaddress: $mac
+        #if $static == True:
+            #if $ip != "":
+                #if $netmask != "":
+                    #set $mask = sum([bin(int(x)).count('1') for x in $netmask.split('.')])
+        dhcp4: false
+        addresses:
+          - $ip/$mask
+                #else
+        dhcp4: false
+        addresses:
+          - $ip/24
+                #end if
+                #if ($gateway and $gateway != "") or ($routes and $routes[0] != ""):
+        routes:
+                    #if $gateway and $gateway != "":
+          - to: 0.0.0.0/0
+            via: $gateway
+                    #end if
+                    #for $route in $routes
+                        #set $netroute = $route.split(":")
+                        #if $netroute[1] != "":
+          - to: $netroute[0]
+            via: $netroute[1]
+                        #end if
+                    #end for
+                #end if
+                #if $name_servers and $name_servers[0] != "":
+        nameservers:
+          addresses:
+                    #for $dns in $name_servers
+            - $dns
+                    #end for
+                #end if
+            #else
+        dhcp4: true
+            #end if
+        #else
+        dhcp4: true
+        #end if
+    #end for
+    version: 2
+#else
+## profile based install so use DHCP
+  network:
+    ethernets:
+      eth0:
+        dhcp4: true
+    version: 2
+#end if

--- a/autoinstall_snippets/cloud_config_user_data
+++ b/autoinstall_snippets/cloud_config_user_data
@@ -1,0 +1,10 @@
+##Configurations in this section are applied upon first boot, after the system installation completes and exits.
+  user-data:
+    ntp:
+      enabled: true
+      ntp_client: chrony
+      pools: [$http_server, us.pool.ntp.org]
+    rsyslog:
+      config_filename: rsyslog_remote.conf
+      configs:
+        - "*.* @@127.0.0.1"

--- a/autoinstall_templates/cloud_config_autoinstall
+++ b/autoinstall_templates/cloud_config_autoinstall
@@ -1,0 +1,49 @@
+#cloud-config
+autoinstall:
+  version: 1
+  refresh-installer:
+    update: no
+  apt:
+    preserve_sources_list: true
+    primary:
+    - arches: [amd64, i386]
+      uri: http://$http_server/cblr/links/$distro
+    - arches: [default]
+      uri: http://ports.ubuntu.com/ubuntu-ports
+    disable_components: [restricted,multiverse]
+    disable_suites: [backports,security,updates]
+  identity:
+$SNIPPET('cloud_config_hostname')
+    password: $default_password_crypted
+    realname: user
+    username: user
+  kernel:
+    package: linux-generic
+  keyboard:
+    layout: us
+    toggle: null
+    variant: ''
+  locale: en_US.UTF-8
+  timezone: America/New_York
+$SNIPPET('cloud_config_network')
+##$SNIPPET('cloud_config_user_data')
+  ssh:
+    allow-pw: false
+    install-server: true
+##    authorized-keys:
+##      - ssh-rsa AAA...
+  storage:
+    layout:
+      name: lvm
+      sizing-policy: all
+  package_update: false
+  package_upgrade: false
+  late-commands:
+## Figure out if we're automating OS installation for a system or a profile
+#if $getVar('system_name','') != ''
+#set $what = "system"
+#else
+#set $what = "profile"
+#end if
+    - wget -O /target/root/autoinstall-user-data.yaml http://$http_server/cblr/svc/op/autoinstall/$what/$name
+##    - rm /target/etc/apt/apt.conf.d/99needrestart # This prompt will prevent the apt command from completing

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -32,6 +32,31 @@ from cobbler.cexceptions import CX
 from cobbler.enums import Archs
 from cobbler.validate import validate_autoinstall_script_name
 
+ubuntu_preseed = [
+    "artful",
+    "bionic",
+    "cosmic",
+    "disco",
+    "eoan",
+    "groovy",
+    "hirsute",
+    "impish",
+    "kinetic",
+    "lucid",
+    "lunar",
+    "oneiric",
+    "precise",
+    "quantal",
+    "raring",
+    "saucy",
+    "trusty",
+    "utopic",
+    "vivid",
+    "wily",
+    "xenial",
+    "yakkety",
+    "zesty"
+]
 
 class TFTPGen:
     """
@@ -925,10 +950,16 @@ class TFTPGen:
                 if management_mac and distro.arch not in (enums.Archs.S390, enums.Archs.S390X):
                     append_line += " netdevice=%s" % management_mac
             elif distro.breed == "debian" or distro.breed == "ubuntu":
-                append_line = "%s auto-install/enable=true priority=critical netcfg/choose_interface=auto url=%s" \
-                              % (append_line, autoinstall_path)
-                if management_interface:
-                    append_line += " netcfg/choose_interface=%s" % management_interface
+                if distro.breed == "debian" or distro.os_version in ubuntu_preseed:
+                    append_line = "%s auto-install/enable=true priority=critical netcfg/choose_interface=auto url=%s" \
+                                  % (append_line, autoinstall_path)
+                    if management_interface:
+                        append_line += " netcfg/choose_interface=%s" % management_interface`
+                else:
+                    re_ccu_kopt = re.search("(\\s|\\^){1}(cloud-config-url=/dev/null){1}(\\s|$){1}", append_line)
+                    append_line = append_line.replace(re_ccu_kopt.group(0), " ")
+                    append_line ="%s %s" \
+                                  % (append_line, ''.join(("autoinstall cloud-config-url=", autoinstall_path)))
             elif distro.breed == "freebsd":
                 append_line = "%s ks=%s" % (append_line, autoinstall_path)
 

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -1543,6 +1543,58 @@
         "kernel_file": "(linux|vmlinuz(.*))",
         "initrd_file": "initrd($|.gz$|.lz$)",
         "isolinux_ok": false,
+        "default_autoinstall": "cloud_config_autoinstall",
+        "kernel_options": "root=/dev/ram0, ramdisk_size=1500000, ip=dhcp, url=http://@@http_server@@/cblr/links/@@distro_name@@/media.iso, cloud-config-url=/dev/null",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "groovy": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: groovy|Ubuntu 20.10",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "hirsute": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: hirsute|Ubuntu 21.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
         "default_autoinstall": "",
         "kernel_options": "",
         "kernel_options_post": "",
@@ -1571,6 +1623,136 @@
         "isolinux_ok": false,
         "default_autoinstall": "",
         "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "jammy": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: jammy|Ubuntu 22.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "cloud_config_autoinstall",
+        "kernel_options": "root=/dev/ram0, ramdisk_size=1500000, ip=dhcp, url=http://@@http_server@@/cblr/links/@@distro_name@@/media.iso, cloud-config-url=/dev/null",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "kinetic": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: kinetic|Ubuntu 22.10",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "lunar": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: lunar|Ubuntu 23.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "mantic": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: mantic|Ubuntu 23.10",
+        "kernel_arch": "linux_headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "template_files": "",
+        "boot_files": [],
+        "boot_loaders": {}
+      },
+      "noble": {
+        "signatures": [
+          "dists",
+          ".disk"
+        ],
+        "version_file": "Release|info",
+        "version_file_regex": "Suite: noble|Ubuntu 24.04",
+        "kernel_arch": "linux-headers-(.*)\\.deb",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "i386",
+          "amd64"
+        ],
+        "supported_repo_breeds": [
+          "apt"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd($|.gz$|.lz$)",
+        "isolinux_ok": false,
+        "default_autoinstall": "cloud-init_autoinstall",
+        "kernel_options": "root=/dev/ram0, ramdisk_size=1500000, ip=dhcp, url=http://@@http_server@@/cblr/links/@@distro_name@@/media.iso, cloud-config-url=/dev/null",
         "kernel_options_post": "",
         "template_files": "",
         "boot_files": [],


### PR DESCRIPTION
## Linked Items

Fixes #2339 #3218 

## Description

See related discussion post #3916 

## Behaviour changes

Old: Cobbler did not have proper support for Ubuntu cloud-init/cloud-config autoinstalls since Debian-style preseed was dropped in Ubuntu 20.04

New: base support for proper importing, managing and deploying of Ubuntu distributions/breeds via interactive or autoinstall via PXE, with some exceptions like IPv6 and bridged/teamed interfaces, and an additional requirement for users of copying the installation media (ISO file) to the respective distro_mirror folder immediately after an import of a supported Ubuntu version with the filename "media.iso" as referenced in the kernel_options (I can get this added to the docs somewhere or to the "cobbler check" command).

## Category

This is related to a:

- [ x] Bugfix
- [ x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
