### PR TITLE
Use systemctl is-active --quiet to check status of services

### DIFF
--- a/changelog.d/3942.fixed
+++ b/changelog.d/3942.fixed
@@ -1,0 +1,1 @@
+check: Use systemctl is-active --quiet to check the status of services

--- a/cobbler/actions/check.py
+++ b/cobbler/actions/check.py
@@ -142,7 +142,7 @@ class CobblerCheck:
                     return
         elif process_management.is_systemd():
             return_code = utils.subprocess_call(
-                ["systemctl", "status", which], shell=False
+                ["systemctl", "is-active", "--quiet", which], shell=False
             )
             if return_code != 0:
                 status.append(f'service "{which}" is not running{notes}')


### PR DESCRIPTION
## Linked Items

Fixes #3942 

<!-- A PR without an issue that is fixed might be merged at a later point in time. --> 

## Description

Use `systemctl is-active --quiet` to check the status of services

## Behaviour changes

Old: Used `systemctl status` to check the status of services, which did more than is necessary

New: Use `systemctl is-active --quiet` which does the least necessary to check if a service is running

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
