### PR TITLE
Update XCP-ng support for latest releases

### DIFF
--- a/autoinstall_scripts/xcp_post_install
+++ b/autoinstall_scripts/xcp_post_install
@@ -1,0 +1,2 @@
+#!/bin/bash
+$SNIPPET('autoinstall_done')

--- a/autoinstall_scripts/xcp_pre_install
+++ b/autoinstall_scripts/xcp_pre_install
@@ -1,0 +1,2 @@
+#!/bin/sh
+$SNIPPET('autoinstall_start')

--- a/autoinstall_snippets/network_config_xcp
+++ b/autoinstall_snippets/network_config_xcp
@@ -1,0 +1,59 @@
+## start of cobbler network_config generated code
+#if $getVar("system_name","") != ""
+    #set ikeys = $interfaces.keys()
+    #import re
+    #for $iname in $ikeys
+        #set $idata    = $interfaces[$iname]
+        #set $mac      = $idata["mac_address"]
+        #set $static   = $idata["static"]
+        #set $ip       = $idata["ip_address"]
+        #set $netmask  = $idata["netmask"]
+        #set $type     = $idata["interface_type"]
+        ## Ignore BMC interface
+        #if $type == "bmc"
+            #continue
+        #end if
+        #if $iname != "default":
+            #set $if_id = 'name="' + $iname + '"'
+        #elif $mac != "":
+            #set $if_id = 'hwaddr="' + $mac + '"'
+        #else
+            #set $if_id = 'name="*"'
+        #end if
+        #if $static == True:
+            #if $ip != "":
+  <admin-interface $if_id proto="static">
+   <ipaddr>$ip</ipaddr>
+                #if $netmask != "":
+   <subnet>$netmask</subnet>
+                #else
+   <subnet>255.255.255.0</subnet>
+                #end if
+                #if $gateway != "":
+   <gateway>$gateway</gateway>
+                #end if
+  </admin-interface>
+            #else
+  <admin-interface $if_id proto="dhcp" />
+            #end if
+        #else
+  <admin-interface $if_id proto="dhcp" />
+        #end if
+        #if $name_servers and $name_servers[0] != "":
+            #for $ns in $name_servers
+  <name-server>$ns</name-server>
+            #end for
+        #end if
+        #if $hostname != ""
+  <hostname>$hostname</hostname>
+        #else
+            #set $myhostname = $getVar('name','').replace("_","-")
+  <hostname>$myhostname</hostname>
+        #end if
+    #end for
+#else
+## profile based install so just provide one interface for starters
+#set $myhostname = $getVar('hostname',$getVar('name','cobbler')).replace("_","-")
+  <admin-interface name="*" proto="dhcp" />
+  <hostname>$myhostname</hostname>
+#end if

--- a/autoinstall_templates/answerfile.xml
+++ b/autoinstall_templates/answerfile.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+ <installation sr-type="ext" mode="fresh" netinstall-gpg-check="true">
+  <keymap>us</keymap>
+  <timezone>US/Eastern</timezone>
+  <source type="url">$tree/</source>
+  <driver-source type="url">$tree/</driver-source>
+  <primary-disk>sda</primary-disk>
+  <root-password type="hash">$default_password_crypted</root-password>
+  <bootloader location="mbr">grub2</bootloader>
+$SNIPPET('network_config_xcp')
+  <ntp-server>us.pool.ntp.org</ntp-server>
+  <network-backend>vswitch</network-backend>
+## Figure out if we're automating OS installation for a system or a profile
+#if $getVar('system_name','') != ''
+#set $what = "system"
+#else
+#set $what = "profile"
+#end if
+  <script stage="installation-start" type="url">http://$http_server/cblr/svc/op/script/$what/$name/?script=xcp_pre_install</script>
+  <script stage="installation-complete" type="url">http://$http_server/cblr/svc/op/script/$what/$name/?script=xcp_post_install</script>
+ </installation>

--- a/changelog.d/3980.fixed
+++ b/changelog.d/3980.fixed
@@ -1,0 +1,1 @@
+Added support for interactive and automatic network installations of XCP-ng 7.x and 8.x latest releases.

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -146,6 +146,12 @@ class MkLoaders:
             self.bootloaders_dir.joinpath("pxelinux.0"),
             skip_existing=True
         )
+        # Make mboot.c32
+        symlink(
+            self.syslinux_folder.joinpath("mboot.c32"),
+            self.bootloaders_dir.joinpath("mboot.c32"),
+            skip_existing=True
+        )
         # Make linux.c32 for syslinux + wimboot
         libcom32_c32_path = self.syslinux_folder.joinpath("libcom32.c32")
         if syslinux_version > 4 and libcom32_c32_path.exists():

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -690,7 +690,7 @@ class TFTPGen:
         else:
             append_line = "append "
         append_line = "%s%s" % (append_line, kernel_options)
-        if distro and distro.os_version.startswith("xenserver620"):
+        if distro and distro.os_version.startswith(("xenserver620", "xcp")):
             append_line = "%s" % (kernel_options)
         metadata["append_line"] = append_line
 
