### PR TITLE
Fix kernel options - ensure deterministic ordering

### DIFF
--- a/cobbler/autoinstall/generate/legacy.py
+++ b/cobbler/autoinstall/generate/legacy.py
@@ -58,9 +58,9 @@ class LegacyGenerator(AutoinstallBaseGenerator):
                 obj, "yum_config_stanza"
             )
 
-        meta["kernel_options"] = utils.dict_to_string(meta["kernel_options"])
+        meta["kernel_options"] = utils.kernel_options_to_string(meta["kernel_options"])
         if "kernel_options_post" in meta:
-            meta["kernel_options_post"] = utils.dict_to_string(
+            meta["kernel_options_post"] = utils.kernel_options_to_string(
                 meta["kernel_options_post"]
             )
 

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1501,7 +1501,7 @@ class TFTPGen:
         # support additional initrd= entries in kernel options.
         if "initrd" in kopts:
             append_line.append_raw(f",{kopts.pop('initrd')}")
-        hkopts = utils.dict_to_string(kopts)
+        hkopts = utils.kernel_options_to_string(kopts)
         if hkopts:
             append_line.append_raw(hkopts)
 
@@ -1605,7 +1605,7 @@ class TFTPGen:
                 if distro.os_version.find("esxi") != -1:
                     # ESXi is very picky, it's easier just to redo the
                     # entire append line here since
-                    hkopts = utils.dict_to_string(kopts)
+                    hkopts = utils.kernel_options_to_string(kopts)
                     append_line.append_key_value("ks", autoinstall_path)
                 else:
                     append_line.append_key_value("vmkopts", "debugLogToSerial:1")

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -31,6 +31,7 @@ from typing import (
     Pattern,
     Tuple,
     Union,
+    cast,
 )
 
 import distro
@@ -550,9 +551,11 @@ def flatten(data: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if "environment" in data:
         data["environment"] = dict_to_string(data["environment"])
     if "kernel_options" in data:
-        data["kernel_options"] = dict_to_string(data["kernel_options"])
+        data["kernel_options"] = kernel_options_to_string(data["kernel_options"])
     if "kernel_options_post" in data:
-        data["kernel_options_post"] = dict_to_string(data["kernel_options_post"])
+        data["kernel_options_post"] = kernel_options_to_string(
+            data["kernel_options_post"]
+        )
     if "yumopts" in data:
         data["yumopts"] = dict_to_string(data["yumopts"])
     if "autoinstall_meta" in data:
@@ -641,6 +644,38 @@ def dict_annihilate(dictionary: Dict[Any, Any]) -> None:
             del dictionary[key]
 
 
+ORDER_SENSITIVE_KERNEL_OPTION_KEYS = ("dud", "console")
+# TODO(issue-3797): remove hard coded list once kernel options are persisted as ordered structures.
+ORDER_SENSITIVE_KERNEL_OPTION_PRIORITIES = {
+    key: priority for priority, key in enumerate(ORDER_SENSITIVE_KERNEL_OPTION_KEYS)
+}
+
+
+def _dict_item_to_tokens(key: Any, value: Any) -> List[str]:
+    """
+    Convert a single dictionary entry into the list of cli tokens that should be emitted.
+    """
+
+    tokens: List[str] = []
+    if not value:
+        tokens.append(str(key))
+    elif isinstance(value, list):  # type: ignore
+        value = cast(List[Any], value)
+        for item in value:
+            item_str = str(item).strip()
+            if " " in item_str:
+                tokens.append(f"{key}='{item_str}'")
+            else:
+                tokens.append(f"{key}={item_str}")
+    else:
+        value_str = str(value).strip()
+        if " " in value_str:
+            tokens.append(f"{key}='{value_str}'")
+        else:
+            tokens.append(f"{key}={value_str}")
+    return tokens
+
+
 def dict_to_string(_dict: Dict[Any, Any]) -> str:
     """
     Convert a dictionary to a printable string. Used primarily in the kernel options string and for some legacy stuff
@@ -652,30 +687,58 @@ def dict_to_string(_dict: Dict[Any, Any]) -> str:
     :return: The string which was previously a dictionary.
     """
 
-    buffer = ""
     if not isinstance(_dict, dict):  # type: ignore
         return _dict
-    for key in _dict:
-        value = _dict[key]
-        if not value:
-            buffer += str(key) + " "
-        elif isinstance(value, list):  # type: ignore
-            # this value is an array, so we print out every key=value
-            value: List[Any]  # type: ignore[no-redef]
-            for item in value:
-                # strip possible leading and trailing whitespaces
-                _item = str(item).strip()
-                if " " in _item:
-                    buffer += str(key) + "='" + _item + "' "
-                else:
-                    buffer += str(key) + "=" + _item + " "
+
+    tokens: List[str] = []
+    for key, value in _dict.items():
+        tokens.extend(_dict_item_to_tokens(key, value))
+
+    return " ".join(tokens) + (" " if tokens else "")
+
+
+def kernel_options_to_string(options: Dict[Any, Any]) -> Union[str, Dict[Any, Any]]:
+    """
+    Convert kernel options to a deterministic string representation. Options that are not order-sensitive are sorted
+    alphabetically by key, while order-sensitive keys are appended in a defined priority (currently ``dud`` followed by
+    ``console``) while respecting their relative insertion order.
+
+    :param options: The kernel options to convert.
+    :return: A deterministic string representation of the kernel options.
+    """
+
+    if not isinstance(options, dict):  # type: ignore
+        return dict_to_string(options)  # type: ignore[arg-type]
+
+    key_map: Dict[str, Any] = {}
+    deterministic_key_names: List[str] = []
+    trailing_keys: List[Tuple[int, int, str]] = []
+
+    for index, key in enumerate(options.keys()):
+        key_str = str(key)
+        if key_str in key_map and key_map[key_str] is not key:
+            raise ValueError(
+                "Kernel option keys must be unique once converted to string form."
+            )
+        key_map[key_str] = key
+        if key_str in ORDER_SENSITIVE_KERNEL_OPTION_PRIORITIES:
+            trailing_keys.append(
+                (ORDER_SENSITIVE_KERNEL_OPTION_PRIORITIES[key_str], index, key_str)
+            )
         else:
-            _value = str(value).strip()
-            if " " in _value:
-                buffer += str(key) + "='" + _value + "' "
-            else:
-                buffer += str(key) + "=" + _value + " "
-    return buffer
+            deterministic_key_names.append(key_str)
+
+    deterministic_key_names.sort()
+    trailing_keys.sort(key=lambda entry: (entry[0], entry[1]))
+    ordered_keys: List[Any] = [key_map[name] for name in deterministic_key_names]
+    ordered_keys.extend(key_map[name] for _, _, name in trailing_keys)
+
+    tokens: List[str] = []
+    for key in ordered_keys:
+        tokens.extend(_dict_item_to_tokens(key, options[key]))
+
+    # Maintain trailing space for backward compatibility with callers that expect the legacy formatting.
+    return " ".join(tokens) + (" " if tokens else "")
 
 
 def rsync_files(src: str, dst: str, args: str, quiet: bool = True) -> bool:
@@ -1241,9 +1304,9 @@ def kopts_overwrite(
             kopts["textmode"] = ["1"]
         if system_name and cobbler_server_hostname:
             # only works if pxe_just_once is enabled in global settings
-            kopts[
-                "info"
-            ] = f"http://{cobbler_server_hostname}/cblr/svc/op/nopxe/system/{system_name}"
+            kopts["info"] = (
+                f"http://{cobbler_server_hostname}/cblr/svc/op/nopxe/system/{system_name}"
+            )
 
 
 def is_str_int(value: str) -> bool:

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -337,6 +337,80 @@ def test_dict_to_string(testinput, expected_result):  # type: ignore
     assert expected_result == result
 
 
+def test_kernel_options_to_string_sorts_regular_keys():  # type: ignore
+    # Arrange
+    kernel_options = {
+        "panic": "5",
+        "nosshkey": None,
+        "rescue": "1",
+        "printk.devkmsg": "on",
+    }
+
+    # Act
+    result = utils.kernel_options_to_string(kernel_options)
+
+    # Assert
+    assert result == "nosshkey panic=5 printk.devkmsg=on rescue=1 "
+
+
+def test_kernel_options_to_string_keeps_special_order():  # type: ignore
+    # Arrange
+    kernel_options = {
+        "panic": "5",
+        "console": ["ttyS0", "ttyS1"],
+        "dud": ["driver2", "driver 1"],
+    }
+
+    # Act
+    result = utils.kernel_options_to_string(kernel_options)
+
+    # Assert
+    assert result == "panic=5 dud=driver2 dud='driver 1' console=ttyS0 console=ttyS1 "
+
+
+def test_kernel_options_to_string_reorders_prioritised_keys():  # type: ignore
+    # Arrange
+    kernel_options = {
+        "console": ["ttyS0", "ttyS1"],
+        "dud": ["driver2", "driver 1"],
+    }
+
+    # Act
+    result = utils.kernel_options_to_string(kernel_options)
+
+    # Assert
+    assert result == "dud=driver2 dud='driver 1' console=ttyS0 console=ttyS1 "
+
+
+def test_kernel_options_to_string_mixed_regular_and_special_keys():  # type: ignore
+    # Arrange
+    kernel_options = {
+        "z": 1,
+        "console": "ttyS0",
+        "a": 1,
+        "dud": "drv",
+    }
+
+    # Act
+    result = utils.kernel_options_to_string(kernel_options)
+
+    # Assert
+    assert result == "a=1 z=1 dud=drv console=ttyS0 "
+
+
+def test_kernel_options_to_string_preserves_single_quotes():  # type: ignore
+    # Arrange
+    kernel_options = {
+        "foo": "value 'with quote'",
+    }
+
+    # Act
+    result = utils.kernel_options_to_string(kernel_options)
+
+    # Assert
+    assert result == "foo='value 'with quote'' "
+
+
 @pytest.mark.skip("This method needs mocking of subprocess_call. We do this later.")
 def test_rsync_files():
     # Arrange


### PR DESCRIPTION
## Linked Items

  Fixes #3797

  ## Description

  Introduces `kernel_options_to_string` so kernel option strings are generated deterministically, keeps
  order-sensitive keys (dud, console) in a defined trailing position, and updates all callers plus unit
  tests accordingly.

  ## Behaviour changes

  Old: Kernel option reporting/order was based on raw dictionary iteration, causing non-deterministic
  output and needless updates when tooling compared values.

  New: Kernel options are formatted consistently—non-special keys are alphabetized while dud and console
  remain at the tail in priority order—so repeated edit/report cycles now match.

  ## Category

  This is related to a:

  - [x] Bugfix
  - [ ] Feature
  - [ ] Packaging
  - [ ] Docs
  - [ ] Code Quality
  - [ ] Refactoring
  - [ ] Miscellaneous

  ## Tests

  - [x] Unit-Tests were created
  - [ ] System-Tests were created
  - [ ] Code is already covered by Unit-Tests
  - [ ] Code is already covered by System-Tests
  - [ ] No tests required
