### PR TITLE
Add `DistroGroup`, `ProfileGroup` and `SystemGroup` item types

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         # supported by your project here, or alternatively use
         # pre-commit's default_language_version, see
         # https://pre-commit.com/#top_level-default_language_version
-        language_version: python3.10
+        language_version: python3.11
         additional_dependencies: ['click==8.0.4']
   - repo: https://github.com/pycqa/isort
     # Configuration for isort is in "pyproject.toml"

--- a/changelog.d/3983.added
+++ b/changelog.d/3983.added
@@ -1,0 +1,1 @@
+Introduce new item type "ItemGroup"

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -160,25 +160,28 @@ from cobbler.autoinstall.manager import AutoInstallationManager
 from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import manager
 from cobbler.decorator import InheritableDictProperty, InheritableProperty
-from cobbler.items import distro
+from cobbler.items import distro, distro_group
 from cobbler.items import image as image_module
 from cobbler.items import menu, network_interface
 from cobbler.items import profile as profile_module
-from cobbler.items import repo
+from cobbler.items import profile_group, repo
 from cobbler.items import system as system_module
-from cobbler.items import template
+from cobbler.items import system_group, template
 from cobbler.items.abstract import bootable_item as item_base
 from cobbler.items.abstract.inheritable_item import InheritableItem
 from cobbler.utils import filesystem_helpers, input_converters, signatures
 
 if TYPE_CHECKING:
     from cobbler.cobbler_collections.collection import FIND_KWARGS, ITEM, Collection
+    from cobbler.cobbler_collections.distro_group import DistroGroups
     from cobbler.cobbler_collections.distros import Distros
     from cobbler.cobbler_collections.images import Images
     from cobbler.cobbler_collections.menus import Menus
     from cobbler.cobbler_collections.network_interfaces import NetworkInterfaces
+    from cobbler.cobbler_collections.profile_group import ProfileGroups
     from cobbler.cobbler_collections.profiles import Profiles
     from cobbler.cobbler_collections.repos import Repos
+    from cobbler.cobbler_collections.system_group import SystemGroups
     from cobbler.cobbler_collections.systems import Systems
     from cobbler.cobbler_collections.templates import Templates
     from cobbler.items.abstract.base_item import BaseItem
@@ -570,6 +573,24 @@ class CobblerAPI:
         """
         return self._collection_mgr.templates()
 
+    def distro_groups(self) -> "DistroGroups":
+        """
+        Return the current list of distro groups
+        """
+        return self._collection_mgr.distro_groups()
+
+    def profile_groups(self) -> "ProfileGroups":
+        """
+        Return the current list of profile groups
+        """
+        return self._collection_mgr.profile_groups()
+
+    def system_groups(self) -> "SystemGroups":
+        """
+        Return the current list of system groups
+        """
+        return self._collection_mgr.system_groups()
+
     # =======================================================================
 
     def __item_resolved_helper(
@@ -834,6 +855,35 @@ class CobblerAPI:
         """
         self._collection_mgr.templates().copy(ref, newname)
 
+    def copy_distro_group(self, ref: "distro_group.DistroGroup", newname: str) -> None:
+        """
+        This method copies a distro group which is just different in the name of the object.
+
+        :param ref: The object itself which gets copied.
+        :param newname: The new name of the newly created object.
+        """
+        self._collection_mgr.distro_groups().copy(ref, newname)
+
+    def copy_profile_group(
+        self, ref: "profile_group.ProfileGroup", newname: str
+    ) -> None:
+        """
+        This method copies a profile group which is just different in the name of the object.
+
+        :param ref: The object itself which gets copied.
+        :param newname: The new name of the newly created object.
+        """
+        self._collection_mgr.profile_groups().copy(ref, newname)
+
+    def copy_system_group(self, ref: "system_group.SystemGroup", newname: str) -> None:
+        """
+        This method copies a system group which is just different in the name of the object.
+
+        :param ref: The object itself which gets copied.
+        :param newname: The new name of the newly created object.
+        """
+        self._collection_mgr.system_groups().copy(ref, newname)
+
     # ==========================================================================
 
     def remove_item(
@@ -852,7 +902,7 @@ class CobblerAPI:
         :param what: The type of the item.
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -885,7 +935,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -911,7 +961,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -937,7 +987,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -963,7 +1013,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -989,7 +1039,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -1015,7 +1065,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -1041,7 +1091,7 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
@@ -1067,12 +1117,90 @@ class CobblerAPI:
 
         :param ref: The internal unique handle for the item.
         :param recursive: If the item should recursively should delete dependencies on itself.
-        :param delete: Not known what this parameter does exactly.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
         :param with_triggers: Whether you would like to have the removal triggers executed or not.
         :param with_sync: In case a Cobbler Sync should be executed after the action.
         """
         self.remove_item(
             "network_interface",
+            ref,
+            recursive=recursive,
+            delete=delete,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+        )
+
+    def remove_distro_group(
+        self,
+        ref: Union["distro_group.DistroGroup", str],
+        recursive: bool = False,
+        delete: bool = True,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+    ) -> None:
+        """
+        Remove a distro group from Cobbler.
+
+        :param ref: The internal unique handle for the item.
+        :param recursive: If the item should recursively should delete dependencies on itself.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
+        :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
+        """
+        self.remove_item(
+            "distro_group",
+            ref,
+            recursive=recursive,
+            delete=delete,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+        )
+
+    def remove_profile_group(
+        self,
+        ref: Union["profile_group.ProfileGroup", str],
+        recursive: bool = False,
+        delete: bool = True,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+    ) -> None:
+        """
+        Remove a profile group from Cobbler.
+
+        :param ref: The internal unique handle for the item.
+        :param recursive: If the item should recursively should delete dependencies on itself.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
+        :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
+        """
+        self.remove_item(
+            "profile_group",
+            ref,
+            recursive=recursive,
+            delete=delete,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+        )
+
+    def remove_system_group(
+        self,
+        ref: Union["system_group.SystemGroup", str],
+        recursive: bool = False,
+        delete: bool = True,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+    ) -> None:
+        """
+        Remove a system group from Cobbler.
+
+        :param ref: The internal unique handle for the item.
+        :param recursive: If the item should recursively should delete dependencies on itself.
+        :param delete: Additional condition that controls if with_triggers and with_sync should be executed.
+        :param with_triggers: Whether you would like to have the removal triggers executed or not.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
+        """
+        self.remove_item(
+            "system_group",
             ref,
             recursive=recursive,
             delete=delete,
@@ -1167,6 +1295,39 @@ class CobblerAPI:
         :param newname: The new name for the item.
         """
         self.rename_item("network_interface", ref, newname)
+
+    def rename_distro_group(
+        self, ref: "distro_group.DistroGroup", newname: str
+    ) -> None:
+        """
+        Rename a distro group to a new name.
+
+        :param ref: The internal unique handle for the item.
+        :param newname: The new name for the item.
+        """
+        self.rename_item("distro_group", ref, newname)
+
+    def rename_profile_group(
+        self, ref: "profile_group.ProfileGroup", newname: str
+    ) -> None:
+        """
+        Rename a profile group to a new name.
+
+        :param ref: The internal unique handle for the item.
+        :param newname: The new name for the item.
+        """
+        self.rename_item("profile_group", ref, newname)
+
+    def rename_system_group(
+        self, ref: "system_group.SystemGroup", newname: str
+    ) -> None:
+        """
+        Rename a system group to a new name.
+
+        :param ref: The internal unique handle for the item.
+        :param newname: The new name for the item.
+        """
+        self.rename_item("system_group", ref, newname)
 
     # ==========================================================================
 
@@ -1284,6 +1445,45 @@ class CobblerAPI:
         """
         self.log("new_network_interface", kwargs)
         return template.Template(self, **kwargs)
+
+    def new_distro_group(
+        self, is_subobject: bool = False, **kwargs: Any
+    ) -> "distro_group.DistroGroup":
+        """
+        Returns a new empty distro group object. This distro group is not automatically persisted. Persistence is achieved via
+        ``save()``.
+
+        :param is_subobject: If the object is a subobject of an already existing object or not.
+        :return: An empty DistroGroup object.
+        """
+        self.log("new_distro_group", kwargs)
+        return distro_group.DistroGroup(self, is_subobject, **kwargs)
+
+    def new_profile_group(
+        self, is_subobject: bool = False, **kwargs: Any
+    ) -> "profile_group.ProfileGroup":
+        """
+        Returns a new empty profile group object. This profile group is not automatically persisted. Persistence is achieved via
+        ``save()``.
+
+        :param is_subobject: If the object is a subobject of an already existing object or not.
+        :return: An empty ProfileGroup object.
+        """
+        self.log("new_profile_group", kwargs)
+        return profile_group.ProfileGroup(self, is_subobject, **kwargs)
+
+    def new_system_group(
+        self, is_subobject: bool = False, **kwargs: Any
+    ) -> "system_group.SystemGroup":
+        """
+        Returns a new empty system group object. This system group is not automatically persisted. Persistence is achieved via
+        ``save()``.
+
+        :param is_subobject: If the object is a subobject of an already existing object or not.
+        :return: An empty SystemGroup object.
+        """
+        self.log("new_system_group", kwargs)
+        return system_group.SystemGroup(self, is_subobject, **kwargs)
 
     # ==========================================================================
     def add_remove_items(self, items: List["TransactionTuple"]) -> None:
@@ -1588,6 +1788,84 @@ class CobblerAPI:
             with_sync=with_sync,
         )
 
+    def add_distro_group(
+        self,
+        ref: "distro_group.DistroGroup",
+        check_for_duplicate_names: bool = False,
+        save: bool = True,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+    ) -> None:
+        """
+        Add a distro group to Cobbler.
+
+        :param ref: The identifier for the object to add to a collection.
+        :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
+        :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
+        """
+        self.add_item(
+            "distro_group",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+        )
+
+    def add_profile_group(
+        self,
+        ref: "profile_group.ProfileGroup",
+        check_for_duplicate_names: bool = False,
+        save: bool = True,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+    ) -> None:
+        """
+        Add a profile group to Cobbler.
+
+        :param ref: The identifier for the object to add to a collection.
+        :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
+        :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
+        """
+        self.add_item(
+            "profile_group",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+        )
+
+    def add_system_group(
+        self,
+        ref: "system_group.SystemGroup",
+        check_for_duplicate_names: bool = False,
+        save: bool = True,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+    ) -> None:
+        """
+        Add a system group to Cobbler.
+
+        :param ref: The identifier for the object to add to a collection.
+        :param check_for_duplicate_names: If the name should be unique or can be present multiple times.
+        :param save: If the item should be persisted.
+        :param with_triggers: If triggers should be run when the object is added.
+        :param with_sync: In case a Cobbler Sync should be executed after the action.
+        """
+        self.add_item(
+            "system_group",
+            ref,
+            check_for_duplicate_names=check_for_duplicate_names,
+            save=save,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+        )
+
     # ==========================================================================
 
     def find_items(
@@ -1823,6 +2101,62 @@ class CobblerAPI:
             return_list=return_list, no_errors=no_errors, **kwargs
         )
 
+    def find_distro_group(
+        self,
+        return_list: bool = False,
+        no_errors: bool = False,
+        **kwargs: "FIND_KWARGS",
+    ) -> Optional[Union[List["distro_group.DistroGroup"], "distro_group.DistroGroup"]]:
+        """
+        Find a distro group via a name or keys specified in the ``**kwargs``.
+
+        :param return_list: If only the first result or all results should be returned.
+        :param no_errors: Silence some errors which would raise if this turned to False.
+        :param kwargs: Key-value pairs which help in finding the desired objects.
+        :return: A single object or a list of all search results.
+        """
+        return self._collection_mgr.distro_groups().find(
+            return_list=return_list, no_errors=no_errors, **kwargs
+        )
+
+    def find_profile_group(
+        self,
+        return_list: bool = False,
+        no_errors: bool = False,
+        **kwargs: "FIND_KWARGS",
+    ) -> Optional[
+        Union[List["profile_group.ProfileGroup"], "profile_group.ProfileGroup"]
+    ]:
+        """
+        Find a profile group via a name or keys specified in the ``**kwargs``.
+
+        :param return_list: If only the first result or all results should be returned.
+        :param no_errors: Silence some errors which would raise if this turned to False.
+        :param kwargs: Key-value pairs which help in finding the desired objects.
+        :return: A single object or a list of all search results.
+        """
+        return self._collection_mgr.profile_groups().find(
+            return_list=return_list, no_errors=no_errors, **kwargs
+        )
+
+    def find_system_group(
+        self,
+        return_list: bool = False,
+        no_errors: bool = False,
+        **kwargs: "FIND_KWARGS",
+    ) -> Optional[Union[List["system_group.SystemGroup"], "system_group.SystemGroup"]]:
+        """
+        Find a system group via a name or keys specified in the ``**kwargs``.
+
+        :param return_list: If only the first result or all results should be returned.
+        :param no_errors: Silence some errors which would raise if this turned to False.
+        :param kwargs: Key-value pairs which help in finding the desired objects.
+        :return: A single object or a list of all search results.
+        """
+        return self._collection_mgr.system_groups().find(
+            return_list=return_list, no_errors=no_errors, **kwargs
+        )
+
     # ==========================================================================
 
     @staticmethod
@@ -1952,6 +2286,45 @@ class CobblerAPI:
         :return: The list of files which are newer then the given timestamp.
         """
         return self.__since(mtime, self.templates, collapse=collapse)
+
+    def get_distro_groups_since(
+        self, mtime: float, collapse: bool = False
+    ) -> List["distro_group.DistroGroup"]:
+        """
+        Return distro groups modified since a certain time (in seconds since Epoch)
+
+        :param mtime: The timestamp which marks the gate if an object is included or not.
+        :param collapse: If True then this specifies that a list of dicts should be returned instead of a list of
+                         objects.
+        :return: The list of distro groups which are newer then the given timestamp.
+        """
+        return self.__since(mtime, self.distro_groups, collapse=collapse)
+
+    def get_profile_groups_since(
+        self, mtime: float, collapse: bool = False
+    ) -> List["profile_group.ProfileGroup"]:
+        """
+        Return profile groups modified since a certain time (in seconds since Epoch)
+
+        :param mtime: The timestamp which marks the gate if an object is included or not.
+        :param collapse: If True then this specifies that a list of dicts should be returned instead of a list of
+                         objects.
+        :return: The list of profile groups which are newer then the given timestamp.
+        """
+        return self.__since(mtime, self.profile_groups, collapse=collapse)
+
+    def get_system_groups_since(
+        self, mtime: float, collapse: bool = False
+    ) -> List["system_group.SystemGroup"]:
+        """
+        Return system groups modified since a certain time (in seconds since Epoch)
+
+        :param mtime: The timestamp which marks the gate if an object is included or not.
+        :param collapse: If True then this specifies that a list of dicts should be returned instead of a list of
+                         objects.
+        :return: The list of system groups which are newer then the given timestamp.
+        """
+        return self.__since(mtime, self.system_groups, collapse=collapse)
 
     # ==========================================================================
 

--- a/cobbler/cobbler_collections/distro_group.py
+++ b/cobbler/cobbler_collections/distro_group.py
@@ -1,0 +1,37 @@
+"""
+DistroGroupCollection
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from cobbler.cobbler_collections.collection import Collection
+from cobbler.items import distro_group
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
+class DistroGroups(Collection[distro_group.DistroGroup]):
+    """
+    The collection for distro groups.
+    """
+
+    @staticmethod
+    def collection_type() -> str:
+        return "distro_group"
+
+    @staticmethod
+    def collection_types() -> str:
+        return "distro_groups"
+
+    def factory_produce(
+        self, api: "CobblerAPI", seed_data: Dict[str, Any]
+    ) -> distro_group.DistroGroup:
+        """
+        Return a Distro Group forged from seed_data
+
+        :param api: Parameter is skipped.
+        :param seed_data: The data the object is initialized with.
+        :returns: The created DistroGroup.
+        """
+        return distro_group.DistroGroup(api, **seed_data)

--- a/cobbler/cobbler_collections/manager.py
+++ b/cobbler/cobbler_collections/manager.py
@@ -12,12 +12,15 @@ from typing import TYPE_CHECKING, Any, Dict, cast
 from cobbler import serializer, validate
 from cobbler.cexceptions import CX
 from cobbler.cobbler_collections.collection import Collection
+from cobbler.cobbler_collections.distro_group import DistroGroups
 from cobbler.cobbler_collections.distros import Distros
 from cobbler.cobbler_collections.images import Images
 from cobbler.cobbler_collections.menus import Menus
 from cobbler.cobbler_collections.network_interfaces import NetworkInterfaces
+from cobbler.cobbler_collections.profile_group import ProfileGroups
 from cobbler.cobbler_collections.profiles import Profiles
 from cobbler.cobbler_collections.repos import Repos
+from cobbler.cobbler_collections.system_group import SystemGroups
 from cobbler.cobbler_collections.systems import Systems
 from cobbler.cobbler_collections.templates import Templates
 from cobbler.settings import Settings
@@ -63,6 +66,9 @@ class CollectionManager:
         self._menus = Menus(weakref.proxy(self))
         self._network_interfaces = NetworkInterfaces(weakref.proxy(self))
         self._templates = Templates(weakref.proxy(self))
+        self._distro_groups = DistroGroups(weakref.proxy(self))
+        self._profile_groups = ProfileGroups(weakref.proxy(self))
+        self._system_groups = SystemGroups(weakref.proxy(self))
 
     def distros(self) -> Distros:
         """
@@ -118,6 +124,24 @@ class CollectionManager:
         """
         return self._templates
 
+    def distro_groups(self) -> DistroGroups:
+        """
+        Return the definitive copy of the DistroGroups collection
+        """
+        return self._distro_groups
+
+    def profile_groups(self) -> ProfileGroups:
+        """
+        Return the definitive copy of the ProfileGroups collection
+        """
+        return self._profile_groups
+
+    def system_groups(self) -> SystemGroups:
+        """
+        Return the definitive copy of the SystemGroups collection
+        """
+        return self._system_groups
+
     def serialize(self) -> None:
         """
         Save all cobbler_collections to disk
@@ -131,6 +155,9 @@ class CollectionManager:
         self.__serializer.serialize(self._menus)
         self.__serializer.serialize(self._network_interfaces)
         self.__serializer.serialize(self._templates)
+        self.__serializer.serialize(self._distro_groups)
+        self.__serializer.serialize(self._profile_groups)
+        self.__serializer.serialize(self._system_groups)
 
     def serialize_one_item(self, item: "BaseItem") -> None:
         """
@@ -186,6 +213,9 @@ class CollectionManager:
             (self._images, False),
             (self._systems, False),
             (self._network_interfaces, False),
+            (self._distro_groups, True),
+            (self._profile_groups, True),
+            (self._system_groups, True),
         ):
             try:
                 cast_collection = cast(Collection["BaseItem"], args[0])
@@ -212,7 +242,7 @@ class CollectionManager:
         Get a full collection of a single type.
 
         Valid Values vor ``collection_type`` are: "distro", "profile", "repo", "image", "menu", "network_interface",
-        "template" and "settings".
+        "template", "distro_group", "profile_group", "system_group" and "settings".
 
         :param collection_type: The type of collection to return.
         :return: The collection if ``collection_type`` is valid.

--- a/cobbler/cobbler_collections/profile_group.py
+++ b/cobbler/cobbler_collections/profile_group.py
@@ -1,0 +1,37 @@
+"""
+ProfileGroupCollection
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from cobbler.cobbler_collections.collection import Collection
+from cobbler.items import profile_group
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
+class ProfileGroups(Collection[profile_group.ProfileGroup]):
+    """
+    The collection for profile groups.
+    """
+
+    @staticmethod
+    def collection_type() -> str:
+        return "profile_group"
+
+    @staticmethod
+    def collection_types() -> str:
+        return "profile_groups"
+
+    def factory_produce(
+        self, api: "CobblerAPI", seed_data: Dict[str, Any]
+    ) -> profile_group.ProfileGroup:
+        """
+        Return a Profile Group forged from seed_data
+
+        :param api: Parameter is skipped.
+        :param seed_data: The data the object is initialized with.
+        :returns: The created ProfileGroup.
+        """
+        return profile_group.ProfileGroup(api, **seed_data)

--- a/cobbler/cobbler_collections/system_group.py
+++ b/cobbler/cobbler_collections/system_group.py
@@ -1,0 +1,37 @@
+"""
+SystemGroupCollection
+"""
+
+from typing import TYPE_CHECKING, Any, Dict
+
+from cobbler.cobbler_collections.collection import Collection
+from cobbler.items import system_group
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
+class SystemGroups(Collection[system_group.SystemGroup]):
+    """
+    The collection for system groups.
+    """
+
+    @staticmethod
+    def collection_type() -> str:
+        return "system_group"
+
+    @staticmethod
+    def collection_types() -> str:
+        return "system_groups"
+
+    def factory_produce(
+        self, api: "CobblerAPI", seed_data: Dict[str, Any]
+    ) -> system_group.SystemGroup:
+        """
+        Return a System Group forged from seed_data
+
+        :param api: Parameter is skipped.
+        :param seed_data: The data the object is initialized with.
+        :returns: The created SystemGroup.
+        """
+        return system_group.SystemGroup(api, **seed_data)

--- a/cobbler/data/config/cobbler/settings.yaml
+++ b/cobbler/data/config/cobbler/settings.yaml
@@ -703,3 +703,15 @@ memory_indexes:
         dns.name:
             nonunique: *allow_duplicate_hostnames
             disabled: *allow_duplicate_hostnames
+    distro_group:
+      name:
+        nonunique: false
+        disabled: false
+    profile_group:
+      name:
+        nonunique: false
+        disabled: false
+    system_group:
+      name:
+        nonunique: false
+        disabled: false

--- a/cobbler/enums.py
+++ b/cobbler/enums.py
@@ -109,6 +109,18 @@ class ItemTypes(ConvertableEnum):
     """
     See :func:`~cobbler.items.template.Template`
     """
+    DISTRO_GROUP = "distro_group"
+    """
+    See :func:`~cobbler.items.distro_group.DistroGroup`
+    """
+    PROFILE_GROUP = "profile_group"
+    """
+    See :func:`~cobbler.items.profile_group.ProfileGroup`
+    """
+    SYSTEM_GROUP = "system_group"
+    """
+    See :func:`~cobbler.items.system_group.SystemGroup`
+    """
 
 
 class DHCP(enum.Enum):

--- a/cobbler/items/abstract/inheritable_item.py
+++ b/cobbler/items/abstract/inheritable_item.py
@@ -68,6 +68,10 @@ class InheritableItem(BaseItem, ABC):
         ],
         "distro": [
             HierarchyItem("profile", "distro"),
+            HierarchyItem("distro_group", "members"),
+        ],
+        "distro_group": [
+            HierarchyItem("distro_group", "parent"),
         ],
         "menu": [
             HierarchyItem("menu", "parent"),
@@ -78,11 +82,21 @@ class InheritableItem(BaseItem, ABC):
         "profile": [
             HierarchyItem("profile", "parent"),
             HierarchyItem("system", "profile"),
+            HierarchyItem("profile_group", "members"),
+        ],
+        "profile_group": [
+            HierarchyItem("profile_group", "parent"),
         ],
         "image": [
             HierarchyItem("system", "image"),
         ],
-        "system": [HierarchyItem("network_interface", "system_uid")],
+        "system": [
+            HierarchyItem("network_interface", "system_uid"),
+            HierarchyItem("system_group", "members"),
+        ],
+        "system_group": [
+            HierarchyItem("system_group", "parent"),
+        ],
     }
 
     # Defines a logical hierarchy of Item Types.
