### PR TITLE
Allow trailing dots on name_servers_search

### DIFF
--- a/changelog.d/2290.fixed
+++ b/changelog.d/2290.fixed
@@ -1,0 +1,1 @@
+Allow trailing dots for name_server_search attributes on Profile and Systems

--- a/cobbler/validate.py
+++ b/cobbler/validate.py
@@ -34,6 +34,10 @@ RE_HOSTNAME = re.compile(
     r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])"
     r"(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*$"
 )
+RE_HOSTNAME_WITH_DOT = re.compile(
+    r"^([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])"
+    r"(\.([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]{0,61}[a-zA-Z0-9]))*\.?$"
+)
 RE_URL_GRUB = re.compile(r"^\((?P<protocol>http|tftp),(?P<server>.*)\)/(?P<path>.*)$")
 RE_URL = re.compile(
     r"^[a-zA-Z\d-]{,63}(\.[a-zA-Z\d-]{,63})*$"
@@ -50,11 +54,12 @@ AUTOINSTALL_REPO_BLACKLIST = ["enabled", "gpgcheck", "gpgkey"]
 # FIXME: Allow the <<inherit>> magic string to be parsed correctly.
 
 
-def hostname(dnsname: str) -> str:
+def hostname(dnsname: str, allow_trailing_dot: bool = False) -> str:
     """
     Validate the DNS name.
 
     :param dnsname: Hostname or FQDN
+    :param allow_trailing_dot: If True, allows an optional trailing dot for absolute FQDNs
     :returns: Hostname or FQDN
     :raises TypeError: If the Hostname/FQDN is not a string or in an invalid format.
     """
@@ -66,7 +71,8 @@ def hostname(dnsname: str) -> str:
         # hostname is not required
         return dnsname
 
-    if not RE_HOSTNAME.match(dnsname):
+    pattern = RE_HOSTNAME_WITH_DOT if allow_trailing_dot else RE_HOSTNAME
+    if not pattern.match(dnsname):
         raise ValueError(f"Invalid hostname format ({dnsname})")
 
     return dnsname
@@ -219,6 +225,9 @@ def name_servers_search(
     """
     Validate nameservers search domains.
 
+    Allows trailing dots to specify absolute FQDNs that should not have additional
+    search domains appended by the resolver.
+
     :param search: One or more search domains to validate.
     :param for_item: enable/disable special handling for Item objects
     :return: The list of valid nameservers.
@@ -236,7 +245,7 @@ def name_servers_search(
 
     if isinstance(search, list):  # type: ignore
         for nameserver in search:
-            hostname(nameserver)
+            hostname(nameserver, allow_trailing_dot=True)
     else:
         raise TypeError(f'Invalid input type "{type(search)}", expected str or list')
 

--- a/tests/validate_test.py
+++ b/tests/validate_test.py
@@ -339,3 +339,105 @@ def test_validate_uuid():
 
     # Arrange
     assert result is expected_result
+
+
+@pytest.mark.parametrize(
+    "input_dnsname,allow_trailing,expected_result,expected_exception",
+    [
+        ("", False, "", does_not_raise()),
+        ("host", False, "host", does_not_raise()),
+        ("host.cobbler.org", False, "host.cobbler.org", does_not_raise()),
+        (
+            "host.cobbler.org.",
+            False,
+            "",
+            pytest.raises(ValueError),
+        ),  # Trailing dot rejected
+        ("example..", False, "", pytest.raises(ValueError)),  # Double dot
+        (".example", False, "", pytest.raises(ValueError)),  # Leading dot
+        ("host-name", False, "host-name", does_not_raise()),  # Hyphens OK
+        (0, False, "", pytest.raises(TypeError)),  # Type check
+    ],
+)
+def test_hostname_trailing_dot_variants(
+    input_dnsname: Any,
+    allow_trailing: bool,
+    expected_result: str,
+    expected_exception: Any,
+):
+    """
+    Test hostname validation with default behavior (no trailing dots allowed).
+    """
+    # Arrange & Act
+    with expected_exception:
+        result = validate.hostname(input_dnsname, allow_trailing_dot=allow_trailing)
+        # Assert
+        assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_dnsname,expected_result,expected_exception",
+    [
+        ("host.cobbler.org.", "host.cobbler.org.", does_not_raise()),
+        ("example.com.", "example.com.", does_not_raise()),
+        ("sub.example.com.", "sub.example.com.", does_not_raise()),
+        ("example.com", "example.com", does_not_raise()),  # Still optional
+        (
+            "localhost.",
+            "localhost.",
+            does_not_raise(),
+        ),  # Single label with trailing dot
+        ("example..", "", pytest.raises(ValueError)),  # Double dot still fails
+        (".example", "", pytest.raises(ValueError)),  # Leading dot still fails
+        (".", "", pytest.raises(ValueError)),  # Just a dot is invalid
+    ],
+)
+def test_hostname_allow_trailing_dot(
+    input_dnsname: Any,
+    expected_result: str,
+    expected_exception: Any,
+):
+    """
+    Test hostname validation with trailing dots allowed.
+    """
+    # Arrange & Act
+    with expected_exception:
+        result = validate.hostname(input_dnsname, allow_trailing_dot=True)
+        # Assert
+        assert result == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_search,expected_result,expected_exception",
+    [
+        ([], [], does_not_raise()),
+        (["example.com"], ["example.com"], does_not_raise()),
+        (["example.com."], ["example.com."], does_not_raise()),  # Trailing dot
+        (
+            ["example.com", "internal.local."],
+            ["example.com", "internal.local."],
+            does_not_raise(),
+        ),  # Mixed
+        (
+            "example.com example.org.",
+            ["example.com", "example.org."],
+            does_not_raise(),
+        ),  # String input
+        (["sub.domain.example.com."], ["sub.domain.example.com."], does_not_raise()),
+        (["example.."], [], pytest.raises(ValueError)),  # Malformed
+        ([".example"], [], pytest.raises(ValueError)),  # Leading dot
+    ],
+)
+def test_name_servers_search_trailing_dot(
+    input_search: Any,
+    expected_result: Any,
+    expected_exception: Any,
+):
+    """
+    Test name_servers_search validation with trailing dots allowed.
+    """
+    # Arrange & Act
+    with expected_exception:
+        result = validate.name_servers_search(input_search, for_item=False)
+        # Assert
+        assert result == expected_result


### PR DESCRIPTION
## Linked Items

Fixes #2290

## Description

Fix an issue where the Profile and System attribute `name_servers_search` refused to accept absolute DNS names that contain a dot on their closing TLD suffix.

## Behaviour changes

Old: `name_servers_search` rejected valid configurations.

New: `name_servers_search` is now able to accept absolute DNS names.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
