### PR TITLE
Fix ESXi import signatures

### DIFF
--- a/changelog.d/2889.fixed
+++ b/changelog.d/2889.fixed
@@ -1,0 +1,1 @@
+Handle byte-based kernel metadata when detecting the architecture of imported ESXi trees

--- a/cobbler/modules/managers/import_signatures.py
+++ b/cobbler/modules/managers/import_signatures.py
@@ -578,6 +578,8 @@ class _ImportSignatureManager(ManagerModule):
                     re_krn2 = re.compile(self.signature["kernel_arch_regex"])
                     krn_lines = self.get_file_lines(os.path.join(dirname, fname))
                     for line in krn_lines:
+                        if isinstance(line, bytes):
+                            line = line.decode("utf-8", "ignore")
                         match_obj = re_krn2.match(line)
                         if match_obj:
                             for group in match_obj.groups():

--- a/tests/modules/managers/import_signatures_test.py
+++ b/tests/modules/managers/import_signatures_test.py
@@ -2,7 +2,10 @@
 Tests that validate the functionality of the module that is responsible for managing imported distribution trees.
 """
 
+import os
+
 import pytest
+from pytest_mock import MockerFixture
 
 from cobbler.api import CobblerAPI
 from cobbler.modules.managers import import_signatures
@@ -40,3 +43,26 @@ def test_manager_what():
     # Arrange & Act & Assert
     # pylint: disable-next=protected-access
     assert import_signatures._ImportSignatureManager.what() == "import/signatures"  # type: ignore
+
+
+def test_arch_walker_matches_kernel_arch_regex_from_bytes(
+    cobbler_api: CobblerAPI, mocker: MockerFixture
+):
+    # Arrange
+    manager = import_signatures.get_import_manager(cobbler_api)
+    manager.signature = {
+        "kernel_arch": "tools\\.t00",
+        "kernel_arch_regex": "^.*(x86_64).*$",
+        "supported_arches": ["x86_64"],
+    }
+    get_file_lines = mocker.patch.object(
+        manager, "get_file_lines", return_value=[b"architecture=x86_64\n"]
+    )
+    result = {}
+
+    # Act
+    manager.arch_walker(result, "/tmp/esxi", ["tools.t00"])
+
+    # Assert
+    assert result == {"x86_64": 1}
+    get_file_lines.assert_called_once_with(os.path.join("/tmp/esxi", "tools.t00"))


### PR DESCRIPTION
 ## Linked Items

  Fixes #2889

  ## Description

  Decode byte-based kernel metadata before applying `kernel_arch_regex` during import.

  This fixes ESXi imports that fail while detecting the architecture from `tools.t00`.

  ## Behaviour changes

  Old: Importing ESXi trees could fail with `TypeError: cannot use a string pattern on a bytes-like object`.

  New: Byte-based kernel metadata is decoded before regex matching, so ESXi architecture detection works during import.

  ## Category

  This is related to a:

  - [x] Bugfix
  - [ ] Feature
  - [ ] Packaging
  - [ ] Docs
  - [ ] Code Quality
  - [ ] Refactoring
  - [ ] Miscellaneous

  ## Tests

  - [x] Unit-Tests were created
  - [ ] System-Tests were created
  - [ ] Code is already covered by Unit-Tests
  - [ ] Code is already covered by System-Tests
  - [ ] No tests required