@@ -95,12 +109,28 @@ class InheritableItem(BaseItem, ABC):
                 HierarchyItem("profile", "distro"),
             ],
         ),
+        "distro_group": LogicalHierarchy(
+            [
+                HierarchyItem("distro_group", "parent"),
+            ],
+            [
+                HierarchyItem("distro_group", "parent"),
+            ],
+        ),
         "profile": LogicalHierarchy(
             [
                 HierarchyItem("distro", "distro"),
             ],
             [
                 HierarchyItem("system", "profile"),
+            ],
+        ),
+        "profile_group": LogicalHierarchy(
+            [
+                HierarchyItem("profile_group", "parent"),
+            ],
+            [
+                HierarchyItem("profile_group", "parent"),
             ],
         ),
         "image": LogicalHierarchy(
@@ -110,8 +140,19 @@ class InheritableItem(BaseItem, ABC):
             ],
         ),
         "system": LogicalHierarchy(
-            [HierarchyItem("image", "image"), HierarchyItem("profile", "profile")],
+            [
+                HierarchyItem("image", "image"),
+                HierarchyItem("profile", "profile"),
+            ],
             [],
+        ),
+        "system_group": LogicalHierarchy(
+            [
+                HierarchyItem("system_group", "parent"),
+            ],
+            [
+                HierarchyItem("system_group", "parent"),
+            ],
         ),
     }
 

--- a/cobbler/items/abstract/item_group.py
+++ b/cobbler/items/abstract/item_group.py
@@ -1,0 +1,68 @@
+"""
+"ItemGroup" is the abstract base class for groups of items.
+
+Changelog:
+    * V3.4.0 (unreleased):
+        * Initial creation of the class
+"""
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+# SPDX-FileCopyrightText: Enno Gotthold <enno.gotthold@suse.com>
+
+from abc import ABC
+from typing import TYPE_CHECKING, Any, List
+
+from cobbler.items.abstract.inheritable_item import InheritableItem
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+    LazyProperty = property
+else:
+    from cobbler.decorator import LazyProperty
+
+
+class ItemGroup(InheritableItem, ABC):
+    """
+    Abstract class for item groups in Cobbler.
+    """
+
+    TYPE_NAME = "item_group_abstract"
+    COLLECTION_TYPE = "item_groups"
+
+    def __init__(self, api: "CobblerAPI", *args: Any, **kwargs: Any):
+        """
+        Constructor.
+
+        :param api: The Cobbler API object.
+        """
+        super().__init__(api, *args, **kwargs)
+
+        self._members: List[str] = []
+
+        if len(kwargs) > 0:
+            self.from_dict(kwargs)
+
+    @LazyProperty
+    def members(self) -> List[str]:
+        """
+        :getter: The members of this group.
+        :setter: Set the members of this group.
+        """
+        return self._members
+
+    @members.setter
+    def members(self, value: List[str]) -> None:
+        """
+        Set the members of this item group.
+
+        :param value: A list of string uids representing the members of the group.
+        """
+        if not isinstance(value, list):  # pyright: ignore[reportUnnecessaryIsInstance]
+            raise TypeError("members must be a list")
+        for member in value:
+            if not isinstance(
+                member, str
+            ):  # pyright: ignore[reportUnnecessaryIsInstance]
+                raise TypeError("All members must be of type string")
+        self._members = value

--- a/cobbler/items/abstract/item_group.py
+++ b/cobbler/items/abstract/item_group.py
@@ -10,8 +10,9 @@ Changelog:
 # SPDX-FileCopyrightText: Enno Gotthold <enno.gotthold@suse.com>
 
 from abc import ABC
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, List, Type
 
+from cobbler import enums
 from cobbler.items.abstract.inheritable_item import InheritableItem
 
 if TYPE_CHECKING:
@@ -36,12 +37,78 @@ class ItemGroup(InheritableItem, ABC):
 
         :param api: The Cobbler API object.
         """
-        super().__init__(api, *args, **kwargs)
+        super().__init__(api)
+        # Prevent attempts to clear the to_dict cache before the object is initialized.
+        self._has_initialized = False
 
         self._members: List[str] = []
 
         if len(kwargs) > 0:
             self.from_dict(kwargs)
+
+    def _resolve(self, property_name: List[str]) -> Any:
+        settings_name = property_name[-1]
+        if property_name[-1] == "owners":
+            settings_name = "default_ownership"
+        raw_value = self.__get_raw_value(self, property_name)
+        if raw_value == enums.VALUE_INHERITED:
+            return getattr(self.api.settings(), settings_name)
+        else:
+            return raw_value
+
+    def _resolve_enum(
+        self, property_name: List[str], enum_type: Type[enums.ConvertableEnum]
+    ) -> Any:
+        # The DistroGroup doesn't have any enum types that need resolving.
+        return None
+
+    def _resolve_list(self, property_name: List[str]) -> List[Any]:
+        """
+        Resolves and merges a list property from the current object, its parent, and global settings.
+
+        :param property_name: The list of strings that represent the names of the attributes/properties to travel to
+            the target attribute.
+        :returns: The list with all values blended together.
+        """
+        property_name_raw = property_name.copy()
+        property_name_raw[-1] = "_" + property_name_raw[-1]
+
+        attribute_value = self.__get_raw_value(self, property_name_raw)
+        settings = self.api.settings()
+
+        merged_list: List[Any] = []
+
+        parent = self.parent
+        if self.parent is None:
+            parent = self.get_conceptual_parent()  # type: ignore
+        try:
+            merged_list.extend(self.__get_raw_value(parent, property_name))
+        except AttributeError:
+            # Does not have the requested attribute
+            pass
+        if hasattr(settings, property_name[-1]):
+            merged_list.extend(getattr(settings, property_name[-1]))
+
+        if attribute_value != enums.VALUE_INHERITED:
+            merged_list.extend(attribute_value)
+
+        return merged_list
+
+    def __get_raw_value(self, obj: Any, property_name: List[str]) -> Any:
+        """
+        Retrieves the raw value of a nested attribute from an object using a list of property names.
+
+        :returns: The raw value of the property.
+        :raises AttributeError: In case the property doesn't have the requested attribute.
+        """
+        if hasattr(obj, f"_{property_name[0]}"):
+            property_key = property_name.pop(0)
+            if len(property_name) > 0:
+                return self.__get_raw_value(getattr(obj, property_key), property_name)
+            return getattr(obj, f"_{property_key}")
+        raise AttributeError(
+            f'Could not retrieve "{property_name[0]}" with obj "{obj}!'
+        )
 
     @LazyProperty
     def members(self) -> List[str]:

--- a/cobbler/items/distro.py
+++ b/cobbler/items/distro.py
@@ -134,6 +134,7 @@ from cobbler.utils import input_converters, signatures
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.items.abstract.inheritable_item import InheritableItem
+    from cobbler.items.distro_group import DistroGroup
     from cobbler.items.profile import Profile
 
     InheritableProperty = property
@@ -520,7 +521,7 @@ class Distro(BootableItem):
         old_arch = self._arch
         self._arch = enums.Archs.to_enum(arch)
         self.api.distros().update_index_value(self, "arch", old_arch, self._arch)
-        profiles: Optional[List[Profile]] = self.api.find_profile(  # type: ignore
+        profiles: Optional[List["Profile"]] = self.api.find_profile(  # type: ignore
             return_list=True,
             **{"distro": self._uid},  # type: ignore[reportArgumentType,arg-type]
         )
@@ -680,3 +681,16 @@ class Distro(BootableItem):
                 self.logger.warning(
                     "- symlink creation failed: %s, %s", base, dest_link
                 )
+
+    @property
+    def distro_groups(self) -> List["DistroGroup"]:
+        """
+        Finds all DistroGroups that this distro is a member of.
+        """
+        groups: List["DistroGroup"] = []
+        group_collection = self.api.distro_groups()
+
+        for group in group_collection.listing.values():
+            if self.uid in getattr(group, "members", []):
+                groups.append(group)
+        return groups

--- a/cobbler/items/distro_group.py
+++ b/cobbler/items/distro_group.py
@@ -1,0 +1,34 @@
+"""
+DistroGroup class for grouping distros.
+"""
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from cobbler.items.abstract.base_item import BaseItem
+from cobbler.items.abstract.item_group import ItemGroup
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
+class DistroGroup(ItemGroup):
+    """
+    DistroGroup class
+    """
+
+    TYPE_NAME = "distro_group"
+    COLLECTION_TYPE = "distro_group"
+
+    def __init__(self, api: "CobblerAPI", *args: Any, **kwargs: Any):
+        super().__init__(api, *args, **kwargs)
+        if not self._has_initialized:
+            self._has_initialized = True
+
+    def make_clone(self) -> "BaseItem":
+        """
+        Clone this distro group
+        """
+        _dict = copy.deepcopy(self.to_dict())
+        _dict.pop("uid", None)
+        return DistroGroup(self.api, **_dict)

--- a/cobbler/items/profile.py
+++ b/cobbler/items/profile.py
@@ -175,6 +175,7 @@ from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
+    from cobbler.items.profile_group import ProfileGroup
     from cobbler.items.template import Template
 
     InheritableProperty = property
@@ -776,3 +777,16 @@ class Profile(BootableItem):
         :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
         """
         self._display_name = display_name
