### PR TITLE
Add Docker deps for pip install

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -9,20 +9,6 @@ on:
     branches: [main, release*]
 
 jobs:
-  build-rockylinux8-rpms:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build a Rocky Linux 8 Package
-        shell: 'script -q -e -c "bash {0}"'
-        run: |
-          ./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
-      - name: Archive RPMs
-        uses: actions/upload-artifact@v4
-        with:
-          name: rpms-rockylinux-8
-          path: |
-            rpm-build/*.rpm
   build-rockylinux9-rpms:
     runs-on: ubuntu-latest
     steps:
@@ -156,7 +142,6 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       [
-        build-rockylinux8-rpms,
         build-rockylinux9-rpms,
         build-fedora37-rpms,
         build-opensuse-leap-rpms,
@@ -186,7 +171,6 @@ jobs:
             artifacts/rpms-fedora-37/*.rpm
             artifacts/rpms-opensuse-leap/*.rpm
             artifacts/rpms-opensuse-tumbleweed/*.rpm
-            artifacts/rpms-rockylinux-8/*.rpm
             artifacts/rpms-rockylinux-9/*.rpm
             artifacts/wheel/*.tar.gz
             artifacts/wheel/*.whl

--- a/Makefile
+++ b/Makefile
@@ -87,11 +87,11 @@ release: clean qa authors sdist ## Creates the full release.
 	@cp distro_build_configs.sh release/
 	@cp cobbler.spec release/
 
-test-rocky8: ## Executes the testscript for testing cobbler in a docker container on Rocky Linux 8.
-	./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
-
 test-rocky9: ## Executes the testscript for testing cobbler in a docker container on Rocky Linux 9.
 	./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_9/Rocky_Linux_9.dockerfile
+
+test-rocky10: ## Executes the testscript for testing cobbler in a docker container on Rocky Linux 10.
+	./docker/rpms/build-and-install-rpms.sh rl10 docker/rpms/Rocky_Linux_10/Rocky_Linux_10.dockerfile
 
 test-fedora37: ## Executes the testscript for testing cobbler in a docker container on Fedora 37.
 	./docker/rpms/build-and-install-rpms.sh fc37 docker/rpms/Fedora_37/Fedora37.dockerfile

--- a/docker/debs/Debian_11/Debian11.dockerfile
+++ b/docker/debs/Debian_11/Debian11.dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update -qq && \
     gnupg \
     curl \
     wget \
+    libsystemd-dev \
+    libsasl2-dev \
     pycodestyle \
     pyflakes3 \
+    python3-pip  \
     python3-cheetah  \
     python3-gunicorn  \
     python3-coverage \
@@ -41,6 +44,7 @@ RUN apt-get update -qq && \
     python3-setuptools \
     python3-simplejson  \
     python3-sphinx \
+    python3-sphinx-rtd-theme \
     python3-tz \
     python3-yaml \
     python3-schema \

--- a/docker/debs/Debian_12/Debian12.dockerfile
+++ b/docker/debs/Debian_12/Debian12.dockerfile
@@ -20,8 +20,11 @@ RUN apt-get update -qq && \
     gnupg \
     curl \
     wget \
+    libsystemd-dev \
+    libsasl2-dev \
     pycodestyle \
     pyflakes3 \
+    python3-pip  \
     python3-cheetah  \
     python3-gunicorn  \
     python3-coverage \
@@ -41,6 +44,7 @@ RUN apt-get update -qq && \
     python3-setuptools \
     python3-simplejson  \
     python3-sphinx \
+    python3-sphinx-rtd-theme \
     python3-tz \
     python3-yaml \
     python3-schema \

--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -41,8 +41,12 @@ RUN zypper install --no-recommends -y \
     wget2                      \
     openssl                    \
     bind                       \
+    systemd-devel              \
+    cyrus-sasl-devel           \
     python311                  \
+    python311-pip              \
     python311-Sphinx           \
+    python311-sphinx_rtd_theme \
     python311-coverage         \
     python311-devel            \
     python311-distro           \

--- a/docker/rpms/Fedora_37/Fedora37.dockerfile
+++ b/docker/rpms/Fedora_37/Fedora37.dockerfile
@@ -5,26 +5,30 @@ FROM fedora:37
 RUN dnf makecache
 
 # Dev dependencies
-RUN dnf install -y          \
-    git                     \
-    rsync                   \
-    make                    \
-    curl                    \
-    wget2                   \
-    openssl                 \
-    mod_ssl                 \
-    initscripts             \
-    python-sphinx           \
-    python3-coverage        \
-    python3-devel           \
-    python3-wheel           \
-    python3-distro          \
-    python3-pyflakes        \
-    python3-pycodestyle     \
-    python3-setuptools      \
-    python3-sphinx          \
-    python3-pip             \
-    rpm-build               \
+RUN dnf install -y           \
+    git                      \
+    rsync                    \
+    make                     \
+    curl                     \
+    wget2                    \
+    openssl                  \
+    mod_ssl                  \
+    systemd-devel            \
+    cyrus-sasl-devel         \
+    initscripts              \
+    python-sphinx            \
+    python3-pip              \
+    python3-coverage         \
+    python3-devel            \
+    python3-wheel            \
+    python3-distro           \
+    python3-pyflakes         \
+    python3-pycodestyle      \
+    python3-setuptools       \
+    python3-sphinx           \
+    python3-sphinx_rtd_theme \
+    python3-pip              \
+    rpm-build                \
     which
 
 # Runtime dependencies

--- a/docker/rpms/Rocky_Linux_10/Rocky_Linux_10.dockerfile
+++ b/docker/rpms/Rocky_Linux_10/Rocky_Linux_10.dockerfile
@@ -1,10 +1,11 @@
 # vim: ft=dockerfile
 
-FROM rockylinux:8
+FROM rockylinux/rockylinux:10
 
 RUN dnf makecache && \
     dnf install -y epel-release dnf-utils && \
-    dnf config-manager --set-enabled powertools && \
+    dnf config-manager --set-enabled crb && \
+    dnf config-manager --set-enabled highavailability && \
     dnf makecache
 
 # overlay2 bug with yum/dnf
@@ -20,8 +21,6 @@ RUN touch /var/lib/rpm/* &&   \
     iproute                   \
     git                       \
     rsync                     \
-    curl                      \
-    wget                      \
     make                      \
     openssl                   \
     mod_ssl                   \
@@ -30,25 +29,25 @@ RUN touch /var/lib/rpm/* &&   \
     initscripts               \
     python3-pip               \
     python3-sphinx            \
-    platform-python-coverage  \
     python3-devel             \
     python3-wheel             \
     python3-distro            \
-    python3-pyflakes          \
-    python3-pycodestyle       \
     python3-setuptools        \
     python3-sphinx            \
     python3-sphinx_rtd_theme  \
-    python3-schema            \
     epel-rpm-macros           \
     rpm-build                 \
     which
+
+# python3-schema is not available as an RPM in RL 10.
+RUN pip install schema
 
 # Runtime dependencies
 RUN touch /var/lib/rpm/* &&   \
     dnf install -y            \
     httpd                     \
     python3-gunicorn          \
+    python3-mod_wsgi          \
     python3-pyyaml            \
     python3-netaddr           \
     python3-cheetah           \
@@ -57,27 +56,23 @@ RUN touch /var/lib/rpm/* &&   \
     python3-ldap              \
     python3-librepo           \
     python3-pymongo           \
-    python3-systemd           \
+    python3-coverage          \
     createrepo_c              \
     dnf-plugins-core          \
     xorriso                   \
-    grub2-efi-ia32-modules    \
     grub2-efi-x64-modules     \
     logrotate                 \
     syslinux                  \
     tftp-server               \
-    fence-agents              \
     supervisor                \
-    systemd                   \
-    mtools                    \
     dosfstools
 
 # Dependencies for system tests
+# isc-dhcpd is missing (Kea isn't compatible with Cobbler yet)
 RUN touch /var/lib/rpm/* &&   \
     dnf install -y            \
     shim                      \
     ipxe-bootimgs             \
-    dhcp-server               \
     qemu-kvm                  \
     time
 RUN dnf --enablerepo=plus -y install openldap-servers

--- a/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
+++ b/docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile
@@ -25,7 +25,10 @@ RUN touch /var/lib/rpm/* &&   \
     make                      \
     openssl                   \
     mod_ssl                   \
+    systemd-devel             \
+    cyrus-sasl-devel          \
     initscripts               \
+    python3-pip               \
     python3-sphinx            \
     platform-python-coverage  \
     python3-devel             \
@@ -35,6 +38,7 @@ RUN touch /var/lib/rpm/* &&   \
     python3-pycodestyle       \
     python3-setuptools        \
     python3-sphinx            \
+    python3-sphinx_rtd_theme  \
     python3-schema            \
     epel-rpm-macros           \
     rpm-build                 \

--- a/docker/rpms/Rocky_Linux_9/Rocky_Linux_9.dockerfile
+++ b/docker/rpms/Rocky_Linux_9/Rocky_Linux_9.dockerfile
@@ -24,7 +24,10 @@ RUN touch /var/lib/rpm/* &&   \
     make                      \
     openssl                   \
     mod_ssl                   \
+    systemd-devel             \
+    cyrus-sasl-devel          \
     initscripts               \
+    python3-pip               \
     python3-sphinx            \
     python3-devel             \
     python3-wheel             \
@@ -33,6 +36,7 @@ RUN touch /var/lib/rpm/* &&   \
     python3-pycodestyle       \
     python3-setuptools        \
     python3-sphinx            \
+    python3-sphinx_rtd_theme  \
     python3-schema            \
     epel-rpm-macros           \
     rpm-build                 \

--- a/docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
@@ -26,9 +26,13 @@ RUN zypper install -y          \
     fence-agents               \
     rsync                      \
     createrepo_c               \
+    systemd-devel              \
+    cyrus-sasl-devel           \
     python-rpm-macros          \
     python3                    \
+    python3-pip                \
     python3-Sphinx             \
+    python3-sphinx_rtd_theme   \
     python3-gunicorn           \
     python3-Cheetah3           \
     python3-Sphinx             \
@@ -36,7 +40,7 @@ RUN zypper install -y          \
     python3-coverage           \
     python3-devel              \
     python3-distro             \
-    python3-file-magic         \
+    python3-magic              \
     python3-ldap               \
     python3-netaddr            \
     python3-pyflakes           \
@@ -47,6 +51,8 @@ RUN zypper install -y          \
     python3-pip                \
     python3-PyYAML             \
     python3-wheel              \
+    python3-dataclasses        \
+    python3-importlib_resources \
     rpm-build                  \
     which                      \
     mtools                     \

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -28,9 +28,13 @@ RUN zypper install -y          \
     fence-agents               \
     rsync                      \
     createrepo_c               \
+    systemd-devel              \
+    cyrus-sasl-devel           \
     python-rpm-macros          \
     python3                    \
+    python3-pip                \
     python3-Sphinx             \
+    python3-sphinx_rtd_theme   \
     python3-gunicorn           \
     python3-Cheetah3           \
     python3-Sphinx             \
@@ -38,7 +42,7 @@ RUN zypper install -y          \
     python3-coverage           \
     python3-devel              \
     python3-distro             \
-    python3-file-magic         \
+    python3-magic              \
     python3-ldap               \
     python3-netaddr            \
     python3-pyflakes           \
@@ -49,6 +53,7 @@ RUN zypper install -y          \
     python3-pip                \
     python3-PyYAML             \
     python3-wheel              \
+    python3-black              \
     rpm-build                  \
     which                      \
     mtools                     \

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -115,7 +115,8 @@ However we provide docker files for
 - Fedora 37
 - openSUSE Leap 15.6
 - openSUSE Tumbleweed
-- Rocky Linux 8
+- Rocky Linux 9
+- Rocky Linux 10
 - Debian 11 Bullseye
 - Debian 12 Bookworm
 
@@ -124,11 +125,14 @@ which will give you packages which will work better then building from source yo
 .. note:: If you have a close look at our ``docker`` folder you may see more folders and files but they are meant for
           testing or other purposes. Please ignore them, this page is always aligned and up to date.
 
+.. note:: Rocky Linux 10 is missing python3-schema and as such building a native RPM will not be successful.
+
 To build the packages you to need to execute the following in the root folder of the cloned repository:
 
 - openSUSE Leap 15.6: ``./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile``
 - Fedora 37: ``./docker/rpms/build-and-install-rpms.sh fc37 docker/rpms/Fedora_37/Fedora37.dockerfile``
-- Rocky Linux 8: ``./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_8/Rocky_Linux_8.dockerfile``
+- Rocky Linux 9: ``./docker/rpms/build-and-install-rpms.sh rl9 docker/rpms/Rocky_Linux_9/Rocky_Linux_9.dockerfile``
+- Rocky Linux 10: ``./docker/rpms/build-and-install-rpms.sh rl10 docker/rpms/Rocky_Linux_10/Rocky_Linux_10.dockerfile``
 - Debian 11: ``./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile``
 - Debian 12: ``./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile``
 


### PR DESCRIPTION
## Linked Items

Split-out for #3922 

## Description

Add the dependencies for the main PR and deprecate Rocky Linux 8.

## Behaviour changes

Old: The main PR doesn't build due to outdated Docker images.

New: PR should build due to updates dependencies.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