@@ -774,6 +774,10 @@ class TFTPGen:
                     kernel_path = distro.remote_grub_kernel
                 if distro.remote_grub_initrd:
                     initrd_path = distro.remote_grub_initrd
+            elif boot_loader == "pxe":
+                if distro and distro.os_version.startswith("xcp"):
+                    metadata["kernel_path"] = "mboot.c32"
+                    kernel_path = metadata["kernel_path"]
 
             if 'http' in distro.kernel and 'http' in distro.initrd:
                 if not kernel_path:
@@ -957,6 +961,10 @@ class TFTPGen:
                     append_line = "append %s/xen.gz dom0_max_vcpus=2 dom0_mem=752M com1=115200,8n1 console=com1," \
                                   "vga --- %s/vmlinuz xencons=hvc console=hvc0 console=tty0 install answerfile=%s ---" \
                                   " %s/install.img" % (img_path, img_path, autoinstall_path, img_path)
+                    return append_line
+                elif distro.os_version.startswith("xcp"):
+                    img_path = os.path.join("/images", distro.name)
+                    append_line = " %s install answerfile=%s" % (hkopts, autoinstall_path)
                     return append_line
             elif distro.breed == "powerkvm":
                 append_line += " kssendmac"

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -732,7 +732,7 @@ class TFTPGen:
         else:
             append_line = "append "
         append_line = "%s%s" % (append_line, kernel_options)
-        if distro and distro.os_version.startswith("xenserver620"):
+        if distro and distro.os_version.startswith(("xenserver620", "xcp")):
             append_line = "%s" % (kernel_options)
         metadata["append_line"] = append_line
 
@@ -816,6 +816,10 @@ class TFTPGen:
                     kernel_path = distro.remote_grub_kernel
                 if distro.remote_grub_initrd:
                     initrd_path = distro.remote_grub_initrd
+            elif boot_loader == "pxe":
+                if distro and distro.os_version.startswith("xcp"):
+                    metadata["kernel_path"] = "mboot.c32"
+                    kernel_path = metadata["kernel_path"]
 
             if 'http' in distro.kernel and 'http' in distro.initrd:
                 if not kernel_path:
@@ -1001,6 +1005,10 @@ class TFTPGen:
                     append_line = "append %s/xen.gz dom0_max_vcpus=2 dom0_mem=752M com1=115200,8n1 console=com1," \
                                   "vga --- %s/vmlinuz xencons=hvc console=hvc0 console=tty0 install answerfile=%s ---" \
                                   " %s/install.img" % (img_path, img_path, autoinstall_path, img_path)
+                    return append_line
+                elif distro.os_version.startswith("xcp"):
+                    img_path = os.path.join("/images", distro.name)
+                    append_line = " %s install answerfile=%s" % (hkopts, autoinstall_path)
                     return append_line
             elif distro.breed == "powerkvm":
                 append_line += " kssendmac"

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1007,7 +1007,6 @@ class TFTPGen:
                                   " %s/install.img" % (img_path, img_path, autoinstall_path, img_path)
                     return append_line
                 elif distro.os_version.startswith("xcp"):
-                    img_path = os.path.join("/images", distro.name)
                     append_line = " %s install answerfile=%s" % (hkopts, autoinstall_path)
                     return append_line
             elif distro.breed == "powerkvm":

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -3324,6 +3324,202 @@
           "install.img"
         ]
       },
+      "xcp75": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-7\\.5\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-7\\.5\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp76": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-7\\.6\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-7\\.6\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp80": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.0\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.0\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp81": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.1\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.1\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp82": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.2\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.2\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp821": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.2\\.1.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.2\\.1.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp83": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.3\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.3\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
       "xenserver620": {
         "signatures": [
           "packages.xenserver"

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -3372,6 +3372,202 @@
           "install.img"
         ]
       },