+
+    @property
+    def profile_groups(self) -> List["ProfileGroup"]:
+        """
+        Finds all ProfileGroups that this profile is a member of.
+        """
+        groups: List["ProfileGroup"] = []
+        group_collection = self.api.profile_groups()
+
+        for group in group_collection.listing.values():
+            if self.uid in getattr(group, "members", []):
+                groups.append(group)
+        return groups

--- a/cobbler/items/profile_group.py
+++ b/cobbler/items/profile_group.py
@@ -1,0 +1,34 @@
+"""
+ProfileGroup class for grouping profiles.
+"""
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from cobbler.items.abstract.base_item import BaseItem
+from cobbler.items.abstract.item_group import ItemGroup
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
+class ProfileGroup(ItemGroup):
+    """
+    ProfileGroup class
+    """
+
+    TYPE_NAME = "profile_group"
+    COLLECTION_TYPE = "profile_group"
+
+    def __init__(self, api: "CobblerAPI", *args: Any, **kwargs: Any):
+        super().__init__(api, *args, **kwargs)
+        if not self._has_initialized:
+            self._has_initialized = True
+
+    def make_clone(self) -> "BaseItem":
+        """
+        Clone this profile group
+        """
+        _dict = copy.deepcopy(self.to_dict())
+        _dict.pop("uid", None)
+        return ProfileGroup(self.api, **_dict)

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -784,7 +784,7 @@ class System(BootableItem):
         profile = None
         if isinstance(profile_uid, Profile):
             profile = profile_uid
-            profile_uid = profile.name
+            profile_uid = profile.uid
         elif not isinstance(profile_uid, str):  # type: ignore
             raise TypeError("The name of a profile needs to be of type str.")
 

--- a/cobbler/items/system.py
+++ b/cobbler/items/system.py
@@ -220,6 +220,7 @@ from cobbler.utils import input_converters
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
+    from cobbler.items.system_group import SystemGroup
     from cobbler.items.template import Template
 
     InheritableProperty = property
@@ -1038,3 +1039,16 @@ class System(BootableItem):
         :param display_name: The new display_name. If ``None`` the display_name will be set to an emtpy string.
         """
         self._display_name = display_name
+
+    @property
+    def system_groups(self) -> List["SystemGroup"]:
+        """
+        Finds all SystemGroups that this system is a member of.
+        """
+        groups: List["SystemGroup"] = []
+        group_collection = self.api.system_groups()
+
+        for group in group_collection.listing.values():
+            if self.uid in getattr(group, "members", []):
+                groups.append(group)
+        return groups

--- a/cobbler/items/system_group.py
+++ b/cobbler/items/system_group.py
@@ -1,0 +1,34 @@
+"""
+SystemGroup class for grouping systems.
+"""
+
+import copy
+from typing import TYPE_CHECKING, Any
+
+from cobbler.items.abstract.base_item import BaseItem
+from cobbler.items.abstract.item_group import ItemGroup
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+
+
+class SystemGroup(ItemGroup):
+    """
+    SystemGroup class
+    """
+
+    TYPE_NAME = "system_group"
+    COLLECTION_TYPE = "system_group"
+
+    def __init__(self, api: "CobblerAPI", *args: Any, **kwargs: Any):
+        super().__init__(api, *args, **kwargs)
+        if not self._has_initialized:
+            self._has_initialized = True
+
+    def make_clone(self) -> "BaseItem":
+        """
+        Clone this system group
+        """
+        _dict = copy.deepcopy(self.to_dict())
+        _dict.pop("uid", None)
+        return SystemGroup(self.api, **_dict)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1309,6 +1309,75 @@ class CobblerXMLRPCInterface:
             "template", name, flatten=flatten, resolved=resolved, token=token
         )
 
+    def get_distro_group(
+        self,
+        name: str,
+        flatten: bool = False,
+        resolved: bool = False,
+        token: Optional[str] = None,
+        **rest: Any,
+    ):
+        """
+        Get a distro group.
+
+        :param name: The name of the distro group to get.
+        :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
+        :param token: The API-token obtained via the login() method.
+        :param rest: Not used with this method currently.
+        :return: The item or None.
+        """
+        return self.get_item(
+            "distro_group", name, flatten=flatten, resolved=resolved, token=token
+        )
+
+    def get_profile_group(
+        self,
+        name: str,
+        flatten: bool = False,
+        resolved: bool = False,
+        token: Optional[str] = None,
+        **rest: Any,
+    ):
+        """
+        Get a profile group.
+
+        :param name: The name of the profile group to get.
+        :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
+        :param token: The API-token obtained via the login() method.
+        :param rest: Not used with this method currently.
+        :return: The item or None.
+        """
+        return self.get_item(
+            "profile_group", name, flatten=flatten, resolved=resolved, token=token
+        )
+
+    def get_system_group(
+        self,
+        name: str,
+        flatten: bool = False,
+        resolved: bool = False,
+        token: Optional[str] = None,
+        **rest: Any,
+    ):
+        """
+        Get a system group.
+
+        :param name: The name of the system group to get.
+        :param flatten: If the item should be flattened.
+        :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
+                         objects raw value.
+        :param token: The API-token obtained via the login() method.
+        :param rest: Not used with this method currently.
+        :return: The item or None.
+        """
+        return self.get_item(
+            "system_group", name, flatten=flatten, resolved=resolved, token=token
+        )
+
     def get_template_content(self, uid: str, token: Optional[str] = None) -> str:
         """
         Search for the given object and return the content of the template. Call
@@ -1488,6 +1557,60 @@ class CobblerXMLRPCInterface:
         :return: The list of all files.
         """
         return self.get_items("template")
+
+    def get_distro_groups(
+        self,
+        page: Any = None,
+        results_per_page: Any = None,
+        token: Optional[str] = None,
+        **rest: Any,
+    ) -> List[Dict[str, Any]]:
+        """
+        This returns all distro groups.
+
+        :param page: This parameter is not used currently.
+        :param results_per_page: This parameter is not used currently.
+        :param token: The API-token obtained via the login() method.
+        :param rest: This parameter is not used currently.
+        :return: The list of all distro groups.
+        """
+        return self.get_items("distro_group")
+
+    def get_profile_groups(
+        self,
+        page: Any = None,
+        results_per_page: Any = None,
+        token: Optional[str] = None,
+        **rest: Any,
+    ) -> List[Dict[str, Any]]:
+        """
+        This returns all profile groups.
+
+        :param page: This parameter is not used currently.
+        :param results_per_page: This parameter is not used currently.
+        :param token: The API-token obtained via the login() method.
+        :param rest: This parameter is not used currently.
+        :return: The list of all profile groups.
+        """
+        return self.get_items("profile_group")
+
+    def get_system_groups(
+        self,
+        page: Any = None,
+        results_per_page: Any = None,
+        token: Optional[str] = None,
+        **rest: Any,
+    ) -> List[Dict[str, Any]]:
+        """
+        This returns all system groups.
+
+        :param page: This parameter is not used currently.
+        :param results_per_page: This parameter is not used currently.
+        :param token: The API-token obtained via the login() method.
+        :param rest: This parameter is not used currently.
+        :return: The list of all system groups.
+        """
+        return self.get_items("system_group")
 
     def find_items(
         self,
@@ -1696,6 +1819,75 @@ class CobblerXMLRPCInterface:
         """
         return self.find_items("template", criteria, expand=expand, resolved=resolved)
 
