### PR TITLE
Reduce logging severity to WARNING

### DIFF
--- a/changelog.d/3929.changed
+++ b/changelog.d/3929.changed
@@ -1,0 +1,1 @@
+Reduce logging severity for journal to WARNING

--- a/cobbler/data/config/cobbler/logging_config.conf
+++ b/cobbler/data/config/cobbler/logging_config.conf
@@ -19,7 +19,7 @@ qualname=compiler.parser
 
 [handler_stdout]
 class=StreamHandler
-level=INFO
+level=WARNING
 formatter=stdout
 args=(sys.stdout,)
 


### PR DESCRIPTION
Logging only WARNING level messages to /var/log/messages from Cobbler, while keeping INFO level messages in cobbler.log, is a good strategy. This helps reduce log duplication and optimizes disk usage by centralizing more critical alerts.