### PR TITLE
Add public methods to reload distro signatures

### DIFF
--- a/changelog.d/3791.added
+++ b/changelog.d/3791.added
@@ -1,0 +1,1 @@
+Add API and XML-RPC endpoint for signature reloading

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -1999,6 +1999,12 @@ class CobblerAPI:
         except Exception:
             utils.log_exc()
 
+    def signature_reload(self) -> None:
+        """
+        Reload all signatures from disk.
+        """
+        self.__load_signatures()
+
     # ==========================================================================
 
     def dump_vars(

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -544,6 +544,23 @@ class CobblerXMLRPCInterface:
             runner, token, "sigupdate", "Updating Signatures", options
         )
 
+    def background_signature_reload(self, options: Dict[str, Any], token: str) -> str:
+        """
+        Run a signature reload in the background.
+
+        :param options: No additional parameters needed.
+        :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
+        :return: The id of the task which was started.
+        """
+
+        def runner(self: "CobblerThread"):
+            self.remote.api.signature_reload()
+
+        self.check_access(token, "sigreload")
+        return self.__start_task(
+            runner, token, "sigreload", "Reloading Signatures", options
+        )
+
     def background_mkloaders(self, options: Dict[str, Any], token: str) -> str:
         """
         Create the bootloaders that Cobbler uses inside its TFTP-directory and stage them in the background.
@@ -1713,7 +1730,7 @@ class CobblerXMLRPCInterface:
         else:
             items = self.api.find_items(what, criteria=criteria)  # type: ignore[assignment]
         items = self.__sort(items, sort_field)  # type: ignore
-        (items, pageinfo) = self.__paginate(items, page, items_per_page)  # type: ignore
+        items, pageinfo = self.__paginate(items, page, items_per_page)  # type: ignore
         items = [x.to_dict(resolved=resolved) for x in items]  # type: ignore
         return self.xmlrpc_hacks({"items": items, "pageinfo": pageinfo})
 
@@ -4014,13 +4031,13 @@ class CobblerXMLRPCInterface:
         """
         timenow = time.time()
         for token in list(self.token_cache.keys()):
-            (tokentime, _) = self.token_cache[token]
+            tokentime, _ = self.token_cache[token]
             if timenow > tokentime + self.api.settings().auth_token_expiration:
                 self._log("expiring token", token=token, debug=True)
                 del self.token_cache[token]
         # and also expired objects
         for oid in list(self.unsaved_items.keys()):
-            (tokentime, _) = self.unsaved_items[oid]
+            tokentime, _ = self.unsaved_items[oid]
             if timenow > tokentime + CACHE_TIMEOUT:
                 del self.unsaved_items[oid]
         for tid in list(self.events.keys()):


### PR DESCRIPTION
## Linked Items

Fixes #3791

## Description

This PR adds a Python API and an XML-RPC API endpoint to enable remote signature reloading. This is required for the new Golang-based CLI.

## Behaviour changes

Old: Signatures couldn't be reloaded by the Golang-based CLI.

New: The new CLI has an endpoint to reload the distro signatures.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