+    def find_distro_group(
+        self,
+        criteria: Optional[Dict[str, Any]] = None,
+        expand: bool = False,
+        resolved: bool = False,
+        token: Optional[str] = None,
+        **rest: Any,
+    ) -> List[Any]:
+        """
+        Find a distro group matching certain criteria.
+
+        :param criteria: The criteria a distro group needs to match.
+        :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
+        :param token: The API-token obtained via the login() method.
+        :param rest: This parameter is not used currently.
+        :return: All distro groups which have matched the criteria.
+        """
+        return self.find_items(
+            "distro_group", criteria, expand=expand, resolved=resolved
+        )
+
+    def find_profile_group(
+        self,
+        criteria: Optional[Dict[str, Any]] = None,
+        expand: bool = False,
+        resolved: bool = False,
+        token: Optional[str] = None,
+        **rest: Any,
+    ) -> List[Any]:
+        """
+        Find a profile group matching certain criteria.
+
+        :param criteria: The criteria a profile group needs to match.
+        :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
+        :param token: The API-token obtained via the login() method.
+        :param rest: This parameter is not used currently.
+        :return: All profile groups which have matched the criteria.
+        """
+        return self.find_items(
+            "profile_group", criteria, expand=expand, resolved=resolved
+        )
+
+    def find_system_group(
+        self,
+        criteria: Optional[Dict[str, Any]] = None,
+        expand: bool = False,
+        resolved: bool = False,
+        token: Optional[str] = None,
+        **rest: Any,
+    ) -> List[Any]:
+        """
+        Find a system group matching certain criteria.
+
+        :param criteria: The criteria a system group needs to match.
+        :param expand: Not only get the names but also the complete object in form of a dict.
+        :param resolved: This only has an effect when ``expand = True``. It returns the resolved representation of the
+                         object instead of the raw data.
+        :param token: The API-token obtained via the login() method.
+        :param rest: This parameter is not used currently.
+        :return: All system groups which have matched the criteria.
+        """
+        return self.find_items(
+            "system_group", criteria, expand=expand, resolved=resolved
+        )
+
     def find_items_paged(
         self,
         what: str,
@@ -1863,6 +2055,33 @@ class CobblerXMLRPCInterface:
         :return: The handle of the desired object.
         """
         return self.get_item_handle("template", name)
+
+    def get_distro_group_handle(self, name: str):
+        """
+        Get a handle for a distro group which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+
+        :param name: The name of the item.
+        :return: The handle of the desired object.
+        """
+        return self.get_item_handle("distro_group", name)
+
+    def get_profile_group_handle(self, name: str):
+        """
+        Get a handle for a profile group which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+
+        :param name: The name of the item.
+        :return: The handle of the desired object.
+        """
+        return self.get_item_handle("profile_group", name)
+
+    def get_system_group_handle(self, name: str):
+        """
+        Get a handle for a system group which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+
+        :param name: The name of the item.
+        :return: The handle of the desired object.
+        """
+        return self.get_item_handle("system_group", name)
 
     def _transaction_get_modified(self, token: str, obj: "InheritableItem"):
         """
@@ -2073,6 +2292,45 @@ class CobblerXMLRPCInterface:
         """
         return self.remove_item("template", name, token, recursive)
 
+    def remove_distro_group(
+        self, name: str, token: str, recursive: bool = True
+    ) -> bool:
+        """
+        Deletes a distro group from Cobbler.
+
+        :param name: The name of the item to remove.
+        :param token: The API-token obtained via the login() method.
+        :param recursive: If items which are depending on this one should be erased too.
+        :return: True if the action was successful.
+        """
+        return self.remove_item("distro_group", name, token, recursive)
+
+    def remove_profile_group(
+        self, name: str, token: str, recursive: bool = True
+    ) -> bool:
+        """
+        Deletes a profile group from Cobbler.
+
+        :param name: The name of the item to remove.
+        :param token: The API-token obtained via the login() method.
+        :param recursive: If items which are depending on this one should be erased too.
+        :return: True if the action was successful.
+        """
+        return self.remove_item("profile_group", name, token, recursive)
+
+    def remove_system_group(
+        self, name: str, token: str, recursive: bool = True
+    ) -> bool:
+        """
+        Deletes a system group from Cobbler.
+
+        :param name: The name of the item to remove.
+        :param token: The API-token obtained via the login() method.
+        :param recursive: If items which are depending on this one should be erased too.
+        :return: True if the action was successful.
+        """
+        return self.remove_item("system_group", name, token, recursive)
+
     def copy_item(
         self, what: str, object_id: str, newname: str, token: Optional[str] = None
     ) -> bool:
@@ -2207,6 +2465,45 @@ class CobblerXMLRPCInterface:
         :return: True if the action succeeded.
         """
         return self.copy_item("template", object_id, newname, token)
+
+    def copy_distro_group(
+        self, object_id: str, newname: str, token: Optional[str] = None
+    ) -> bool:
+        """
+        Copies a distro group and renames it afterwards.
+
+        :param object_id: The object id of the item in question.
+        :param newname: The new name for the copied object.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action succeeded.
+        """
+        return self.copy_item("distro_group", object_id, newname, token)
+
+    def copy_profile_group(
+        self, object_id: str, newname: str, token: Optional[str] = None
+    ) -> bool:
+        """
+        Copies a profile group and renames it afterwards.
+
+        :param object_id: The object id of the item in question.
+        :param newname: The new name for the copied object.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action succeeded.
+        """
+        return self.copy_item("profile_group", object_id, newname, token)
+
+    def copy_system_group(
+        self, object_id: str, newname: str, token: Optional[str] = None
+    ) -> bool:
+        """
+        Copies a system group and renames it afterwards.
+
+        :param object_id: The object id of the item in question.
+        :param newname: The new name for the copied object.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action succeeded.
+        """
+        return self.copy_item("system_group", object_id, newname, token)
 
     def rename_item(
         self, what: str, object_id: str, newname: str, token: Optional[str] = None
@@ -2360,6 +2657,45 @@ class CobblerXMLRPCInterface:
         """
         return self.rename_item("template", object_id, newname, token)
 
+    def rename_distro_group(
+        self, object_id: str, newname: str, token: Optional[str] = None
+    ) -> bool:
+        """
+        Renames a distro group specified by object_id to a new name.
+
+        :param object_id: The id which refers to the object.
+        :param newname: The new name for the object.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action succeeded.
+        """
+        return self.rename_item("distro_group", object_id, newname, token)
+
+    def rename_profile_group(
+        self, object_id: str, newname: str, token: Optional[str] = None
+    ) -> bool:
+        """
+        Renames a profile group specified by object_id to a new name.
+
+        :param object_id: The id which refers to the object.
+        :param newname: The new name for the object.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action succeeded.
+        """
+        return self.rename_item("profile_group", object_id, newname, token)
+
+    def rename_system_group(
+        self, object_id: str, newname: str, token: Optional[str] = None
+    ) -> bool:
+        """
+        Renames a system group specified by object_id to a new name.
+
+        :param object_id: The id which refers to the object.
+        :param newname: The new name for the object.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action succeeded.
+        """
+        return self.rename_item("system_group", object_id, newname, token)
+
     def new_item(
         self, what: str, token: str, is_subobject: bool = False, **kwargs: Any
     ) -> str:
@@ -2465,6 +2801,33 @@ class CobblerXMLRPCInterface:
         :return: The object id for the newly created object.
         """
         return self.new_item("template", token)
+
+    def new_distro_group(self, token: str) -> str:
+        """
+        See ``new_item()``.
+
+        :param token: The API-token obtained via the login() method.
+        :return: The object id for the newly created object.
+        """
+        return self.new_item("distro_group", token)
+
+    def new_profile_group(self, token: str) -> str:
+        """
+        See ``new_item()``.
+
+        :param token: The API-token obtained via the login() method.
+        :return: The object id for the newly created object.
+        """
+        return self.new_item("profile_group", token)
+
+    def new_system_group(self, token: str) -> str:
+        """
+        See ``new_item()``.
+
+        :param token: The API-token obtained via the login() method.
+        :return: The object id for the newly created object.
+        """
+        return self.new_item("system_group", token)
 
     def __get_raw_value(self, obj: Any, attribute_path: List[str]) -> Any:
         """
@@ -2680,6 +3043,48 @@ class CobblerXMLRPCInterface:
         """
         return self.modify_item("template", object_id, attribute, arg, token)
 
+    def modify_distro_group(
+        self, object_id: str, attribute: List[str], arg: Any, token: str
+    ) -> bool:
+        """
+        Modify a single attribute of a distro group.
+
+        :param object_id: The id of the object which shall be modified.
+        :param attribute: The attribute name which shall be edited.
+        :param arg: The new value for the argument.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action was successful. Otherwise False.
+        """
+        return self.modify_item("distro_group", object_id, attribute, arg, token)
+
+    def modify_profile_group(
+        self, object_id: str, attribute: List[str], arg: Any, token: str
+    ) -> bool:
+        """
+        Modify a single attribute of a profile group.
+
+        :param object_id: The id of the object which shall be modified.
+        :param attribute: The attribute name which shall be edited.
+        :param arg: The new value for the argument.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action was successful. Otherwise False.
+        """
+        return self.modify_item("profile_group", object_id, attribute, arg, token)
+
+    def modify_system_group(
+        self, object_id: str, attribute: List[str], arg: Any, token: str
+    ) -> bool:
+        """
+        Modify a single attribute of a system group.
+
+        :param object_id: The id of the object which shall be modified.
+        :param attribute: The attribute name which shall be edited.
+        :param arg: The new value for the argument.
+        :param token: The API-token obtained via the login() method.
+        :return: True if the action was successful. Otherwise False.
+        """
+        return self.modify_item("system_group", object_id, attribute, arg, token)
+
     def modify_setting(
         self,
         setting_name: str,
@@ -2871,6 +3276,48 @@ class CobblerXMLRPCInterface:
         :return: True if the action succeeded.
         """
         return self.save_item("template", object_id, token, editmode=editmode)
+
+    def save_distro_group(
+        self, object_id: str, token: str, editmode: str = "bypass"
+    ) -> bool:
+        """
+        Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
+
+        :param object_id: The id of the object to save.
+        :param token: The API-token obtained via the login() method.
+        :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
+                         supported.
+        :return: True if the action succeeded.
+        """
+        return self.save_item("distro_group", object_id, token, editmode=editmode)
+
+    def save_profile_group(
+        self, object_id: str, token: str, editmode: str = "bypass"
+    ) -> bool:
+        """
+        Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
+
+        :param object_id: The id of the object to save.
+        :param token: The API-token obtained via the login() method.
+        :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
+                         supported.
+        :return: True if the action succeeded.
+        """
+        return self.save_item("profile_group", object_id, token, editmode=editmode)
+
+    def save_system_group(
+        self, object_id: str, token: str, editmode: str = "bypass"
+    ) -> bool:
+        """
+        Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
+
+        :param object_id: The id of the object to save.
+        :param token: The API-token obtained via the login() method.
+        :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
+                         supported.
+        :return: True if the action succeeded.
+        """
+        return self.save_item("system_group", object_id, token, editmode=editmode)
 
     def is_autoinstall_in_use(
         self, ai: str, token: Optional[str] = None, **rest: Any
@@ -3714,6 +4161,42 @@ class CobblerXMLRPCInterface:
         data = self.api.get_templates_since(mtime, collapse=True)
         return self.xmlrpc_hacks(data)
 
+    def get_distro_groups_since(
+        self, mtime: float
+    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
+        """
+        See documentation for get_distros_since
+
+        :param mtime: The time after which all items should be included. Everything before this will be excluded.
+        :return: The list of items which were modified after ``mtime``.
+        """
+        data = self.api.get_distro_groups_since(mtime, collapse=True)
+        return self.xmlrpc_hacks(data)
+
+    def get_profile_groups_since(
+        self, mtime: float
+    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
+        """
+        See documentation for get_distros_since
+
+        :param mtime: The time after which all items should be included. Everything before this will be excluded.
+        :return: The list of items which were modified after ``mtime``.
+        """
+        data = self.api.get_profile_groups_since(mtime, collapse=True)
+        return self.xmlrpc_hacks(data)
+
+    def get_system_groups_since(
+        self, mtime: float
+    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
+        """
+        See documentation for get_distros_since
+
+        :param mtime: The time after which all items should be included. Everything before this will be excluded.
+        :return: The list of items which were modified after ``mtime``.
+        """
+        data = self.api.get_system_groups_since(mtime, collapse=True)
+        return self.xmlrpc_hacks(data)
+
     def get_repos_compatible_with_profile(
         self, profile: str, token: Optional[str] = None, **rest: Any
     ) -> List[Dict[Any, Any]]:
@@ -3943,6 +4426,60 @@ class CobblerXMLRPCInterface:
 
         self._log("get_network_interface_as_rendered", name=name, token=token)
         obj = self.api.find_network_interface(name=name)
+        if obj is not None and not isinstance(obj, list):
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
+        return self.xmlrpc_hacks({})
+
+    def get_distro_group_as_rendered(
+        self, name: str, token: Optional[str] = None, **rest: Any
+    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
+        """
+        Get distro group after passing through Cobbler's inheritance engine
+
+        :param name: DistroGroup name
+        :param token: Authentication token
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: Get a template rendered as a file.
+        """
+
+        self._log("get_distro_group_as_rendered", name=name, token=token)
+        obj = self.api.find_distro_group(name=name)
+        if obj is not None and not isinstance(obj, list):
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
+        return self.xmlrpc_hacks({})
+
+    def get_profile_group_as_rendered(
+        self, name: str, token: Optional[str] = None, **rest: Any
+    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
+        """
+        Get profile group after passing through Cobbler's inheritance engine
+
+        :param name: ProfileGroup name
+        :param token: Authentication token
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: Get a template rendered as a file.
+        """
+
+        self._log("get_profile_group_as_rendered", name=name, token=token)
+        obj = self.api.find_profile_group(name=name)
+        if obj is not None and not isinstance(obj, list):
+            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
+        return self.xmlrpc_hacks({})
+
+    def get_system_group_as_rendered(
+        self, name: str, token: Optional[str] = None, **rest: Any
+    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
+        """
+        Get system group after passing through Cobbler's inheritance engine
+
+        :param name: SystemGroup name
+        :param token: Authentication token
+        :param rest: This is dropped in this method since it is not needed here.
+        :return: Get a template rendered as a file.
+        """
+
+        self._log("get_system_group_as_rendered", name=name, token=token)
+        obj = self.api.find_system_group(name=name)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
         return self.xmlrpc_hacks({})

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -345,6 +345,15 @@ class Settings:
                 "image": {"nonunique": True, "disabled": False},
                 "profile": {"nonunique": True, "disabled": False},
             },
+            "distro_group": {
+                "name": {"nonunique": False, "disabled": False},
+            },
+            "profile_group": {
+                "name": {"nonunique": False, "disabled": False},
+            },
+            "system_group": {
+                "name": {"nonunique": False, "disabled": False},
+            },
         }
 
     @property

--- a/cobbler/settings/migrations/V3_4_0.py
+++ b/cobbler/settings/migrations/V3_4_0.py
@@ -297,6 +297,27 @@ schema = Schema(
                     Optional("disabled"): bool,
                 },
             },
+            Optional("distro_group"): {
+                Optional("name"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("profile_group"): {
+                Optional("name"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
+            Optional("system_group"): {
+                Optional("name"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
         },
     },  # type: ignore
     ignore_extra_keys=False,

--- a/cobbler/utils/filesystem_helpers.py
+++ b/cobbler/utils/filesystem_helpers.py
@@ -37,8 +37,8 @@ def is_safe_to_hardlink(src: str, dst: str, api: "CobblerAPI") -> bool:
              Otherwise returns False.
     """
     # FIXME: Calling this with emtpy strings returns True?!
-    (dev1, path1) = mtab.get_file_device_path(src)
-    (dev2, _) = mtab.get_file_device_path(dst)
+    dev1, path1 = mtab.get_file_device_path(src)
+    dev2, _ = mtab.get_file_device_path(dst)
     if dev1 != dev2:
         return False
     # Do not hardlink to a symbolic link! Chances are high the new link will be dangling.
@@ -510,6 +510,15 @@ def create_trigger_dirs(api: "CobblerAPI") -> None:
         trigger_directory / "add" / "template",
         trigger_directory / "add" / "template" / "pre",
         trigger_directory / "add" / "template" / "post",
+        trigger_directory / "add" / "distro_group",
+        trigger_directory / "add" / "distro_group" / "pre",
+        trigger_directory / "add" / "distro_group" / "post",
+        trigger_directory / "add" / "profile_group",
+        trigger_directory / "add" / "profile_group" / "pre",
+        trigger_directory / "add" / "profile_group" / "post",
+        trigger_directory / "add" / "system_group",
+        trigger_directory / "add" / "system_group" / "pre",
+        trigger_directory / "add" / "system_group" / "post",
         trigger_directory / "delete",
         trigger_directory / "delete" / "distro",
         trigger_directory / "delete" / "distro" / "pre",
@@ -532,6 +541,15 @@ def create_trigger_dirs(api: "CobblerAPI") -> None:
         trigger_directory / "delete" / "template",
         trigger_directory / "delete" / "template" / "pre",
         trigger_directory / "delete" / "template" / "post",
+        trigger_directory / "delete" / "distro_group",
+        trigger_directory / "delete" / "distro_group" / "pre",
+        trigger_directory / "delete" / "distro_group" / "post",
+        trigger_directory / "delete" / "profile_group",
+        trigger_directory / "delete" / "profile_group" / "pre",
+        trigger_directory / "delete" / "profile_group" / "post",
+        trigger_directory / "delete" / "system_group",
+        trigger_directory / "delete" / "system_group" / "pre",
+        trigger_directory / "delete" / "system_group" / "post",
         trigger_directory / "install",
         trigger_directory / "install" / "pre",
         trigger_directory / "install" / "post",
@@ -562,6 +580,15 @@ def create_trigger_dirs(api: "CobblerAPI") -> None:
         trigger_directory / "task" / "template",
         trigger_directory / "task" / "template" / "pre",
         trigger_directory / "task" / "template" / "post",
+        trigger_directory / "task" / "distro_group",
+        trigger_directory / "task" / "distro_group" / "pre",
+        trigger_directory / "task" / "distro_group" / "post",
+        trigger_directory / "task" / "profile_group",
+        trigger_directory / "task" / "profile_group" / "pre",
+        trigger_directory / "task" / "profile_group" / "post",
+        trigger_directory / "task" / "system_group",
+        trigger_directory / "task" / "system_group" / "pre",
+        trigger_directory / "task" / "system_group" / "post",
     ]
 
     for directory_path in trigger_directories:
@@ -586,6 +613,9 @@ def create_json_database_dirs(api: "CobblerAPI") -> None:
         libpath / "collections" / "menus",
         libpath / "collections" / "network_interfaces",
         libpath / "collections" / "templates",
+        libpath / "collections" / "distro_groups",
+        libpath / "collections" / "profile_groups",
+        libpath / "collections" / "system_groups",
     ]
 
     for directory_path in database_directories:

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -624,6 +624,9 @@ def validate_obj_type(object_type: str) -> bool:
         "menu",
         "network_interface",
         "template",
+        "distro_group",
+        "profile_group",
+        "system_group",
     ]
 
 

--- a/docs/code-autodoc/cobbler.autoinstall.generate.rst
+++ b/docs/code-autodoc/cobbler.autoinstall.generate.rst
@@ -28,6 +28,14 @@ cobbler.autoinstall.generate.base module
    :undoc-members:
    :show-inheritance:
 
+cobbler.autoinstall.generate.cloud\_init module
+-----------------------------------------------
+
+.. automodule:: cobbler.autoinstall.generate.cloud_init
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cobbler.autoinstall.generate.kickstart module
 ---------------------------------------------
 

--- a/docs/code-autodoc/cobbler.cobbler_collections.rst
+++ b/docs/code-autodoc/cobbler.cobbler_collections.rst
@@ -12,6 +12,14 @@ cobbler.cobbler\_collections.collection module
    :undoc-members:
    :show-inheritance:
 
+cobbler.cobbler\_collections.distro\_group module
+-------------------------------------------------
+
+.. automodule:: cobbler.cobbler_collections.distro_group
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cobbler.cobbler\_collections.distros module
 -------------------------------------------
 
@@ -52,6 +60,14 @@ cobbler.cobbler\_collections.network\_interfaces module
    :undoc-members:
    :show-inheritance:
 
+cobbler.cobbler\_collections.profile\_group module
+--------------------------------------------------
+
+.. automodule:: cobbler.cobbler_collections.profile_group
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cobbler.cobbler\_collections.profiles module
 --------------------------------------------
 
@@ -64,6 +80,14 @@ cobbler.cobbler\_collections.repos module
 -----------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.repos
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cobbler.cobbler\_collections.system\_group module
+-------------------------------------------------
+
+.. automodule:: cobbler.cobbler_collections.system_group
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/code-autodoc/cobbler.items.abstract.rst
+++ b/docs/code-autodoc/cobbler.items.abstract.rst
@@ -36,6 +36,14 @@ cobbler.items.abstract.item\_cache module
    :undoc-members:
    :show-inheritance:
 
+cobbler.items.abstract.item\_group module
+-----------------------------------------
+
+.. automodule:: cobbler.items.abstract.item_group
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 Module contents
 ---------------
 

--- a/docs/code-autodoc/cobbler.items.rst
+++ b/docs/code-autodoc/cobbler.items.rst
@@ -21,6 +21,14 @@ cobbler.items.distro module
    :undoc-members:
    :show-inheritance:
 
+cobbler.items.distro\_group module
+----------------------------------
+
+.. automodule:: cobbler.items.distro_group
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cobbler.items.image module
 --------------------------
 
@@ -53,6 +61,14 @@ cobbler.items.profile module
    :undoc-members:
    :show-inheritance:
 
+cobbler.items.profile\_group module
+-----------------------------------
+
+.. automodule:: cobbler.items.profile_group
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 cobbler.items.repo module
 -------------------------
 
@@ -65,6 +81,14 @@ cobbler.items.system module
 ---------------------------
 
 .. automodule:: cobbler.items.system
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+cobbler.items.system\_group module
+----------------------------------
+
+.. automodule:: cobbler.items.system_group
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/requirements.rtd.txt
+++ b/docs/requirements.rtd.txt
@@ -4,6 +4,6 @@ Cheetah3
 dnspython
 pyyaml
 distro
-sphinx_rtd_theme==1.0.0
+sphinx-rtd-theme
 file-magic
 schema

--- a/tests/api/add_test.py
+++ b/tests/api/add_test.py
@@ -7,7 +7,59 @@ import pathlib
 from typing import Callable
 
 from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
+from cobbler.items.distro_group import DistroGroup
 from cobbler.items.image import Image
