### PR TITLE
anamon: also monitor packaging.log

### DIFF
--- a/changelog.d/3931.added
+++ b/changelog.d/3931.added
@@ -1,0 +1,1 @@
+Added packaging.log to anamon collected logs

--- a/cobbler/data/misc/anamon
+++ b/cobbler/data/misc/anamon
@@ -167,6 +167,7 @@ def anamon_loop():
     slog = WatchedFile("/tmp/syslog", "sys.log")
     xlog = WatchedFile("/tmp/X.log", "X.log")
     llog = WatchedFile("/tmp/lvmout", "lvmout.log")
+    packaging_log = WatchedFile("/tmp/packaging.log", "packaging.log")
     storage_log = WatchedFile("/tmp/storage.log", "storage.log")
     prgm_log = WatchedFile("/tmp/program.log", "program.log")
     vnc_log = WatchedFile("/tmp/vncserver.log", "vncserver.log")
@@ -219,6 +220,7 @@ def anamon_loop():
             mod,
             llog,
             kcfg,
+            packaging_log,
             storage_log,
             prgm_log,
             vnc_log,


### PR DESCRIPTION
## Description

anamon also sends packaging.log back to the server.  Probably should be a more comprehensive review of what logs are sent, but this is the glaring one.

## Behaviour changes

Old: packaging log is not sent
New: packaging.log is sent during install

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