+      "xcp75": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-7\\.5\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-7\\.5\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp76": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-7\\.6\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-7\\.6\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp80": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.0\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.0\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp81": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.1\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.1\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp82": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.2\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.2\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp821": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.2\\.1.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.2\\.1.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
+      "xcp83": {
+        "signatures": [
+          "Packages"
+        ],
+        "version_file": "^xcp-ng-release-8\\.3\\.0.*\\.x86_64\\.rpm$",
+        "version_file_regex": null,
+        "kernel_arch": "xcp-ng-release-8\\.3\\.0.*\\.x86_64\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "x86_64"
+        ],
+        "boot_loaders":{
+          "x86_64":[
+            "pxe",
+            "grub"
+          ]
+        },
+        "supported_repo_breeds": [],
+        "kernel_file": "vmlinuz",
+        "initrd_file": "xen\\.gz",
+        "isolinux_ok": false,
+        "default_autoinstall": "answerfile.xml",
+        "kernel_options": "xencons=hvc console=hvc0 console=tty0",
+        "kernel_options_post": "",
+        "boot_files": [
+          "install.img"
+        ]
+      },
       "xenserver620": {
         "signatures": [
           "packages.xenserver"

--- a/system-tests/tests/basic-mkloaders
+++ b/system-tests/tests/basic-mkloaders
@@ -20,5 +20,6 @@ cobbler mkloaders
 [ -f /var/lib/cobbler/loaders/grub/shim.efi ]
 [ -f /var/lib/cobbler/loaders/memdisk ]
 [ -f /var/lib/cobbler/loaders/menu.c32 ]
+[ -f /var/lib/cobbler/loaders/mboot.c32 ]
 [ -f /var/lib/cobbler/loaders/pxelinux.0 ]
 [ -f /var/lib/cobbler/loaders/undionly.pxe ]

--- a/templates/boot_loader_conf/grub.template
+++ b/templates/boot_loader_conf/grub.template
@@ -8,6 +8,14 @@ set default='local'
 #end if
 #end if
 menuentry '$menu_name' --class gnu-linux --class gnu --class os {
+#if $breed == "xen" and $os_version.startswith("xcp")
+  echo 'Loading Xen kernel ...'
+  multiboot2 $initrd_path dom0_mem=max:2048M watchdog dom0_max_vcpus=4 com1=115200,8n1 console=com1,vga
+  echo 'Loading Dom0 kernel ...'
+  module2 $kernel_path $kernel_options
+  echo 'Loading initial ramdisk ...'
+  module2 $img_path/install.img
+#else
   echo 'Loading kernel ...'
   clinux $kernel_path $kernel_options
 #if "wimboot" in $kernel_path
@@ -19,6 +27,7 @@ menuentry '$menu_name' --class gnu-linux --class gnu --class os {
 #if $breed != "windows" or "wimboot" in $kernel_path
   echo 'Loading initial ramdisk ...'
   cinitrd $initrd_path
+#end if
 #end if
   echo '...done'
 }

--- a/templates/boot_loader_conf/pxe.template
+++ b/templates/boot_loader_conf/pxe.template
@@ -1,6 +1,9 @@
 #if $breed == "vmware"
 #set $append_line="append -c " + $img_path + "/cobbler-boot.cfg" + $append_line
 #end if
+#if $breed == "xen" and $os_version.startswith("xcp")
+#set $append_line="append " + $initrd_path + " dom0_max_vcpus=2 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- " + $img_path + "/" + os.path.basename($kernel) + $append_line + " --- " + $img_path + "/" + "install.img"
+#end if
 #set $system_local=False
 #if $varExists('system_name')
 #if not $netboot_enabled

--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -26,10 +26,10 @@ def test_grubimage_run(cobbler_api, mocker):
     test_image_creator.run()
 
     # Assert
-    # On a full install: 3 common formats, 4 syslinux links and 9 bootloader formats
-    # In our test container we have: shim (1x), ipxe (1x), syslinux v4 (3x) and 3 grubs (4x)
-    # On GH we have: shim (1x), ipxe (1x), syslinux v4 (3x) and 3 grubs (3x)
-    assert mkloaders.symlink.call_count == 8
+    # On a full install: 3 common formats, 5 syslinux links and 9 bootloader formats
+    # In our test container we have: shim (1x), ipxe (1x), syslinux v4 (4x) and 3 grubs (4x)
+    # On GH we have: shim (1x), ipxe (1x), syslinux v4 (4x) and 3 grubs (3x)
+    assert mkloaders.symlink.call_count == 9
     # In our test container we have: x86_64, arm64-efi, i386-efi & i386-pc-pxe
     # On GH we have: x86_64, i386-efi & i386-pc-pxe
     assert mkloaders.mkimage.call_count == 3

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -257,3 +257,32 @@ def test_build_kernel_options_suse_installer_selection(
 
     # Assert
     assert expected_snippet in result
+
+
+def test_build_kernel_options_xcp(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    Test that asserts that XCP-ng distros get an "install answerfile=" append line.
+    """
+    # Arrange
+    test_distro = create_distro()
+    test_distro.breed = "xen"
+    test_distro.os_version = "xcp82"
+    test_profile = create_profile(test_distro.name)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    result = test_gen.build_kernel_options(
+        None,
+        test_profile,
+        test_distro,
+        None,
+        test_distro.arch,
+        "http://192.168.1.1/autoinstall",
+    )
+
+    # Assert
+    assert "install answerfile=http://192.168.1.1/autoinstall" in result


### PR DESCRIPTION
## Linked Items

Fixes #3980

For the forward-port see #4068

## Description

see behavior changes below

## Behaviour changes

Old: cobbler failed to import the latest XCP-ng 7.x & 8.x releases. If the `distro_signatures.json` file is updated with latest XCP-ng releases, the bootloader config files generate incorrectly, and there is no compatible `autoinstall` template.

New: able to import XCP-ng 7.x & 8.x and network boot+install via PXE or GRUB, automatically or interactively, with standard configurability at the Profile and System level.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