+from cobbler.items.menu import Menu
+from cobbler.items.network_interface import NetworkInterface
+from cobbler.items.profile import Profile
+from cobbler.items.profile_group import ProfileGroup
+from cobbler.items.repo import Repo
+from cobbler.items.system import System
+from cobbler.items.system_group import SystemGroup
+from cobbler.items.template import Template
+
+
+def test_distro_add(
+    cobbler_api: CobblerAPI,
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+):
+    # Arrange
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    test_distro = Distro(cobbler_api)
+    test_distro.name = "test_cobbler_api_add_distro"
+    test_distro.kernel = str(pathlib.Path(folder) / fk_kernel)
+    test_distro.initrd = str(pathlib.Path(folder) / fk_initrd)
+
+    # Act
+    cobbler_api.add_distro(test_distro)
+
+    # Assert
+    result_distro_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/distros/").iterdir()
+    )
+    assert result_distro_json.exists()
+    json_content = json.loads(result_distro_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_distro.name
+
+
+def test_distro_group_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_distro_group = DistroGroup(cobbler_api)
+    test_distro_group.name = "test_cobbler_api_add_distro_group"
+
+    # Act
+    cobbler_api.add_distro_group(test_distro_group)
+
+    # Assert
+    result_distro_group_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/distro_groups/").iterdir()
+    )
+    assert result_distro_group_json.exists()
+    json_content = json.loads(result_distro_group_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_distro_group.name
 
 
 def test_image_add(cobbler_api: CobblerAPI):
@@ -22,9 +74,155 @@ def test_image_add(cobbler_api: CobblerAPI):
     result_image_json = next(
         pathlib.Path("/var/lib/cobbler/collections/images/").iterdir()
     )
-    json_content = json.loads(result_image_json.read_text(encoding="UTF-8"))
     assert result_image_json.exists()
+    json_content = json.loads(result_image_json.read_text(encoding="UTF-8"))
     assert json_content.get("name") == test_image.name
+
+
+def test_menu_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_menu = Menu(cobbler_api)
+    test_menu.name = "test_cobbler_api_add_menu"
+
+    # Act
+    cobbler_api.add_menu(test_menu)
+
+    # Assert
+    result_menu_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/menus/").iterdir()
+    )
+    assert result_menu_json.exists()
+    json_content = json.loads(result_menu_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_menu.name
+
+
+def test_network_interface_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_network_interface = NetworkInterface(cobbler_api, system_uid="test_uid")
+    test_network_interface.name = "test_cobbler_api_add_network_interface"
+
+    # Act
+    cobbler_api.add_network_interface(test_network_interface)
+
+    # Assert
+    result_network_interface_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/network_interfaces/").iterdir()
+    )
+    assert result_network_interface_json.exists()
+    json_content = json.loads(result_network_interface_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_network_interface.name
+
+
+def test_profile_add(cobbler_api: CobblerAPI, create_distro: Callable[[], Distro]):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = Profile(cobbler_api)
+    test_profile.name = "test_cobbler_api_add_profile"
+    test_profile.distro = test_distro
+
+    # Act
+    cobbler_api.add_profile(test_profile)
+
+    # Assert
+    result_profile_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/profiles/").iterdir()
+    )
+    assert result_profile_json.exists()
+    json_content = json.loads(result_profile_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_profile.name
+
+
+def test_profile_group_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_profile_group = ProfileGroup(cobbler_api)
+    test_profile_group.name = "test_cobbler_api_add_profile_group"
+
+    # Act
+    cobbler_api.add_profile_group(test_profile_group)
+
+    # Assert
+    result_profile_group_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/profile_groups/").iterdir()
+    )
+    assert result_profile_group_json.exists()
+    json_content = json.loads(result_profile_group_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_profile_group.name
+
+
+def test_repo_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_repo = Repo(cobbler_api)
+    test_repo.name = "test_cobbler_api_add_repo"
+
+    # Act
+    cobbler_api.add_repo(test_repo)
+
+    # Assert
+    result_repo_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/repos/").iterdir()
+    )
+    assert result_repo_json.exists()
+    json_content = json.loads(result_repo_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_repo.name
+
+
+def test_system_add(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_system = System(cobbler_api)
+    test_system.name = "test_cobbler_api_add_system"
+    test_system.profile = test_profile
+
+    # Act
+    cobbler_api.add_system(test_system)
+
+    # Assert
+    result_system_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/systems/").iterdir()
+    )
+    assert result_system_json.exists()
+    json_content = json.loads(result_system_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_system.name
+
+
+def test_system_group_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_system_group = SystemGroup(cobbler_api)
+    test_system_group.name = "test_cobbler_api_add_system_group"
+
+    # Act
+    cobbler_api.add_system_group(test_system_group)
+
+    # Assert
+    result_system_group_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/system_groups/").iterdir()
+    )
+    assert result_system_group_json.exists()
+    json_content = json.loads(result_system_group_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_system_group.name
+
+
+def test_template_add(cobbler_api: CobblerAPI):
+    # Arrange
+    test_template = Template(cobbler_api)
+    test_template.name = "test_cobbler_api_add_template"
+    test_template.template_type = "jinja"
+
+    # Act
+    cobbler_api.add_template(test_template)
+
+    # Assert
+    result_template_json = next(
+        pathlib.Path("/var/lib/cobbler/collections/templates/").iterdir()
+    )
+    assert result_template_json.exists()
+    json_content = json.loads(result_template_json.read_text(encoding="UTF-8"))
+    assert json_content.get("name") == test_template.name
 
 
 def test_case_sensitive_add(

--- a/tests/api/find_test.py
+++ b/tests/api/find_test.py
@@ -327,3 +327,114 @@ def test_find_template(
             assert result is None
         else:
             assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "return_list,no_errors,criteria,expected_exception,expected_result",
+    [
+        (False, False, {}, pytest.raises(ValueError), None),
+        (False, False, {"name": "test"}, does_not_raise(), None),
+        (False, False, None, pytest.raises(ValueError), None),
+        (False, False, {"name": "testdistro"}, does_not_raise(), None),
+    ],
+)
+def test_find_distro_group(
+    find_fillup: CobblerAPI,
+    return_list: bool,
+    no_errors: bool,
+    criteria: Optional[Dict[str, Any]],
+    expected_exception: Any,
+    expected_result: None,
+):
+    """
+    Test to verify that distro groups can be searched for.
+    """
+    # Arrange
+    test_api = find_fillup
+
+    # Act
+    with expected_exception:
+        if criteria is not None:
+            result = test_api.find_distro_group(return_list, no_errors, **criteria)
+        else:
+            result = test_api.find_distro_group(return_list, no_errors)
+
+        # Assert
+        if expected_result is None:
+            assert result is None
+        else:
+            assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "return_list,no_errors,criteria,expected_exception,expected_result",
+    [
+        (False, False, {}, pytest.raises(ValueError), None),
+        (False, False, {"name": "test"}, does_not_raise(), None),
+        (False, False, None, pytest.raises(ValueError), None),
+        (False, False, {"name": "testdistro"}, does_not_raise(), None),
+    ],
+)
+def test_find_profile_group(
+    find_fillup: CobblerAPI,
+    return_list: bool,
+    no_errors: bool,
+    criteria: Optional[Dict[str, Any]],
+    expected_exception: Any,
+    expected_result: None,
+):
+    """
+    Test to verify that profile groups can be searched for.
+    """
+    # Arrange
+    test_api = find_fillup
+
+    # Act
+    with expected_exception:
+        if criteria is not None:
+            result = test_api.find_profile_group(return_list, no_errors, **criteria)
+        else:
+            result = test_api.find_profile_group(return_list, no_errors)
+
+        # Assert
+        if expected_result is None:
+            assert result is None
+        else:
+            assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "return_list,no_errors,criteria,expected_exception,expected_result",
+    [
+        (False, False, {}, pytest.raises(ValueError), None),
+        (False, False, {"name": "test"}, does_not_raise(), None),
+        (False, False, None, pytest.raises(ValueError), None),
+        (False, False, {"name": "testdistro"}, does_not_raise(), None),
+    ],
+)
+def test_find_system_group(
+    find_fillup: CobblerAPI,
+    return_list: bool,
+    no_errors: bool,
+    criteria: Optional[Dict[str, Any]],
+    expected_exception: Any,
+    expected_result: None,
+):
+    """
+    Test to verify that system groups can be searched for.
+    """
+    # Arrange
+    test_api = find_fillup
+
+    # Act
+    with expected_exception:
+        if criteria is not None:
+            result = test_api.find_system_group(return_list, no_errors, **criteria)
+        else:
+            result = test_api.find_system_group(return_list, no_errors)
+
+        # Assert
+        if expected_result is None:
+            assert result is None
+        else:
+            assert result == expected_result

--- a/tests/cobbler_collections/distro_group_collection_test.py
+++ b/tests/cobbler_collections/distro_group_collection_test.py
@@ -1,0 +1,332 @@
+"""
+Tests that validate the functionality of the module that is responsible for managing the list of distro groups.
+"""
+
+from typing import Callable
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import distro_group
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items.distro_group import DistroGroup
+
+
+@pytest.fixture(name="distro_group_collection")
+def fixture_distro_group_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (DistroGroups) of a generic collection.
+    """
+    return cobbler_api.distro_groups()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    """
+    Test to verify that a collection object can be created.
+    """
+    # Arrange & Act
+    distro_group_collection = distro_group.DistroGroups(collection_mgr)
+
+    # Assert
+    assert isinstance(distro_group_collection, distro_group.DistroGroups)
+
+
+def test_distro_group_factory_produce(
+    cobbler_api: CobblerAPI, distro_group_collection: distro_group.DistroGroups
+):
+    """
+    Test to verify that a distro group object can be created by the factory method of the collection.
+    """
+    # Arrange & Act
+    result_distro_group = distro_group_collection.factory_produce(cobbler_api, {})
+
+    # Assert
+    assert isinstance(result_distro_group, DistroGroup)
+
+
+def test_get(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that a distro group can be retrieved from the collection by name.
+    """
+    # Arrange
+    name = "test_get"
+    create_distro_group(name)
+
+    # Act
+    item = distro_group_collection.get(name)
+    fake_item = distro_group_collection.get("fake_name")
+
+    # Assert
+    assert isinstance(item, DistroGroup)
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that a distro group can be found inside the collection.
+    """
+    # Arrange
+    name = "test_find"
+    create_distro_group(name)
+
+    # Act
+    result = distro_group_collection.find(True, True, name=name)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that the collection can be converted to a list of dictionaries.
+    """
+    # Arrange
+    name = "test_to_list"
+    create_distro_group(name)
+
+    # Act
+    result = distro_group_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that the collection can be populated from a list of dictionaries.
+    """
+    # Arrange
+    item_list = [{"name": "test_from_list"}]
+
+    # Act
+    distro_group_collection.from_list(item_list)
+
+    # Assert
+    assert len(distro_group_collection.listing) == 1
+    assert len(distro_group_collection.indexes["name"]) == 1
+
+
+def test_copy(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that a distro group can be copied inside the collection.
+    """
+    # Arrange
+    name = "test_copy"
+    item1 = create_distro_group(name)
+
+    # Act
+    new_item_name = "test_copy_new"
+    distro_group_collection.copy(item1, new_item_name)
+    item2: DistroGroup = distro_group_collection.find(False, name=new_item_name)  # type: ignore
+
+    # Assert
+    assert len(distro_group_collection.listing) == 2
+    assert item1.uid in distro_group_collection.listing
+    assert item2.uid in distro_group_collection.listing
+    assert len(distro_group_collection.indexes["name"]) == 2
+    assert (distro_group_collection.indexes["name"])[item1.name] == item1.uid
+    assert (distro_group_collection.indexes["name"])[item2.name] == item2.uid
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    create_distro_group: Callable[[], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+    input_new_name: str,
+):
+    """
+    Test to verify that a distro group can be renamed inside the collection.
+    """
+    # Arrange
+    item1 = create_distro_group()
+    distro_group_collection.add(item1)
+
+    # Act
+    distro_group_collection.rename(item1, input_new_name)
+
+    # Assert
+    assert distro_group_collection.listing[item1.uid].name == input_new_name
+    assert (distro_group_collection.indexes["name"])[input_new_name] == item1.uid
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that a distro group can be added to the collection.
+    """
+    # Arrange
+    name = "test_collection_add"
+    item1 = DistroGroup(cobbler_api)
+    item1.name = name  # type: ignore[method-assign]
+
+    # Act
+    distro_group_collection.add(item1)
+
+    # Assert
+    assert item1.uid in distro_group_collection.listing
+    assert name in distro_group_collection.indexes["name"]
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that adding a duplicate distro group raises an exception.
+    """
+    # Arrange
+    name = "test_duplicate_add"
+    create_distro_group(name)
+    item2 = DistroGroup(cobbler_api)
+    item2.name = name  # type: ignore[method-assign]
+
+    # Act & Assert
+    with pytest.raises(CX):
+        distro_group_collection.add(item2, check_for_duplicate_names=True)
+
+
+def test_remove(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that a distro group can be removed from the collection.
+    """
+    # Arrange
+    name = "test_remove"
+    item1 = create_distro_group(name)
+    assert item1.uid in distro_group_collection.listing
+    assert len(distro_group_collection.indexes["name"]) == 1
+    assert (distro_group_collection.indexes["name"])[name] == item1.uid
+
+    # Act
+    distro_group_collection.remove(item1)
+
+    # Assert
+    assert item1.uid not in distro_group_collection.listing
+    assert len(distro_group_collection.indexes["name"]) == 0
+
+
+def test_indexes(
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that the collection's indexes are initialized correctly.
+    """
+    # Arrange
+
+    # Assert
+    assert len(distro_group_collection.indexes) == 1
+    assert len(distro_group_collection.indexes["name"]) == 0
+
+
+def test_add_to_indexes(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that an item can be added to the collection's indexes.
+    """
+    # Arrange
+    name = "test_add_to_indexes"
+    item1 = create_distro_group(name)
+
+    # Act
+    del (distro_group_collection.indexes["name"])[name]
+    distro_group_collection.add_to_indexes(item1)
+
+    # Assert
+    assert name in distro_group_collection.indexes["name"]
+
+
+def test_remove_from_indexes(
+    create_distro_group: Callable[[str], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that an item can be removed from the collection's indexes.
+    """
+    # Arrange
+    name = "test_remove_from_indexes"
+    item1 = create_distro_group(name)
+
+    # Act
+    distro_group_collection.remove_from_indexes(item1)
+
+    # Assert
+    assert name not in distro_group_collection.indexes["name"]
+
+
+def test_update_indexes(
+    create_distro_group: Callable[[], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that the collection's indexes are updated correctly after modifying an item's attributes.
+    """
+    # Arrange
+    item1 = create_distro_group()
+    new_name = "test_update_indicies_post"
+
+    # Act
+    item1.name = new_name  # type: ignore[method-assign]
+
+    # Assert
+    assert distro_group_collection.indexes["name"][new_name] == item1.uid
+
+
+def test_find_by_indexes(
+    create_distro_group: Callable[[], DistroGroup],
+    distro_group_collection: distro_group.DistroGroups,
+):
+    """
+    Test to verify that items can be found by various indexes.
+    """
+    # Arrange
+    item1 = create_distro_group()
+    kargs1 = {"name": item1.name}
+    kargs2 = {"name": "fake_name"}
+    kargs3 = {"fake_index": item1.uid}
+
+    # Act
+    result1 = distro_group_collection.find_by_indexes(kargs1)
+    result2 = distro_group_collection.find_by_indexes(kargs2)
+    result3 = distro_group_collection.find_by_indexes(kargs3)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == item1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1

--- a/tests/cobbler_collections/profile_group_collection_test.py
+++ b/tests/cobbler_collections/profile_group_collection_test.py
@@ -1,0 +1,331 @@
+"""
+Tests that validate the functionality of the module that is responsible for managing the list of profile groups.
+"""
+
+from typing import Any, Callable, Dict, List
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import profile_group
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import profile_group as item_profile_group
+
+
+@pytest.fixture(name="profile_group_collection")
+def fixture_profile_group_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (ProfileGroups) of a generic collection.
+    """
+    return cobbler_api.profile_groups()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    """
+    Test to verify that a collection object can be created.
+    """
+    # Arrange & Act
+    collection = profile_group.ProfileGroups(collection_mgr)
+
+    # Assert
+    assert isinstance(collection, profile_group.ProfileGroups)
+
+
+def test_profile_group_collection_factory_produce(
+    cobbler_api: CobblerAPI, collection_mgr: CollectionManager
+):
+    collection = profile_group.ProfileGroups(collection_mgr)
+    item_dict = {"name": "test_group", "members": ["profile1"]}
+    item = collection.factory_produce(cobbler_api, item_dict)
+    assert isinstance(item, item_profile_group.ProfileGroup)
+    assert getattr(item, "name") == "test_group"
+    assert getattr(item, "members") == ["profile1"]
+
+
+def test_get(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be retrieved from the collection by name.
+    """
+    # Arrange
+    name = "test_get"
+    create_profile_group(name)
+
+    # Act
+    item = profile_group_collection.get(name)
+    fake_item = profile_group_collection.get("fake_name")
+
+    # Assert
+    assert isinstance(item, item_profile_group.ProfileGroup)
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be found inside the collection.
+    """
+    # Arrange
+    name = "test_find"
+    create_profile_group(name)
+
+    # Act
+    result = profile_group_collection.find(True, True, name=name)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that the collection can be converted to a list of dictionaries.
+    """
+    # Arrange
+    name = "test_to_list"
+    create_profile_group(name)
+
+    # Act
+    result = profile_group_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that the collection can be populated from a list of dictionaries.
+    """
+    # Arrange
+    item_list: List[Dict[str, Any]] = [{"name": "test_from_list", "members": []}]
+
+    # Act
+    profile_group_collection.from_list(item_list)
+
+    # Assert
+    assert len(profile_group_collection.listing) == 1
+    assert len(profile_group_collection.indexes["name"]) == 1
+
+
+def test_copy(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be copied inside the collection.
+    """
+    # Arrange
+    name = "test_copy"
+    item1 = create_profile_group(name)
+
+    # Act
+    new_item_name = "test_copy_new"
+    profile_group_collection.copy(item1, new_item_name)
+    item2: item_profile_group.ProfileGroup = profile_group_collection.find(False, name=new_item_name)  # type: ignore
+
+    # Assert
+    assert len(profile_group_collection.listing) == 2
+    assert item1.uid in profile_group_collection.listing
+    assert item2.uid in profile_group_collection.listing
+    assert len(profile_group_collection.indexes["name"]) == 2
+    assert (profile_group_collection.indexes["name"])[item1.name] == item1.uid
+    assert (profile_group_collection.indexes["name"])[item2.name] == item2.uid
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        "to_be_renamed",
+        "UpperCase",
+    ],
+)
+def test_rename(
+    create_profile_group: Callable[[], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+    input_new_name: str,
+):
+    """
+    Test to verify that an item can be renamed inside the collection.
+    """
+    # Arrange
+    item1 = create_profile_group()
+    profile_group_collection.add(item1)
+
+    # Act
+    profile_group_collection.rename(item1, input_new_name)
+
+    # Assert
+    assert profile_group_collection.listing[item1.uid].name == input_new_name
+    assert (profile_group_collection.indexes["name"])[input_new_name] == item1.uid
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be added to the collection.
+    """
+    # Arrange
+    name = "test_collection_add"
+    item1 = item_profile_group.ProfileGroup(cobbler_api)
+    item1.name = name  # type: ignore[method-assign]
+    profile_group_collection.add(item1)
+
+    # Act
+    profile_group_collection.add(item1)
+
+    # Assert
+    assert item1.uid in profile_group_collection.listing
+    assert name in profile_group_collection.indexes["name"]
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that adding a duplicate item raises an exception.
+    """
+    # Arrange
+    name = "test_duplicate_add"
+    create_profile_group(name)
+    item2 = item_profile_group.ProfileGroup(cobbler_api)
+    item2.name = name  # type: ignore[method-assign]
+
+    # Act & Assert
+    with pytest.raises(CX):
+        profile_group_collection.add(item2, check_for_duplicate_names=True)
+
+
+def test_remove(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be removed from the collection.
+    """
+    # Arrange
+    name = "test_remove"
+    item1 = create_profile_group(name)
+    assert item1.uid in profile_group_collection.listing
+    assert len(profile_group_collection.indexes["name"]) == 1
+    assert (profile_group_collection.indexes["name"])[name] == item1.uid
+
+    # Act
+    profile_group_collection.remove(item1)
+
+    # Assert
+    assert item1.uid not in profile_group_collection.listing
+    assert len(profile_group_collection.indexes["name"]) == 0
+
+
+def test_indexes(
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that the collection's indexes are initialized correctly.
+    """
+    # Arrange
+
+    # Assert
+    assert len(profile_group_collection.indexes) == 1
+    assert len(profile_group_collection.indexes["name"]) == 0
+
+
+def test_add_to_indexes(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be added to the collection's indexes.
+    """
+    # Arrange
+    name = "test_add_to_indexes"
+    item1 = create_profile_group(name)
+
+    # Act
+    del (profile_group_collection.indexes["name"])[name]
+    profile_group_collection.add_to_indexes(item1)
+
+    # Assert
+    assert name in profile_group_collection.indexes["name"]
+
+
+def test_remove_from_indexes(
+    create_profile_group: Callable[[str], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that an item can be removed from the collection's indexes.
+    """
+    # Arrange
+    name = "test_remove_from_indexes"
+    item1 = create_profile_group(name)
+
+    # Act
+    profile_group_collection.remove_from_indexes(item1)
+
+    # Assert
+    assert name not in profile_group_collection.indexes["name"]
+
+
+def test_update_indexes(
+    create_profile_group: Callable[[], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that the collection's indexes are updated correctly after modifying an item's attributes.
+    """
+    # Arrange
+    item1 = create_profile_group()
+    new_name = "test_update_indicies_post"
+
+    # Act
+    item1.name = new_name  # type: ignore[method-assign]
+
+    # Assert
+    assert profile_group_collection.indexes["name"][new_name] == item1.uid
+
+
+def test_find_by_indexes(
+    create_profile_group: Callable[[], item_profile_group.ProfileGroup],
+    profile_group_collection: profile_group.ProfileGroups,
+):
+    """
+    Test to verify that items can be found by various indexes.
+    """
+    # Arrange
+    item1 = create_profile_group()
+    kargs1 = {"name": item1.name}
+    kargs2 = {"name": "fake_name"}
+    kargs3 = {"fake_index": item1.uid}
+
+    # Act
+    result1 = profile_group_collection.find_by_indexes(kargs1)
+    result2 = profile_group_collection.find_by_indexes(kargs2)
+    result3 = profile_group_collection.find_by_indexes(kargs3)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == item1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1

--- a/tests/cobbler_collections/system_group_collection_test.py
+++ b/tests/cobbler_collections/system_group_collection_test.py
@@ -1,0 +1,331 @@
+"""
+Tests that validate the functionality of the module that is responsible for managing the list of system groups.
+"""
+
+from typing import Any, Callable, Dict, List
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.cexceptions import CX
+from cobbler.cobbler_collections import system_group
+from cobbler.cobbler_collections.manager import CollectionManager
+from cobbler.items import system_group as item_system_group
+
+
+@pytest.fixture(name="system_group_collection")
+def fixture_system_group_collection(cobbler_api: CobblerAPI):
+    """
+    Fixture to provide a concrete implementation (SystemGroups) of a generic collection.
+    """
+    return cobbler_api.system_groups()
+
+
+def test_obj_create(collection_mgr: CollectionManager):
+    """
+    Test to verify that a collection object can be created.
+    """
+    # Arrange & Act
+    collection = system_group.SystemGroups(collection_mgr)
+
+    # Assert
+    assert isinstance(collection, system_group.SystemGroups)
+
+
+def test_system_group_collection_factory_produce(
+    cobbler_api: CobblerAPI, collection_mgr: CollectionManager
+):
+    collection = system_group.SystemGroups(collection_mgr)
+    item_dict = {"name": "test_group", "members": ["system1"]}
+    item = collection.factory_produce(cobbler_api, item_dict)
+    assert isinstance(item, item_system_group.SystemGroup)
+    assert getattr(item, "name") == "test_group"
+    assert getattr(item, "members") == ["system1"]
+
+
+def test_get(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be retrieved from the collection by name.
+    """
+    # Arrange
+    name = "test_get"
+    create_system_group(name)
+
+    # Act
+    item = system_group_collection.get(name)
+    fake_item = system_group_collection.get("fake_name")
+
+    # Assert
+    assert isinstance(item, item_system_group.SystemGroup)
+    assert item.name == name
+    assert fake_item is None
+
+
+def test_find(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be found inside the collection.
+    """
+    # Arrange
+    name = "test_find"
+    create_system_group(name)
+
+    # Act
+    result = system_group_collection.find(True, True, name=name)
+
+    # Assert
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0].name == name
+
+
+def test_to_list(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that the collection can be converted to a list of dictionaries.
+    """
+    # Arrange
+    name = "test_to_list"
+    create_system_group(name)
+
+    # Act
+    result = system_group_collection.to_list()
+
+    # Assert
+    assert len(result) == 1
+    assert result[0].get("name") == name
+
+
+def test_from_list(
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that the collection can be populated from a list of dictionaries.
+    """
+    # Arrange
+    item_list: List[Dict[str, Any]] = [{"name": "test_from_list", "members": []}]
+
+    # Act
+    system_group_collection.from_list(item_list)
+
+    # Assert
+    assert len(system_group_collection.listing) == 1
+    assert len(system_group_collection.indexes["name"]) == 1
+
+
+def test_copy(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be copied inside the collection.
+    """
+    # Arrange
+    name = "test_copy"
+    item1 = create_system_group(name)
+
+    # Act
+    new_item_name = "test_copy_new"
+    system_group_collection.copy(item1, new_item_name)
+    item2: item_system_group.SystemGroup = system_group_collection.find(False, name=new_item_name)  # type: ignore
+
+    # Assert
+    assert len(system_group_collection.listing) == 2
+    assert item1.uid in system_group_collection.listing
+    assert item2.uid in system_group_collection.listing
+    assert len(system_group_collection.indexes["name"]) == 2
+    assert (system_group_collection.indexes["name"])[item1.name] == item1.uid
+    assert (system_group_collection.indexes["name"])[item2.name] == item2.uid
+
+
+@pytest.mark.parametrize(
+    "input_new_name",
+    [
+        ("to_be_renamed"),
+        ("UpperCase"),
+    ],
+)
+def test_rename(
+    create_system_group: Callable[[], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+    input_new_name: str,
+):
+    """
+    Test to verify that an item can be renamed inside the collection.
+    """
+    # Arrange
+    item1 = create_system_group()
+    system_group_collection.add(item1)
+
+    # Act
+    system_group_collection.rename(item1, input_new_name)
+
+    # Assert
+    assert system_group_collection.listing[item1.uid].name == input_new_name
+    assert (system_group_collection.indexes["name"])[input_new_name] == item1.uid
+
+
+def test_collection_add(
+    cobbler_api: CobblerAPI,
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be added to the collection.
+    """
+    # Arrange
+    name = "test_collection_add"
+    item1 = item_system_group.SystemGroup(cobbler_api)
+    item1.name = name  # type: ignore[method-assign]
+    system_group_collection.add(item1)
+
+    # Act
+    system_group_collection.add(item1)
+
+    # Assert
+    assert item1.uid in system_group_collection.listing
+    assert name in system_group_collection.indexes["name"]
+
+
+def test_duplicate_add(
+    cobbler_api: CobblerAPI,
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that adding a duplicate item raises an exception.
+    """
+    # Arrange
+    name = "test_duplicate_add"
+    create_system_group(name)
+    item2 = item_system_group.SystemGroup(cobbler_api)
+    item2.name = name  # type: ignore[method-assign]
+
+    # Act & Assert
+    with pytest.raises(CX):
+        system_group_collection.add(item2, check_for_duplicate_names=True)
+
+
+def test_remove(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be removed from the collection.
+    """
+    # Arrange
+    name = "test_remove"
+    item1 = create_system_group(name)
+    assert item1.uid in system_group_collection.listing
+    assert len(system_group_collection.indexes["name"]) == 1
+    assert (system_group_collection.indexes["name"])[name] == item1.uid
+
+    # Act
+    system_group_collection.remove(item1)
+
+    # Assert
+    assert item1.uid not in system_group_collection.listing
+    assert len(system_group_collection.indexes["name"]) == 0
+
+
+def test_indexes(
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that the collection's indexes are initialized correctly.
+    """
+    # Arrange
+
+    # Assert
+    assert len(system_group_collection.indexes) == 1
+    assert len(system_group_collection.indexes["name"]) == 0
+
+
+def test_add_to_indexes(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be added to the collection's indexes.
+    """
+    # Arrange
+    name = "test_add_to_indexes"
+    item1 = create_system_group(name)
+
+    # Act
+    del (system_group_collection.indexes["name"])[name]
+    system_group_collection.add_to_indexes(item1)
+
+    # Assert
+    assert name in system_group_collection.indexes["name"]
+
+
+def test_remove_from_indexes(
+    create_system_group: Callable[[str], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that an item can be removed from the collection's indexes.
+    """
+    # Arrange
+    name = "test_remove_from_indexes"
+    item1 = create_system_group(name)
+
+    # Act
+    system_group_collection.remove_from_indexes(item1)
+
+    # Assert
+    assert name not in system_group_collection.indexes["name"]
+
+
+def test_update_indexes(
+    create_system_group: Callable[[], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that the collection's indexes are updated correctly after modifying an item's attributes.
+    """
+    # Arrange
+    item1 = create_system_group()
+    new_name = "test_update_indicies_post"
+
+    # Act
+    item1.name = new_name  # type: ignore[method-assign]
+
+    # Assert
+    assert system_group_collection.indexes["name"][new_name] == item1.uid
+
+
+def test_find_by_indexes(
+    create_system_group: Callable[[], item_system_group.SystemGroup],
+    system_group_collection: system_group.SystemGroups,
+):
+    """
+    Test to verify that items can be found by various indexes.
+    """
+    # Arrange
+    item1 = create_system_group()
+    kargs1 = {"name": item1.name}
+    kargs2 = {"name": "fake_name"}
+    kargs3 = {"fake_index": item1.uid}
+
+    # Act
+    result1 = system_group_collection.find_by_indexes(kargs1)
+    result2 = system_group_collection.find_by_indexes(kargs2)
+    result3 = system_group_collection.find_by_indexes(kargs3)
+
+    # Assert
+    assert isinstance(result1, list)
+    assert len(result1) == 1
+    assert result1[0] == item1
+    assert len(kargs1) == 0
+    assert result2 is None
+    assert len(kargs2) == 0
+    assert result3 is None
+    assert len(kargs3) == 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,13 @@ import pytest
 from cobbler.api import CobblerAPI
 from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.items.distro import Distro
+from cobbler.items.distro_group import DistroGroup
 from cobbler.items.image import Image
 from cobbler.items.menu import Menu
 from cobbler.items.profile import Profile
+from cobbler.items.profile_group import ProfileGroup
 from cobbler.items.system import System
+from cobbler.items.system_group import SystemGroup
 
 logger = logging.getLogger()
 
@@ -147,6 +150,28 @@ def create_distro(
 
 
 @pytest.fixture(scope="function")
+def create_distro_group(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Returns a function which has the distro group name as an argument. The function returns a distro group object.
+    """
+
+    def _create_distro_group(name: str = "", with_add: bool = True) -> DistroGroup:
+        test_distro_group = cobbler_api.new_distro_group()
+        test_distro_group.name = (  # type: ignore[method-assign]
+            request.node.originalname  # type: ignore
+            if request.node.originalname  # type: ignore
+            else request.node.name  # type: ignore
+        )
+        if name != "":
+            test_distro_group.name = name  # type: ignore[method-assign]
+        if with_add:
+            cobbler_api.add_distro_group(test_distro_group)
+        return test_distro_group
+
+    return _create_distro_group
+
+
+@pytest.fixture(scope="function")
 def create_profile(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
     Returns a function which has the distro or profile name as an argument. The function returns a profile object. The profile is
@@ -154,7 +179,10 @@ def create_profile(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
 
     def _create_profile(
-        distro_uid: str = "", profile_uid: str = "", name: str = ""
+        distro_uid: str = "",
+        profile_uid: str = "",
+        name: str = "",
+        with_add: bool = True,
     ) -> Profile:
         test_profile = cobbler_api.new_profile()
         test_profile.name = (  # type: ignore[method-assign]
@@ -168,10 +196,33 @@ def create_profile(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
             test_profile.distro = distro_uid  # type: ignore
         else:
             test_profile.parent = profile_uid  # type: ignore
-        cobbler_api.add_profile(test_profile)
+        if with_add:
+            cobbler_api.add_profile(test_profile)
         return test_profile
 
     return _create_profile
+
+
+@pytest.fixture(scope="function")
+def create_profile_group(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Returns a function which has the profile group name as an argument. The function returns a profile group object.
+    """
+
+    def _create_profile_group(name: str = "", with_add: bool = True) -> ProfileGroup:
+        test_profile_group = cobbler_api.new_profile_group()
+        test_profile_group.name = (  # type: ignore[method-assign]
+            request.node.originalname  # type: ignore
+            if request.node.originalname  # type: ignore
+            else request.node.name  # type: ignore
+        )
+        if name != "":
+            test_profile_group.name = name  # type: ignore[method-assign]
+        if with_add:
+            cobbler_api.add_profile_group(test_profile_group)
+        return test_profile_group
+
+    return _create_profile_group
 
 
 @pytest.fixture(scope="function")
@@ -204,7 +255,10 @@ def create_system(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
     """
 
     def _create_system(
-        profile_uid: str = "", image_uid: str = "", name: str = ""
+        profile_uid: str = "",
+        image_uid: str = "",
+        name: str = "",
+        with_add: bool = True,
     ) -> System:
         test_system = cobbler_api.new_system()
         if name == "":
@@ -219,15 +273,41 @@ def create_system(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
             test_system.profile = profile_uid  # type: ignore
         if image_uid != "":
             test_system.image = image_uid  # type: ignore
-        cobbler_api.add_system(test_system)
+
         test_system_default_interface = cobbler_api.new_network_interface(
             system_uid=test_system.uid, name="default"
         )
         test_system_default_interface.name = "default"  # type: ignore[method-assign]
-        cobbler_api.add_network_interface(test_system_default_interface)
+
+        if with_add:
+            cobbler_api.add_system(test_system)
+            cobbler_api.add_network_interface(test_system_default_interface)
+
         return test_system
 
     return _create_system
+
+
+@pytest.fixture(scope="function")
+def create_system_group(request: "pytest.FixtureRequest", cobbler_api: CobblerAPI):
+    """
+    Returns a function which has the system group name as an argument. The function returns a system group object.
+    """
+
+    def _create_system_group(name: str = "", with_add: bool = True) -> SystemGroup:
+        test_system_group = cobbler_api.new_system_group()
+        test_system_group.name = (  # type: ignore[method-assign]
+            request.node.originalname  # type: ignore
+            if request.node.originalname  # type: ignore
+            else request.node.name  # type: ignore
+        )
+        if name != "":
+            test_system_group.name = name  # type: ignore[method-assign]
+        if with_add:
+            cobbler_api.add_system_group(test_system_group)
+        return test_system_group
+
+    return _create_system_group
 
 
 @pytest.fixture(scope="function")
@@ -270,6 +350,9 @@ def cleanup_leftover_items():
         "systems",
         "network_interfaces",
         "templates",
+        "distro_groups",
+        "profile_groups",
+        "system_groups",
     ]
     for collection in cobbler_collections:
         path = collection_path / collection

--- a/tests/integration/data/test_svc_settings/expected_settings.json
+++ b/tests/integration/data/test_svc_settings/expected_settings.json
@@ -377,6 +377,24 @@
                 "nonunique": true,
                 "disabled": false
             }
+        },
+        "distro_group": {
+            "name": {
+                "nonunique": false,
+                "disabled": false
+            }
+        },
+        "profile_group": {
+            "name": {
+                "nonunique": false,
+                "disabled": false
+            }
+        },
+        "system_group": {
+            "name": {
+                "nonunique": false,
+                "disabled": false
+            }
         }
     }
 }

--- a/tests/items/cache_test.py
+++ b/tests/items/cache_test.py
@@ -35,7 +35,7 @@ def test_collection_types(cobbler_api: CobblerAPI):
     result = mgr.__dict__.items()
 
     # Assert
-    assert len(result) == 10
+    assert len(result) == 13
 
 
 @pytest.mark.parametrize(

--- a/tests/items/distro_group_test.py
+++ b/tests/items/distro_group_test.py
@@ -1,0 +1,115 @@
+"""
+Tests that validate the functionality of the module that is responsible for providing distro group related functionality.
+"""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.items.distro_group import DistroGroup
+from cobbler.settings import Settings
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(name="test_settings")
+def fixture_test_settings(mocker: "MockerFixture", cobbler_api: CobblerAPI) -> Settings:
+    settings = mocker.MagicMock(
+        name="distro_group_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
+    # Arrange
+
+    # Act
+    distro_group = DistroGroup(cobbler_api)
+
+    # Assert
+    assert isinstance(distro_group, DistroGroup)
+
+
+def test_make_clone(cobbler_api: CobblerAPI):
+    # Arrange
+    distro_group = DistroGroup(cobbler_api)
+
+    # Act
+    result = distro_group.make_clone()
+
+    # Assert
+    assert distro_group != result
+
+
+def test_to_dict(cobbler_api: CobblerAPI):
+    # Arrange
+    titem = DistroGroup(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
+    # Arrange
+    titem = DistroGroup(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)
+
+
+def test_inheritance(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI, test_settings: Settings
+):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    distro_group = DistroGroup(cobbler_api)
+
+    # Act
+    for key, key_value in distro_group.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(distro_group, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(distro_group, new_key)
+            setattr(distro_group, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(distro_group, new_key)

--- a/tests/items/item_group_test.py
+++ b/tests/items/item_group_test.py
@@ -7,6 +7,7 @@ from typing import Any, List, Type
 import pytest
 
 from cobbler import enums
+from cobbler.api import CobblerAPI
 from cobbler.items.abstract.base_item import BaseItem
 from cobbler.items.abstract.item_group import ItemGroup
 
@@ -16,7 +17,7 @@ class DummyItemGroup(ItemGroup):
     A concrete dummy class to instantiate the abstract ItemGroup class for testing.
     """
 
-    def __init__(self, api: Any, **kwargs: Any):
+    def __init__(self, api: CobblerAPI, **kwargs: Any):
         super().__init__(api, **kwargs)
 
     def make_clone(self) -> "BaseItem":
@@ -34,47 +35,46 @@ class DummyItemGroup(ItemGroup):
         return []
 
 
-class TestItemGroup:
+def test_members_initialization(cobbler_api: CobblerAPI):
     """
-    Tests for ItemGroup class
+    Test that members is initialized as an empty list.
     """
+    group = DummyItemGroup(api=cobbler_api)
+    assert getattr(group, "members") == []
 
-    def test_members_initialization(self):
-        """
-        Test that members is initialized as an empty list.
-        """
-        group = DummyItemGroup(api=None)
-        assert getattr(group, "members") == []
 
-    def test_members_setter_valid(self):
-        """
-        Test that the members setter works with a valid list of strings.
-        """
-        group = DummyItemGroup(api=None)
-        valid_members = ["member1", "member2"]
-        setattr(group, "members", valid_members)
-        assert getattr(group, "members") == valid_members
+def test_members_setter_valid(cobbler_api: CobblerAPI):
+    """
+    Test that the members setter works with a valid list of strings.
+    """
+    group = DummyItemGroup(api=cobbler_api)
+    valid_members = ["member1", "member2"]
+    setattr(group, "members", valid_members)
+    assert getattr(group, "members") == valid_members
 
-    def test_members_setter_invalid_type_not_list(self):
-        """
-        Test that the members setter raises a TypeError if the value is not a list.
-        """
-        group = DummyItemGroup(api=None)
-        with pytest.raises(TypeError, match="members must be a list"):
-            setattr(group, "members", "not a list")
 
-    def test_members_setter_invalid_member_type(self):
-        """
-        Test that the members setter raises a TypeError if any member is not a string.
-        """
-        group = DummyItemGroup(api=None)
-        with pytest.raises(TypeError, match="All members must be of type string"):
-            setattr(group, "members", ["member1", 123])
+def test_members_setter_invalid_type_not_list(cobbler_api: CobblerAPI):
+    """
+    Test that the members setter raises a TypeError if the value is not a list.
+    """
+    group = DummyItemGroup(api=cobbler_api)
+    with pytest.raises(TypeError, match="members must be a list"):
+        setattr(group, "members", "not a list")
 
-    def test_from_dict_initialization(self):
-        """
-        Test that passing a dict to __init__ correctly sets members via from_dict.
-        """
-        # Note: In from_dict, the keys correspond to properties.
-        group = DummyItemGroup(api=None, members=["m1", "m2"])
-        assert getattr(group, "members") == ["m1", "m2"]
+
+def test_members_setter_invalid_member_type(cobbler_api: CobblerAPI):
+    """
+    Test that the members setter raises a TypeError if any member is not a string.
+    """
+    group = DummyItemGroup(api=cobbler_api)
+    with pytest.raises(TypeError, match="All members must be of type string"):
+        setattr(group, "members", ["member1", 123])
+
+
+def test_from_dict_initialization(cobbler_api: CobblerAPI):
+    """
+    Test that passing a dict to __init__ correctly sets members via from_dict.
+    """
+    # Note: In from_dict, the keys correspond to properties.
+    group = DummyItemGroup(api=cobbler_api, members=["m1", "m2"])
+    assert getattr(group, "members") == ["m1", "m2"]

--- a/tests/items/item_group_test.py
+++ b/tests/items/item_group_test.py
@@ -1,0 +1,80 @@
+"""
+Tests for the ItemGroup abstract class.
+"""
+
+from typing import Any, List, Type
+
+import pytest
+
+from cobbler import enums
+from cobbler.items.abstract.base_item import BaseItem
+from cobbler.items.abstract.item_group import ItemGroup
+
+
+class DummyItemGroup(ItemGroup):
+    """
+    A concrete dummy class to instantiate the abstract ItemGroup class for testing.
+    """
+
+    def __init__(self, api: Any, **kwargs: Any):
+        super().__init__(api, **kwargs)
+
+    def make_clone(self) -> "BaseItem":
+        return self
+
+    def _resolve(self, property_name: List[str]) -> Any:
+        return None
+
+    def _resolve_enum(
+        self, property_name: List[str], enum_type: Type[enums.ConvertableEnum]
+    ) -> Any:
+        return None
+
+    def _resolve_list(self, property_name: List[str]) -> Any:
+        return []
+
+
+class TestItemGroup:
+    """
+    Tests for ItemGroup class
+    """
+
+    def test_members_initialization(self):
+        """
+        Test that members is initialized as an empty list.
+        """
+        group = DummyItemGroup(api=None)
+        assert getattr(group, "members") == []
+
+    def test_members_setter_valid(self):
+        """
+        Test that the members setter works with a valid list of strings.
+        """
+        group = DummyItemGroup(api=None)
+        valid_members = ["member1", "member2"]
+        setattr(group, "members", valid_members)
+        assert getattr(group, "members") == valid_members
+
+    def test_members_setter_invalid_type_not_list(self):
+        """
+        Test that the members setter raises a TypeError if the value is not a list.
+        """
+        group = DummyItemGroup(api=None)
+        with pytest.raises(TypeError, match="members must be a list"):
+            setattr(group, "members", "not a list")
+
+    def test_members_setter_invalid_member_type(self):
+        """
+        Test that the members setter raises a TypeError if any member is not a string.
+        """
+        group = DummyItemGroup(api=None)
+        with pytest.raises(TypeError, match="All members must be of type string"):
+            setattr(group, "members", ["member1", 123])
+
+    def test_from_dict_initialization(self):
+        """
+        Test that passing a dict to __init__ correctly sets members via from_dict.
+        """
+        # Note: In from_dict, the keys correspond to properties.
+        group = DummyItemGroup(api=None, members=["m1", "m2"])
+        assert getattr(group, "members") == ["m1", "m2"]

--- a/tests/items/profile_group_test.py
+++ b/tests/items/profile_group_test.py
@@ -1,0 +1,115 @@
+"""
+Tests that validate the functionality of the module that is responsible for providing profile group related functionality.
+"""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.items.profile_group import ProfileGroup
+from cobbler.settings import Settings
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(name="test_settings")
+def fixture_test_settings(mocker: "MockerFixture", cobbler_api: CobblerAPI) -> Settings:
+    settings = mocker.MagicMock(
+        name="profile_group_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
+    # Arrange
+
+    # Act
+    profile_group = ProfileGroup(cobbler_api)
+
+    # Assert
+    assert isinstance(profile_group, ProfileGroup)
+
+
+def test_make_clone(cobbler_api: CobblerAPI):
+    # Arrange
+    profile_group = ProfileGroup(cobbler_api)
+
+    # Act
+    result = profile_group.make_clone()
+
+    # Assert
+    assert profile_group != result
+
+
+def test_to_dict(cobbler_api: CobblerAPI):
+    # Arrange
+    titem = ProfileGroup(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
+    # Arrange
+    titem = ProfileGroup(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)
+
+
+def test_inheritance(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI, test_settings: Settings
+):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    profile_group = ProfileGroup(cobbler_api)
+
+    # Act
+    for key, key_value in profile_group.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(profile_group, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(profile_group, new_key)
+            setattr(profile_group, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(profile_group, new_key)

--- a/tests/items/system_group_test.py
+++ b/tests/items/system_group_test.py
@@ -1,0 +1,115 @@
+"""
+Tests that validate the functionality of the module that is responsible for providing system group related functionality.
+"""
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cobbler import enums
+from cobbler.api import CobblerAPI
+from cobbler.items.system_group import SystemGroup
+from cobbler.settings import Settings
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(name="test_settings")
+def fixture_test_settings(mocker: "MockerFixture", cobbler_api: CobblerAPI) -> Settings:
+    settings = mocker.MagicMock(
+        name="system_group_setting_mock", spec=cobbler_api.settings()
+    )
+    orig = cobbler_api.settings()
+    for key in orig.to_dict():
+        setattr(settings, key, getattr(orig, key))
+    return settings
+
+
+def test_object_creation(cobbler_api: CobblerAPI):
+    # Arrange
+
+    # Act
+    system_group = SystemGroup(cobbler_api)
+
+    # Assert
+    assert isinstance(system_group, SystemGroup)
+
+
+def test_make_clone(cobbler_api: CobblerAPI):
+    # Arrange
+    system_group = SystemGroup(cobbler_api)
+
+    # Act
+    result = system_group.make_clone()
+
+    # Assert
+    assert system_group != result
+
+
+def test_to_dict(cobbler_api: CobblerAPI):
+    # Arrange
+    titem = SystemGroup(cobbler_api)
+
+    # Act
+    result = titem.to_dict()
+
+    # Assert
+    assert isinstance(result, dict)
+
+
+def test_to_dict_resolved(cobbler_api: CobblerAPI):
+    # Arrange
+    titem = SystemGroup(cobbler_api)
+
+    # Act
+    result = titem.to_dict(resolved=True)
+
+    # Assert
+    assert isinstance(result, dict)
+    assert enums.VALUE_INHERITED not in str(result)
+
+
+def test_inheritance(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI, test_settings: Settings
+):
+    """
+    Checking that inherited properties are correctly inherited from settings and
+    that the <<inherit>> value can be set for them.
+    """
+    # Arrange
+    mocker.patch.object(cobbler_api, "settings", return_value=test_settings)
+    system_group = SystemGroup(cobbler_api)
+
+    # Act
+    for key, key_value in system_group.__dict__.items():
+        if key_value == enums.VALUE_INHERITED:
+            new_key = key[1:].lower()
+            new_value = getattr(system_group, new_key)
+            settings_name = new_key
+            if new_key == "owners":
+                settings_name = "default_ownership"
+            if hasattr(test_settings, f"default_{settings_name}"):
+                settings_name = f"default_{settings_name}"
+            if hasattr(test_settings, settings_name):
+                setting = getattr(test_settings, settings_name)
+                if isinstance(setting, str):
+                    new_value = "test_inheritance"
+                elif isinstance(setting, bool):
+                    new_value = True
+                elif isinstance(setting, int):
+                    new_value = 1
+                elif isinstance(setting, float):
+                    new_value = 1.0
+                elif isinstance(setting, dict):
+                    new_value = {"test_inheritance": "test_inheritance"}
+                elif isinstance(setting, list):
+                    new_value = ["test_inheritance"]
+                setattr(test_settings, settings_name, new_value)
+
+            prev_value = getattr(system_group, new_key)
+            setattr(system_group, new_key, enums.VALUE_INHERITED)
+
+            # Assert
+            assert prev_value == new_value
+            assert prev_value == getattr(system_group, new_key)

--- a/tests/test_data/V3_4_0/settings.yaml
+++ b/tests/test_data/V3_4_0/settings.yaml
@@ -703,3 +703,15 @@ memory_indexes:
         dns.name:
             nonunique: *allow_duplicate_hostnames
             disabled: *allow_duplicate_hostnames
+    distro_group:
+      name:
+        nonunique: false
+        disabled: false
+    profile_group:
+      name:
+        nonunique: false
+        disabled: false
+    system_group:
+      name:
+        nonunique: false
+        disabled: false

--- a/tests/utils/filesystem_helpers_test.py
+++ b/tests/utils/filesystem_helpers_test.py
@@ -6,16 +6,18 @@ import os
 import pathlib
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
-from pytest_mock import MockerFixture
 
 from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.utils import filesystem_helpers
 
 from tests.conftest import does_not_raise
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 
 @pytest.mark.parametrize(
@@ -292,7 +294,7 @@ def test_safe_filter(test_input: str, expected_exception: Any):
         filesystem_helpers.safe_filter(test_input)
 
 
-def test_create_web_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
+def test_create_web_dirs(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     """
     Test to verify the behavior of the create_web_dirs function.
     """
@@ -312,7 +314,7 @@ def test_create_web_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     assert mock_copyfile.call_count == 2
 
 
-def test_create_tftpboot_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
+def test_create_tftpboot_dirs(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     """
     Test to verify the behavior of the create_tftpboot_dirs function.
     """
@@ -333,7 +335,7 @@ def test_create_tftpboot_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     assert mock_path_symlink_to.call_count == 3
 
 
-def test_create_trigger_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
+def test_create_trigger_dirs(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     """
     Test to verify the behavior of the create_trigger_dirs function.
     """
@@ -345,10 +347,10 @@ def test_create_trigger_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
     filesystem_helpers.create_trigger_dirs(cobbler_api)
 
     # Assert
-    assert mock_mkdir.call_count == 75
+    assert mock_mkdir.call_count == 102
 
 
-def test_create_json_database_dirs(mocker: MockerFixture, cobbler_api: CobblerAPI):
+def test_create_json_database_dirs(mocker: "MockerFixture", cobbler_api: CobblerAPI):
     """
     Test to verify the behavior of the create_json_database_dirs function.
     """
@@ -361,5 +363,5 @@ def test_create_json_database_dirs(mocker: MockerFixture, cobbler_api: CobblerAP
 
     # Assert
     mock_mkdir.assert_any_call("/var/lib/cobbler/collections")
-    # 1 collections parent directory + (1 child directory per item type * 9 item types atm)
-    assert mock_mkdir.call_count == 9
+    # 1 collections parent directory + (1 child directory per item type * 11 item types atm)
+    assert mock_mkdir.call_count == 12

--- a/tests/xmlrpcapi/distro_group_test.py
+++ b/tests/xmlrpcapi/distro_group_test.py
@@ -1,0 +1,169 @@
+"""
+Tests for DistroGroup XML-RPC endpoints
+"""
+
+import time
+
+import pytest
+
+from cobbler.remote import CobblerXMLRPCInterface
+
+
+def test_get_distro_groups(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get distro groups
+    """
+    # Arrange --> Nothing to arrange
+
+    # Act
+    result = remote.get_distro_groups(token)
+
+    # Assert
+    assert result == []
+
+
+def test_new_distro_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: create a new distro group object
+    """
+    # Arrange --> Nothing to arrange
+
+    # Act
+    handle = remote.new_distro_group(token)
+
+    # Assert
+    assert handle is not None
+
+
+def test_modify_save_and_get_distro_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: modify, save and get a distro group object
+    """
+    # Arrange
+    handle = remote.new_distro_group(token)
+    remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
+    remote.save_distro_group(handle, token, editmode="new")
+
+    # Act
+    group = remote.get_distro_group("test_distro_group", token=token)
+
+    # Assert
+    assert group is not None
+    assert group["name"] == "test_distro_group"  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "create_item,expected_len",
+    [
+        (False, 0),
+        (True, 1),
+    ],
+)
+def test_find_distro_group(
+    remote: CobblerXMLRPCInterface, token: str, create_item: bool, expected_len: int
+):
+    """
+    Test: find a distro group object
+    """
+    # Arrange
+    if create_item:
+        handle = remote.new_distro_group(token)
+        remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
+        remote.save_distro_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.find_distro_group(
+        criteria={"name": "test_distro_group"}, token=token
+    )
+
+    # Assert
+    assert len(result) == expected_len
+
+
+def test_copy_distro_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: copy a distro group object
+    """
+    # Arrange
+    handle = remote.new_distro_group(token)
+    remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
+    remote.save_distro_group(handle, token, editmode="new")
+    distro_group = remote.get_distro_group_handle("test_distro_group")
+
+    # Act
+    result = remote.copy_distro_group(distro_group, "test_distro_group_copy", token)
+
+    # Assert
+    assert result
+
+
+def test_rename_distro_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: rename a distro group object
+    """
+    # Arrange
+    handle = remote.new_distro_group(token)
+    remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
+    remote.save_distro_group(handle, token, editmode="new")
+    distro_group = remote.get_distro_group_handle("test_distro_group")
+
+    # Act
+    result = remote.rename_distro_group(
+        distro_group, "test_distro_group_renamed", token
+    )
+
+    # Assert
+    assert result
+
+
+def test_remove_distro_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: remove a distro group object
+    """
+    # Arrange
+    handle = remote.new_distro_group(token)
+    remote.modify_distro_group(handle, ["name"], "test_distro_group_to_remove", token)
+    remote.save_distro_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.remove_distro_group("test_distro_group_to_remove", token)
+
+    # Assert
+    assert result is True
+    group = remote.get_distro_group("test_distro_group_to_remove", token=token)
+    assert group == "~"
+
+
+def test_get_distro_groups_since(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get distro groups since
+    """
+    # Arrange
+    mtime = time.time()
+    handle = remote.new_distro_group(token)
+    remote.modify_distro_group(handle, ["name"], "test_distro_group_since", token)
+    remote.save_distro_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.get_distro_groups_since(mtime)
+
+    # Assert
+    assert len(result) == 1  # pyright: ignore[reportArgumentType]
+    assert result[0]["name"] == "test_distro_group_since"  # type: ignore
+
+
+def test_get_distro_group_as_rendered(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get distro group as rendered
+    """
+    # Arrange
+    handle = remote.new_distro_group(token)
+    remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
+    remote.save_distro_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.get_distro_group_as_rendered("test_distro_group", token)
+
+    # Assert
+    assert result is not None
+    assert result["name"] == "test_distro_group"  # type: ignore

--- a/tests/xmlrpcapi/profile_group_test.py
+++ b/tests/xmlrpcapi/profile_group_test.py
@@ -1,0 +1,169 @@
+"""
+Tests for ProfileGroup XML-RPC endpoints
+"""
+
+import time
+
+import pytest
+
+from cobbler.remote import CobblerXMLRPCInterface
+
+
+def test_get_profile_groups(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get profile groups
+    """
+    # Arrange --> Nothing to arrange
+
+    # Act
+    result = remote.get_profile_groups(token)
+
+    # Assert
+    assert result == []
+
+
+def test_new_profile_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: create a new profile group object
+    """
+    # Arrange --> Nothing to arrange
+
+    # Act
+    handle = remote.new_profile_group(token)
+
+    # Assert
+    assert handle is not None
+
+
+def test_modify_save_and_get_profile_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: modify, save and get a profile group object
+    """
+    # Arrange
+    handle = remote.new_profile_group(token)
+    remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
+    remote.save_profile_group(handle, token, editmode="new")
+
+    # Act
+    group = remote.get_profile_group("test_profile_group", token=token)
+
+    # Assert
+    assert group is not None
+    assert group["name"] == "test_profile_group"  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "create_item,expected_len",
+    [
+        (False, 0),
+        (True, 1),
+    ],
+)
+def test_find_profile_group(
+    remote: CobblerXMLRPCInterface, token: str, create_item: bool, expected_len: int
+):
+    """
+    Test: find a profile group object
+    """
+    # Arrange
+    if create_item:
+        handle = remote.new_profile_group(token)
+        remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
+        remote.save_profile_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.find_profile_group(
+        criteria={"name": "test_profile_group"}, token=token
+    )
+
+    # Assert
+    assert len(result) == expected_len
+
+
+def test_copy_profile_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: copy a profile group object
+    """
+    # Arrange
+    handle = remote.new_profile_group(token)
+    remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
+    remote.save_profile_group(handle, token, editmode="new")
+    profile_group = remote.get_profile_group_handle("test_profile_group")
+
+    # Act
+    result = remote.copy_profile_group(profile_group, "test_profile_group_copy", token)
+
+    # Assert
+    assert result
+
+
+def test_rename_profile_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: rename a profile group object
+    """
+    # Arrange
+    handle = remote.new_profile_group(token)
+    remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
+    remote.save_profile_group(handle, token, editmode="new")
+    profile_group = remote.get_profile_group_handle("test_profile_group")
+
+    # Act
+    result = remote.rename_profile_group(
+        profile_group, "test_profile_group_renamed", token
+    )
+
+    # Assert
+    assert result
+
+
+def test_remove_profile_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: remove a profile group object
+    """
+    # Arrange
+    handle = remote.new_profile_group(token)
+    remote.modify_profile_group(handle, ["name"], "test_profile_group_to_remove", token)
+    remote.save_profile_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.remove_profile_group("test_profile_group_to_remove", token)
+
+    # Assert
+    assert result is True
+    group = remote.get_profile_group("test_profile_group_to_remove", token=token)
+    assert group == "~"
+
+
+def test_get_profile_groups_since(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get profile groups since
+    """
+    # Arrange
+    mtime = time.time()
+    handle = remote.new_profile_group(token)
+    remote.modify_profile_group(handle, ["name"], "test_profile_group_since", token)
+    remote.save_profile_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.get_profile_groups_since(mtime)
+
+    # Assert
+    assert len(result) == 1  # pyright: ignore[reportArgumentType]
+    assert result[0]["name"] == "test_profile_group_since"  # type: ignore
+
+
+def test_get_profile_group_as_rendered(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get profile group as rendered
+    """
+    # Arrange
+    handle = remote.new_profile_group(token)
+    remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
+    remote.save_profile_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.get_profile_group_as_rendered("test_profile_group", token)
+
+    # Assert
+    assert result is not None
+    assert result["name"] == "test_profile_group"  # type: ignore

--- a/tests/xmlrpcapi/system_group_test.py
+++ b/tests/xmlrpcapi/system_group_test.py
@@ -1,0 +1,169 @@
+"""
+Tests for SystemGroup XML-RPC endpoints
+"""
+
+import time
+
+import pytest
+
+from cobbler.remote import CobblerXMLRPCInterface
+
+
+def test_get_system_groups(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get system groups
+    """
+    # Arrange --> Nothing to arrange
+
+    # Act
+    result = remote.get_system_groups(token)
+
+    # Assert
+    assert result == []
+
+
+def test_new_system_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: create a new system group object
+    """
+    # Arrange --> Nothing to arrange
+
+    # Act
+    handle = remote.new_system_group(token)
+
+    # Assert
+    assert handle is not None
+
+
+def test_modify_save_and_get_system_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: modify, save and get a system group object
+    """
+    # Arrange
+    handle = remote.new_system_group(token)
+    remote.modify_system_group(handle, ["name"], "test_system_group", token)
+    remote.save_system_group(handle, token, editmode="new")
+
+    # Act
+    group = remote.get_system_group("test_system_group", token=token)
+
+    # Assert
+    assert group is not None
+    assert group["name"] == "test_system_group"  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "create_item,expected_len",
+    [
+        (False, 0),
+        (True, 1),
+    ],
+)
+def test_find_system_group(
+    remote: CobblerXMLRPCInterface, token: str, create_item: bool, expected_len: int
+):
+    """
+    Test: find a system group object
+    """
+    # Arrange
+    if create_item:
+        handle = remote.new_system_group(token)
+        remote.modify_system_group(handle, ["name"], "test_system_group", token)
+        remote.save_system_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.find_system_group(
+        criteria={"name": "test_system_group"}, token=token
+    )
+
+    # Assert
+    assert len(result) == expected_len
+
+
+def test_copy_system_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: copy a system group object
+    """
+    # Arrange
+    handle = remote.new_system_group(token)
+    remote.modify_system_group(handle, ["name"], "test_system_group", token)
+    remote.save_system_group(handle, token, editmode="new")
+    system_group = remote.get_system_group_handle("test_system_group")
+
+    # Act
+    result = remote.copy_system_group(system_group, "test_system_group_copy", token)
+
+    # Assert
+    assert result
+
+
+def test_rename_system_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: rename a system group object
+    """
+    # Arrange
+    handle = remote.new_system_group(token)
+    remote.modify_system_group(handle, ["name"], "test_system_group", token)
+    remote.save_system_group(handle, token, editmode="new")
+    system_group = remote.get_system_group_handle("test_system_group")
+
+    # Act
+    result = remote.rename_system_group(
+        system_group, "test_system_group_renamed", token
+    )
+
+    # Assert
+    assert result
+
+
+def test_remove_system_group(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: remove a system group object
+    """
+    # Arrange
+    handle = remote.new_system_group(token)
+    remote.modify_system_group(handle, ["name"], "test_system_group_to_remove", token)
+    remote.save_system_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.remove_system_group("test_system_group_to_remove", token)
+
+    # Assert
+    assert result is True
+    group = remote.get_system_group("test_system_group_to_remove", token=token)
+    assert group == "~"
+
+
+def test_get_system_groups_since(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get system groups since
+    """
+    # Arrange
+    mtime = time.time()
+    handle = remote.new_system_group(token)
+    remote.modify_system_group(handle, ["name"], "test_system_group_since", token)
+    remote.save_system_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.get_system_groups_since(mtime)
+
+    # Assert
+    assert len(result) == 1  # pyright: ignore[reportArgumentType]
+    assert result[0]["name"] == "test_system_group_since"  # type: ignore
+
+
+def test_get_system_group_as_rendered(remote: CobblerXMLRPCInterface, token: str):
+    """
+    Test: get system group as rendered
+    """
+    # Arrange
+    handle = remote.new_system_group(token)
+    remote.modify_system_group(handle, ["name"], "test_system_group", token)
+    remote.save_system_group(handle, token, editmode="new")
+
+    # Act
+    result = remote.get_system_group_as_rendered("test_system_group", token)
+
+    # Assert
+    assert result is not None
+    assert result["name"] == "test_system_group"  # type: ignore


### PR DESCRIPTION
## Linked Items

Fixes #3983

## Description

This PR adds support for the `DistroGroup`, `ProfileGroup`, and `SystemGroup` item types that allow grouping of items that belong to the same item type.

Large portions of this PR were created using Google Gemini. Please review with caution.

## Behaviour changes

Old: Items could not be grouped (aka identical metadata must be duplicated).

New: Distros, Profiles and Systems can now be grouped.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 