### PR TITLE
Tests: Use legacycrypt for Python > 3.12

### DIFF
--- a/docker/develop/develop.dockerfile
+++ b/docker/develop/develop.dockerfile
@@ -65,6 +65,7 @@ RUN zypper install --no-recommends -y \
     python3-pytest-benchmark   \
     python3-black              \
     python3-librepo            \
+    python3-legacycrypt        \
     go                         \
     rpm-build                  \
     rsync                      \

--- a/setup.py
+++ b/setup.py
@@ -620,6 +620,7 @@ if __name__ == "__main__":
                 "coverage",
                 "pytest-mock>3.3.0",
                 "pytest-benchmark",
+                "legacycrypt; python_version > '3.12'",
             ],
             "docs": ["sphinx", "sphinx-rtd-theme", "sphinxcontrib-apidoc"],
             # We require the current version to properly detect duplicate issues

--- a/tests/special_cases/security_test.py
+++ b/tests/special_cases/security_test.py
@@ -4,7 +4,6 @@ This test module tries to automatically replicate all security incidents we had 
 
 # SPDX-License-Identifier: GPL-2.0-or-later
 import base64
-import crypt
 import os
 import subprocess
 import xmlrpc.client
@@ -15,6 +14,11 @@ import pytest
 from cobbler.api import CobblerAPI
 from cobbler.modules.authentication import pam
 from cobbler.utils import get_shared_secret
+
+try:
+    import crypt
+except ModuleNotFoundError:
+    import legacycrypt as crypt
 
 # ==================== Start tnpconsultants ====================
 


### PR DESCRIPTION
## Linked Items

Split-out of #3922 

## Description

This PR adds a dependency for Python 3.13 to allow the CVE verification tests to pass again.

## Behaviour changes

Old: CVE tests cause the testsuite to fail due to a removed import for the stdlibrary

New: Tests can start again

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
