### PR TITLE
Fix for recursive remove

### DIFF
--- a/changelog.d/3940.fixed
+++ b/changelog.d/3940.fixed
@@ -1,0 +1,1 @@
+Fix for recursive remove

--- a/cobbler/cobbler_collections/images.py
+++ b/cobbler/cobbler_collections/images.py
@@ -8,8 +8,6 @@ Cobbler module that at runtime holds all images in Cobbler.
 
 from typing import TYPE_CHECKING, Any, Dict
 
-from cobbler import utils
-from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import collection
 from cobbler.items import image
 
@@ -40,71 +38,6 @@ class Images(collection.Collection[image.Image]):
         :returns: The created object.
         """
         return image.Image(self.api, **seed_data)
-
-    def remove(
-        self,
-        ref: image.Image,
-        with_delete: bool = True,
-        with_sync: bool = True,
-        with_triggers: bool = True,
-        recursive: bool = True,
-        rebuild_menu: bool = True,
-    ) -> None:
-        """
-        Remove the given element from the collection
-
-        :param ref: The object to delete
-        :param with_delete: In case the deletion triggers are executed for this image.
-        :param with_sync: In case a Cobbler Sync should be executed after the action.
-        :param with_triggers: In case the Cobbler Trigger mechanism should be executed.
-        :param recursive: In case you want to delete all objects this image references.
-        :param rebuild_menu: unused
-        :raises CX: Raised in case you want to delete a none existing image.
-        """
-        # rebuild_menu is not used
-        _ = rebuild_menu
-
-        if ref is None:  # type: ignore
-            raise CX("cannot delete an object that does not exist")
-
-        # first see if any Groups use this distro
-        if not recursive:
-            search_result = self.api.find_system(True, image=ref.uid)
-            if isinstance(search_result, list) and len(search_result) > 0:
-                raise CX(
-                    f"removal would orphan the following system(s): {', '.join([ref.uid for ref in search_result])}"
-                )
-
-        if recursive:
-            kids = self.api.find_system(return_list=True, image=ref.uid)
-            if kids is None:
-                kids = []
-            if not isinstance(kids, list):
-                raise ValueError("Expected list or None from find_items!")
-            for k in kids:
-                self.api.remove_system(k, recursive=True, with_sync=with_sync)
-
-        if with_delete:
-            if with_triggers:
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/delete/image/pre/*", []
-                )
-            if with_sync:
-                self.remove_quick_pxe_sync(ref)
-
-        with self.lock:
-            self.remove_from_indexes(ref)
-            del self.listing[ref.uid]
-        self.collection_mgr.serialize_delete(self, ref)
-
-        if with_delete:
-            if with_triggers:
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/delete/image/post/*", []
-                )
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/change/*", []
-                )
 
     def remove_quick_pxe_sync(
         self, ref: image.Image, rebuild_menu: bool = True

--- a/cobbler/cobbler_collections/menus.py
+++ b/cobbler/cobbler_collections/menus.py
@@ -7,8 +7,6 @@ Cobbler module that at runtime holds all menus in Cobbler.
 
 from typing import TYPE_CHECKING, Any, Dict
 
-from cobbler import utils
-from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import collection
 from cobbler.items import menu
 
@@ -40,74 +38,6 @@ class Menus(collection.Collection[menu.Menu]):
         :returns: The created object.
         """
         return menu.Menu(self.api, **seed_data)
