### PR TITLE
Add performance tests for NetworkInterface, DistroGroup, ProfileGroup and SystemGroup

### DIFF
--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -16,6 +16,7 @@ from cobbler.items.profile import Profile
 from cobbler.items.profile_group import ProfileGroup
 from cobbler.items.repo import Repo
 from cobbler.items.system import System
+from cobbler.items.system_group import SystemGroup
 
 
 class CobblerTree:
@@ -32,6 +33,7 @@ class CobblerTree:
     systems_count = 1000
     distro_groups_count = objs_default_count
     profile_groups_count = objs_default_count
+    system_groups_count = objs_default_count
     test_rounds = int(os.environ.get("COBBLER_PERFORMANCE_TEST_ROUNDS", 1))
     test_iterations = int(os.environ.get("COBBLER_PERFORMANCE_TEST_ITERATIONS", -1))
     tree_levels = 3
@@ -217,6 +219,7 @@ class CobblerTree:
         CobblerTree.create_systems(api, save, with_triggers, with_sync)
         CobblerTree.create_distro_groups(api, save, with_triggers, with_sync)
         CobblerTree.create_profile_groups(api, save, with_triggers, with_sync)
+        CobblerTree.create_system_groups(api, save, with_triggers, with_sync)
 
     @staticmethod
     def remove_repos(api: CobblerAPI):
@@ -321,6 +324,28 @@ class CobblerTree:
             api.profile_groups().remove(test_item, with_triggers=False, with_sync=False)
 
     @staticmethod
