### PR TITLE
Docs: Specify kernel_options(_post) type

### DIFF
--- a/changelog.d/3212.fixed
+++ b/changelog.d/3212.fixed
@@ -1,0 +1,1 @@
+Docs: Specify type of kernel_options and kernel_options_post

--- a/changelog.d/3847.docs
+++ b/changelog.d/3847.docs
@@ -1,1 +1,0 @@
-Installation guide now lists Cobbler dependencies per distribution family with up-to-date required and optional package names

--- a/changelog.d/3847.fixed
+++ b/changelog.d/3847.fixed
@@ -1,0 +1,1 @@
+Docs: Installation guide now lists Cobbler dependencies per distribution family with up-to-date required and optional package names

--- a/cobbler/items/abstract/bootable_item.py
+++ b/cobbler/items/abstract/bootable_item.py
@@ -127,6 +127,7 @@ else:
 
 
 T = TypeVar("T")
+KernelOptionsValueType = Optional[Union[str, int, float, List[Union[str, int, float]]]]
 
 
 class BootableItem(InheritableItem, ABC):
@@ -149,8 +150,8 @@ class BootableItem(InheritableItem, ABC):
         """
         super().__init__(api, *args, **kwargs)
 
-        self._kernel_options: Union[Dict[Any, Any], str] = {}
-        self._kernel_options_post: Union[Dict[Any, Any], str] = {}
+        self._kernel_options: Union[Dict[str, Any], str] = {}
+        self._kernel_options_post: Union[Dict[str, Any], str] = {}
         self._autoinstall_meta: Union[Dict[Any, Any], str] = {}
         self._template_files: Dict[str, str] = {}
         self._inmemory = True
@@ -423,9 +424,13 @@ class BootableItem(InheritableItem, ABC):
         return value
 
     @InheritableDictProperty
-    def kernel_options(self) -> Dict[Any, Any]:
+    def kernel_options(self) -> Dict[str, KernelOptionsValueType]:
         """
         Kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict.
+
+        The dict must have str keys and the values can be of type str, int or float. If a key is present multiple times
+        a List with a union of type str, int and float may be used. The conversion back to string is performed with the
+        function :func:`~cobbler.utils.dict_to_string`.
 
         .. note:: This property can be set to ``<<inherit>>``.
 
@@ -435,7 +440,7 @@ class BootableItem(InheritableItem, ABC):
         return self._resolve_dict(["kernel_options"])
 
     @kernel_options.setter
-    def kernel_options(self, options: Dict[str, Any]):
+    def kernel_options(self, options: Dict[str, KernelOptionsValueType]):
         """
         Setter for ``kernel_options``.
 
@@ -453,9 +458,10 @@ class BootableItem(InheritableItem, ABC):
             raise TypeError("invalid kernel value") from error
 
     @InheritableDictProperty
-    def kernel_options_post(self) -> Dict[str, Any]:
+    def kernel_options_post(self) -> Dict[str, KernelOptionsValueType]:
         """
-        Post kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict.
+        Post kernel options are a space delimited list, like 'a=b c=d e=f g h i=j' or a dict. Has the same limitations
+        as kernel_options.
 
         .. note:: This property can be set to ``<<inherit>>``.
 
@@ -465,7 +471,9 @@ class BootableItem(InheritableItem, ABC):
         return self._resolve_dict(["kernel_options_post"])
 
     @kernel_options_post.setter
-    def kernel_options_post(self, options: Union[Dict[Any, Any], str]) -> None:
+    def kernel_options_post(
+        self, options: Union[Dict[str, KernelOptionsValueType], str]
+    ) -> None:
         """
         Setter for ``kernel_options_post``.
 

--- a/cobbler/utils/input_converters.py
+++ b/cobbler/utils/input_converters.py
@@ -46,8 +46,8 @@ def input_string_or_list(
 
 
 def input_string_or_dict(
-    options: Union[str, List[Any], Dict[Any, Any]], allow_multiples: bool = True
-) -> Union[str, Dict[Any, Any]]:
+    options: Union[str, List[Any], Dict[str, Any]], allow_multiples: bool = True
+) -> Union[str, Dict[str, Any]]:
     """
     Older Cobbler files stored configurations in a flat way, such that all values for strings. Newer versions of Cobbler
     allow dictionaries. This function is used to allow loading of older value formats so new users of Cobbler aren't
@@ -64,8 +64,8 @@ def input_string_or_dict(
 
 
 def input_string_or_dict_no_inherit(
-    options: Union[str, List[Any], Dict[Any, Any]], allow_multiples: bool = True
-) -> Dict[Any, Any]:
+    options: Union[str, List[Any], Dict[str, Any]], allow_multiples: bool = True
+) -> Dict[str, Any]:
     """
     See :meth:`~cobbler.utils.input_converters.input_string_or_dict`
     """

--- a/docs/installation-guide.rst
+++ b/docs/installation-guide.rst
@@ -44,7 +44,7 @@ lists below document the packages so you can validate a manual or source based
 installation. Package names reflect the native repositories of each platform.
 
 DNF based distributions (Fedora, RHEL, CentOS Stream, Rocky, AlmaLinux)
-----------------------------------------------------------------------
+-----------------------------------------------------------------------
 
 **Required packages**
 


### PR DESCRIPTION
## Linked Items

Fixes #3212

## Description

This PR specifies the type of `kernel_options` and `kernel_options_post` for both type checkers and documentation.

## Behaviour changes

Old: Exact type of `kernel_options` and `kernel_options_post` was unknown.

New: Exact type is now known.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [x] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
