### PR TITLE
snippet 'keep_files': global variable 'keys_found' should be per-service

### DIFF
--- a/cobbler/data/templates/cheetah/autoinstall/snippets/keep_files.template
+++ b/cobbler/data/templates/cheetah/autoinstall/snippets/keep_files.template
@@ -145,7 +145,7 @@ function restore_keys
  TEMPDIR=$2
  PATTERN=$3
  # Loop until the corresponding rpm is installed if the keys are saved
- if [ "$keys_found" = "yes" ] && ls /tmp/${TEMPDIR}/${PATTERN}*; then
+ if ls /tmp/${TEMPDIR}/${PATTERN}*; then
     while : ; do
         sleep 10
         if [ -d /mnt/sysimage${SEARCHDIR} ] ; then
@@ -160,17 +160,41 @@ function restore_keys
  fi
 }
 
+# Record whether preservable keys for 'ssh', 'cfengine', 'rhn' or 'puppet' have been found.
+# For most, there is a single directory, but 'puppet' has two directories.
+declare -A pkfound
+pkfound[ssh]="no"
+pkfound[cfengine]="no"
+pkfound[rhn]="no"
+pkfound[puppet-certs]="no"
+pkfound[puppet-keys]="no"
+
 for key in $preserve_files
 do
  if [ $key = 'ssh' ]; then
    search_for_keys '/etc/ssh' 'ssh' 'ssh_host_'
+   if [ "$keys_found" = "yes" ]; then
+     pkfound[ssh]="yes"
+   fi
  elif [ $key = 'cfengine' ]; then
    search_for_keys '/var/cfengine/ppkeys' 'cfengine' 'localhost'
+   if [ "$keys_found" = "yes" ]; then
+     pkfound[cfengine]="yes"
+   fi
  elif [ $key = 'rhn' ]; then
    search_for_keys '/etc/sysconfig/rhn', 'rhn', '*'
+   if [ "$keys_found" = "yes" ]; then
+     pkfound[rhn]="yes"
+   fi
  elif [ $key = 'puppet' ]; then
    search_for_keys '/etc/puppetlabs/puppet/ssl/certs' 'puppet-certs' '*.pem'
+   if [ "$keys_found" = "yes" ]; then
+     pkfound[puppet-certs]="yes"
+   fi
    search_for_keys '/etc/puppetlabs/puppet/ssl/private_keys' 'puppet-keys' '*.pem'
+   if [ "$keys_found" = "yes" ]; then
+     pkfound[puppet-keys]="yes"
+   fi
  else
    echo "No keys to save!" > /dev/ttyS0
  fi
@@ -180,14 +204,15 @@ done
 
 for key in $preserve_files
 do
- if [ $key = 'ssh' ]; then
+ if [ $key = 'ssh' && "${pkfound[ssh]}" = "yes" ]; then
    restore_keys '/etc/ssh' 'ssh' 'ssh_host_'
- elif [ $key = 'cfengine' ]; then
+ elif [ $key = 'cfengine' && "${pkfound[cfengine]}" = "yes" ]; then
    restore_keys '/var/cfengine/ppkeys' 'cfengine' 'localhost'
- elif [ $key = 'rhn' ]; then
+ elif [ $key = 'rhn' && "${pkfound[rhn]}" = "yes" ]; then
    restore_keys '/etc/sysconfig/rhn', 'rhn', '*'
- elif [ $key = 'puppet' ]; then
+ elif [ $key = 'puppet' && "${pkfound[puppet-certs]}" = "yes"]; then
    restore_keys '/etc/puppetlabs/puppet/ssl/certs' 'puppet-certs' '*.pem'
+ elif [ $key = 'puppet' && "${pkfound[puppet-keys]}" = "yes"]; then
    restore_keys '/etc/puppetlabs/puppet/ssl/private_keys' 'puppet-keys' '*.pem'
  else
    echo "Nothing to restore!" > /dev/ttyS0


### PR DESCRIPTION
Snippet `keep_files` attempts to preserve keys from potentially multiple services: currently 'ssh', 'cfengine', 'rhn', 'puppet'.

Each per-service key-search of the old OS sets a variable `keys_found` to `yes` or `no`, partly with the intention of guiding the behaviour of the subsequent `restore_keys` function.

The first act of each per-service call to `search_for_keys` sets `keys_found` to `no`. In particular, if the final service examined results in `no`, then its final value is `no`.

That single variable is, in effect, global across all the services.

The first act of each per-service `restore_keys` is to examine that single variable. So if the final service that had been examined had resulted in `no`, then no keys are restored for any of the services.

This change converts that single variable into a per-service array of variables for the benefit of `restore_keys`.

## Linked Items

Fixes #<!-- insert issue here -->

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

<!-- What does this PR do? -->

## Behaviour changes

Old: <!-- This is the old way Cobbler behaved -->

New: <!-- This is the new way Cobbler behaves -->

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
