### PR TITLE
Fix ipv6 reverse zones

### DIFF
--- a/changelog.d/3988.fixed
+++ b/changelog.d/3988.fixed
@@ -1,0 +1,1 @@
+Fix crash during IP conversion with non-numeric characters for the bind manager

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -11,7 +11,7 @@ import pathlib
 import re
 import socket
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Tuple, Union
 
 from cobbler import enums, utils
 from cobbler.modules.managers import DnsManagerModule
@@ -197,7 +197,7 @@ class _BindManager(DnsManagerModule):
 
         return zones
 
-    def __reverse_zones(self) -> Dict[Any, Any]:
+    def __reverse_zones(self) -> Dict[str, Dict[str, Union[str, List[str]]]]:
         """
         Returns a map of zones and the records that belong in them
 
@@ -404,7 +404,10 @@ zone "{arpa}." {{
         return [".".join(i) for i in octets_str] + [":".join(i) for i in quartets_str]
 
     def __pretty_print_host_records(
-        self, hosts: Dict[str, Any], rectype: str = "A", rclass: str = "IN"
+        self,
+        hosts: Dict[str, Union[str, List[str]]],
+        rectype: str = "A",
+        rclass: str = "IN",
     ) -> str:
         """
         Format host records by order and with consistent indentation
@@ -430,6 +433,7 @@ zone "{arpa}." {{
             return ""  # zones with no hosts
 
         if rectype == "PTR":
+
             def translate_ip(ip: str) -> str:
                 if ":" in ip:
                     tokens = list(re.sub(":", "", ip))
@@ -451,7 +455,6 @@ zone "{arpa}." {{
             spacing = " " * (max_name - len(name))
             my_name = f"{name}{spacing}"
             my_host_record = hosts[name]
-            my_host_list = []
             if isinstance(my_host_record, str):
                 my_host_list = [my_host_record]
             else:
@@ -466,14 +469,10 @@ zone "{arpa}." {{
                 result += f"{my_name}  {rclass}  {my_rectype}  {my_host};\n"
         return result
 
-    def __pretty_print_cname_records(
-        self, hosts: Dict[str, Any], rectype: str = "CNAME"
-    ) -> str:
+    def __pretty_print_cname_records(self) -> str:
         """
         Format CNAMEs and with consistent indentation
 
-        :param hosts: This parameter is currently unused.
-        :param rectype: The type of record which shall be pretty printed.
         :return: The pretty printed version of the cname records.
         """
         result = ""
@@ -489,7 +488,7 @@ zone "{arpa}." {{
                     if interface.dns.name != "":
                         dnsname = interface.dns.name.split(".")[0]
                         for cname in cnames:
-                            result += f"{cname.split('.')[0]}  {rectype}  {dnsname};\n"
+                            result += f"{cname.split('.')[0]}  CNAME  {dnsname};\n"
                     else:
                         self.logger.warning(
                             'CNAME generation for system "%s" was skipped due to a missing dns_name entry while writing'
@@ -576,7 +575,7 @@ zone "{arpa}." {{
                 else:
                     template_data = search_result.content
 
-            metadata["cname_record"] = self.__pretty_print_cname_records(hosts)
+            metadata["cname_record"] = self.__pretty_print_cname_records()
             metadata["host_record"] = self.__pretty_print_host_records(hosts)
 
             zonefilename = zonefileprefix + zone
@@ -608,7 +607,7 @@ zone "{arpa}." {{
             if not found_zone_specific_template:
                 template_data = search_result.content
 
-            metadata["cname_record"] = self.__pretty_print_cname_records(hosts)
+            metadata["cname_record"] = self.__pretty_print_cname_records()
             metadata["host_record"] = self.__pretty_print_host_records(
                 hosts, rectype="PTR"
             )

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -247,9 +247,6 @@ class _BindManager(DnsManagerModule):
                         ip_address = ip_address.replace(best_match, "", 1)
                         if ip_address[0] == ".":  # strip leading '.' if it's there
                             ip_address = ip_address[1:]
-                        tokens = ip_address.split(".")
-                        tokens.reverse()
-                        ip_address = ".".join(tokens)
                         zones[best_match][ip_address] = host + "."
 
                 if ipv6 or ipv6_sec_addrs:
@@ -262,10 +259,7 @@ class _BindManager(DnsManagerModule):
                         # All IPv6 zones are forced to have the format xxxx:xxxx:xxxx:xxxx
                         zone = long_ipv6[:19]
                         ipv6_host_part = long_ipv6[20:]
-                        tokens = list(re.sub(":", "", ipv6_host_part))
-                        tokens.reverse()
-                        ip_address = ".".join(tokens)
-                        zones[zone][ip_address] = host + "."
+                        zones[zone][ipv6_host_part] = host + "."
 
         return zones
 
@@ -432,14 +426,23 @@ zone "{arpa}." {{
                         system.name,
                     )
 
-        names = list(hosts.keys())
-        if not names:
+        if not len(hosts):
             return ""  # zones with no hosts
 
         if rectype == "PTR":
-            names = self.__ip_sort(names)
+            def translate_ip(ip: str) -> str:
+                if ":" in ip:
+                    tokens = list(re.sub(":", "", ip))
+                else:
+                    tokens = ip.split(".")
+                tokens.reverse()
+                return ".".join(tokens)
+
+            names = self.__ip_sort(hosts.keys())
+            hosts = dict(map(lambda ip: (translate_ip(ip), hosts[ip]), names))
+            names = list(map(translate_ip, names))
         else:
-            names.sort()
+            names = sorted(hosts.keys())
 
         max_name = max([len(i) for i in names])
 

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -94,9 +94,28 @@ zone "${arpa}." {
 #end for
 """,
         "/etc/cobbler/secondary.template": "garbage",
-        "/etc/cobbler/zone.template": "garbage 2",
+        "/etc/cobbler/zone.template":
+        """\\$TTL 3600
+@                       IN      SOA     $cobbler_server. nobody.example.com. (
+                                        $serial      ; Serial
+                                        86400        ; Refresh (1 day)
+                                        7200         ; Retry   (2 hours)
+                                        604800       ; Expire  (1 week)
+                                        3600         ; TTL     (1 hour)
+                                        )
+
+@                       IN      NS      $cobbler_server.
+
+;; CNAMEs
+$cname_record
+
+;; Hosts
+$host_record
+""",
     }
-    return MockFiles(mocker, files)
+    mock_files = MockFiles(mocker, files)
+    mock_files.real_patterns.append("/etc/cobbler/*")
+    return mock_files
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -149,8 +168,15 @@ def test_write_configs(
     Test if the manager is able to correctly write the configuration files.
     """
     # Arrange
+    settings = cobbler_api.settings()
+    settings.from_dict({
+        "server": "cobbler.example.com",
+        "manage_dns": True,
+        "manage_forward_zones": [ "example.com" ],
+        "manage_reverse_zones": [ "192.168.1", "2001:db8:0:1" ],
+    })
+
     manager = bind.get_manager(cobbler_api)
-    # TODO Mock settings for manage_dns and forward/reverse zones
 
     # Act
     manager.write_configs()
@@ -160,6 +186,30 @@ def test_write_configs(
     mocker.stopall()
 
     assert open("/var/lib/cobbler/bind_serial").read() == time.strftime("%Y%m%d00")
+
+    def assert_zone_has(path: str, *expect: List[str]) -> None:
+        parsed = list(map(
+            lambda line: line[:line.find(';')].split(),
+            open(path).readlines()))
+        for line in expect:
+            assert line in parsed
+
+    assert_zone_has(
+        "/var/lib/named/example.com",
+        ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
+        ["IN", "NS", "cobbler.example.com."],
+    )
+    assert_zone_has(
+        "/var/lib/named/192.168.1",
+        ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
+        ["IN", "NS", "cobbler.example.com."],
+    )
+    assert_zone_has(
+        "/var/lib/named/2001:0db8:0000:0001",
+        ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
+        ["IN", "NS", "cobbler.example.com."],
+    )
+
     mock_config_files.open_unknown.assert_not_called()
 
 

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -206,6 +206,14 @@ def test_write_configs(
         dns={"name": "test.example.com"},
     )
     cobbler_api.add_network_interface(test_interface)
+    test_interface = cobbler_api.new_network_interface(
+        system_uid=test_system.uid,
+        name="secondary",
+        ipv4={"address": "192.168.1.123"},
+        ipv6={"address": "2001:db8:0:1::abcd"},
+        dns={"name": "second.example.com"},
+    )
+    cobbler_api.add_network_interface(test_interface)
 
     manager = bind.get_manager(cobbler_api)
 
@@ -231,18 +239,22 @@ def test_write_configs(
         ["IN", "NS", "cobbler.example.com."],
         ["test", "IN", "A", "192.168.1.2"],
         ["test", "IN", "AAAA", "2001:db8:0:1::2"],
+        ["second", "IN", "A", "192.168.1.123"],
+        ["second", "IN", "AAAA", "2001:db8:0:1::abcd"],
     )
     assert_zone_has(
         "/var/lib/named/192.168.1",
         ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
         ["IN", "NS", "cobbler.example.com."],
         ["2", "IN", "PTR", "test.example.com."],
+        ["123", "IN", "PTR", "second.example.com."],
     )
     assert_zone_has(
         "/var/lib/named/2001:0db8:0000:0001",
         ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
         ["IN", "NS", "cobbler.example.com."],
         ["2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "test.example.com."],
+        ["d.c.b.a.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "second.example.com."],
     )
 
     mock_config_files.open_unknown.assert_not_called()

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -4,7 +4,7 @@ Test to verify the functionallity of the isc bind module.
 
 import pathlib
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Dict, TextIO
 
 import pytest
 
@@ -15,12 +15,38 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
-@pytest.fixture(name="named_template", scope="function")
-def fixture_named_template() -> str:
+class MockFiles:
     """
-    This provides a minmal test templated for named that is close to the real one.
+    Implements a mock filesystem using MockerFixture.
     """
-    return """options {
+
+    def __init__(self, mocker: "MockerFixture", files: Dict[str, str]):
+        self.mocker = mocker
+        self.files = files
+        self.open_unknown = mocker.mock_open()
+        self.patch = mocker.patch("builtins.open", self.open)
+
+    def open(self, *args: Any, **kwargs: Any) -> TextIO:
+        """
+        Open a mock file.
+        """
+        path = args[0]
+        open_data = self.files.get(path, self.open_unknown)
+        if isinstance(open_data, str):
+            open_data = self.mocker.mock_open(read_data=open_data)
+            self.files[path] = open_data
+        return open_data(*args, **kwargs)
+
+
+@pytest.fixture(scope="function")
+def mock_config_files(mocker: "MockerFixture") -> MockFiles:
+    """
+    Provide BIND config files for testing.
+    """
+
+    files = {
+        "/etc/cobbler/named.template":
+        """options {
           listen-on port 53 { 127.0.0.1; };
           directory       "@@bind_zonefiles@@";
           dump-file       "@@bind_zonefiles@@/data/cache_dump.db";
@@ -44,7 +70,13 @@ zone "${arpa}." {
 };
 
 #end for
-"""
+""",
+        "/etc/cobbler/secondary.template": "garbage",
+        "/etc/cobbler/zone.template": "garbage 2",
+        "/etc/named.conf": "",
+        "/etc/secondary.conf": "",
+    }
+    return MockFiles(mocker, files)
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -90,34 +122,15 @@ def test_get_manager(cobbler_api: CobblerAPI):
 
 
 def test_write_configs(
-    mocker: "MockerFixture", cobbler_api: CobblerAPI, named_template: str
+    mocker: "MockerFixture", cobbler_api: CobblerAPI,
+    mock_config_files: MockFiles
 ):
     """
     Test if the manager is able to correctly write the configuration files.
     """
     # Arrange
-    open_mock = mocker.mock_open()
-    mock_named_template = mocker.mock_open(read_data=named_template)
-    mock_secondary_template = mocker.mock_open(read_data="garbage")
-    mock_zone_template = mocker.mock_open(read_data="garbage 2")
-    mock_etc_named_conf = mocker.mock_open()
-    mock_etc_secondary_conf = mocker.mock_open()
     mock_pathlib_path = mocker.patch.object(pathlib.Path, "write_text")
 
-    def mock_open(*args: Any, **kwargs: Any):
-        if args[0] == "/etc/cobbler/named.template":
-            return mock_named_template(*args, **kwargs)
-        if args[0] == "/etc/cobbler/secondary.template":
-            return mock_secondary_template(*args, **kwargs)
-        if args[0] == "/etc/cobbler/zone.template":
-            return mock_zone_template(*args, **kwargs)
-        if args[0] == "/etc/named.conf":
-            return mock_etc_named_conf(*args, **kwargs)
-        if args[0] == "/etc/secondary.conf":
-            return mock_etc_secondary_conf(*args, **kwargs)
-        return open_mock(*args, **kwargs)
-
-    mocker.patch("builtins.open", mock_open)
     manager = bind.get_manager(cobbler_api)
     # TODO Mock settings for manage_dns and forward/reverse zones
 
@@ -129,7 +142,7 @@ def test_write_configs(
     mock_pathlib_path.assert_called_once_with(
         time.strftime("%Y%m%d00"), encoding="UTF-8"
     )
-    open_mock.assert_not_called()
+    mock_config_files.open_unknown.assert_not_called()
 
 
 @pytest.mark.skip("Advanced complicated test scenario for now.")

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -139,8 +139,6 @@ def test_write_configs(
     Test if the manager is able to correctly write the configuration files.
     """
     # Arrange
-    mock_pathlib_path = mocker.patch.object(pathlib.Path, "write_text")
-
     manager = bind.get_manager(cobbler_api)
     # TODO Mock settings for manage_dns and forward/reverse zones
 
@@ -149,9 +147,9 @@ def test_write_configs(
 
     # Assert
     # TODO: Extend assertions
-    mock_pathlib_path.assert_called_once_with(
-        time.strftime("%Y%m%d00"), encoding="UTF-8"
-    )
+    mocker.stopall()
+
+    assert open("/var/lib/cobbler/bind_serial").read() == time.strftime("%Y%m%d00")
     mock_config_files.open_unknown.assert_not_called()
 
 

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -2,10 +2,9 @@
 Test to verify the functionallity of the isc bind module.
 """
 
-from fnmatch import fnmatch
-import pathlib
 import time
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, TextIO
+from fnmatch import fnmatch
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, TextIO, Tuple
 
 import pytest
 
@@ -14,17 +13,19 @@ from cobbler.items import distro, profile
 from cobbler.modules.managers import bind
 
 if TYPE_CHECKING:
-    from pytest_mock import MockerFixture
     from pytest import TempPathFactory
+    from pytest_mock import MockerFixture
 
 
-def _get_file_and_mode(file, mode='r', *args, **kwargs):
+def _get_file_and_mode(
+    file: Any, mode: str = "r", *args: Any, **kwargs: Any
+) -> Tuple[Any, str]:
     """
     Helper to extract the file and mode arguments from a call to open(),
     Because it is an actual callable function, it can handle the exact
     same combinations of positional and keyword arguments as open().
     """
-    return (file, mode)
+    return file, mode
 
 
 class MockFiles:
@@ -51,7 +52,7 @@ class MockFiles:
         Open a mock file.
         """
         path, mode = _get_file_and_mode(*args, **kwargs)
-        if 'r' not in mode:
+        if "r" not in mode:
             return self._real_open(*args, **kwargs)
         open_data = self.files.get(path, self.open_unknown)
         if isinstance(open_data, str):
@@ -72,8 +73,7 @@ def mock_config_files(
     """
 
     files = {
-        "/etc/cobbler/named.template":
-        """options {
+        "/etc/cobbler/named.template": """options {
           listen-on port 53 { 127.0.0.1; };
           directory       "@@bind_zonefiles@@";
           dump-file       "@@bind_zonefiles@@/data/cache_dump.db";
@@ -99,8 +99,7 @@ zone "${arpa}." {
 #end for
 """,
         "/etc/cobbler/secondary.template": "garbage",
-        "/etc/cobbler/zone.template":
-        """\\$TTL 3600
+        "/etc/cobbler/zone.template": """\\$TTL 3600
 @                       IN      SOA     $cobbler_server. nobody.example.com. (
                                         $serial      ; Serial
                                         86400        ; Refresh (1 day)
@@ -119,13 +118,15 @@ $host_record
 """,
     }
     mock_files = MockFiles(mocker, files)
-    mock_files.real_patterns.extend((
-        "/code/*",
-        "/etc/cobbler/*",
-        "/etc/mtab",
-        "/var/lib/cobbler/*",
-        str(tmp_path_factory.getbasetemp().joinpath("*")),
-    ))
+    mock_files.real_patterns.extend(
+        (
+            "/code/*",
+            "/etc/cobbler/*",
+            "/etc/mtab",
+            "/var/lib/cobbler/*",
+            str(tmp_path_factory.getbasetemp().joinpath("*")),
+        )
+    )
     return mock_files
 
 
@@ -133,9 +134,9 @@ def assert_zone_has(path: str, *expect: List[str]) -> None:
     """
     Test that a zone file contains the expected tokens in the given order.
     """
-    parsed = list(map(
-        lambda line: line[:line.find(';')].split(),
-        open(path).readlines()))
+    parsed = list(
+        map(lambda line: line[: line.find(";")].split(), open(path).readlines())
+    )
     it = iter(parsed)
     for line in expect:
         while True:
@@ -193,31 +194,31 @@ def test_get_manager(cobbler_api: CobblerAPI):
 
 
 def test_write_configs(
-    mocker: "MockerFixture", cobbler_api: CobblerAPI,
+    mocker: "MockerFixture",
+    cobbler_api: CobblerAPI,
     mock_config_files: MockFiles,
     create_distro: Callable[[], distro.Distro],
-    create_profile: Callable[[str], profile.Profile]
+    create_profile: Callable[[str], profile.Profile],
 ):
     """
     Test if the manager is able to correctly write the configuration files.
     """
     # Arrange
     settings = cobbler_api.settings()
-    settings.from_dict({
-        "server": "cobbler.example.com",
-        "manage_dns": True,
-        "manage_forward_zones": [ "example.com" ],
-        "manage_reverse_zones": [ "192.168.1", "2001:db8:0:1" ],
-        "manage_dhcp_v4": False,
-        "manage_dhcp_v6": False,
-    })
+    settings.from_dict(
+        {
+            "server": "cobbler.example.com",
+            "manage_dns": True,
+            "manage_forward_zones": ["example.com"],
+            "manage_reverse_zones": ["192.168.1", "2001:db8:0:1"],
+            "manage_dhcp_v4": False,
+            "manage_dhcp_v6": False,
+        }
+    )
 
     test_distro = create_distro()
     test_profile = create_profile(test_distro.uid)
-    test_system = cobbler_api.new_system(
-        name = "test",
-        profile = test_profile.uid
-    )
+    test_system = cobbler_api.new_system(name="test", profile=test_profile.uid)
     cobbler_api.add_system(test_system)
     test_interface = cobbler_api.new_network_interface(
         system_uid=test_system.uid,
@@ -242,7 +243,6 @@ def test_write_configs(
     manager.write_configs()
 
     # Assert
-    # TODO: Extend assertions
     mocker.stopall()
 
     assert open("/var/lib/cobbler/bind_serial").read() == time.strftime("%Y%m%d00")
@@ -275,32 +275,32 @@ def test_write_configs(
 
 
 def test_sort_zones(
-    mocker: "MockerFixture", cobbler_api: CobblerAPI,
+    mocker: "MockerFixture",
+    cobbler_api: CobblerAPI,
     mock_config_files: MockFiles,
     create_distro: Callable[[], distro.Distro],
-    create_profile: Callable[[str], profile.Profile]
+    create_profile: Callable[[str], profile.Profile],
 ):
     """
     Test if the RRs in a zone file are correctly sorted.
     """
     # Arrange
     settings = cobbler_api.settings()
-    settings.from_dict({
-        "server": "cobbler.example.com",
-        "manage_dns": True,
-        "manage_forward_zones": [ "example.com" ],
-        "manage_reverse_zones": [ "192.168", "2001:db8:0:1" ],
-        "manage_dhcp_v4": False,
-        "manage_dhcp_v6": False,
-    })
+    settings.from_dict(
+        {
+            "server": "cobbler.example.com",
+            "manage_dns": True,
+            "manage_forward_zones": ["example.com"],
+            "manage_reverse_zones": ["192.168", "2001:db8:0:1"],
+            "manage_dhcp_v4": False,
+            "manage_dhcp_v6": False,
+        }
+    )
 
     test_distro = create_distro()
     test_profile = create_profile(test_distro.uid)
 
-    test_system = cobbler_api.new_system(
-        name = "alpha",
-        profile = test_profile.uid
-    )
+    test_system = cobbler_api.new_system(name="alpha", profile=test_profile.uid)
     cobbler_api.add_system(test_system)
     test_interface = cobbler_api.new_network_interface(
         system_uid=test_system.uid,
@@ -311,10 +311,7 @@ def test_sort_zones(
     )
     cobbler_api.add_network_interface(test_interface)
 
-    test_system = cobbler_api.new_system(
-        name = "beta",
-        profile = test_profile.uid
-    )
+    test_system = cobbler_api.new_system(name="beta", profile=test_profile.uid)
     cobbler_api.add_system(test_system)
     test_interface = cobbler_api.new_network_interface(
         system_uid=test_system.uid,
@@ -325,10 +322,7 @@ def test_sort_zones(
     )
     cobbler_api.add_network_interface(test_interface)
 
-    test_system = cobbler_api.new_system(
-        name = "gamma",
-        profile = test_profile.uid
-    )
+    test_system = cobbler_api.new_system(name="gamma", profile=test_profile.uid)
     cobbler_api.add_system(test_system)
     test_interface = cobbler_api.new_network_interface(
         system_uid=test_system.uid,
@@ -345,7 +339,6 @@ def test_sort_zones(
     manager.write_configs()
 
     # Assert
-    # TODO: Extend assertions
     mocker.stopall()
 
     assert_zone_has(

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -5,15 +5,17 @@ Test to verify the functionallity of the isc bind module.
 from fnmatch import fnmatch
 import pathlib
 import time
-from typing import TYPE_CHECKING, Any, Dict, List, TextIO
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, TextIO
 
 import pytest
 
 from cobbler.api import CobblerAPI
+from cobbler.items import distro, profile
 from cobbler.modules.managers import bind
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
+    from pytest import TempPathFactory
 
 
 def _get_file_and_mode(file, mode='r', *args, **kwargs):
@@ -61,7 +63,10 @@ class MockFiles:
 
 
 @pytest.fixture(scope="function")
-def mock_config_files(mocker: "MockerFixture") -> MockFiles:
+def mock_config_files(
+    mocker: "MockerFixture",
+    tmp_path_factory: "TempPathFactory",
+) -> MockFiles:
     """
     Provide BIND config files for testing.
     """
@@ -114,7 +119,13 @@ $host_record
 """,
     }
     mock_files = MockFiles(mocker, files)
-    mock_files.real_patterns.append("/etc/cobbler/*")
+    mock_files.real_patterns.extend((
+        "/code/*",
+        "/etc/cobbler/*",
+        "/etc/mtab",
+        "/var/lib/cobbler/*",
+        str(tmp_path_factory.getbasetemp().joinpath("*")),
+    ))
     return mock_files
 
 
@@ -162,7 +173,9 @@ def test_get_manager(cobbler_api: CobblerAPI):
 
 def test_write_configs(
     mocker: "MockerFixture", cobbler_api: CobblerAPI,
-    mock_config_files: MockFiles
+    mock_config_files: MockFiles,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile]
 ):
     """
     Test if the manager is able to correctly write the configuration files.
@@ -174,7 +187,25 @@ def test_write_configs(
         "manage_dns": True,
         "manage_forward_zones": [ "example.com" ],
         "manage_reverse_zones": [ "192.168.1", "2001:db8:0:1" ],
+        "manage_dhcp_v4": False,
+        "manage_dhcp_v6": False,
     })
+
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_system = cobbler_api.new_system(
+        name = "test",
+        profile = test_profile.uid
+    )
+    cobbler_api.add_system(test_system)
+    test_interface = cobbler_api.new_network_interface(
+        system_uid=test_system.uid,
+        name="default",
+        ipv4={"address": "192.168.1.2"},
+        ipv6={"address": "2001:db8:0:1::2"},
+        dns={"name": "test.example.com"},
+    )
+    cobbler_api.add_network_interface(test_interface)
 
     manager = bind.get_manager(cobbler_api)
 
@@ -198,16 +229,20 @@ def test_write_configs(
         "/var/lib/named/example.com",
         ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
         ["IN", "NS", "cobbler.example.com."],
+        ["test", "IN", "A", "192.168.1.2"],
+        ["test", "IN", "AAAA", "2001:db8:0:1::2"],
     )
     assert_zone_has(
         "/var/lib/named/192.168.1",
         ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
         ["IN", "NS", "cobbler.example.com."],
+        ["2", "IN", "PTR", "test.example.com."],
     )
     assert_zone_has(
         "/var/lib/named/2001:0db8:0000:0001",
         ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
         ["IN", "NS", "cobbler.example.com."],
+        ["2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "test.example.com."],
     )
 
     mock_config_files.open_unknown.assert_not_called()

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -15,6 +15,15 @@ if TYPE_CHECKING:
     from pytest_mock import MockerFixture
 
 
+def _get_file_and_mode(file, mode='r', *args, **kwargs):
+    """
+    Helper to extract the file and mode arguments from a call to open(),
+    Because it is an actual callable function, it can handle the exact
+    same combinations of positional and keyword arguments as open().
+    """
+    return (file, mode)
+
+
 class MockFiles:
     """
     Implements a mock filesystem using MockerFixture.
@@ -24,13 +33,16 @@ class MockFiles:
         self.mocker = mocker
         self.files = files
         self.open_unknown = mocker.mock_open()
+        self._real_open = open
         self.patch = mocker.patch("builtins.open", self.open)
 
     def open(self, *args: Any, **kwargs: Any) -> TextIO:
         """
         Open a mock file.
         """
-        path = args[0]
+        path, mode = _get_file_and_mode(*args, **kwargs)
+        if 'r' not in mode:
+            return self._real_open(*args, **kwargs)
         open_data = self.files.get(path, self.open_unknown)
         if isinstance(open_data, str):
             open_data = self.mocker.mock_open(read_data=open_data)
@@ -73,8 +85,6 @@ zone "${arpa}." {
 """,
         "/etc/cobbler/secondary.template": "garbage",
         "/etc/cobbler/zone.template": "garbage 2",
-        "/etc/named.conf": "",
-        "/etc/secondary.conf": "",
     }
     return MockFiles(mocker, files)
 

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -2,9 +2,10 @@
 Test to verify the functionallity of the isc bind module.
 """
 
+from fnmatch import fnmatch
 import pathlib
 import time
-from typing import TYPE_CHECKING, Any, Dict, TextIO
+from typing import TYPE_CHECKING, Any, Dict, List, TextIO
 
 import pytest
 
@@ -32,9 +33,16 @@ class MockFiles:
     def __init__(self, mocker: "MockerFixture", files: Dict[str, str]):
         self.mocker = mocker
         self.files = files
+        self.real_patterns: List[str] = list()
         self.open_unknown = mocker.mock_open()
         self._real_open = open
         self.patch = mocker.patch("builtins.open", self.open)
+
+    def _is_real(self, path: str) -> bool:
+        for pat in self.real_patterns:
+            if fnmatch(path, pat):
+                return True
+        return False
 
     def open(self, *args: Any, **kwargs: Any) -> TextIO:
         """
@@ -47,6 +55,8 @@ class MockFiles:
         if isinstance(open_data, str):
             open_data = self.mocker.mock_open(read_data=open_data)
             self.files[path] = open_data
+        elif open_data == self.open_unknown and self._is_real(path):
+            return self._real_open(*args, **kwargs)
         return open_data(*args, **kwargs)
 
 

--- a/tests/modules/managers/bind_test.py
+++ b/tests/modules/managers/bind_test.py
@@ -129,6 +129,27 @@ $host_record
     return mock_files
 
 
+def assert_zone_has(path: str, *expect: List[str]) -> None:
+    """
+    Test that a zone file contains the expected tokens in the given order.
+    """
+    parsed = list(map(
+        lambda line: line[:line.find(';')].split(),
+        open(path).readlines()))
+    it = iter(parsed)
+    for line in expect:
+        while True:
+            try:
+                actual = next(it)
+            except StopIteration:
+                if line in parsed:
+                    raise AssertionError(f"{line} misplaced in {parsed}")
+                else:
+                    raise AssertionError(f"{line} not found in {parsed}")
+            if line == actual:
+                break
+
+
 @pytest.fixture(scope="function", autouse=True)
 def reset_singleton():
     """
@@ -226,21 +247,14 @@ def test_write_configs(
 
     assert open("/var/lib/cobbler/bind_serial").read() == time.strftime("%Y%m%d00")
 
-    def assert_zone_has(path: str, *expect: List[str]) -> None:
-        parsed = list(map(
-            lambda line: line[:line.find(';')].split(),
-            open(path).readlines()))
-        for line in expect:
-            assert line in parsed
-
     assert_zone_has(
         "/var/lib/named/example.com",
         ["@", "IN", "SOA", "cobbler.example.com.", "nobody.example.com.", "("],
         ["IN", "NS", "cobbler.example.com."],
-        ["test", "IN", "A", "192.168.1.2"],
-        ["test", "IN", "AAAA", "2001:db8:0:1::2"],
         ["second", "IN", "A", "192.168.1.123"],
         ["second", "IN", "AAAA", "2001:db8:0:1::abcd"],
+        ["test", "IN", "A", "192.168.1.2"],
+        ["test", "IN", "AAAA", "2001:db8:0:1::2"],
     )
     assert_zone_has(
         "/var/lib/named/192.168.1",
@@ -255,6 +269,105 @@ def test_write_configs(
         ["IN", "NS", "cobbler.example.com."],
         ["2.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "test.example.com."],
         ["d.c.b.a.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "second.example.com."],
+    )
+
+    mock_config_files.open_unknown.assert_not_called()
+
+
+def test_sort_zones(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI,
+    mock_config_files: MockFiles,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile]
+):
+    """
+    Test if the RRs in a zone file are correctly sorted.
+    """
+    # Arrange
+    settings = cobbler_api.settings()
+    settings.from_dict({
+        "server": "cobbler.example.com",
+        "manage_dns": True,
+        "manage_forward_zones": [ "example.com" ],
+        "manage_reverse_zones": [ "192.168", "2001:db8:0:1" ],
+        "manage_dhcp_v4": False,
+        "manage_dhcp_v6": False,
+    })
+
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+
+    test_system = cobbler_api.new_system(
+        name = "alpha",
+        profile = test_profile.uid
+    )
+    cobbler_api.add_system(test_system)
+    test_interface = cobbler_api.new_network_interface(
+        system_uid=test_system.uid,
+        name="default",
+        ipv4={"address": "192.168.2.1"},
+        ipv6={"address": "2001:db8:0:1::21"},
+        dns={"name": "alpha.example.com"},
+    )
+    cobbler_api.add_network_interface(test_interface)
+
+    test_system = cobbler_api.new_system(
+        name = "beta",
+        profile = test_profile.uid
+    )
+    cobbler_api.add_system(test_system)
+    test_interface = cobbler_api.new_network_interface(
+        system_uid=test_system.uid,
+        name="default",
+        ipv4={"address": "192.168.1.1"},
+        ipv6={"address": "2001:db8:0:1::11"},
+        dns={"name": "beta.example.com"},
+    )
+    cobbler_api.add_network_interface(test_interface)
+
+    test_system = cobbler_api.new_system(
+        name = "gamma",
+        profile = test_profile.uid
+    )
+    cobbler_api.add_system(test_system)
+    test_interface = cobbler_api.new_network_interface(
+        system_uid=test_system.uid,
+        name="default",
+        ipv4={"address": "192.168.1.2"},
+        ipv6={"address": "2001:db8:0:1::12"},
+        dns={"name": "gamma.example.com"},
+    )
+    cobbler_api.add_network_interface(test_interface)
+
+    manager = bind.get_manager(cobbler_api)
+
+    # Act
+    manager.write_configs()
+
+    # Assert
+    # TODO: Extend assertions
+    mocker.stopall()
+
+    assert_zone_has(
+        "/var/lib/named/example.com",
+        ["alpha", "IN", "A", "192.168.2.1"],
+        ["alpha", "IN", "AAAA", "2001:db8:0:1::21"],
+        ["beta", "IN", "A", "192.168.1.1"],
+        ["beta", "IN", "AAAA", "2001:db8:0:1::11"],
+        ["gamma", "IN", "A", "192.168.1.2"],
+        ["gamma", "IN", "AAAA", "2001:db8:0:1::12"],
+    )
+    assert_zone_has(
+        "/var/lib/named/192.168",
+        ["1.1", "IN", "PTR", "beta.example.com."],
+        ["2.1", "IN", "PTR", "gamma.example.com."],
+        ["1.2", "IN", "PTR", "alpha.example.com."],
+    )
+    assert_zone_has(
+        "/var/lib/named/2001:0db8:0000:0001",
+        ["1.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "beta.example.com."],
+        ["2.1.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "gamma.example.com."],
+        ["1.2.0.0.0.0.0.0.0.0.0.0.0.0.0.0", "IN", "PTR", "alpha.example.com."],
     )
 
     mock_config_files.open_unknown.assert_not_called()


### PR DESCRIPTION
## Linked Items

Fixes #3988

## Description

Expand the bind test suite to trigger the failure, then fix it.

## Behaviour changes

Old: server exception

New: normal operattion

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
