### PR TITLE
Docker: Update openSUSE Leap to 15.6

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -57,10 +57,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install System dependencies
         run: sudo apt-get install -y rename
-      - name: Build a openSUSE Leap 15.3 Package
+      - name: Build a openSUSE Leap 15 Package
         shell: 'script -q -e -c "bash {0}"'
         run: |
-          ./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+          ./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
       - name: Rename RPM
         run: |
           file-rename -v -d -e 's/cobbler-(\d+\.\d+\.\d+)-1\.(\w+)\.rpm/cobbler-$1-1.leap.$2.rpm/' rpm-build/*.rpm

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,11 @@
-version: '3.8'
+version: "3.8"
 
 services:
   opensuse-leap-tests:
     image: local/cobbler-test-opensuse-leap
     build:
       context: .
-      dockerfile: docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+      dockerfile: docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
     container_name: cobbler-test-openSUSE-Leap
 
   opensuse-leap-build:
@@ -13,7 +13,7 @@ services:
     container_name: cobbler-opensuse-leap
     build:
       context: .
-      dockerfile: docker/rpms/opensuse_leap/openSUSE_Leap153.dockerfile
+      dockerfile: docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
     volumes:
       - ./rpm-build/opensuse-leap:/usr/src/cobbler/rpm-build
 

--- a/docker/debs/Debian_11/Debian11.dockerfile
+++ b/docker/debs/Debian_11/Debian11.dockerfile
@@ -75,7 +75,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
     dpkg-reconfigure dash
 
-COPY ./docker/debs/Debian_10/supervisord/conf.d /etc/supervisor/conf.d
+COPY ./docker/debs/Debian_11/supervisord/conf.d /etc/supervisor/conf.d
 
 COPY . /usr/src/cobbler
 WORKDIR /usr/src/cobbler

--- a/docker/debs/Debian_12/Debian12.dockerfile
+++ b/docker/debs/Debian_12/Debian12.dockerfile
@@ -75,7 +75,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
     dpkg-reconfigure dash
 
-COPY ./docker/debs/Debian_10/supervisord/conf.d /etc/supervisor/conf.d
+COPY ./docker/debs/Debian_11/supervisord/conf.d /etc/supervisor/conf.d
 
 COPY . /usr/src/cobbler
 WORKDIR /usr/src/cobbler

--- a/docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
@@ -1,6 +1,6 @@
 # vim: ft=dockerfile
 
-FROM registry.opensuse.org/opensuse/leap:15.3
+FROM registry.opensuse.org/opensuse/leap:15.6
 
 # ENV Variables we are using.
 ENV container docker

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -113,7 +113,7 @@ We leave packaging to downstream; this means you have to check the repositories 
 However we provide docker files for
 
 - Fedora 37
-- openSUSE Leap 15.3
+- openSUSE Leap 15.6
 - openSUSE Tumbleweed
 - Rocky Linux 8
 - Debian 11 Bullseye
@@ -126,6 +126,7 @@ which will give you packages which will work better then building from source yo
 
 To build the packages you to need to execute the following in the root folder of the cloned repository:
 
+- openSUSE Leap 15.6: ``./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile``
 - Fedora 37: ``./docker/rpms/build-and-install-rpms.sh fc37 docker/rpms/Fedora_37/Fedora37.dockerfile``
 - Rocky Linux 8: ``./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile``
 - Debian 11: ``./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile``


### PR DESCRIPTION
## Linked Items

This is a split-out of #3922 

## Description

This PR doesn't fix any of the issues but updates the dated openSUSE Leap 15.3 container to 15.6.

## Behaviour changes

Old: Outdated openSUSE Leap 15.3 image used

New: Up-to-date openSUSE Leap 15.6 image used

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
