### PR TITLE
Collections: unify kwargs naming

### DIFF
--- a/changelog.d/3732.fixed
+++ b/changelog.d/3732.fixed
@@ -1,0 +1,1 @@
+Unified keyword argument naming

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1794,7 +1794,7 @@ class CobblerAPI:
         ]
     ]:
         """
-        Find a network interface via a name or keys specified in the ``**kargs``.
+        Find a network interface via a name or keys specified in the ``**kwargs``.
 
         :param return_list: If only the first result or all results should be returned.
         :param no_errors: Silence some errors which would raise if this turned to False.
@@ -1812,7 +1812,7 @@ class CobblerAPI:
         **kwargs: "FIND_KWARGS",
     ) -> Optional[Union[List["template.Template"], "template.Template"]]:
         """
-        Find a network interface via a name or keys specified in the ``**kargs``.
+        Find a network interface via a name or keys specified in the ``**kwargs``.
 
         :param return_list: If only the first result or all results should be returned.
         :param no_errors: Silence some errors which would raise if this turned to False.

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -289,7 +289,7 @@ class Collection(Generic[ITEM]):
             self._deserialize()
 
         with self.lock:
-            orig_kargs_len = len(kwargs)
+            orig_kwargs_len = len(kwargs)
             result = self.find_by_indexes(kwargs)
             new_kwargs_len = len(kwargs)
             if new_kwargs_len > 0:
@@ -297,7 +297,7 @@ class Collection(Generic[ITEM]):
                 if result is not None:
                     obj_list = result
                 else:
-                    if new_kwargs_len == orig_kargs_len:
+                    if new_kwargs_len == orig_kwargs_len:
                         obj_list = list(self)
                 for obj in obj_list:
                     if obj.inmemory and obj.find_match(kwargs, no_errors=no_errors):

