### PR TITLE
openSUSE Agama Support for 3.3.x

### DIFF
--- a/autoinstall_scripts/agama_early_default
+++ b/autoinstall_scripts/agama_early_default
@@ -1,0 +1,2 @@
+#!/bin/sh
+$SNIPPET('autoinstall_start')

--- a/autoinstall_scripts/agama_init_default
+++ b/autoinstall_scripts/agama_init_default
@@ -1,0 +1,2 @@
+#!/bin/bash
+$SNIPPET('first_boot')

--- a/autoinstall_scripts/agama_late_default
+++ b/autoinstall_scripts/agama_late_default
@@ -1,0 +1,3 @@
+#!/bin/bash
+$SNIPPET('autoinstall_done')
+systemctl enable sshd.service

--- a/autoinstall_snippets/agama_hostname
+++ b/autoinstall_snippets/agama_hostname
@@ -1,0 +1,15 @@
+  "hostname": {
+#if $getVar("system_name","") != ""
+    #if $hostname != ""
+    "static": "$hostname"
+    #else
+    #set $myhostname = $getVar('name','').replace("_","-")
+    "static": "$myhostname"
+    #end if
+#else
+## profile based install so just provide one interface for starters
+#set $myhostname = $getVar('hostname',$getVar('name','cobbler')).replace("_","-")
+    "static": "$myhostname"
+#end if
+  },
+

