### PR TITLE
API: rename task options parameter

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -662,7 +662,7 @@ class CobblerXMLRPCInterface:
         token: str,
         role_name: str,
         name: str,
-        args: Dict[str, Any],
+        options: Dict[str, Any],
         on_done: Optional[Callable[["CobblerThread"], None]] = None,
     ):
         """
@@ -673,7 +673,7 @@ class CobblerXMLRPCInterface:
                       tasks require tokens.
         :param role_name: used to check token against authn/authz layers
         :param name: display name to show in logs/events
-        :param args: usually this is a single dict, containing options
+        :param options: usually this is a single dict, containing options
         :param on_done: an optional second function handle to run after success (and only success)
         :return: a task id.
         """
@@ -682,9 +682,9 @@ class CobblerXMLRPCInterface:
 
         self._log(f"create_task({name}); event_id({new_event.event_id})")
 
-        args["load_items_lock"] = self.load_items_lock
+        options["load_items_lock"] = self.load_items_lock
         thr_obj = CobblerThread(
-            new_event.event_id, self, args, role_name, self.api, thr_obj_fn, on_done
+            new_event.event_id, self, options, role_name, self.api, thr_obj_fn, on_done
         )
         thr_obj.start()
         return new_event.event_id


### PR DESCRIPTION
  ## Linked Items

  Fixes #3718
  <!-- A PR without an issue that is fixed might be merged at a later point in time. -->

  ## Description

  Renamed the private XML-RPC helper __start_task parameter from args to options, updated the docstring, and ensured the
  new name flows through to the CobblerThread setup for consistency with the rest of the API.

  ## Behaviour changes

  Old: Background task helper accepted an args dict, diverging from the options naming used elsewhere in the API.

  New: Helper now consistently uses options, keeping naming uniform and removing the last args reference.

  ## Category

  This is related to a:

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Packaging
  - [ ] Docs
  - [ ] Code Quality
  - [x] Refactoring
  - [ ] Miscellaneous

  ## Tests

  - [ ] Unit-Tests were created
  - [ ] System-Tests were created
  - [ ] Code is already covered by Unit-Tests
  - [ ] Code is already covered by System-Tests
  - [x] No tests required
