### PR TITLE
Fix server-side issues part 2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,3 @@ updates:
         applies-to: version-updates
         patterns:
           - "github/codeql-action/*"
-        update-types:
-          - "minor"
-          - "patch"

--- a/cobbler/items/abstract/inheritable_item.py
+++ b/cobbler/items/abstract/inheritable_item.py
@@ -97,6 +97,7 @@ class InheritableItem(BaseItem, ABC):
         "system_group": [
             HierarchyItem("system_group", "parent"),
         ],
+        "template": [],
     }
 
     # Defines a logical hierarchy of Item Types.

--- a/cobbler/items/network_interface.py
+++ b/cobbler/items/network_interface.py
@@ -128,6 +128,8 @@ class NetworkInterface(BaseItem):
         self._interface_type = enums.NetworkInterfaceType.NA
         self._ipv4 = IPv4Option(api=api, item=self)
         self._ipv6 = IPv6Option(api=api, item=self)
+        self._ipv6_default_gateway = ""
+        self._ipv6_static_routes: List[str] = []
         self._mac_address = ""
         self._management = False
         self._static = False

--- a/cobbler/items/template.py
+++ b/cobbler/items/template.py
@@ -174,14 +174,14 @@ class Template(BaseItem):
         """
         if not self._uri.path:
             raise ValueError("Setting the content with an empty URI is not possible!")
-        if self._uri.schema == enums.TemplateSchema.IMPORTLIB:
+        if self._uri.schema == enums.TemplateSchema.IMPORTLIB.value:
             raise ValueError("The content of built-in templates cannot be updated.")
-        elif self._uri.schema == enums.TemplateSchema.ENVIRONMENT:
+        elif self._uri.schema == enums.TemplateSchema.ENVIRONMENT.value:
             os.environ[self.uri.path] = val
-        elif self._uri.schema == enums.TemplateSchema.FILE:
+        elif self._uri.schema == enums.TemplateSchema.FILE.value:
             pathlib.Path(self._uri.path).write_text(val, encoding="UTF-8")
         else:
-            raise ValueError("Unspported template type!")
+            raise ValueError("Unsupported template uri schema!")
         self.__content = val
 
     @property

--- a/cobbler/power_manager.py
+++ b/cobbler/power_manager.py
@@ -108,26 +108,26 @@ class PowerManager:
         :param system: Cobbler system
         """
 
-        if (system.power_pass or password) and system.power_identity_file:
+        if (system.power.password or password) and system.power.identity_file:
             self.logger.warning("Both password and identity-file are specified")
-        if system.power_identity_file:
-            ident_path = Path(system.power_identity_file)
+        if system.power.identity_file:
+            ident_path = Path(system.power.identity_file)
             if not ident_path.exists():
                 self.logger.warning(
-                    "identity-file %s does not exist", system.power_identity_file
+                    "identity-file %s does not exist", system.power.identity_file
                 )
             else:
                 ident_stat = stat.S_IMODE(ident_path.stat().st_mode)
                 if (ident_stat & stat.S_IRWXO) or (ident_stat & stat.S_IRWXG):
                     self.logger.warning(
                         "identity-file %s must not be read/write/exec by group or others",
-                        system.power_identity_file,
+                        system.power.identity_file,
                     )
-        if not system.power_address:
+        if not system.power.address:
             self.logger.warning("power-address is missing")
-        if not (system.power_user or user):
+        if not (system.power.user or user):
             self.logger.warning("power-user is missing")
-        if not (system.power_pass or password) and not system.power_identity_file:
+        if not (system.power.password or password) and not system.power.identity_file:
             self.logger.warning(
                 "neither power-identity-file nor power-password specified"
             )
@@ -155,18 +155,18 @@ class PowerManager:
         if not power_operation or power_operation not in ["on", "off", "status"]:
             raise CX("invalid power operation")
         power_input += "action=" + power_operation + "\n"