+    def create_system_groups(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
+        """
+        Create a number of system groups for benchmark testing.
+        """
+        for i in range(CobblerTree.system_groups_count):
+            test_item: SystemGroup = SystemGroup(api)
+            test_item.name = f"test_system_group_{i}"
+            api.system_groups().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
+
+    @staticmethod
+    def remove_system_groups(api: CobblerAPI):
+        """
+        Method that removes all system groups.
+        """
+        for test_item in api.system_groups():
+            api.system_groups().remove(test_item, with_triggers=False, with_sync=False)
+
+    @staticmethod
     def create_network_interfaces(
         api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
     ):
@@ -353,6 +378,7 @@ class CobblerTree:
         """
         Method that collectively removes all items at the same time.
         """
+        CobblerTree.remove_system_groups(api)
         CobblerTree.remove_profile_groups(api)
         CobblerTree.remove_distro_groups(api)
         CobblerTree.remove_network_interfaces(api)

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -271,6 +271,24 @@ class CobblerTree:
             api.systems().remove(test_item, with_triggers=False, with_sync=False)
 
     @staticmethod
+    def create_network_interfaces(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
+        """
+        Create an additional network interface ("eth1") for each system in the collection.
+        """
+        for test_system in api.systems():
+            test_interface = NetworkInterface(
+                api=api, system_uid=test_system.uid, name="eth1"
+            )
+            api.network_interfaces().add(
+                test_interface,
+                save=save,
+                with_triggers=with_triggers,
+                with_sync=with_sync,
+            )
+
+    @staticmethod
     def remove_network_interfaces(api: CobblerAPI):
         """
         Method that removes all network interfaces.

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -13,6 +13,7 @@ from cobbler.items.image import Image
 from cobbler.items.menu import Menu
 from cobbler.items.network_interface import NetworkInterface
 from cobbler.items.profile import Profile
+from cobbler.items.profile_group import ProfileGroup
 from cobbler.items.repo import Repo
 from cobbler.items.system import System
 
@@ -30,6 +31,7 @@ class CobblerTree:
     images_count = objs_default_count
     systems_count = 1000
     distro_groups_count = objs_default_count
+    profile_groups_count = objs_default_count
     test_rounds = int(os.environ.get("COBBLER_PERFORMANCE_TEST_ROUNDS", 1))
     test_iterations = int(os.environ.get("COBBLER_PERFORMANCE_TEST_ITERATIONS", -1))
     tree_levels = 3
@@ -214,6 +216,7 @@ class CobblerTree:
         CobblerTree.create_images(api, save, with_triggers, with_sync)
         CobblerTree.create_systems(api, save, with_triggers, with_sync)
         CobblerTree.create_distro_groups(api, save, with_triggers, with_sync)
+        CobblerTree.create_profile_groups(api, save, with_triggers, with_sync)
 
     @staticmethod
     def remove_repos(api: CobblerAPI):
@@ -296,6 +299,28 @@ class CobblerTree:
             api.distro_groups().remove(test_item, with_triggers=False, with_sync=False)
 
     @staticmethod
+    def create_profile_groups(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
+        """
+        Create a number of profile groups for benchmark testing.
+        """
+        for i in range(CobblerTree.profile_groups_count):
+            test_item: ProfileGroup = ProfileGroup(api)
+            test_item.name = f"test_profile_group_{i}"
+            api.profile_groups().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
+
+    @staticmethod
+    def remove_profile_groups(api: CobblerAPI):
+        """
+        Method that removes all profile groups.
+        """
+        for test_item in api.profile_groups():
+            api.profile_groups().remove(test_item, with_triggers=False, with_sync=False)
+
+    @staticmethod
     def create_network_interfaces(
         api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
     ):
@@ -328,6 +353,7 @@ class CobblerTree:
         """
         Method that collectively removes all items at the same time.
         """
+        CobblerTree.remove_profile_groups(api)
         CobblerTree.remove_distro_groups(api)
         CobblerTree.remove_network_interfaces(api)
         CobblerTree.remove_systems(api)

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -8,6 +8,7 @@ from typing import Callable
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
+from cobbler.items.distro_group import DistroGroup
 from cobbler.items.image import Image
 from cobbler.items.menu import Menu
 from cobbler.items.network_interface import NetworkInterface
@@ -28,6 +29,7 @@ class CobblerTree:
     profiles_count = 300
     images_count = objs_default_count
     systems_count = 1000
+    distro_groups_count = objs_default_count
     test_rounds = int(os.environ.get("COBBLER_PERFORMANCE_TEST_ROUNDS", 1))
     test_iterations = int(os.environ.get("COBBLER_PERFORMANCE_TEST_ITERATIONS", -1))
     tree_levels = 3
@@ -211,6 +213,7 @@ class CobblerTree:
         CobblerTree.create_profiles(api, save, with_triggers, with_sync)
         CobblerTree.create_images(api, save, with_triggers, with_sync)
         CobblerTree.create_systems(api, save, with_triggers, with_sync)
+        CobblerTree.create_distro_groups(api, save, with_triggers, with_sync)
 
     @staticmethod
     def remove_repos(api: CobblerAPI):
@@ -271,6 +274,28 @@ class CobblerTree:
             api.systems().remove(test_item, with_triggers=False, with_sync=False)
 
     @staticmethod
+    def create_distro_groups(
+        api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
+    ):
+        """
+        Create a number of distro groups for benchmark testing.
+        """
+        for i in range(CobblerTree.distro_groups_count):
+            test_item: DistroGroup = DistroGroup(api)
+            test_item.name = f"test_distro_group_{i}"
+            api.distro_groups().add(
+                test_item, save=save, with_triggers=with_triggers, with_sync=with_sync
+            )
+
+    @staticmethod
+    def remove_distro_groups(api: CobblerAPI):
+        """
+        Method that removes all distro groups.
+        """
+        for test_item in api.distro_groups():
+            api.distro_groups().remove(test_item, with_triggers=False, with_sync=False)
+
+    @staticmethod
     def create_network_interfaces(
         api: CobblerAPI, save: bool, with_triggers: bool, with_sync: bool
     ):
@@ -303,6 +328,7 @@ class CobblerTree:
         """
         Method that collectively removes all items at the same time.
         """
+        CobblerTree.remove_distro_groups(api)
         CobblerTree.remove_network_interfaces(api)
         CobblerTree.remove_systems(api)
         CobblerTree.remove_images(api)

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -294,6 +294,62 @@ def test_systems_create(
         ),
     ],
 )
+def test_network_interfaces_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str, bool], Distro],
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating network interfaces is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_all_objs(cobbler_api)
+        CobblerTree.create_all_objs(cobbler_api, create_distro, False, False, False)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(  # type: ignore
+        CobblerTree.create_network_interfaces,
+        setup=setup_func,
+        rounds=CobblerTree.test_rounds,
+    )
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
 def test_all_items_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -294,6 +294,60 @@ def test_systems_create(
         ),
     ],
 )
+def test_distro_groups_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating distro groups is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_distro_groups(cobbler_api)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(  # type: ignore
+        CobblerTree.create_distro_groups,
+        setup=setup_func,
+        rounds=CobblerTree.test_rounds,
+    )
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
 def test_network_interfaces_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -294,6 +294,60 @@ def test_systems_create(
         ),
     ],
 )
+def test_profile_groups_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating profile groups is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_profile_groups(cobbler_api)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(  # type: ignore
+        CobblerTree.create_profile_groups,
+        setup=setup_func,
+        rounds=CobblerTree.test_rounds,
+    )
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
 def test_distro_groups_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,

--- a/tests/performance/item_add_test.py
+++ b/tests/performance/item_add_test.py
@@ -294,6 +294,60 @@ def test_systems_create(
         ),
     ],
 )
+def test_system_groups_create(
+    benchmark: BenchmarkFixture,
+    cobbler_api: CobblerAPI,
+    cache_enabled: bool,
+    enable_menu: bool,
+):
+    """
+    Test that asserts if creating system groups is running without a performance decrease.
+    """
+
+    def setup_func() -> Tuple[Tuple[Any, ...], Dict[str, Any]]:
+        CobblerTree.remove_system_groups(cobbler_api)
+        return (
+            cobbler_api,
+            True,
+            True,
+            False,
+        ), {}
+
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    cobbler_api.settings().enable_menu = enable_menu
+
+    # Act
+    result = benchmark.pedantic(  # type: ignore
+        CobblerTree.create_system_groups,
+        setup=setup_func,
+        rounds=CobblerTree.test_rounds,
+    )
+
+    # Assert
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,enable_menu",
+    [
+        (
+            False,
+            False,
+        ),
+        (
+            True,
+            False,
+        ),
+        (
+            False,
+            True,
+        ),
+        (
+            True,
+            True,
+        ),
+    ],
+)
 def test_profile_groups_create(
     benchmark: BenchmarkFixture,
     cobbler_api: CobblerAPI,

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -25,6 +25,7 @@ from tests.performance import CobblerTree
         "image",
         "system",
         "network_interface",
+        "distro_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -24,6 +24,7 @@ from tests.performance import CobblerTree
         "profile",
         "image",
         "system",
+        "network_interface",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -27,6 +27,7 @@ from tests.performance import CobblerTree
         "network_interface",
         "distro_group",
         "profile_group",
+        "system_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_copy_test.py
+++ b/tests/performance/item_copy_test.py
@@ -26,6 +26,7 @@ from tests.performance import CobblerTree
         "system",
         "network_interface",
         "distro_group",
+        "profile_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -32,6 +32,7 @@ from tests.performance import CobblerTree
         "profile",
         "image",
         "system",
+        "network_interface",
     ],
 )
 @pytest.mark.parametrize(
@@ -70,7 +71,7 @@ def test_item_edit(
 
     def item_edit(api: CobblerAPI, what: str):
         for test_item in api.get_items(what):
-            if inherit_property:
+            if inherit_property and hasattr(test_item, "owners"):
                 old_owners = test_item.owners
                 test_item.owners = "test owners"  # type: ignore[method-assign]
                 test_item.owners = old_owners

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -33,6 +33,7 @@ from tests.performance import CobblerTree
         "image",
         "system",
         "network_interface",
+        "distro_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -35,6 +35,7 @@ from tests.performance import CobblerTree
         "network_interface",
         "distro_group",
         "profile_group",
+        "system_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_edit_test.py
+++ b/tests/performance/item_edit_test.py
@@ -34,6 +34,7 @@ from tests.performance import CobblerTree
         "system",
         "network_interface",
         "distro_group",
+        "profile_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -25,6 +25,7 @@ from tests.performance import CobblerTree
         "image",
         "system",
         "network_interface",
+        "distro_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -24,6 +24,7 @@ from tests.performance import CobblerTree
         "profile",
         "image",
         "system",
+        "network_interface",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -27,6 +27,7 @@ from tests.performance import CobblerTree
         "network_interface",
         "distro_group",
         "profile_group",
+        "system_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -26,6 +26,7 @@ from tests.performance import CobblerTree
         "system",
         "network_interface",
         "distro_group",
+        "profile_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_rename_test.py
+++ b/tests/performance/item_rename_test.py
@@ -25,6 +25,7 @@ from tests.performance import CobblerTree
         "image",
         "system",
         "network_interface",
+        "distro_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_rename_test.py
+++ b/tests/performance/item_rename_test.py
@@ -24,6 +24,7 @@ from tests.performance import CobblerTree
         "profile",
         "image",
         "system",
+        "network_interface",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_rename_test.py
+++ b/tests/performance/item_rename_test.py
@@ -27,6 +27,7 @@ from tests.performance import CobblerTree
         "network_interface",
         "distro_group",
         "profile_group",
+        "system_group",
     ],
 )
 @pytest.mark.parametrize(

--- a/tests/performance/item_rename_test.py
+++ b/tests/performance/item_rename_test.py
@@ -26,6 +26,7 @@ from tests.performance import CobblerTree
         "system",
         "network_interface",
         "distro_group",
+        "profile_group",
     ],
 )
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Linked Items

None

## Description

This PR adds the missing performance tests for the newly added item types for Cobbler 4.0.0.

## Behaviour changes

None

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [x] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
