### PR TITLE
Fix dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dependabot:
+        applies-to: version-updates
+        patterns:
+          - "github/codeql-action/*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,18 +1,24 @@
 Documentation:
-- docs/**/*
+- changed-files:
+  - any-glob-to-any-file: 'docs/*'
 
 Tests:
-- tests/**/*
-- system-tests/**/*
+- changed-files:
+  - any-glob-to-any-file: 'tests/*'
+  - any-glob-to-any-file: 'system-tests/*'
 
 CI:
-- .github/**/*
+- changed-files:
+  - any-glob-to-any-file: '.github/*'
 
 Packaging:
-- .obs/**/*
+- changed-files:
+  - any-glob-to-any-file: '.obs/*'
+  - any-glob-to-any-file: 'cobbler.spec'
+  - any-glob-to-any-file: 'debian/*'
 
 API:
-- cobbler/api.py
-- cobbler/remote.py
-- cobbler/services.py
-- svc/services.py
+- changed-files:
+  - any-glob-to-any-file: 'cobbler/api.py'
+  - any-glob-to-any-file: 'cobbler/remote.py'
+  - any-glob-to-any-file: 'services.py'

--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -18,6 +18,7 @@ on:
 
 jobs:
   run_performance_tests:
+    if: github.actor != 'dependabot[bot]'
     runs-on: fireactions
     name: "Performance-Tests"
     timeout-minutes: 720


### PR DESCRIPTION
## Linked Items

None

## Description

Groups dependabot updates for CodeQL and skips the performance testsuite for Dependabot PRs.

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