--- a/autoinstall_snippets/agama_networking
+++ b/autoinstall_snippets/agama_networking
@@ -1,0 +1,111 @@
+  "network": {
+    "connections": [
+#if $getVar("system_name","") != ""
+  #import re
+  #set $ikeys = $interfaces.keys()
+  #set $ifaces = 0
+  #for $iface in $ikeys
+    #set $idata                = $interfaces[$iface]
+    #set $mac                  = $idata.get("mac_address", "").lower()
+    #set $static               = $idata.get("static", "")
+    #set $ip                   = $idata.get("ip_address", "")
+    #set $netmask              = $idata.get("netmask", "")
+    #set $static_routes        = $idata.get("static_routes", "")
+    #set $iface_type           = $idata.get("interface_type", "").lower()
+    #set $iface_master         = $idata.get("interface_master", "")
+    #set $bonding_opts         = $idata.get("bonding_opts", "").lower()
+    #set $ipv6_address         = $idata.get("ipv6_address", "")
+    #set $ipv6_secondaries     = $idata.get("ipv6_secondaries", "")
+    #set $ipv6_mtu             = $idata.get("ipv6_mtu", "")
+    #set $ipv6_default_gateway = $idata.get("ipv6_default_gateway", "")
+    #set $ipv6_static_routes   = $idata.get("ipv6_static_routes", "")
+    ## start of interface section
+    #if $iface_type in ("bmc","BMC")
+      ##Cobbler only sets DHCP reservations for BMC interfaces
+      #continue
+    #end if
+    #if $iface_type in ("","na")
+      #if $ifaces > 0
+      },
+      {
+      #else
+      {
+      #end if
+      #set $ifaces += 1
+      #if $static
+        #if $ip != ""
+        "method4": "manual",
+          #if $netmask != ""
+            #set $mask = sum([bin(int(x)).count('1') for x in $netmask.split('.')])
+          #else
+            #set $mask = 24
+          #end if
+        "addresses": ["$ip/$mask"],
+          #if $len($ikeys) == 1
+            #if $gateway != ""
+        "gateway4": "$gateway",
+            #elif $idata.get("if_gateway") != ""
+        "gateway4": "$idata.get("if_gateway")"
+            #end if
+          #elif $idata.get("if_gateway") != ""
+        "gateway4": "$idata.get("if_gateway")"
+          #end if
+        #else
+        "method4": "auto",
+        #end if
+      #else
+        "method4": "auto",
+      #end if
+      #if $mac != ""
+        "macAddress": "$mac",
+      #elif $iface not in ("default","")
+        "interface": "$iface",
+      #end if
+      #if $name_servers and $name_servers[0] != ""
+        #set $servers = 0
+        #for $ns in $name_servers
+          #if $servers > 0
+            #set $dns = $dns + ', "' + $ns + '"'
+          #else
+            #set $dns = '"' + $ns + '"'
+          #end if
+          #set $servers += 1
+        #end for
+        "nameservers": [$dns],
+      #end if
+      #if $getVar("name_servers_search",[]) != []
+        #set $domains = 0
+        #for $sd in $name_servers_search
+          #if $domains > 0
+            #set $dns = $dns + ', "' + $sd + '"'
+          #else
+            #set $dns = '"' + $sd + '"'
+          #end if
+          #set $domains += 1
+        #end for
+        "dnsSearchlist": [$dns]
+      #end if
+        "id": "$iface"
+    #elif $iface_type in ("bond","bridge","bond_slave","bridge_slave","bonded_bridge_slave")
+      #if $ifaces > 0
+      },
+      {
+      #else
+      {
+      #end if
+      #set $ifaces += 1
+##$SNIPPET('agama_networking_bridge')
+##$SNIPPET('agama_networking_bond')
+    #end if
+  #end for
+      }
+#else
+## profile based install so just provide one interface for starters
+      {
+        "id": "default",
+        "method4": "auto"
+      }
+#end if
+    ]
+  },
+

--- a/autoinstall_snippets/first_boot
+++ b/autoinstall_snippets/first_boot
@@ -1,0 +1,31 @@
+## Figure out if we're automating OS installation for a system or a profile
+#set system_name = $getVar('system_name','')
+#set profile_name = $getVar('profile_name','')
+#if $system_name != ''
+    #set object_type = 'system'
+    #set object_name = $system_name
+#else if $profile_name != ''
+    #set object_type = 'profile'
+    #set object_name = $profile_name
+#else
+    #set object_type = ''
+    #set object_name = ''
+#end if
+#set breed = $getVar('breed','')
+#set os_version = $getVar('os_version','')
+#set srv = $getVar('http_server','')
+#set run_install_triggers = $getVar('run_install_triggers','')
+#set runpost = ""
+#if $object_type != ''
+    ## RUN POST TRIGGER
+    #if $run_install_triggers
+        #if $breed == 'redhat'
+            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/first_boot/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
+        #else if $breed == 'vmware' and $os_version == 'esx4'
+            #set runpost = "\ncurl \"http://%s/cblr/svc/op/trig/mode/first_boot/%s/%s\" -o /dev/null" % (srv, object_type, object_name)
+        #else
+            #set runpost = "\nwget \"http://%s/cblr/svc/op/trig/mode/first_boot/%s/%s\" -O /dev/null" % (srv, object_type, object_name)
+        #end if
+    #end if
+#end if
+#echo $runpost

--- a/autoinstall_templates/sample_agama.json
+++ b/autoinstall_templates/sample_agama.json
@@ -1,0 +1,75 @@
+{
+  "product": {
+    "id": "openSUSE_Leap"
+  },
+  "localization": {
+    "language": "en_US.UTF-8",
+    "keyboard": "us",
+    "timezone": "America/New_York"
+  },
+
+$SNIPPET('agama_hostname')
+$SNIPPET('agama_networking')
+
+  "user": {
+    "fullName": "susadmin",
+    "userName": "susadmin",
+    "hashedPassword": true,
+    "password": "$default_password_crypted"
+  },
+
+  "software": {
+    "patterns": ["basesystem"],
+    "packages": ["agama-scripts", "sudo"],
+    "onlyRequired": false
+  },
+
+  "bootloader": {
+#if $kernel_options_post != ""
+    "extraKernelParams": "$kernel_options_post",
+#end if
+    "timeout": 3
+  },
+
+  "storage": {
+    "drives": [
+      {
+        "partitions": [
+          {
+            "generate": {
+              "partitions": "default"
+            }
+          }
+        ]
+      }
+    ]
+  },
+
+## Figure out if we're automating OS installation for a system or a profile
+#if $getVar('system_name','') != ''
+#set $what = "system"
+#else
+#set $what = "profile"
+#end if
+  "scripts": {
+    "pre": [
+      {
+        "name": "pre-install",
+        "url": "http://$http_server/cblr/svc/op/script/$what/$name/?script=agama_early_default"
+      }
+    ],
+    "post": [
+      {
+        "name": "post-install",
+        "chroot": true,
+        "url": "http://$http_server/cblr/svc/op/script/$what/$name/?script=agama_late_default"
+      }
+    ],
+    "init": [
+      {
+        "name": "first-boot",
+        "url": "http://$http_server/cblr/svc/op/script/$what/$name/?script=agama_init_default"
+      }
+    ]
+  }
+}

--- a/changelog.d/3419.fixed
+++ b/changelog.d/3419.fixed
@@ -1,0 +1,1 @@
+support for import and manage of openSUSE Leap 16 and new Agama installer

--- a/changelog.d/3826.fixed
+++ b/changelog.d/3826.fixed
@@ -1,0 +1,1 @@
+Basic support for Python 3.13

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -23,7 +23,10 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
 import logging
 import os
 import os.path
-import pipes
+try:
+    from shlex import quote as shell_quote
+except ImportError:
+    from pipes import quote as shell_quote
 import stat
 import shutil
 from typing import Optional, Union
@@ -272,7 +275,7 @@ class RepoSync:
             blended = utils.blender(self.api, False, repo)
             flags = blended.get("createrepo_flags", "(ERROR: FLAGS)")
             try:
-                cmd = "createrepo %s %s %s" % (" ".join(mdoptions), flags, pipes.quote(dirname))
+                cmd = "createrepo %s %s %s" % (" ".join(mdoptions), flags, shell_quote(dirname))
                 utils.subprocess_call(cmd)
             except:
                 utils.log_exc()
@@ -302,7 +305,7 @@ class RepoSync:
         dest_path = os.path.join(self.settings.webdir, "repo_mirror", repo.name)
 
         # FIXME: wrapper for subprocess that logs to logger
-        cmd = ["wget", "-N", "-np", "-r", "-l", "inf", "-nd", "-P", pipes.quote(dest_path), pipes.quote(repo.mirror)]
+        cmd = ["wget", "-N", "-np", "-r", "-l", "inf", "-nd", "-P", shell_quote(dest_path), shell_quote(repo.mirror)]
         rc = utils.subprocess_call(cmd)
 
         if rc != 0:
@@ -348,7 +351,7 @@ class RepoSync:
             flags = self.settings.reposync_rsync_flags
 
         cmd = "rsync %s --delete-after %s --delete --exclude-from=/etc/cobbler/rsync.exclude %s %s" \
-              % (flags, spacer, pipes.quote(repo.mirror), pipes.quote(dest_path))
+              % (flags, spacer, shell_quote(repo.mirror), shell_quote(dest_path))
         rc = utils.subprocess_call(cmd)
 
         if rc != 0:
@@ -438,8 +441,8 @@ class RepoSync:
         rest = repo.mirror[6:]  # everything after rhn://
         cmd = "%s %s --repo=%s -p %s" % (cmd,
                                          self.rflags,
-                                         pipes.quote(rest),
-                                         pipes.quote(repos_path))
+                                         shell_quote(rest),
+                                         shell_quote(repos_path))
         if repo.name != rest:
             args = {"name": repo.name, "rest": rest}
             raise CX("ERROR: repository %(name)s needs to be renamed %(rest)s as the name of the cobbler repository "
@@ -545,8 +548,8 @@ class RepoSync:
         if not has_rpm_list:
             # If we have not requested only certain RPMs, use reposync
             cmd = "%s %s --config=%s --repoid=%s -p %s" \
-                  % (cmd, self.rflags, temp_file, pipes.quote(repo.name),
-                     pipes.quote(repos_path))
+                  % (cmd, self.rflags, temp_file, shell_quote(repo.name),
+                     shell_quote(repos_path))
             if arch != "none":
                 cmd = "%s -a %s" % (cmd, arch)
 
@@ -563,7 +566,7 @@ class RepoSync:
             extra_flags = self.settings.yumdownloader_flags
             cmd = "/usr/bin/dnf download"
             cmd = "%s %s %s --disablerepo=* --enablerepo=%s -c %s --destdir=%s %s" \
-                  % (cmd, extra_flags, use_source, pipes.quote(repo.name), temp_file, pipes.quote(dest_path),
+                  % (cmd, extra_flags, use_source, shell_quote(repo.name), temp_file, shell_quote(dest_path),
                      " ".join(repo.rpm_list))
 
         # Now regardless of whether we're doing yumdownloader or reposync or whether the repo was http://, ftp://, or
@@ -670,8 +673,8 @@ class RepoSync:
             components = ",".join(repo.apt_components)
 
             mirror_data = "--method=%s --host=%s --root=%s --dist=%s --section=%s" \
-                          % (pipes.quote(method), pipes.quote(host), pipes.quote(mirror), pipes.quote(dists),
-                             pipes.quote(components))
+                          % (shell_quote(method), shell_quote(host), shell_quote(mirror), shell_quote(dists),
+                             shell_quote(components))
 
             rflags = "--nocleanup"
             for x in repo.yumopts:
@@ -679,7 +682,7 @@ class RepoSync:
                     rflags += " %s=%s" % (x, repo.yumopts[x])
                 else:
                     rflags += " %s" % x
-            cmd = "%s %s %s %s" % (mirror_program, rflags, mirror_data, pipes.quote(dest_path))
+            cmd = "%s %s %s %s" % (mirror_program, rflags, mirror_data, shell_quote(dest_path))
             if repo.arch == RepoArchs.SRC:
                 cmd = "%s --source" % cmd
             else:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -33,6 +33,47 @@ from cobbler.enums import Archs
 from cobbler.validate import validate_autoinstall_script_name
 
 
+suse_yast = [
+    "opensuse11.2",
+    "opensuse11.3",
+    "opensuse11.4",
+    "opensuse12.1",
+    "opensuse12.2",
+    "opensuse12.3",
+    "opensuse13.1",
+    "opensuse13.2",
+    "opensuse15.0",
+    "opensuse15.1",
+    "opensuse15.2",
+    "opensuse15.3",
+    "opensuse15.4",
+    "opensuse15.5",
+    "opensuse15.6",
+    "leapmicro5.5",
+    "sles10generic",
+    "sles11",
+    "sles11sp1",
+    "sles11sp2",
+    "sles11sp3",
+    "sles11sp4",
+    "sles11generic",
+    "sles12",
+    "sles12generic",
+    "sles12sp1",
+    "sles12sp2",
+    "sles12sp3",
+    "sles12sp4",
+    "sles12sp5",
+    "sles15",
+    "sles15generic",
+    "sles15sp1",
+    "sles15sp2",
+    "sles15sp3",
+    "sles15sp4",
+    "sles15sp5",
+    "sles15sp6"
+]
+
 class TFTPGen:
     """
     Generate files provided by TFTP server
@@ -920,6 +961,8 @@ class TFTPGen:
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')
+            elif distro.breed == "suse" and distro.os_version not in suse_yast:
+                append_line = "%s inst.auto=%s" % (append_line, autoinstall_path)
             elif distro.breed == "suse":
                 append_line = "%s autoyast=%s" % (append_line, autoinstall_path)
                 if management_mac and distro.arch not in (enums.Archs.S390, enums.Archs.S390X):

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -962,12 +962,12 @@ class TFTPGen:
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')
-            elif distro.breed == "suse" and distro.os_version not in suse_yast:
-                append_line = "%s inst.auto=%s" % (append_line, autoinstall_path)
-            elif distro.breed == "suse":
+            elif distro.breed == "suse" and distro.os_version in suse_yast:
                 append_line = "%s autoyast=%s" % (append_line, autoinstall_path)
                 if management_mac and distro.arch not in (enums.Archs.S390, enums.Archs.S390X):
                     append_line += " netdevice=%s" % management_mac
+            elif distro.breed == "suse":
+                append_line = "%s inst.auto=%s" % (append_line, autoinstall_path)
             elif distro.breed == "debian" or distro.breed == "ubuntu":
                 append_line = "%s auto-install/enable=true priority=critical netcfg/choose_interface=auto url=%s" \
                               % (append_line, autoinstall_path)

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -33,6 +33,48 @@ from cobbler.enums import Archs
 from cobbler.validate import validate_autoinstall_script_name
 
 
+suse_yast = [
+    "opensuse11.2",
+    "opensuse11.3",
+    "opensuse11.4",
+    "opensuse12.1",
+    "opensuse12.2",
+    "opensuse12.3",
+    "opensuse13.1",
+    "opensuse13.2",
+    "opensuse15.0",
+    "opensuse15.1",
+    "opensuse15.2",
+    "opensuse15.3",
+    "opensuse15.4",
+    "opensuse15.5",
+    "opensuse15.6",
+    "leapmicro5.5",
+    "sles10generic",
+    "sles11",
+    "sles11sp1",
+    "sles11sp2",
+    "sles11sp3",
+    "sles11sp4",
+    "sles11generic",
+    "sles12",
+    "sles12generic",
+    "sles12sp1",
+    "sles12sp2",
+    "sles12sp3",
+    "sles12sp4",
+    "sles12sp5",
+    "sles15",
+    "sles15generic",
+    "sles15sp1",
+    "sles15sp2",
+    "sles15sp3",
+    "sles15sp4",
+    "sles15sp5",
+    "sles15sp6"
+]
+
+
 class TFTPGen:
     """
     Generate files provided by TFTP server
@@ -920,6 +962,8 @@ class TFTPGen:
                 ipxe = blended["enable_ipxe"]
                 if ipxe:
                     append_line = append_line.replace('ksdevice=bootif', 'ksdevice=${net0/mac}')
+            elif distro.breed == "suse" and distro.os_version not in suse_yast:
+                append_line = "%s inst.auto=%s" % (append_line, autoinstall_path)
             elif distro.breed == "suse":
                 append_line = "%s autoyast=%s" % (append_line, autoinstall_path)
                 if management_mac and distro.arch not in (enums.Archs.S390, enums.Archs.S390X):

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -1962,6 +1962,30 @@
         "kernel_options_post": "",
         "boot_files": []
       },
+      "opensuse16.0": {
+        "signatures": [
+          ""
+        ],
+        "version_file": "\\.treeinfo",
+        "version_file_regex": "^name = openSUSE Leap 16\\.0$",
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "aarch64",
+          "x86_64",
+          "ppc64le"
+        ],
+        "supported_repo_breeds": [
+          "yum"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd(.*)",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample_agama.json",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
       "leapmicro5.3": {
         "signatures": [
           ""

--- a/config/cobbler/distro_signatures.json
+++ b/config/cobbler/distro_signatures.json
@@ -1986,6 +1986,30 @@
         "kernel_options_post": "",
         "boot_files": []
       },
+      "opensuse16.1": {
+        "signatures": [
+          ""
+        ],
+        "version_file": "\\.treeinfo",
+        "version_file_regex": "^name = openSUSE Leap 16\\.1$",
+        "kernel_arch": "kernel-(.*)\\.rpm",
+        "kernel_arch_regex": null,
+        "supported_arches": [
+          "aarch64",
+          "x86_64",
+          "ppc64le"
+        ],
+        "supported_repo_breeds": [
+          "yum"
+        ],
+        "kernel_file": "(linux|vmlinuz(.*))",
+        "initrd_file": "initrd(.*)",
+        "isolinux_ok": false,
+        "default_autoinstall": "sample_agama.json",
+        "kernel_options": "",
+        "kernel_options_post": "",
+        "boot_files": []
+      },
       "leapmicro5.3": {
         "signatures": [
           ""

--- a/docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
+++ b/docker/rpms/opensuse_leap/openSUSE_Leap15.dockerfile
@@ -6,8 +6,7 @@ FROM registry.opensuse.org/opensuse/leap:15.6
 ENV container docker
 ENV DISTRO SUSE
 
-# Runtime & dev dependencies
-RUN zypper install -y          \
+RUN zypper install --no-recommends -y \
     acl                        \
     apache2                    \
     apache2-devel              \
@@ -29,7 +28,6 @@ RUN zypper install -y          \
     python3                    \
     python3-Sphinx             \
     python3-Cheetah3           \
-    python3-Sphinx             \
     python3-dnspython          \
     python3-coverage           \
     python3-devel              \
@@ -46,34 +44,22 @@ RUN zypper install -y          \
     python3-wheel              \
     rpm-build                  \
     which                      \
-    dosfstools
-
-# Add bootloader packages
-RUN zypper install --no-recommends -y \
-    syslinux \
-    shim \
-    ipxe-bootimgs \
-    grub2 \
-    grub2-i386-efi \
-    grub2-x86_64-efi \
-    grub2-arm64-efi
-
-# Required for dhcpd
-RUN zypper install --no-recommends -y \
-    system-user-nobody                \
-    sysvinit-tools
-
-# Required for ldap tests
-RUN zypper install --no-recommends -y \
-    openldap2                         \
-    openldap2-client                  \
-    hostname
-
-# Dependencies for system-tests
-RUN zypper install --no-recommends -y \
-    dhcp-server                       \
-    iproute2                          \
-    qemu-kvm                          \
+    dosfstools                 \
+    syslinux                   \
+    shim                       \
+    ipxe-bootimgs              \
+    grub2                      \
+    grub2-i386-efi             \
+    grub2-x86_64-efi           \
+    grub2-arm64-efi            \
+    system-user-nobody         \
+    sysvinit-tools             \
+    openldap2                  \
+    openldap2-client           \
+    hostname                   \
+    dhcp-server                \
+    iproute2                   \
+    qemu-kvm                   \
     time
 
 COPY ./docker/rpms/opensuse_leap/supervisord/supervisord.conf /etc/supervisord.conf

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -76,6 +76,11 @@ RUN zypper install --no-recommends -y \
     qemu-kvm                          \
     time
 
+# apache2 only declares /srv/www/htdocs (and other runtime dirs) via tmpfiles.d, it no longer ships
+# them as literal package payload. Nothing in this image runs systemd-tmpfiles at boot, so httpd
+# would otherwise fail to start with "DocumentRoot '/srv/www/htdocs' is not a directory".
+RUN systemd-tmpfiles --create
+
 COPY ./docker/rpms/opensuse_leap/supervisord/supervisord.conf /etc/supervisord.conf
 COPY ./docker/rpms/opensuse_leap/supervisord/conf.d /etc/supervisord/conf.d
 

--- a/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
+++ b/docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
@@ -6,8 +6,7 @@ FROM registry.opensuse.org/opensuse/tumbleweed:latest
 ENV container docker
 ENV DISTRO SUSE
 
-# Runtime & dev dependencies
-RUN zypper install -y          \
+RUN zypper install --no-recommends -y \
     acl                        \
     apache2                    \
     apache2-devel              \
@@ -30,7 +29,6 @@ RUN zypper install -y          \
     python3                    \
     python3-Sphinx             \
     python3-Cheetah3           \
-    python3-Sphinx             \
     python3-dnspython          \
     python3-coverage           \
     python3-devel              \
@@ -47,33 +45,21 @@ RUN zypper install -y          \
     python3-wheel              \
     rpm-build                  \
     which                      \
-    dosfstools
-
-# Add bootloader packages
-RUN zypper install --no-recommends -y \
-    syslinux \
-    shim \
-    ipxe-bootimgs \
-    grub2 \
-    grub2-i386-efi \
-    grub2-x86_64-efi
-
-# Required for dhcpd
-RUN zypper install --no-recommends -y \
-    system-user-nobody                \
-    sysvinit-tools
-
-# Required for ldap tests
-RUN zypper install --no-recommends -y \
-    openldap2                         \
-    openldap2-client                  \
-    hostname
-
-# Dependencies for system-tests
-RUN zypper install --no-recommends -y \
-    dhcp-server                       \
-    iproute2                          \
-    qemu-kvm                          \
+    dosfstools                 \
+    syslinux                   \
+    shim                       \
+    ipxe-bootimgs              \
+    grub2                      \
+    grub2-i386-efi             \
+    grub2-x86_64-efi           \
+    system-user-nobody         \
+    sysvinit-tools             \
+    openldap2                  \
+    openldap2-client           \
+    hostname                   \
+    dhcp-server                \
+    iproute2                   \
+    qemu-kvm                   \
     time
 
 # apache2 only declares /srv/www/htdocs (and other runtime dirs) via tmpfiles.d, it no longer ships

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -216,3 +216,44 @@ def test_write_all_system_files_s390(
     open_mock().write.assert_any_call(
         "foobar1=whatever \nautoyast=http://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx/this-is-a-\nlong-string-that-need-to-be-splitted/zzzzzzzzzzzzzzzzz \nfoobar2=woohooo\n"
     )
+
+
+@pytest.mark.parametrize(
+    "os_version,expected_snippet",
+    [
+        # Versions on the legacy-installer denylist keep the historic "autoyast=" append option.
+        ("sles15generic", "autoyast=http://192.168.1.1/autoinstall"),
+        # Everything else (including future/unlisted versions) defaults to Agama's "inst.auto=".
+        ("opensuse16.0", "inst.auto=http://192.168.1.1/autoinstall"),
+    ],
+)
+def test_build_kernel_options_suse_installer_selection(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    os_version: str,
+    expected_snippet: str,
+):
+    """
+    Test that asserts that SUSE distro versions on the legacy-installer denylist get the AutoYaST
+    "autoyast=" append line, while unlisted (e.g. future) SUSE versions default to Agama's "inst.auto=".
+    """
+    # Arrange
+    test_distro = create_distro()
+    test_distro.breed = "suse"
+    test_distro.os_version = os_version
+    test_profile = create_profile(test_distro.name)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    result = test_gen.build_kernel_options(
+        None,
+        test_profile,
+        test_distro,
+        None,
+        test_distro.arch,
+        "http://192.168.1.1/autoinstall",
+    )
+
+    # Assert
+    assert expected_snippet in result


### PR DESCRIPTION
## Linked Items

Fixes #3419 & #3826

## Description

Cobbler failed to startup on my openSUSE Leap server after upgrading to Leap 16.1, due to the new Python 3.13 version. The only fatal error starting up was due to missing module/function `pipes.quote()` which has a drop-in replacement `shlex.quote()` since Python [3.3](https://docs.python.org/3.3/library/shlex.html) so should be safe to favor `shlex` over `pipes` which I have been testing with Cobbler 3.3.7 deploying Debian Trixie hosts using the `debmirror` package from Cobbler's Leap 15.6 [repo](https://download.opensuse.org/repositories/systemsmanagement:/cobbler:/release33/15.6/systemsmanagement:cobbler:release33.repo) as well as directly installing `perl-Net-INET6Glue` from the openSUSE Tumbleweed .rpm [release](https://software.opensuse.org/download/package?package=perl-Net-INET6Glue&project=openSUSE%3AFactory).

Additionally, I've updated distro_signatures.json, templates, snippets, scripts, and tftpgen.py to support the new Agama installer/auto-installer included with Leap/SLES 16 as opposed to the previous autoyast method, with some caveats like lacking support for bridged/bonded NICs, VLAN assignment, and storage configuration out-of-the-box.

## Behaviour changes

Old: installing Cobbler on a host server with Python3.13 (openSUSE Leap 16's default) fails to start `cobblerd` due to unrecognized Python module/function `pipes.quote()`. Additionally, unable to import and manage openSUSE Leap 16+ distributions.

New: Cobbler is at least able to start with Python3.13 runtime using `shlex.quote()` instead of `pipes.quote()` and I was able to successfully test the only file effected `reposync.py` by mirroring the latest Debian Trixie mirror using `debmirror` and `cobbler reposync` command without issue. Additionally, Cobbler is now able to import openSUSE Leap 16+ distributions and properly generate a templated Agama unattended install profile as well as kernel boot parameters for interactive or automatic PXE boot+install.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 