### PR TITLE
fix: Template.content setter write location

### DIFF
--- a/cobbler/items/template.py
+++ b/cobbler/items/template.py
@@ -179,7 +179,10 @@ class Template(BaseItem):
         elif self._uri.schema == enums.TemplateSchema.ENVIRONMENT.value:
             os.environ[self.uri.path] = val
         elif self._uri.schema == enums.TemplateSchema.FILE.value:
-            pathlib.Path(self._uri.path).write_text(val, encoding="UTF-8")
+            (
+                pathlib.Path(self.api.settings().autoinstall_templates_dir)
+                / self._uri.path
+            ).write_text(val, encoding="UTF-8")
         else:
             raise ValueError("Unsupported template uri schema!")
         self.__content = val

--- a/tests/items/template_test.py
+++ b/tests/items/template_test.py
@@ -2,6 +2,8 @@
 Test module to verify the functionality of the Template item class.
 """
 
+import pathlib
+
 from cobbler import enums
 from cobbler.api import CobblerAPI
 from cobbler.items.template import Template
@@ -64,3 +66,27 @@ def test_to_dict_resolved(cobbler_api: CobblerAPI):
 
     # Assert
     assert isinstance(result, dict)
+
+
+def test_content_setter_writes_under_autoinstall_templates_dir(
+    cobbler_api: CobblerAPI, tmp_path: pathlib.Path
+):
+    """
+    Test that setting the content of a FILE schema template writes to the file resolved against
+    ``autoinstall_templates_dir``, the same location ``refresh_content()`` reads back from.
+    """
+    # Arrange
+    relative_path = "test_content_setter.j2"
+    cobbler_api.settings().autoinstall_templates_dir = str(tmp_path)
+    (tmp_path / relative_path).touch()
+    test_template = Template(
+        cobbler_api,
+        uri={"schema": enums.TemplateSchema.FILE.value, "path": relative_path},
+    )
+
+    # Act
+    test_template.content = "# test content\n"
+
+    # Assert
+    assert (tmp_path / relative_path).read_text(encoding="UTF-8") == "# test content\n"
+    assert test_template.content == "# test content\n"


### PR DESCRIPTION
## Linked Items

None

## Description

The template content setter didn't concat the path with the autoinstall templates directory. This caused the template to be empty after the refresh_content() method was called.

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
