### PR TITLE
docker: add build of debs for Debian 13 Trixie

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -113,6 +113,25 @@ jobs:
           name: debs-debian12
           path: |
             deb-build/*.deb
+  build-debian13-debs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install System dependencies
+        run: sudo apt-get install -y rename
+      - name: Build a Debian 13 Package
+        shell: 'script -q -e -c "bash {0}"'
+        run: |
+          ./docker/debs/build-and-install-debs.sh deb13 docker/debs/Debian_13/Debian13.dockerfile
+      - name: Rename DEB
+        run: |
+          sudo file-rename -v -d -e 's/(^cobbler.*)_(\d+\.\d+\.\d+)_all\.deb/$1_$2_all.deb13.deb/' deb-build/*.deb
+      - name: Archive DEBs
+        uses: actions/upload-artifact@v4
+        with:
+          name: debs-debian13
+          path: |
+            deb-build/*.deb
   build-wheel:
     name: Build Python Wheel
     runs-on: ubuntu-latest
@@ -165,6 +184,7 @@ jobs:
         build-opensuse-tumbleweed-rpms,
         build-debian11-debs,
         build-debian12-debs,
+        build-debian13-debs,
         build-wheel,
       ]
     steps:

--- a/Makefile
+++ b/Makefile
@@ -99,6 +99,9 @@ test-debian11: ## Executes the testscript for testing cobbler in a docker contai
 test-debian12: ## Executes the testscript for testing cobbler in a docker container on Debian 12.
 	./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile
 
+test-debian13: ## Executes the testscript for testing cobbler in a docker container on Debian 13.
+	./docker/debs/build-and-install-debs.sh deb13 docker/debs/Debian_13/Debian13.dockerfile
+
 system-test: ## Runs the system tests
 	${PYTHON} -m pytest -m integration -k ${SYSTESTS}
 

--- a/changelog.d/3979.added
+++ b/changelog.d/3979.added
@@ -1,0 +1,1 @@
+Add build of debs for Debian 13 Trixie

--- a/docker/debs/Debian_13/Debian13.dockerfile
+++ b/docker/debs/Debian_13/Debian13.dockerfile
@@ -1,0 +1,89 @@
+# vim: ft=dockerfile
+
+FROM docker.io/library/debian:13
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# TERM=screen is fairly neutral and works with xterm for example, for others
+# you might need to pass -e TERM=<terminal>, like rxvt-unicode.
+ENV TERM screen
+ENV OSCODENAME trixie
+
+# Add repo for debbuild and install all packages required
+# hadolint ignore=DL3008,DL3015,DL4006
+RUN apt-get update -qq && \
+    apt-get install -qqy \
+    build-essential \
+    devscripts \
+    dh-python \
+    debhelper \
+    gnupg \
+    curl \
+    wget \
+    libsystemd-dev \
+    libsasl2-dev \
+    pycodestyle \
+    pyflakes3 \
+    python3-pip  \
+    python3-cheetah  \
+    python3-gunicorn  \
+    python3-coverage \
+    python3-wheel   \
+    python3-distro \
+    python3-dnspython \
+    python3-dns  \
+    python3-dnsq  \
+    python3-magic  \
+    python3-ldap \
+    python3-netaddr \
+    python3-pip \
+    python3-pycodestyle \
+    python3-pymongo \
+    python3-pytest \
+    python3-setuptools \
+    python3-importlib-resources  \
+    python3-simplejson  \
+    python3-sphinx \
+    python3-sphinx-rtd-theme \
+    python3-tz \
+    python3-yaml \
+    python3-schema \
+    python3-systemd \
+    liblocale-gettext-perl \
+    lsb-release \
+    xz-utils \
+    bzip2 \
+    dpkg-dev \
+    tftpd-hpa \
+    createrepo-c \
+    isc-dhcp-server \
+    rsync \
+    xorriso\
+    fence-agents\
+    fakeroot \
+    patch \
+    pax \
+    git \
+    hardlink \
+    apache2 \
+    iproute2 \
+    systemd \
+    systemd-sysv \
+    supervisor \
+    mtools \
+    dosfstools && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Make /bin/sh point to bash, not dash
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN echo "dash dash/sh boolean false" | debconf-set-selections && \
+    dpkg-reconfigure dash
+
+COPY ./docker/debs/Debian_11/supervisord/conf.d /etc/supervisor/conf.d
+
+COPY . /usr/src/cobbler
+WORKDIR /usr/src/cobbler
+
+VOLUME /usr/src/cobbler/deb-build
+
+CMD ["/bin/bash", "-c", "make debs"]

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -196,6 +196,7 @@ However we provide docker files for
 - Rocky Linux 10
 - Debian 11 Bullseye
 - Debian 12 Bookworm
+- Debian 13 Trixie
 
 which will give you packages which will work better then building from source yourself.
 
@@ -212,6 +213,7 @@ To build the packages you to need to execute the following in the root folder of
 - Rocky Linux 10: ``./docker/rpms/build-and-install-rpms.sh rl10 docker/rpms/Rocky_Linux_10/Rocky_Linux_10.dockerfile``
 - Debian 11: ``./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile``
 - Debian 12: ``./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile``
+- Debian 13: ``./docker/debs/build-and-install-debs.sh deb13 docker/debs/Debian_13/Debian13.dockerfile``
 
 After executing the scripts you should have one folder owned by ``root`` which was created during the build. It is
 either called ``rpm-build`` or ``deb-build``. In these directories you should find the built packages. They are


### PR DESCRIPTION
## Description

This commit adds a Dockerfile to build the debs for Debian 13.

Update the installation guide to provide the build and install command for Debian 13. Also add Debian 13 to the Makefile and GH Action jobs

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [x] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 