### PR TITLE
Enhance "utils.remove_lines_in_file" to work with shared volumes

### DIFF
--- a/changelog.d/3920.fixed
+++ b/changelog.d/3920.fixed
@@ -1,0 +1,1 @@
+Enhance utils.remove_lines_in_file to work with shared volumes

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -1408,12 +1408,11 @@ def remove_lines_in_file(filepath: str, remove_keywords: List[str]) -> None:
 
     raises OSError: In case the file cannot be read or modified.
     """
-    tmp_filepath = filepath + ".tmp"
-    with open(filepath, "r", encoding="UTF-8") as fh, open(
-        tmp_filepath, "w", encoding="UTF-8"
-    ) as tmp_fh:
-        for line in fh:
+    new_content_lines = []
+    with open(filepath, "r", encoding="UTF-8") as fh:
+        for line in fh.readlines():
             if any(keyword in line for keyword in remove_keywords):
                 continue
-            tmp_fh.write(line)
-    os.replace(tmp_filepath, filepath)
+            new_content_lines.append(line)
+    with open(filepath, "w", encoding="UTF-8") as fh:
+        fh.writelines(new_content_lines)

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 from threading import Thread
 from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
 
 import pytest
 from netaddr.ip import IPAddress
@@ -711,3 +712,31 @@ def test_create_files_if_not_existing(tmp_path: Path):
     # Assert
     assert os.path.exists(file1)
     assert os.path.exists(file2)
+
+
+def test_remove_lines_in_file(mocker: "MockerFixture"):
+    # Arrange
+    file_content = '''
+line1
+line2
+foobar
+line4
+deadbeaf
+line6
+'''
+    expected = '''
+line1
+line2
+line4
+line6
+'''
+
+    mock_open = mocker.patch("builtins.open", mocker.mock_open(read_data=file_content))
+    mock_os_replace = mocker.patch("os.replace", MagicMock())
+
+    # Act
+    utils.remove_lines_in_file("randomfile", ["foobar", "deadbeaf"])
+
+    # Assert
+    mock_os_replace.assert_not_called()
+    assert "".join(mock_open.return_value.writelines.call_args[0][0]) == expected


### PR DESCRIPTION
## Linked Items

Fixes #3920

## Description

This PR enhances `utils.remove_lines_in_file` to prevent crashing when dealing with files that are actually shared volumes in a containerized environment.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