--- a/tests/cobbler_collections/distro_collection_test.py
+++ b/tests/cobbler_collections/distro_collection_test.py
@@ -345,30 +345,30 @@ def test_find_by_indexes(
     """
     # Arrange
     item1 = create_distro()
-    kargs1 = {"name": item1.name}
-    kargs2 = {"name": "fake_name"}
-    kargs3 = {"fake_index": item1.uid}
-    kargs4 = {"arch": item1.arch.value}
-    kargs5 = {"arch": "fake_arch"}
+    kwargs1 = {"name": item1.name}
+    kwargs2 = {"name": "fake_name"}
+    kwargs3 = {"fake_index": item1.uid}
+    kwargs4 = {"arch": item1.arch.value}
+    kwargs5 = {"arch": "fake_arch"}
 
     # Act
-    result1 = distro_collection.find_by_indexes(kargs1)
-    result2 = distro_collection.find_by_indexes(kargs2)
-    result3 = distro_collection.find_by_indexes(kargs3)
-    result4 = distro_collection.find_by_indexes(kargs4)
-    result5 = distro_collection.find_by_indexes(kargs5)
+    result1 = distro_collection.find_by_indexes(kwargs1)
+    result2 = distro_collection.find_by_indexes(kwargs2)
+    result3 = distro_collection.find_by_indexes(kwargs3)
+    result4 = distro_collection.find_by_indexes(kwargs4)
+    result5 = distro_collection.find_by_indexes(kwargs5)
 
     # Assert
     assert isinstance(result1, list)
     assert len(result1) == 1
     assert result1[0] == item1
-    assert len(kargs1) == 0
+    assert len(kwargs1) == 0
     assert result2 is None
-    assert len(kargs2) == 0
+    assert len(kwargs2) == 0
     assert result3 is None
-    assert len(kargs3) == 1
+    assert len(kwargs3) == 1
     assert result4 is not None
     assert len(result4) == 1
-    assert len(kargs4) == 0
+    assert len(kwargs4) == 0
     assert result5 is None
-    assert len(kargs5) == 0
+    assert len(kwargs5) == 0

--- a/tests/cobbler_collections/image_collection_test.py
+++ b/tests/cobbler_collections/image_collection_test.py
@@ -406,39 +406,39 @@ def test_find_by_indexes(
     """
     # Arrange
     item1 = create_image()
-    kargs1 = {"name": item1.name}
-    kargs2 = {"name": "fake_uid"}
-    kargs3 = {"fake_index": item1.uid}
-    kargs4 = {"menu": ""}
-    kargs5 = {"menu": "fake_menu"}
-    kargs6 = {"arch": item1.arch.value}
-    kargs7 = {"arch": "fake_arch"}
+    kwargs1 = {"name": item1.name}
+    kwargs2 = {"name": "fake_uid"}
+    kwargs3 = {"fake_index": item1.uid}
+    kwargs4 = {"menu": ""}
+    kwargs5 = {"menu": "fake_menu"}
+    kwargs6 = {"arch": item1.arch.value}
+    kwargs7 = {"arch": "fake_arch"}
 
     # Act
-    result1 = image_collection.find_by_indexes(kargs1)
-    result2 = image_collection.find_by_indexes(kargs2)
-    result3 = image_collection.find_by_indexes(kargs3)
-    result4 = image_collection.find_by_indexes(kargs4)
-    result5 = image_collection.find_by_indexes(kargs5)
-    result6 = image_collection.find_by_indexes(kargs6)
-    result7 = image_collection.find_by_indexes(kargs7)
+    result1 = image_collection.find_by_indexes(kwargs1)
+    result2 = image_collection.find_by_indexes(kwargs2)
+    result3 = image_collection.find_by_indexes(kwargs3)
+    result4 = image_collection.find_by_indexes(kwargs4)
+    result5 = image_collection.find_by_indexes(kwargs5)
+    result6 = image_collection.find_by_indexes(kwargs6)
+    result7 = image_collection.find_by_indexes(kwargs7)
 
     # Assert
     assert isinstance(result1, list)
     assert len(result1) == 1
     assert result1[0] == item1
-    assert len(kargs1) == 0
+    assert len(kwargs1) == 0
     assert result2 is None
-    assert len(kargs2) == 0
+    assert len(kwargs2) == 0
     assert result3 is None
-    assert len(kargs3) == 1
+    assert len(kwargs3) == 1
     assert result4 is not None
     assert len(result4) == 1
-    assert len(kargs4) == 0
+    assert len(kwargs4) == 0
     assert result5 is None
-    assert len(kargs5) == 0
+    assert len(kwargs5) == 0
     assert result6 is not None
     assert len(result6) == 1
-    assert len(kargs6) == 0
+    assert len(kwargs6) == 0
     assert result7 is None
-    assert len(kargs7) == 0
+    assert len(kwargs7) == 0

--- a/tests/cobbler_collections/menu_collection_test.py
+++ b/tests/cobbler_collections/menu_collection_test.py
@@ -390,30 +390,30 @@ def test_find_by_indexes(
     item1 = cobbler_api.new_menu()
     item1.name = name  # type: ignore[method-assign]
     menu_collection.add(item1)
-    kargs1 = {"name": item1.name}
-    kargs2 = {"name": "fake_uid"}
-    kargs3 = {"fake_index": item1.uid}
-    kargs4 = {"parent": ""}
-    kargs5 = {"parent": "fake_parent"}
+    kwargs1 = {"name": item1.name}
+    kwargs2 = {"name": "fake_uid"}
+    kwargs3 = {"fake_index": item1.uid}
+    kwargs4 = {"parent": ""}
+    kwargs5 = {"parent": "fake_parent"}
 
     # Act
-    result1 = menu_collection.find_by_indexes(kargs1)
-    result2 = menu_collection.find_by_indexes(kargs2)
-    result3 = menu_collection.find_by_indexes(kargs3)
-    result4 = menu_collection.find_by_indexes(kargs4)
-    result5 = menu_collection.find_by_indexes(kargs5)
+    result1 = menu_collection.find_by_indexes(kwargs1)
+    result2 = menu_collection.find_by_indexes(kwargs2)
+    result3 = menu_collection.find_by_indexes(kwargs3)
+    result4 = menu_collection.find_by_indexes(kwargs4)
+    result5 = menu_collection.find_by_indexes(kwargs5)
 
     # Assert
     assert isinstance(result1, list)
     assert len(result1) == 1
     assert result1[0] == item1
-    assert len(kargs1) == 0
+    assert len(kwargs1) == 0
     assert result2 is None
-    assert len(kargs2) == 0
+    assert len(kwargs2) == 0
     assert result3 is None
-    assert len(kargs3) == 1
+    assert len(kwargs3) == 1
     assert result4 is not None
     assert len(result4) == 1
-    assert len(kargs4) == 0
+    assert len(kwargs4) == 0
     assert result5 is None
-    assert len(kargs5) == 0
+    assert len(kwargs5) == 0

--- a/tests/cobbler_collections/network_interface_collection_test.py
+++ b/tests/cobbler_collections/network_interface_collection_test.py
@@ -468,21 +468,21 @@ def test_find_by_indexes(
     item1 = cobbler_api.new_network_interface(system_uid=test_system.uid)
     item1.name = name  # type: ignore[method-assign]
     network_interface_collection.add(item1)
-    kargs1 = {"name": item1.name}
-    kargs2 = {"name": "fake_uid"}
-    kargs3 = {"fake_index": item1.uid}
+    kwargs1 = {"name": item1.name}
+    kwargs2 = {"name": "fake_uid"}
+    kwargs3 = {"fake_index": item1.uid}
 
     # Act
-    result1 = network_interface_collection.find_by_indexes(kargs1)
-    result2 = network_interface_collection.find_by_indexes(kargs2)
-    result3 = network_interface_collection.find_by_indexes(kargs3)
+    result1 = network_interface_collection.find_by_indexes(kwargs1)
+    result2 = network_interface_collection.find_by_indexes(kwargs2)
+    result3 = network_interface_collection.find_by_indexes(kwargs3)
 
     # Assert
     assert isinstance(result1, list)
     assert len(result1) == 1
     assert result1[0] == item1
-    assert len(kargs1) == 0
+    assert len(kwargs1) == 0
     assert result2 is None
-    assert len(kargs2) == 0
+    assert len(kwargs2) == 0
     assert result3 is None
-    assert len(kargs3) == 1
+    assert len(kwargs3) == 1

--- a/tests/cobbler_collections/profile_collection_test.py
+++ b/tests/cobbler_collections/profile_collection_test.py
@@ -769,66 +769,66 @@ def test_find_by_indexes(
     # Arrange
     distro1 = create_distro()
     profile1 = create_profile(distro1.uid)
-    kargs1 = {"name": profile1.name}
-    kargs2 = {"name": "fake_uid"}
-    kargs3 = {"fake_index": profile1.uid}
-    kargs4 = {"parent": ""}
-    kargs5 = {"parent": "fake_parent"}
-    kargs6 = {"menu": ""}
-    kargs7 = {"parent": "fake_menu"}
-    kargs8 = {"repos": ""}
-    kargs9 = {"repos": "fake_repos"}
-    kargs10 = {"distro": distro1.uid}
-    kargs11 = {"repos": "fake_distro"}
-    kargs12 = {"arch": profile1.arch.value}  # type: ignore[reportOptionalMemberAccess,union-attr]
-    kargs13 = {"repos": "fake_arch"}
+    kwargs1 = {"name": profile1.name}
+    kwargs2 = {"name": "fake_uid"}
+    kwargs3 = {"fake_index": profile1.uid}
+    kwargs4 = {"parent": ""}
+    kwargs5 = {"parent": "fake_parent"}
+    kwargs6 = {"menu": ""}
+    kwargs7 = {"parent": "fake_menu"}
+    kwargs8 = {"repos": ""}
+    kwargs9 = {"repos": "fake_repos"}
+    kwargs10 = {"distro": distro1.uid}
+    kwargs11 = {"repos": "fake_distro"}
+    kwargs12 = {"arch": profile1.arch.value}  # type: ignore[reportOptionalMemberAccess,union-attr]
+    kwargs13 = {"repos": "fake_arch"}
 
     # Act
-    result1 = profile_collection.find_by_indexes(kargs1)
-    result2 = profile_collection.find_by_indexes(kargs2)
-    result3 = profile_collection.find_by_indexes(kargs3)
-    result4 = profile_collection.find_by_indexes(kargs4)
-    result5 = profile_collection.find_by_indexes(kargs5)
-    result6 = profile_collection.find_by_indexes(kargs6)
-    result7 = profile_collection.find_by_indexes(kargs7)
-    result8 = profile_collection.find_by_indexes(kargs8)
-    result9 = profile_collection.find_by_indexes(kargs9)
-    result10 = profile_collection.find_by_indexes(kargs10)
-    result11 = profile_collection.find_by_indexes(kargs11)
-    result12 = profile_collection.find_by_indexes(kargs12)
-    result13 = profile_collection.find_by_indexes(kargs13)
+    result1 = profile_collection.find_by_indexes(kwargs1)
+    result2 = profile_collection.find_by_indexes(kwargs2)
+    result3 = profile_collection.find_by_indexes(kwargs3)
+    result4 = profile_collection.find_by_indexes(kwargs4)
+    result5 = profile_collection.find_by_indexes(kwargs5)
+    result6 = profile_collection.find_by_indexes(kwargs6)
+    result7 = profile_collection.find_by_indexes(kwargs7)
+    result8 = profile_collection.find_by_indexes(kwargs8)
+    result9 = profile_collection.find_by_indexes(kwargs9)
+    result10 = profile_collection.find_by_indexes(kwargs10)
+    result11 = profile_collection.find_by_indexes(kwargs11)
+    result12 = profile_collection.find_by_indexes(kwargs12)
+    result13 = profile_collection.find_by_indexes(kwargs13)
 
     # Assert
     assert isinstance(result1, list)
     assert len(result1) == 1
     assert result1[0] == profile1
-    assert len(kargs1) == 0
+    assert len(kwargs1) == 0
     assert result2 is None
-    assert len(kargs2) == 0
+    assert len(kwargs2) == 0
     assert result3 is None
-    assert len(kargs3) == 1
+    assert len(kwargs3) == 1
     assert result4 is not None
     assert len(result4) == 1
-    assert len(kargs4) == 0
+    assert len(kwargs4) == 0
     assert result5 is None
-    assert len(kargs5) == 0
+    assert len(kwargs5) == 0
     assert result6 is not None
     assert len(result6) == 1
-    assert len(kargs6) == 0
+    assert len(kwargs6) == 0
     assert result7 is None
-    assert len(kargs7) == 0
+    assert len(kwargs7) == 0
     assert result8 is not None
     assert len(result8) == 1
-    assert len(kargs8) == 0
+    assert len(kwargs8) == 0
     assert result9 is None
-    assert len(kargs9) == 0
+    assert len(kwargs9) == 0
     assert result10 is not None
     assert len(result10) == 1
-    assert len(kargs10) == 0
+    assert len(kwargs10) == 0
     assert result11 is None
-    assert len(kargs11) == 0
+    assert len(kwargs11) == 0
     assert result12 is not None
     assert len(result12) == 1
-    assert len(kargs12) == 0
+    assert len(kwargs12) == 0
     assert result13 is None
-    assert len(kargs13) == 0
+    assert len(kwargs13) == 0


### PR DESCRIPTION
## Linked Items

  Fixes #3732

  ## Description

  Normalize keyword-argument naming across collections by renaming lingering `kargs` references to `kwargs` in the API
  docstrings, collection helper, and associated unit tests. Keeps terminology aligned with the rest of the codebase and
  avoids confusion for contributors.

  ## Behaviour changes

  Old: Documentation and tests referenced `kargs`, even though the code actually uses `kwargs`, leading to inconsistent
  naming in the helper logic and examples.

  New: All references now consistently use `kwargs`, matching Python conventions and the implemented parameter names.

  ## Category

  This is related to a:

  - [ ] Bugfix
  - [ ] Feature
  - [ ] Packaging
  - [ ] Docs
  - [ ] Code Quality
  - [x] Refactoring
  - [ ] Miscellaneous

  ## Tests

  - [ ] Unit-Tests were created
  - [ ] System-Tests were created
  - [ ] Code is already covered by Unit-Tests
  - [ ] Code is already covered by System-Tests
  - [x] No tests required