-
-    def remove(
-        self,
-        ref: menu.Menu,
-        with_delete: bool = True,
-        with_sync: bool = True,
-        with_triggers: bool = True,
-        recursive: bool = False,
-        rebuild_menu: bool = True,
-    ) -> None:
-        """
-        Remove the given element from the collection
-
-        :param ref: The object to delete
-        :param with_delete: In case the deletion triggers are executed for this menu.
-        :param with_sync: In case a Cobbler Sync should be executed after the action.
-        :param with_triggers: In case the Cobbler Trigger mechanism should be executed.
-        :param recursive: In case you want to delete all objects this menu references.
-        :param rebuild_menu: unused
-        :raises CX: Raised in case you want to delete a none existing menu.
-        """
-        # rebuild_menu is not used
-        _ = rebuild_menu
-
-        if ref is None:  # type: ignore
-            raise CX("cannot delete an object that does not exist")
-
-        for item_type in ["image", "profile"]:
-            items = self.api.find_items(item_type, {"menu": ref.uid}, return_list=True)
-            if items is None:
-                continue
-            if not isinstance(items, list):
-                raise ValueError("Expected list or None from find_items!")
-            for item in items:
-                item.menu = ""
-
-        if recursive:
-            kids = ref.descendants
-            kids.sort(key=lambda x: -x.depth)
-            for k in kids:
-                self.api.remove_item(
-                    k.COLLECTION_TYPE,
-                    k,
-                    recursive=False,
-                    delete=with_delete,
-                    with_triggers=with_triggers,
-                    with_sync=with_sync,
-                )
-
-        if with_delete:
-            if with_triggers:
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/delete/menu/pre/*", []
-                )
-        with self.lock:
-            self.remove_from_indexes(ref)
-            del self.listing[ref.uid]
-        self.collection_mgr.serialize_delete(self, ref)
-        if with_delete:
-            if with_triggers:
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/delete/menu/post/*", []
-                )
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/change/*", []
-                )
-            if with_sync:
-                self.remove_quick_pxe_sync(ref)
 
     def remove_quick_pxe_sync(self, ref: menu.Menu, rebuild_menu: bool = True) -> None:
         self.api.get_sync().remove_single_menu()

--- a/cobbler/cobbler_collections/profiles.py
+++ b/cobbler/cobbler_collections/profiles.py
@@ -8,8 +8,6 @@ Cobbler module that at runtime holds all profiles in Cobbler.
 
 from typing import TYPE_CHECKING, Any, Dict
 
-from cobbler import utils
-from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import collection
 from cobbler.items import profile
 
@@ -35,70 +33,6 @@ class Profiles(collection.Collection[profile.Profile]):
         Return a Distro forged from seed_data
         """
         return profile.Profile(self.api, **seed_data)
-
-    def remove(
-        self,
-        ref: profile.Profile,
-        with_delete: bool = True,
-        with_sync: bool = True,
-        with_triggers: bool = True,
-        recursive: bool = False,
-        rebuild_menu: bool = True,
-    ):
-        """
-        Remove the given element from the collection
-
-        :param ref: The object to delete
-        :param with_delete: In case the deletion triggers are executed for this profile.
-        :param with_sync: In case a Cobbler Sync should be executed after the action.
-        :param with_triggers: In case the Cobbler Trigger mechanism should be executed.
-        :param recursive: In case you want to delete all objects this profile references.
-        :param rebuild_menu: unused
-        :raises CX: In case the reference to the object was not given.
-        """
-        if ref is None:  # type: ignore
-            raise CX("cannot delete an object that does not exist")
-
-        if not recursive:
-            search_result = self.api.find_system(True, profile=ref.uid)
-            if isinstance(search_result, list) and len(search_result) > 0:
-                raise CX(
-                    f"removal would orphan the following system(s): {', '.join([ref.uid for ref in search_result])}"
-                )
-
-        if recursive:
-            kids = ref.descendants
-            kids.sort(key=lambda x: -x.depth)
-            for k in kids:
-                self.api.remove_item(
-                    k.COLLECTION_TYPE,
-                    k,
-                    recursive=False,
-                    delete=with_delete,
-                    with_triggers=with_triggers,
-                    with_sync=with_sync,
-                )
-
-        if with_delete:
-            if with_triggers:
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/delete/profile/pre/*", []
-                )
-
-        with self.lock:
-            self.remove_from_indexes(ref)
-            del self.listing[ref.uid]
-        self.collection_mgr.serialize_delete(self, ref)
-        if with_delete:
-            if with_triggers:
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/delete/profile/post/*", []
-                )
-                utils.run_triggers(
-                    self.api, ref, "/var/lib/cobbler/triggers/change/*", []
-                )
-            if with_sync:
-                self.remove_quick_pxe_sync(ref)
 
     def remove_quick_pxe_sync(
         self, ref: profile.Profile, rebuild_menu: bool = True

--- a/tests/items/inheritable_item_test.py
+++ b/tests/items/inheritable_item_test.py
@@ -192,8 +192,8 @@ def test_descendants(
     cobbler_api.remove_profile(test_profile3.name)
     cobbler_api.remove_profile(test_profile2.name)
     cobbler_api.remove_profile(test_profile1.name)
-    cobbler_api.remove_menu(test_menu2.name)
-    cobbler_api.remove_menu(test_menu1.name)
+    cobbler_api.remove_menu(test_menu2.name, recursive=True)
+    cobbler_api.remove_menu(test_menu1.name, recursive=True)
 
 
 def test_tree_walk(cobbler_api: CobblerAPI):


### PR DESCRIPTION
## Linked Items

Fixes #3939

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Unifies the behavior of collections when recursively deleting an item.

## Behaviour changes

Old: Different collection types behave differently when performing recursive deletion.

New: Collections behave predictably when recursively deleting.

## Category

This is related to a:

- [X] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [X] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
