### PR TITLE
Add "no-sync" flags to XML-RPC API

### DIFF
--- a/changelog.d/3996.added
+++ b/changelog.d/3996.added
@@ -1,0 +1,1 @@
+Added "with_triggers" and "with_sync" parameters to the XML-RPC "save_<item>" calls

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3148,16 +3148,24 @@ class CobblerXMLRPCInterface:
         return True
 
     def save_item(
-        self, what: str, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        what: str,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param what: The type of object which shall be saved. This corresponds to the collections.
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
         self._log(f"save_item({what})", object_id=object_id, token=token)
@@ -3168,156 +3176,328 @@ class CobblerXMLRPCInterface:
             # the object will be saved in commit_transaction()
             return True
         if editmode == "new":
-            self.api.add_item(what, obj, check_for_duplicate_names=True)
+            self.api.add_item(
+                what,
+                obj,
+                check_for_duplicate_names=True,
+                with_triggers=with_triggers,
+                with_sync=with_sync,
+            )
         else:
-            self.api.add_item(what, obj)
+            self.api.add_item(
+                what, obj, with_triggers=with_triggers, with_sync=with_sync
+            )
         if object_id in self.unsaved_items:
             del self.unsaved_items[object_id]
         return True
 
-    def save_distro(self, object_id: str, token: str, editmode: str = "bypass") -> bool:
+    def save_distro(
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
+    ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("distro", object_id, token, editmode=editmode)
+        return self.save_item(
+            "distro",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def save_profile(
-        self, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("profile", object_id, token, editmode=editmode)
+        return self.save_item(
+            "profile",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
-    def save_system(self, object_id: str, token: str, editmode: str = "bypass") -> bool:
+    def save_system(
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
+    ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("system", object_id, token, editmode=editmode)
+        return self.save_item(
+            "system",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
-    def save_image(self, object_id: str, token: str, editmode: str = "bypass") -> bool:
+    def save_image(
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
+    ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("image", object_id, token, editmode=editmode)
+        return self.save_item(
+            "image",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
-    def save_repo(self, object_id: str, token: str, editmode: str = "bypass") -> bool:
+    def save_repo(
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
+    ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("repo", object_id, token, editmode=editmode)
+        return self.save_item(
+            "repo",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
-    def save_menu(self, object_id: str, token: str, editmode: str = "bypass") -> bool:
+    def save_menu(
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
+    ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("menu", object_id, token, editmode=editmode)
+        return self.save_item(
+            "menu",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def save_network_interface(
-        self, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("network_interface", object_id, token, editmode=editmode)
+        return self.save_item(
+            "network_interface",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def save_template(
-        self, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("template", object_id, token, editmode=editmode)
+        return self.save_item(
+            "template",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def save_distro_group(
-        self, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("distro_group", object_id, token, editmode=editmode)
+        return self.save_item(
+            "distro_group",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def save_profile_group(
-        self, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("profile_group", object_id, token, editmode=editmode)
+        return self.save_item(
+            "profile_group",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def save_system_group(
-        self, object_id: str, token: str, editmode: str = "bypass"
+        self,
+        object_id: str,
+        with_triggers: bool = True,
+        with_sync: bool = True,
+        editmode: str = "bypass",
+        token: str = "",
     ) -> bool:
         """
         Saves a newly created or modified object to disk. Calling save is required for any changes to persist.
 
         :param object_id: The id of the object to save.
-        :param token: The API-token obtained via the login() method.
+        :param with_triggers: If triggers should be run during save. Set to False to suppress per-save triggers.
+        :param with_sync: If a Cobbler sync should be executed after save. Set to False to suppress per-save syncs.
         :param editmode: The mode which shall be used to persist the changes. Currently "new" and "bypass" are
                          supported.
+        :param token: The API-token obtained via the login() method.
         :return: True if the action succeeded.
         """
-        return self.save_item("system_group", object_id, token, editmode=editmode)
+        return self.save_item(
+            "system_group",
+            object_id,
+            with_triggers=with_triggers,
+            with_sync=with_sync,
+            editmode=editmode,
+            token=token,
+        )
 
     def is_autoinstall_in_use(
         self, ai: str, token: Optional[str] = None, **rest: Any

--- a/contrib/api-examples/bootstrap.py
+++ b/contrib/api-examples/bootstrap.py
@@ -120,7 +120,7 @@ def cobbler_system_create(
     sid = cobbler_api.new_system(token)
     cobbler_api.modify_system(sid, ["name"], system_name, token)
     cobbler_api.modify_system(sid, ["profile"], profile_uid, token)
-    cobbler_api.save_system(sid, token, "new")
+    cobbler_api.save_system(sid, True, True, "new", token)
     return sid
 
 
@@ -150,7 +150,7 @@ def cobbler_network_interface_create(
     nid = cobbler_api.new_network_interface(system_uid, token)
     cobbler_api.modify_network_interface(nid, ["name"], interface_name, token)
     cobbler_api.modify_network_interface(nid, ["mac_address"], mac_address, token)
-    cobbler_api.save_network_interface(nid, token, "new")
+    cobbler_api.save_network_interface(nid, True, True, "new", token)
     return nid
 
 
@@ -258,7 +258,7 @@ def main() -> None:
             namespace.key,
             namespace.value,
         )
-        cobbler_api.save_system(namespace.system_uid, token)
+        cobbler_api.save_system(namespace.system_uid, True, True, "bypass", token)
     elif namespace.subparser_name == "create_network_interface":
         cobbler_network_interface_create(
             cobbler_api,
@@ -275,7 +275,9 @@ def main() -> None:
             namespace.key,
             namespace.value,
         )
-        cobbler_api.save_network_interface(namespace.network_interface_uid, token)
+        cobbler_api.save_network_interface(
+            namespace.network_interface_uid, True, True, "bypass", token
+        )
     elif namespace.subparser_name == "sync":
         cobbler_sync_full(cobbler_api, token)
     elif namespace.subparser_name == "mkloaders":
@@ -361,7 +363,7 @@ def main() -> None:
             token,
         )
         cobbler_api.modify_template(tid, ["tags"], ["dhcpv4"], token)
-        cobbler_api.save_template(tid, token, "new")
+        cobbler_api.save_template(tid, True, True, "new", token)
         # 7. Mkloaders
         logger.info("Generating bootloaders")
         cobbler_mkloaders(cobbler_api, token)

--- a/docs/user-guide/templating.rst
+++ b/docs/user-guide/templating.rst
@@ -184,7 +184,7 @@ disk. The result of the script is that the built-in template is not used anymore
     )
 
     # 6. Save the Template object to make it available
-    server.save_template(template_obj, token)
+    server.save_template(template_obj, True, True, "bypass", token)
 
     # 7. Refresh templates cache
     server.background_templates_refresh_content({}, token)

--- a/tests/integration/autoinstall_dummy_bios_test.py
+++ b/tests/integration/autoinstall_dummy_bios_test.py
@@ -37,11 +37,11 @@ def test_autoinstall_dummy_bios(
     remote.modify_distro(
         distro_id, ["initrd"], str(fake_directory / "initramfs.gz"), token
     )
-    remote.save_distro(distro_id, token, editmode="new")
+    remote.save_distro(distro_id, True, True, "new", token)
     profile_id = remote.new_profile(token)
     remote.modify_profile(profile_id, ["name"], profile_name, token)
     remote.modify_profile(profile_id, ["distro"], distro_id, token)
-    remote.save_profile(profile_id, token, "new")
+    remote.save_profile(profile_id, True, True, "new", token)
     system_id = remote.new_system(token)
     remote.modify_system(system_id, ["name"], "testbed", token)
     remote.modify_system(system_id, ["profile"], profile_id, token)
@@ -53,10 +53,10 @@ def test_autoinstall_dummy_bios(
         token,
     )
     remote.modify_system(system_id, ["netboot_enabled"], True, token)
-    remote.save_system(system_id, token, "new")
+    remote.save_system(system_id, True, True, "new", token)
     network_interface_id = remote.new_network_interface(system_id, token)
     remote.modify_network_interface(network_interface_id, ["name"], "default", token)
-    remote.save_network_interface(network_interface_id, token, "new")
+    remote.save_network_interface(network_interface_id, True, True, "new", token)
     remote.sync(token)
 
     # Act

--- a/tests/integration/basic_test.py
+++ b/tests/integration/basic_test.py
@@ -46,11 +46,11 @@ def test_basic_buildiso(
     profile_id = remote.new_profile(token)
     remote.modify_profile(profile_id, ["name"], "fake", token)
     remote.modify_profile(profile_id, ["distro"], distro_id, token)
-    remote.save_profile(profile_id, token, "new")
+    remote.save_profile(profile_id, True, True, "new", token)
     system_id = remote.new_system(token)
     remote.modify_system(system_id, ["name"], "testbed", token)
     remote.modify_system(system_id, ["profile"], profile_id, token)
-    remote.save_system(system_id, token, "new")
+    remote.save_system(system_id, True, True, "new", token)
     buildisodir.mkdir(parents=True, exist_ok=True)
 
     # Act
@@ -94,7 +94,7 @@ def test_basic_distro_add_remove(
         remote.modify_distro(
             distro_id, ["initrd"], str(images_fake_path / "initramfs"), token
         )
-        remote.save_distro(distro_id, token, "new")
+        remote.save_distro(distro_id, True, True, "new", token)
     # 2. Assert distros are present
     assert len(remote.get_item_names("distro")) == len(distro_names)
     # 3. Remove distros
@@ -129,7 +129,7 @@ def test_basic_distro_rename(
     pid = remote.new_profile(token)
     remote.modify_profile(pid, ["name"], "fake", token)
     remote.modify_profile(pid, ["distro"], did, token)
-    remote.save_profile(pid, token, "new")
+    remote.save_profile(pid, True, True, "new", token)
 
     # Act
     remote.rename_distro(did, "fake-renamed", token)
@@ -466,12 +466,12 @@ def test_basic_system_ipxe_dhcpd_conf_update(
     nid = remote.new_network_interface(sid, token)
     remote.modify_network_interface(nid, ["name"], "default", token)
     remote.modify_network_interface(nid, ["mac_address"], "aa:bb:cc:dd:ee:ff", token)
-    remote.save_network_interface(nid, token)
+    remote.save_network_interface(nid, True, True, "bypass", token)
 
     # Act
     remote.modify_system(sid, ["netboot_enabled"], True, token)
     remote.modify_system(sid, ["enable_ipxe"], True, token)
-    remote.save_system(sid, token)
+    remote.save_system(sid, True, True, "bypass", token)
 
     # Assert
     # We assume that the existence of a single http URL is a successful iPXE group creation.
@@ -495,17 +495,17 @@ def test_basic_system_parent_image(
     # Arrange
     iid = remote.new_image(token)
     remote.modify_image(iid, ["name"], "fake", token)
-    remote.save_image(iid, token, "new")
+    remote.save_image(iid, True, True, "new", token)
 
     # Act
     sid = remote.new_system(token)
     remote.modify_system(sid, ["name"], "testbed", token)
     remote.modify_system(sid, ["image"], iid, token)
-    remote.save_system(sid, token)
+    remote.save_system(sid, True, True, "bypass", token)
     nid = remote.new_network_interface(sid, token)
     remote.modify_network_interface(nid, ["name"], "default", token)
     remote.modify_network_interface(nid, ["mac_address"], "aa:bb:cc:dd:ee:ff", token)
-    remote.save_network_interface(nid, token)
+    remote.save_network_interface(nid, True, True, "bypass", token)
     restart_cobbler()
 
     # Assert - If cobblerd is successfully restarted we should get the image and system loaded successfully.

--- a/tests/integration/buildiso_test.py
+++ b/tests/integration/buildiso_test.py
@@ -134,7 +134,7 @@ def test_buildiso_integration(
     else:
         pid = remote.get_profile_handle("leap-x86_64")
     remote.modify_system(sid, ["profile"], pid, token)
-    remote.save_system(sid, token, "new")
+    remote.save_system(sid, True, True, "new", token)
     print("Testsystem created")
 
     # Tmp: Create "/var/cache/cobbler" because it does not exist per default

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -113,7 +113,7 @@ def fixture_create_distro(remote: CobblerXMLRPCInterface, token: str):
         did = remote.new_distro(token)
         for key, value in args:
             remote.modify_distro(did, key, value, token)
-        remote.save_distro(did, token, "new")
+        remote.save_distro(did, True, True, "new", token)
         return did
 
     return _create_distro
@@ -131,7 +131,7 @@ def fixture_create_profile(
         pid = remote.new_profile(token)
         for key, value in args:
             remote.modify_profile(pid, key, value, token)
-        remote.save_profile(pid, token, "new")
+        remote.save_profile(pid, True, True, "new", token)
         return pid
 
     return _create_profile
@@ -149,7 +149,7 @@ def fixture_create_system(
         sid = remote.new_system(token)
         for key, value in args:
             remote.modify_system(sid, key, value, token)
-        remote.save_system(sid, token, "new")
+        remote.save_system(sid, True, True, "new", token)
         return sid
 
     return _create_system
@@ -167,7 +167,7 @@ def fixture_create_network_interface(
         nid = remote.new_network_interface(sid, token)
         for key, value in args:
             remote.modify_network_interface(nid, key, value, token)
-        remote.save_network_interface(nid, token, "new")
+        remote.save_network_interface(nid, True, True, "new", token)
         return nid
 
     return _create_network_interface
@@ -192,7 +192,7 @@ def fixture_create_autoinstall_template(
         remote.modify_template(template, ["uri", "schema"], "file", token)
         remote.modify_template(template, ["uri", "path"], filename, token)
         remote.modify_template(template, ["tags"], tags, token)
-        remote.save_template(template, token, "new")
+        remote.save_template(template, True, True, "new", token)
         return template
 
     return _create_autoinstall_template

--- a/tests/integration/network_config_kickstart_test.py
+++ b/tests/integration/network_config_kickstart_test.py
@@ -53,7 +53,7 @@ def test_kickstart_vlan_configuration(
     remote.modify_profile(
         profile_id, ["kernel_options"], {"vlan": "em1.1301:em1"}, token
     )
-    remote.save_profile(profile_id, token, "new")
+    remote.save_profile(profile_id, True, True, "new", token)
 
     # Create system with VLAN interface
     system_id = remote.new_system(token)
@@ -73,9 +73,9 @@ def test_kickstart_vlan_configuration(
     remote.modify_network_interface(iface_id, ["static"], True, token)
     remote.modify_network_interface(iface_id, ["management"], True, token)
     remote.modify_network_interface(iface_id, ["if_gateway"], "10.13.1.1", token)
-    remote.save_network_interface(iface_id, token, "new")
+    remote.save_network_interface(iface_id, True, True, "new", token)
 
-    remote.save_system(system_id, token, "new")
+    remote.save_system(system_id, True, True, "new", token)
 
     # Act
     kickstart_data = remote.generate_autoinstall(system_name, "system")
@@ -124,7 +124,7 @@ def test_kickstart_no_duplicate_interfaces(
     remote.modify_profile(profile_id, ["name"], "test-simple-profile", token)
     remote.modify_profile(profile_id, ["distro"], distro_id, token)
     remote.modify_profile(profile_id, ["autoinstall"], "built-in-sample.ks", token)
-    remote.save_profile(profile_id, token, "new")
+    remote.save_profile(profile_id, True, True, "new", token)
 
     system_id = remote.new_system(token)
     remote.modify_system(system_id, ["name"], "test-simple-system", token)
@@ -142,9 +142,9 @@ def test_kickstart_no_duplicate_interfaces(
     remote.modify_network_interface(iface_id, ["netmask"], "255.255.255.0", token)
     remote.modify_network_interface(iface_id, ["static"], True, token)
     remote.modify_network_interface(iface_id, ["management"], True, token)
-    remote.save_network_interface(iface_id, token, "new")
+    remote.save_network_interface(iface_id, True, True, "new", token)
 
-    remote.save_system(system_id, token, "new")
+    remote.save_system(system_id, True, True, "new", token)
 
     # Act
     kickstart_data = remote.generate_autoinstall("test-simple-system", "system")
@@ -185,7 +185,7 @@ def test_kickstart_bridge_configuration(
     remote.modify_profile(profile_id, ["name"], "test-bridge-profile", token)
     remote.modify_profile(profile_id, ["distro"], distro_id, token)
     remote.modify_profile(profile_id, ["autoinstall"], "built-in-sample.ks", token)
-    remote.save_profile(profile_id, token, "new")
+    remote.save_profile(profile_id, True, True, "new", token)
 
     system_id = remote.new_system(token)
     remote.modify_system(system_id, ["name"], "test-bridge-system", token)
@@ -202,7 +202,7 @@ def test_kickstart_bridge_configuration(
     remote.modify_network_interface(br0_id, ["static"], True, token)
     remote.modify_network_interface(br0_id, ["management"], True, token)
     remote.modify_network_interface(br0_id, ["bridge_opts"], "stp=no", token)
-    remote.save_network_interface(br0_id, token, "new")
+    remote.save_network_interface(br0_id, True, True, "new", token)
 
     # Add bridge slave
     eth0_id = remote.new_network_interface(system_id, token)
@@ -212,9 +212,9 @@ def test_kickstart_bridge_configuration(
         eth0_id, ["mac_address"], "00:11:22:33:44:55", token
     )
     remote.modify_network_interface(eth0_id, ["interface_master"], "br0", token)
-    remote.save_network_interface(eth0_id, token, "new")
+    remote.save_network_interface(eth0_id, True, True, "new", token)
 
-    remote.save_system(system_id, token, "new")
+    remote.save_system(system_id, True, True, "new", token)
 
     # Act
     kickstart_data = remote.generate_autoinstall("test-bridge-system", "system")
@@ -255,7 +255,7 @@ def test_kickstart_bond_configuration(
     remote.modify_profile(profile_id, ["name"], "test-bond-profile", token)
     remote.modify_profile(profile_id, ["distro"], distro_id, token)
     remote.modify_profile(profile_id, ["autoinstall"], "built-in-sample.ks", token)
-    remote.save_profile(profile_id, token, "new")
+    remote.save_profile(profile_id, True, True, "new", token)
 
     system_id = remote.new_system(token)
     remote.modify_system(system_id, ["name"], "test-bond-system", token)
@@ -274,7 +274,7 @@ def test_kickstart_bond_configuration(
     remote.modify_network_interface(
         bond0_id, ["bonding_opts"], "mode=active-backup miimon=100", token
     )
-    remote.save_network_interface(bond0_id, token, "new")
+    remote.save_network_interface(bond0_id, True, True, "new", token)
 
     # Add bond slaves
     for iface in ["eth0", "eth1"]:
@@ -286,9 +286,9 @@ def test_kickstart_bond_configuration(
         mac = "00:11:22:33:44:55" if iface == "eth0" else "00:11:22:33:44:66"
         remote.modify_network_interface(iface_id, ["mac_address"], mac, token)
         remote.modify_network_interface(iface_id, ["interface_master"], "bond0", token)
-        remote.save_network_interface(iface_id, token, "new")
+        remote.save_network_interface(iface_id, True, True, "new", token)
 
-    remote.save_system(system_id, token, "new")
+    remote.save_system(system_id, True, True, "new", token)
 
     # Act
     kickstart_data = remote.generate_autoinstall("test-bond-system", "system")

--- a/tests/integration/svc_test.py
+++ b/tests/integration/svc_test.py
@@ -232,7 +232,7 @@ def test_svc_ipxe_image(
     # Arrange
     iid = remote.new_image(token)
     remote.modify_image(iid, ["name"], "fakeimage", token)
-    remote.save_image(iid, token, "new")
+    remote.save_image(iid, True, True, "new", token)
     create_system([(["name"], "testbed"), (["image"], iid)])
     # Prepare expected result
     expected_result = ""
@@ -260,7 +260,7 @@ def test_svc_ipxe_profile(
     # Arrange
     iid = remote.new_image(token)
     remote.modify_image(iid, ["name"], "fakeimage", token)
-    remote.save_image(iid, token, "new")
+    remote.save_image(iid, True, True, "new", token)
     did = create_distro(
         [
             (["name"], "fake"),

--- a/tests/special_cases/security_test.py
+++ b/tests/special_cases/security_test.py
@@ -61,12 +61,12 @@ def setup_profile(
     cobbler_api.modify_distro(distro, ["arch"], "x86_64", token)
     cobbler_api.modify_distro(distro, ["kernel"], str(kernel_path), token)
     cobbler_api.modify_distro(distro, ["initrd"], str(initrd_path), token)
-    cobbler_api.save_distro(distro, token)
+    cobbler_api.save_distro(distro, True, True, "bypass", token)
     # Create a test Profile
     profile = cobbler_api.new_profile(token)
     cobbler_api.modify_profile(profile, ["name"], "security_test_profile", token)
     cobbler_api.modify_profile(profile, ["distro"], distro, token)
-    cobbler_api.save_profile(profile, token)
+    cobbler_api.save_profile(profile, True, True, "bypass", token)
     return
 
 

--- a/tests/xmlrpcapi/conftest.py
+++ b/tests/xmlrpcapi/conftest.py
@@ -84,7 +84,7 @@ def create_distro(remote: CobblerXMLRPCInterface, token: str):
         remote.modify_distro(distro, ["breed"], breed, token)
         remote.modify_distro(distro, ["kernel"], path_kernel, token)
         remote.modify_distro(distro, ["initrd"], path_initrd, token)
-        remote.save_distro(distro, token)
+        remote.save_distro(distro, True, True, "bypass", token)
         return distro
 
     return _create_distro
@@ -115,7 +115,7 @@ def create_profile(remote: CobblerXMLRPCInterface, token: str):
         remote.modify_profile(profile, ["name"], name, token)
         remote.modify_profile(profile, ["distro"], distro, token)
         remote.modify_profile(profile, ["kernel_options"], kernel_options, token)
-        remote.save_profile(profile, token)
+        remote.save_profile(profile, True, True, "bypass", token)
         return profile
 
     return _create_profile
@@ -143,7 +143,7 @@ def create_system(remote: CobblerXMLRPCInterface, token: str):
         system = remote.new_system(token)
         remote.modify_system(system, ["name"], name, token)
         remote.modify_system(system, ["profile"], profile, token)
-        remote.save_system(system, token)
+        remote.save_system(system, True, True, "bypass", token)
         return system
 
     return _create_system
@@ -177,7 +177,7 @@ def fixture_create_autoinstall_template(
         remote.modify_template(template, ["template_type"], "cheetah", token)
         remote.modify_template(template, ["uri", "schema"], "file", token)
         remote.modify_template(template, ["uri", "path"], filename, token)
-        remote.save_template(template, token, "new")
+        remote.save_template(template, True, True, "new", token)
         return template
 
     return _create_autoinstall_template
@@ -196,7 +196,7 @@ def create_repo(
         remote.modify_repo(repo, ["name"], name, token)
         remote.modify_repo(repo, ["mirror"], mirror, token)
         remote.modify_repo(repo, ["mirror_locally"], mirror_locally, token)
-        remote.save_repo(repo, token)
+        remote.save_repo(repo, True, True, "bypass", token)
         return repo
 
     return _create_repo
@@ -226,7 +226,7 @@ def create_menu(remote: CobblerXMLRPCInterface, token: str):
         remote.modify_menu(menu_id, ["name"], name, token)
         remote.modify_menu(menu_id, ["display_name"], display_name, token)
 
-        remote.save_menu(menu_id, token)
+        remote.save_menu(menu_id, True, True, "bypass", token)
         return menu_id
 
     return _create_menu
@@ -258,7 +258,7 @@ def create_testprofile(remote: CobblerXMLRPCInterface, token: str):
     remote.modify_profile(profile, ["distro"], distro_uid, token)
     remote.modify_profile(profile, ["kernel_options"], "a=1 b=2 c=3 c=4 c=5 d e", token)
     remote.modify_profile(profile, ["menu"], menu_uid, token)
-    remote.save_profile(profile, token)
+    remote.save_profile(profile, True, True, "bypass", token)
 
 
 @pytest.fixture(scope="function")
@@ -284,7 +284,7 @@ def create_testdistro(
     remote.modify_distro(distro, ["breed"], "suse", token)
     remote.modify_distro(distro, ["kernel"], os.path.join(folder, fk_kernel), token)
     remote.modify_distro(distro, ["initrd"], os.path.join(folder, fk_initrd), token)
-    remote.save_distro(distro, token)
+    remote.save_distro(distro, True, True, "bypass", token)
 
 
 @pytest.fixture(scope="function")
@@ -298,7 +298,7 @@ def create_testsystem(remote: CobblerXMLRPCInterface, token: str):
     system = remote.new_system(token)
     remote.modify_system(system, ["name"], "testsystem0", token)
     remote.modify_system(system, ["profile"], profile_uid, token)
-    remote.save_system(system, token)
+    remote.save_system(system, True, True, "bypass", token)
 
 
 @pytest.fixture(scope="function")
@@ -312,7 +312,7 @@ def create_testrepo(remote: CobblerXMLRPCInterface, token: str):
     remote.modify_repo(repo, ["name"], "testrepo0", token)
     remote.modify_repo(repo, ["arch"], "x86_64", token)
     remote.modify_repo(repo, ["mirror"], "http://something", token)
-    remote.save_repo(repo, token)
+    remote.save_repo(repo, True, True, "bypass", token)
 
 
 @pytest.fixture(scope="function")
@@ -324,7 +324,7 @@ def create_testimage(remote: CobblerXMLRPCInterface, token: str):
     """
     image = remote.new_image(token)
     remote.modify_image(image, ["name"], "testimage0", token)
-    remote.save_image(image, token)
+    remote.save_image(image, True, True, "bypass", token)
 
 
 @pytest.fixture(scope="function")
@@ -337,7 +337,7 @@ def create_testmenu(remote: CobblerXMLRPCInterface, token: str):
 
     menu = remote.new_menu(token)
     remote.modify_menu(menu, ["name"], "testmenu0", token)
-    remote.save_menu(menu, token)
+    remote.save_menu(menu, True, True, "bypass", token)
 
 
 @pytest.fixture(scope="function")

--- a/tests/xmlrpcapi/distro_group_test.py
+++ b/tests/xmlrpcapi/distro_group_test.py
@@ -42,7 +42,7 @@ def test_modify_save_and_get_distro_group(remote: CobblerXMLRPCInterface, token:
     # Arrange
     handle = remote.new_distro_group(token)
     remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
-    remote.save_distro_group(handle, token, editmode="new")
+    remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
     group = remote.get_distro_group("test_distro_group", token=token)
@@ -69,7 +69,7 @@ def test_find_distro_group(
     if create_item:
         handle = remote.new_distro_group(token)
         remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
-        remote.save_distro_group(handle, token, editmode="new")
+        remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
     result = remote.find_distro_group(
@@ -87,7 +87,7 @@ def test_copy_distro_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_distro_group(token)
     remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
-    remote.save_distro_group(handle, token, editmode="new")
+    remote.save_distro_group(handle, True, True, "new", token)
     distro_group = remote.get_distro_group_handle("test_distro_group")
 
     # Act
@@ -104,7 +104,7 @@ def test_rename_distro_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_distro_group(token)
     remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
-    remote.save_distro_group(handle, token, editmode="new")
+    remote.save_distro_group(handle, True, True, "new", token)
     distro_group = remote.get_distro_group_handle("test_distro_group")
 
     # Act
@@ -123,7 +123,7 @@ def test_remove_distro_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_distro_group(token)
     remote.modify_distro_group(handle, ["name"], "test_distro_group_to_remove", token)
-    remote.save_distro_group(handle, token, editmode="new")
+    remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
     result = remote.remove_distro_group("test_distro_group_to_remove", token)
@@ -142,7 +142,7 @@ def test_get_distro_groups_since(remote: CobblerXMLRPCInterface, token: str):
     mtime = time.time()
     handle = remote.new_distro_group(token)
     remote.modify_distro_group(handle, ["name"], "test_distro_group_since", token)
-    remote.save_distro_group(handle, token, editmode="new")
+    remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
     result = remote.get_distro_groups_since(mtime)
@@ -159,7 +159,7 @@ def test_get_distro_group_as_rendered(remote: CobblerXMLRPCInterface, token: str
     # Arrange
     handle = remote.new_distro_group(token)
     remote.modify_distro_group(handle, ["name"], "test_distro_group", token)
-    remote.save_distro_group(handle, token, editmode="new")
+    remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
     result = remote.get_distro_group_as_rendered("test_distro_group", token)

--- a/tests/xmlrpcapi/image_test.py
+++ b/tests/xmlrpcapi/image_test.py
@@ -22,7 +22,7 @@ class TestImage:
 
         # Assert
         assert remote.modify_image(image, ["name"], "testimage0", token)
-        assert remote.save_image(image, token)
+        assert remote.save_image(image, True, True, "bypass", token)
         image_list = remote.get_images(token)
         assert len(image_list) == 1
 

--- a/tests/xmlrpcapi/menu_test.py
+++ b/tests/xmlrpcapi/menu_test.py
@@ -18,7 +18,7 @@ def create_menu(remote: CobblerXMLRPCInterface, token: str):
     menu = remote.new_menu(token)
     remote.modify_menu(menu, ["name"], "testmenu0", token)
     remote.modify_menu(menu, ["display_name"], "Test Menu0", token)
-    remote.save_menu(menu, token)
+    remote.save_menu(menu, True, True, "bypass", token)
 
 
 @pytest.fixture
@@ -54,7 +54,7 @@ class TestMenu:
         assert remote.modify_menu(submenu, ["name"], "testsubmenu0", token)
         assert remote.modify_menu(submenu, ["parent"], menu_uid, token)
 
-        assert remote.save_menu(submenu, token)
+        assert remote.save_menu(submenu, True, True, "bypass", token)
 
         new_menus = remote.get_menus(token)
         assert len(new_menus) == len(menus) + 1
@@ -70,7 +70,7 @@ class TestMenu:
         menu = remote.new_menu(token)
         assert remote.modify_menu(menu, ["name"], "testmenu0", token)
         assert remote.modify_menu(menu, ["display_name"], "Test Menu0", token)
-        assert remote.save_menu(menu, token)
+        assert remote.save_menu(menu, token=token)
 
     def test_get_menus(self, remote: CobblerXMLRPCInterface):
         """

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -167,7 +167,7 @@ def test_find_system_by_dns_name(
     create_profile(name_profile, name_distro, "text")
     system = create_system(name_system, name_profile)
     remote.modify_system(system, ["dns", "name"], dns_name, token)
-    remote.save_system(system, token)
+    remote.save_system(system, True, True, "bypass", token)
 
     # Act
     result = remote.find_system_by_dns_name(dns_name)
@@ -326,7 +326,7 @@ def test_get_config_data(
     profile_uid = create_profile(name_profile, distro_uid, "text")
     system = create_system(name_system, profile_uid)
     remote.modify_system(system, ["hostname"], system_hostname, token)
-    remote.save_system(system, token)
+    remote.save_system(system, True, True, "bypass", token)
 
     # Act
     result = remote.get_config_data(system_hostname)
@@ -361,9 +361,9 @@ def test_get_repos_compatible_with_profile(
     repo_compatible = create_repo(name_repo_compatible, "http://localhost", False)
     repo_incompatible = create_repo(name_repo_incompatible, "http://localhost", False)
     remote.modify_repo(repo_compatible, ["arch"], "x86_64", token)
-    remote.save_repo(repo_compatible, token)
+    remote.save_repo(repo_compatible, True, True, "bypass", token)
     remote.modify_repo(repo_incompatible, ["arch"], "ppc64le", token)
-    remote.save_repo(repo_incompatible, token)
+    remote.save_repo(repo_incompatible, True, True, "bypass", token)
 
     # Act
     result = remote.get_repos_compatible_with_profile(name_profile, token)
@@ -621,7 +621,7 @@ def test_render_vars(remote: CobblerXMLRPCInterface, token: str):
     # Act
     distro = remote.get_item_handle("distro", "testdistro0")
     remote.modify_distro(distro, ["kernel_options"], kernel_options, token)
-    remote.save_distro(distro, token)
+    remote.save_distro(distro, True, True, "bypass", token)
 
     # Assert --> Let the test pass if the call is okay.
     assert True
@@ -660,3 +660,61 @@ def test_templates_refresh_content(remote: CobblerXMLRPCInterface, token: str):
     # Assert
     # No exception should be enough for a basic smoke test.
     assert True
+
+
+@pytest.mark.integration
+def test_save_distro_with_triggers_false(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Test that save_distro with with_triggers=False succeeds and persists the object.
+    """
+    # Arrange
+    basepath = create_kernel_initrd("vmlinuz1", "initrd1.img")
+    path_kernel = os.path.join(basepath, "vmlinuz1")
+    path_initrd = os.path.join(basepath, "initrd1.img")
+    distro = remote.new_distro(token)
+    remote.modify_distro(distro, ["name"], "testdistro_notriggers", token)
+    remote.modify_distro(distro, ["kernel"], path_kernel, token)
+    remote.modify_distro(distro, ["initrd"], path_initrd, token)
+    remote.modify_distro(distro, ["arch"], "x86_64", token)
+    remote.modify_distro(distro, ["breed"], "suse", token)
+
+    # Act
+    result = remote.save_distro(distro, False, False, "bypass", token)
+
+    # Assert
+    assert result is True
+    assert remote.get_distro("testdistro_notriggers", False, False, token) is not None
+
+
+@pytest.mark.integration
+def test_save_distro_with_sync_false_forwarded(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Test that with_sync=False is correctly forwarded to api.add_item().
+    """
+    from unittest.mock import patch
+
+    # Arrange
+    basepath = create_kernel_initrd("vmlinuz2", "initrd2.img")
+    path_kernel = os.path.join(basepath, "vmlinuz2")
+    path_initrd = os.path.join(basepath, "initrd2.img")
+    distro = remote.new_distro(token)
+    remote.modify_distro(distro, ["name"], "testdistro_nosync", token)
+    remote.modify_distro(distro, ["kernel"], path_kernel, token)
+    remote.modify_distro(distro, ["initrd"], path_initrd, token)
+    remote.modify_distro(distro, ["arch"], "x86_64", token)
+    remote.modify_distro(distro, ["breed"], "suse", token)
+
+    # Act & Assert
+    with patch.object(remote.api, "add_item", wraps=remote.api.add_item) as mock_add:
+        result = remote.save_distro(distro, True, False, "bypass", token)
+        assert result is True
+        _, kwargs = mock_add.call_args
+        assert kwargs.get("with_sync") is False

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -282,7 +282,7 @@ def test_get_item_resolved_value(
     profile_uid = create_profile(name_profile, distro_uid, "a=1 b=2 c=3 c=4 c=5 d e")
     test_system_handle = create_system(name_system, profile_uid)
     remote.modify_system(test_system_handle, ["kernel_options"], "!c !e", token=token)
-    remote.save_system(test_system_handle, token)
+    remote.save_system(test_system_handle, True, True, "bypass", token)
     test_network_interface_handle = remote.new_network_interface(
         test_system_handle, token
     )
@@ -292,7 +292,9 @@ def test_get_item_resolved_value(
     remote.modify_network_interface(
         test_network_interface_handle, ["mac_address"], "aa:bb:cc:dd:ee:ff", token
     )
-    remote.save_network_interface(test_network_interface_handle, token, "new")
+    remote.save_network_interface(
+        test_network_interface_handle, True, True, "new", token
+    )
     if checked_object == "distro":
         test_item = remote.get_distro(name_distro, token=token)
     elif checked_object == "profile":

--- a/tests/xmlrpcapi/profile_group_test.py
+++ b/tests/xmlrpcapi/profile_group_test.py
@@ -42,7 +42,7 @@ def test_modify_save_and_get_profile_group(remote: CobblerXMLRPCInterface, token
     # Arrange
     handle = remote.new_profile_group(token)
     remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
-    remote.save_profile_group(handle, token, editmode="new")
+    remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
     group = remote.get_profile_group("test_profile_group", token=token)
@@ -69,7 +69,7 @@ def test_find_profile_group(
     if create_item:
         handle = remote.new_profile_group(token)
         remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
-        remote.save_profile_group(handle, token, editmode="new")
+        remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
     result = remote.find_profile_group(
@@ -87,7 +87,7 @@ def test_copy_profile_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_profile_group(token)
     remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
-    remote.save_profile_group(handle, token, editmode="new")
+    remote.save_profile_group(handle, True, True, "new", token)
     profile_group = remote.get_profile_group_handle("test_profile_group")
 
     # Act
@@ -104,7 +104,7 @@ def test_rename_profile_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_profile_group(token)
     remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
-    remote.save_profile_group(handle, token, editmode="new")
+    remote.save_profile_group(handle, True, True, "new", token)
     profile_group = remote.get_profile_group_handle("test_profile_group")
 
     # Act
@@ -123,7 +123,7 @@ def test_remove_profile_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_profile_group(token)
     remote.modify_profile_group(handle, ["name"], "test_profile_group_to_remove", token)
-    remote.save_profile_group(handle, token, editmode="new")
+    remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
     result = remote.remove_profile_group("test_profile_group_to_remove", token)
@@ -142,7 +142,7 @@ def test_get_profile_groups_since(remote: CobblerXMLRPCInterface, token: str):
     mtime = time.time()
     handle = remote.new_profile_group(token)
     remote.modify_profile_group(handle, ["name"], "test_profile_group_since", token)
-    remote.save_profile_group(handle, token, editmode="new")
+    remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
     result = remote.get_profile_groups_since(mtime)
@@ -159,7 +159,7 @@ def test_get_profile_group_as_rendered(remote: CobblerXMLRPCInterface, token: st
     # Arrange
     handle = remote.new_profile_group(token)
     remote.modify_profile_group(handle, ["name"], "test_profile_group", token)
-    remote.save_profile_group(handle, token, editmode="new")
+    remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
     result = remote.get_profile_group_as_rendered("test_profile_group", token)

--- a/tests/xmlrpcapi/profile_test.py
+++ b/tests/xmlrpcapi/profile_test.py
@@ -185,7 +185,7 @@ def test_create_subprofile(remote: CobblerXMLRPCInterface, token: str):
     assert remote.modify_profile(subprofile, ["name"], "testsubprofile0", token)
     assert remote.modify_profile(subprofile, ["parent"], profile_uid, token)
 
-    assert remote.save_profile(subprofile, token)
+    assert remote.save_profile(subprofile, True, True, "bypass", token)
 
     new_profiles = remote.get_profiles(token)
     assert len(new_profiles) == len(profiles) + 1

--- a/tests/xmlrpcapi/repo_test.py
+++ b/tests/xmlrpcapi/repo_test.py
@@ -23,7 +23,7 @@ def create_repo(remote: CobblerXMLRPCInterface, token: str):
         repo, ["mirror"], "http://www.sample.com/path/to/some/repo", token
     )
     remote.modify_repo(repo, ["mirror_locally"], False, token)
-    remote.save_repo(repo, token)
+    remote.save_repo(repo, True, True, "bypass", token)
 
 
 class TestRepo:
@@ -45,7 +45,7 @@ class TestRepo:
             repo, ["mirror"], "http://www.sample.com/path/to/some/repo", token
         )
         assert remote.modify_repo(repo, ["mirror_locally"], False, token)
-        assert remote.save_repo(repo, token)
+        assert remote.save_repo(repo, True, True, "bypass", token)
 
     def test_get_repos(self, remote: CobblerXMLRPCInterface):
         """

--- a/tests/xmlrpcapi/system_group_test.py
+++ b/tests/xmlrpcapi/system_group_test.py
@@ -42,7 +42,7 @@ def test_modify_save_and_get_system_group(remote: CobblerXMLRPCInterface, token:
     # Arrange
     handle = remote.new_system_group(token)
     remote.modify_system_group(handle, ["name"], "test_system_group", token)
-    remote.save_system_group(handle, token, editmode="new")
+    remote.save_system_group(handle, True, True, "new", token)
 
     # Act
     group = remote.get_system_group("test_system_group", token=token)
@@ -69,7 +69,7 @@ def test_find_system_group(
     if create_item:
         handle = remote.new_system_group(token)
         remote.modify_system_group(handle, ["name"], "test_system_group", token)
-        remote.save_system_group(handle, token, editmode="new")
+        remote.save_system_group(handle, True, True, "new", token)
 
     # Act
     result = remote.find_system_group(
@@ -87,7 +87,7 @@ def test_copy_system_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_system_group(token)
     remote.modify_system_group(handle, ["name"], "test_system_group", token)
-    remote.save_system_group(handle, token, editmode="new")
+    remote.save_system_group(handle, True, True, "new", token)
     system_group = remote.get_system_group_handle("test_system_group")
 
     # Act
@@ -104,7 +104,7 @@ def test_rename_system_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_system_group(token)
     remote.modify_system_group(handle, ["name"], "test_system_group", token)
-    remote.save_system_group(handle, token, editmode="new")
+    remote.save_system_group(handle, True, True, "new", token)
     system_group = remote.get_system_group_handle("test_system_group")
 
     # Act
@@ -123,7 +123,7 @@ def test_remove_system_group(remote: CobblerXMLRPCInterface, token: str):
     # Arrange
     handle = remote.new_system_group(token)
     remote.modify_system_group(handle, ["name"], "test_system_group_to_remove", token)
-    remote.save_system_group(handle, token, editmode="new")
+    remote.save_system_group(handle, True, True, "new", token)
 
     # Act
     result = remote.remove_system_group("test_system_group_to_remove", token)
@@ -142,7 +142,7 @@ def test_get_system_groups_since(remote: CobblerXMLRPCInterface, token: str):
     mtime = time.time()
     handle = remote.new_system_group(token)
     remote.modify_system_group(handle, ["name"], "test_system_group_since", token)
-    remote.save_system_group(handle, token, editmode="new")
+    remote.save_system_group(handle, True, True, "new", token)
 
     # Act
     result = remote.get_system_groups_since(mtime)
@@ -159,7 +159,7 @@ def test_get_system_group_as_rendered(remote: CobblerXMLRPCInterface, token: str
     # Arrange
     handle = remote.new_system_group(token)
     remote.modify_system_group(handle, ["name"], "test_system_group", token)
-    remote.save_system_group(handle, token, editmode="new")
+    remote.save_system_group(handle, True, True, "new", token)
 
     # Act
     result = remote.get_system_group_as_rendered("test_system_group", token)

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -298,9 +298,9 @@ def test_dns_name_servers_inheritance(
 
     # Act
     remote.modify_profile(profile_handle, ["dns", "name_servers"], "8.8.4.4", token)
-    remote.save_profile(profile_handle, token)
+    remote.save_profile(profile_handle, True, True, "bypass", token)
     remote.modify_system(system_handle, ["dns", "name_servers"], "8.8.8.8", token)
-    remote.save_system(system_handle, token)
+    remote.save_system(system_handle, True, True, "bypass", token)
 
     # Assert
     assert remote.get_item_resolved_value(system_handle, ["dns", "name_servers"]) == [

--- a/tests/xmlrpcapi/transaction_test.py
+++ b/tests/xmlrpcapi/transaction_test.py
@@ -33,7 +33,7 @@ def test_create_profile(
     remote.modify_profile(profile, ["name"], "testprofile0", token)
     remote.modify_profile(profile, ["distro"], distro_uid, token)
 
-    assert remote.save_profile(profile, token)
+    assert remote.save_profile(profile, True, True, "bypass", token)
 
     # uncommited profile is not visible without token
     assert remote.get_item_handle("profile", "testprofile0") == "~"
@@ -62,7 +62,7 @@ def test_modify_profile(
     profile = remote.get_profile_handle("testprofile0")
     remote.modify_profile(profile, ["comment"], "test comment", token)
 
-    assert remote.save_profile(profile, token)
+    assert remote.save_profile(profile, True, True, "bypass", token)
 
     assert remote.get_profile_handle("testprofile0") == profile
 
@@ -174,12 +174,12 @@ def test_remove_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
     subprofile = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile, ["name"], "testsubprofile0", token)
     assert remote.modify_profile(subprofile, ["parent"], profile_uid, token)
-    assert remote.save_profile(subprofile, token)
+    assert remote.save_profile(subprofile, True, True, "bypass", token)
 
     subprofile1 = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile1, ["name"], "testsubprofile1", token)
     assert remote.modify_profile(subprofile1, ["parent"], subprofile, token)
-    assert remote.save_profile(subprofile1, token)
+    assert remote.save_profile(subprofile1, True, True, "bypass", token)
 
     assert remote.transaction_commit(token)
 
@@ -230,7 +230,7 @@ def test_create_profiles(
         profile = remote.new_profile(token)
         remote.modify_profile(profile, ["name"], f"testprofile{i}", token)
         remote.modify_profile(profile, ["distro"], distro_uid, token)
-        remote.save_profile(profile, token)
+        remote.save_profile(profile, True, True, "bypass", token)
     assert remote.transaction_commit(token)
 
     remote.transaction_begin(token)
@@ -254,17 +254,17 @@ def test_parent_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
     profile1 = remote.new_subprofile(token)
     assert remote.modify_profile(profile1, ["name"], "testprofile1", token)
     assert remote.modify_profile(profile1, ["parent"], profile_uid, token)
-    assert remote.save_profile(profile1, token)
+    assert remote.save_profile(profile1, True, True, "bypass", token)
 
     profile2 = remote.new_subprofile(token)
     assert remote.modify_profile(profile2, ["name"], "testprofile2", token)
     assert remote.modify_profile(profile2, ["parent"], profile1, token)
-    assert remote.save_profile(profile2, token)
+    assert remote.save_profile(profile2, True, True, "bypass", token)
 
     profile3 = remote.new_subprofile(token)
     assert remote.modify_profile(profile3, ["name"], "testprofile3", token)
     assert remote.modify_profile(profile3, ["parent"], profile2, token)
-    assert remote.save_profile(profile3, token)
+    assert remote.save_profile(profile3, True, True, "bypass", token)
 
     # Act
     assert cast(Dict[Any, Any], remote.get_profile("testprofile0"))["depth"] == 1
@@ -273,7 +273,7 @@ def test_parent_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
     assert cast(Dict[Any, Any], remote.get_profile("testprofile3"))["depth"] == 4
 
     assert remote.modify_profile(profile2, ["parent"], profile_uid, token)
-    assert remote.save_profile(profile2, token)
+    assert remote.save_profile(profile2, True, True, "bypass", token)
 
     assert cast(Dict[Any, Any], remote.get_profile("testprofile0"))["depth"] == 1
     assert cast(Dict[Any, Any], remote.get_profile("testprofile1"))["depth"] == 2
@@ -300,12 +300,12 @@ def test_reparent_and_delete_profile(remote: CobblerXMLRPCInterface, token: str)
     subprofile1 = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile1, ["name"], "testsubprofile0", token)
     assert remote.modify_profile(subprofile1, ["parent"], profile_uid, token)
-    assert remote.save_profile(subprofile1, token)
+    assert remote.save_profile(subprofile1, True, True, "bypass", token)
 
     subprofile2 = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile2, ["name"], "testsubprofile1", token)
     assert remote.modify_profile(subprofile2, ["parent"], profile_uid, token)
-    assert remote.save_profile(subprofile2, token)
+    assert remote.save_profile(subprofile2, True, True, "bypass", token)
 
     # Act
     remote.transaction_begin(token)
@@ -313,12 +313,12 @@ def test_reparent_and_delete_profile(remote: CobblerXMLRPCInterface, token: str)
     profile1 = remote.new_profile(token)
     assert remote.modify_profile(profile1, ["name"], "testprofile1", token)
     assert remote.modify_profile(profile1, ["distro"], distro_uid, token)
-    assert remote.save_profile(profile1, token)
+    assert remote.save_profile(profile1, True, True, "bypass", token)
 
     subprofile1 = remote.get_item_handle("profile", "testsubprofile0", token)
 
     assert remote.modify_profile(subprofile1, ["parent"], profile1, token)
-    assert remote.save_profile(subprofile1, token)
+    assert remote.save_profile(subprofile1, True, True, "bypass", token)
 
     assert remote.remove_profile("testprofile0", token)
 
@@ -436,13 +436,13 @@ def test_create_distro_profile(
     remote.modify_distro(distro, ["kernel"], path_kernel, token)
     remote.modify_distro(distro, ["initrd"], path_initrd, token)
 
-    assert remote.save_distro(distro, token)
+    assert remote.save_distro(distro, True, True, "bypass", token)
 
     profile = remote.new_profile(token)
     remote.modify_profile(profile, ["name"], "testprofile0", token)
     remote.modify_profile(profile, ["distro"], distro, token)
 
-    assert remote.save_profile(profile, token)
+    assert remote.save_profile(profile, True, True, "bypass", token)
 
     # uncommited profile is not visible without token
     assert remote.get_item_handle("profile", "testprofile0") == "~"
@@ -475,7 +475,7 @@ def test_modify_distro(
     distro = remote.get_distro_handle("testdistro0")
     remote.modify_distro(distro, ["comment"], "test comment", token)
 
-    assert remote.save_distro(distro, token)
+    assert remote.save_distro(distro, True, True, "bypass", token)
 
     assert remote.get_distro_handle("testdistro0") == distro
 
@@ -507,12 +507,12 @@ def test_remove_distro_recursive(remote: CobblerXMLRPCInterface, token: str):
     subprofile = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile, ["name"], "testsubprofile0", token)
     assert remote.modify_profile(subprofile, ["parent"], profile_uid, token)
-    assert remote.save_profile(subprofile, token)
+    assert remote.save_profile(subprofile, True, True, "bypass", token)
 
     subprofile1 = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile1, ["name"], "testsubprofile1", token)
     assert remote.modify_profile(subprofile1, ["parent"], subprofile, token)
-    assert remote.save_profile(subprofile1, token)
+    assert remote.save_profile(subprofile1, True, True, "bypass", token)
 
     assert remote.transaction_commit(token)
 
@@ -570,12 +570,12 @@ def test_reparent_and_remove_distro(
     subprofile = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile, ["name"], "testsubprofile0", token)
     assert remote.modify_profile(subprofile, ["parent"], profile_uid, token)
-    assert remote.save_profile(subprofile, token, "new")
+    assert remote.save_profile(subprofile, True, True, "new", token)
 
     subprofile1 = remote.new_subprofile(token)
     assert remote.modify_profile(subprofile1, ["name"], "testsubprofile1", token)
     assert remote.modify_profile(subprofile1, ["parent"], subprofile, token)
-    assert remote.save_profile(subprofile1, token, "new")
+    assert remote.save_profile(subprofile1, True, True, "new", token)
 
     assert remote.transaction_commit(token)
 
@@ -595,11 +595,11 @@ def test_reparent_and_remove_distro(
     remote.modify_distro(distro, ["kernel"], path_kernel, token)
     remote.modify_distro(distro, ["initrd"], path_initrd, token)
 
-    assert remote.save_distro(distro, token, "new")
+    assert remote.save_distro(distro, True, True, "new", token)
 
     profile = remote.get_item_handle("profile", "testprofile0", token)
     assert remote.modify_profile(profile, ["distro"], distro, token)
-    assert remote.save_profile(profile, token, "new")
+    assert remote.save_profile(profile, True, True, "new", token)
     assert remote.remove_distro("testdistro0", token)
 
     # distro and profiles are visible outside of transaction until commit
@@ -643,7 +643,7 @@ def test_create_system_positive(remote: CobblerXMLRPCInterface, token: str):
     system = remote.new_system(token)
     remote.modify_system(system, ["name"], "testsystem0", token)
     remote.modify_system(system, ["profile"], profile_uid, token)
-    assert remote.save_system(system, token)
+    assert remote.save_system(system, True, True, "bypass", token)
 
     # without token, the new system is not visible
     assert remote.get_item_handle("system", "testsystem0") == "~"


### PR DESCRIPTION
## Linked Items

Fixes #3996

## Description

Before the `with_sync` and `with_triggers` flags were not exposed to the XML-RPC API. This PR adds those to the `save_<item>` methods. Furthermore, this PR moves the `editmode` flag before the `token`, so all arguments are required for saving an item.

## Behaviour changes

Old: Timeouts during bash scripted operations due to constant syncing.

New: No timeouts due to the ability to skip syncing the TFTP-root and skipping the Triggers.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 

<!--
If there are no tests already existing, and you don't want to create them it might be that your PR is only merged after
the maintainer team has added tests for said functionality.
-->
