### PR TITLE
spec: enable mod_wsgi on installation

### DIFF
--- a/cobbler.spec
+++ b/cobbler.spec
@@ -299,6 +299,11 @@ chmod 640 %{_sysconfdir}/cobbler/users.conf
 chmod 640 %{_sysconfdir}/cobbler/users.digest
 chgrp %{apache_group} %{_sysconfdir}/cobbler/settings.yaml
 
+# enable required Apache module on install, but not on upgrade
+if [ $1 -eq 1 ]; then
+    a2enmod wsgi >/dev/null || :
+fi
+
 %preun
 %systemd_preun cobblerd.service
 %systemd_preun cobblerd-gunicorn.service


### PR DESCRIPTION
Previously, apache2-mod_wsgi activated itself during installation, but this behavior was changed to ensure consistency with other Apache modules. Therefore, Cobbler must now enable mod_wsgi during installation. See also:
https://build.opensuse.org/requests/1318897/changes