-        if system.power_address:
-            power_input += "ip=" + system.power_address + "\n"
-        if system.power_user:
-            power_input += "username=" + system.power_user + "\n"
-        if system.power_id:
-            power_input += "plug=" + system.power_id + "\n"
-        if system.power_pass:
-            power_input += "password=" + system.power_pass + "\n"
-        if system.power_identity_file:
-            power_input += "identity-file=" + system.power_identity_file + "\n"
-        if system.power_options:
-            power_input += system.power_options + "\n"
+        if system.power.address:
+            power_input += "ip=" + system.power.address + "\n"
+        if system.power.user:
+            power_input += "username=" + system.power.user + "\n"
+        if system.power.id:
+            power_input += "plug=" + system.power.id + "\n"
+        if system.power.password:
+            power_input += "password=" + system.power.password + "\n"
+        if system.power.identity_file:
+            power_input += "identity-file=" + system.power.identity_file + "\n"
+        if system.power.options:
+            power_input += system.power.options + "\n"
         return power_input
 
     def _power(
@@ -190,25 +190,25 @@ class PowerManager:
         :raise CX: if there are errors
         """
 
-        power_command = get_power_command(system.power_type)
+        power_command = get_power_command(system.power.type)
         if not power_command:
             raise ValueError("no power type set for system")
 
         power_info = {
-            "type": system.power_type,
-            "address": system.power_address,
-            "user": system.power_user,
-            "id": system.power_id,
-            "options": system.power_options,
-            "identity_file": system.power_identity_file,
+            "type": system.power.type,
+            "address": system.power.address,
+            "user": system.power.user,
+            "id": system.power.id,
+            "options": system.power.options,
+            "identity_file": system.power.identity_file,
         }
 
         self.logger.info("cobbler power configuration is: %s", json.dumps(power_info))
 
         # if no username/password data, check the environment, empty user/password could be valid
-        if not system.power_user and user is None:
+        if not system.power.user and user is None:
             user = os.environ.get("COBBLER_POWER_USER", "")
-        if not system.power_pass and password is None:
+        if not system.power.password and password is None:
             password = os.environ.get("COBBLER_POWER_PASS", "")
 
         power_input = self._get_power_input(system, power_operation, user, password)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3776,6 +3776,7 @@ class CobblerXMLRPCInterface:
         :param image_name: The name of the image for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
+        # FIXME: Don't return enum values
         self._log("get_valid_image_boot_loaders", token=token)
         if image_name is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
@@ -3794,6 +3795,7 @@ class CobblerXMLRPCInterface:
         :param profile_name: The name of the profile for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
+        # FIXME: Don't return enum values
         self._log("get_valid_profile_boot_loaders", token=token)
         if profile_name is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
@@ -3813,6 +3815,7 @@ class CobblerXMLRPCInterface:
         :param system_name: The name of the system for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.get_valid_archs
         """
+        # FIXME: Don't return enum values
         self._log("get_valid_system_boot_loaders", token=token)
         if system_name is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
@@ -4574,42 +4577,6 @@ class CobblerXMLRPCInterface:
         obj = self.api.find_menu(name=name)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
-        return self.xmlrpc_hacks({})
-
-    def get_network_interface_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
-    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
-        """
-        Get network interface after passing through Cobbler's inheritance engine
-
-        :param name: Network Interface name
-        :param token: Authentication token
-        :param rest: This is dropped in this method since it is not needed here.
-        :return: Get a template rendered as a file.
-        """
-
-        self._log("get_network_interface_as_rendered", name=name, token=token)
-        obj = self.api.find_network_interface(name=name)
-        if obj is not None and not isinstance(obj, list):
-            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
-        return self.xmlrpc_hacks({})
-
-    def get_template_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
-    ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
-        """
-        Get template after passing through Cobbler's inheritance engine
-
-        :param name: Template name
-        :param token: Authentication token
-        :param rest: This is dropped in this method since it is not needed here.
-        :return: Get a template rendered as a file.
-        """
-
-        self._log("get_network_interface_as_rendered", name=name, token=token)
-        obj = self.api.find_network_interface(name=name)
-        if obj is not None and not isinstance(obj, list):
-            return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
         return self.xmlrpc_hacks({})
 
     def get_distro_group_as_rendered(

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3776,7 +3776,6 @@ class CobblerXMLRPCInterface:
         :param image_name: The name of the image for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
-        # FIXME: Don't return enum values
         self._log("get_valid_image_boot_loaders", token=token)
         if image_name is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
@@ -3795,7 +3794,6 @@ class CobblerXMLRPCInterface:
         :param profile_name: The name of the profile for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
-        # FIXME: Don't return enum values
         self._log("get_valid_profile_boot_loaders", token=token)
         if profile_name is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
@@ -3815,7 +3813,6 @@ class CobblerXMLRPCInterface:
         :param system_name: The name of the system for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.get_valid_archs
         """
-        # FIXME: Don't return enum values
         self._log("get_valid_system_boot_loaders", token=token)
         if system_name is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
@@ -3825,7 +3822,7 @@ class CobblerXMLRPCInterface:
         parent = obj.get_conceptual_parent()
 
         if parent and parent.COLLECTION_TYPE == "profile":  # type: ignore[reportUnnecessaryComparison]
-            return parent.boot_loaders  # type: ignore
+            return [value.value for value in parent.boot_loaders]  # type: ignore
         return [value.value for value in self.api.get_valid_obj_boot_loaders(parent)]  # type: ignore[arg-type]
 
     def get_repo_config_for_profile(self, profile_name: str, **rest: Any):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1079,7 +1079,7 @@ class CobblerXMLRPCInterface:
         attribute: List[str],
         value: Any,
         token: Optional[str] = None,
-    ):
+    ) -> bool:
         """
         .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.set_item_resolved_value`
         """
@@ -1095,7 +1095,8 @@ class CobblerXMLRPCInterface:
         if obj is None or isinstance(obj, list):
             raise ValueError(f'Item with item_uuid "{item_uuid}" did not exist!')
         self.check_access(token, f"modify_{obj.COLLECTION_TYPE}", obj.name, attribute)
-        return self.api.set_item_resolved_value(item_uuid, attribute, value)
+        self.api.set_item_resolved_value(item_uuid, attribute, value)
+        return True
 
     def get_item(
         self,

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -518,9 +518,7 @@ class CobblerXMLRPCInterface:
         :param system_id: system handle
         :param power: power operation (on/off/status/reboot)
         """
-        system_obj = self.api.find_system(
-            criteria={"uid": system_id}, return_list=False
-        )
+        system_obj = self.api.find_system(uid=system_id, return_list=False)
         if system_obj is None or isinstance(system_obj, list):
             raise ValueError(f'System with uid "{system_id}" not found')
         self.check_access(token, "power_system", system_obj.name)

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -64,7 +64,7 @@ def test_network_interface_to_dict(cobbler_api: CobblerAPI):
     assert "logger" not in result
     assert "api" not in result
     assert result.get("virt_bridge") == enums.VALUE_INHERITED
-    assert len(result) == 21
+    assert len(result) == 23
 
 
 def test_network_interface_to_dict_resolved(cobbler_api: CobblerAPI):

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -237,6 +237,8 @@ def test_get_random_mac(remote: CobblerXMLRPCInterface, token: str):
                         "secondaries": [],
                         "static_routes": [],
                     },
+                    "ipv6_default_gateway": "",
+                    "ipv6_static_routes": [],
                     "mac_address": "aa:bb:cc:dd:ee:ff",
                     "management": False,
                     "mtime": 0.0,


### PR DESCRIPTION
## Linked Items

None

## Description

This PR groups changes from the work on https://github.com/cobbler/cobblerclient/pull/82 that are essentially a number of bug fixes:

- Network Interfaces: Initialise the two `ipv6_*` fields correctly
- CI: Group all kind of version updates for dependabot
- Template: Fix incorrect comparison of URI schema
- Collection: Fix template deletion
- Power Mgmt: Use the new Option-style attribute access
- XML-RPC API
  - `return True` on success for `set_item_resolved_value`
  - Remove the `*_as_rendered` methods for non-inherited items
  - Don't return an enum value for `get_valid_system_boot_loaders`
  - Use the new kwargs syntax for `power_system`

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
