### PR TITLE
Performance improvements for the development branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,4 @@ docs/_build
 # Misc
 .dmypy.json
 supervisord.pid
+.claude

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,9 +43,9 @@ pytest -m integration
 make system-test
 
 # Run specific distribution tests in Docker
-make test-rocky9
+make test-rocky10
 make test-fedora41
-make test-debian12
+make test-debian13
 ```
 
 ### Code Quality

--- a/Makefile
+++ b/Makefile
@@ -94,20 +94,17 @@ release: clean qa authors ## Creates the full release.
 	@mkdir release
 	@mv ../${NAME}.tar.gz ./release/${NAME}-${VERSION}.tar.gz
 
-test-rocky9: ## Executes the testscript for testing cobbler in a docker container on Rocky Linux 9.
-	./docker/rpms/build-and-install-rpms.sh rl8 docker/rpms/Rocky_Linux_9/Rocky_Linux_9.dockerfile
-
 test-rocky10: ## Executes the testscript for testing cobbler in a docker container on Rocky Linux 10.
 	./docker/rpms/build-and-install-rpms.sh rl10 docker/rpms/Rocky_Linux_10/Rocky_Linux_10.dockerfile
 
 test-fedora41: ## Executes the testscript for testing cobbler in a docker container on Fedora 41.
 	./docker/rpms/build-and-install-rpms.sh fc41 docker/rpms/Fedora_43/Fedora43.dockerfile
 
-test-debian11: ## Executes the testscript for testing cobbler in a docker container on Debian 11.
-	./docker/debs/build-and-install-debs.sh deb11 docker/debs/Debian_11/Debian11.dockerfile
+test-opensuse-leap: ## Executes the testscript for testing cobbler in a docker container on openSUSE Leap.
+	./docker/rpms/build-and-install-rpms.sh opensuse-leap docker/rpms/opensuse_leap/openSUSE_Leap16.dockerfile
 
-test-debian12: ## Executes the testscript for testing cobbler in a docker container on Debian 12.
-	./docker/debs/build-and-install-debs.sh deb12 docker/debs/Debian_12/Debian12.dockerfile
+test-opensuse-tumbleweed: ## Executes the testscript for testing cobbler in a docker container on openSUSE Tumbleweed.
+	./docker/rpms/build-and-install-rpms.sh opensuse-tumbleweed docker/rpms/opensuse_tumbleweed/openSUSE_TW.dockerfile
 
 test-debian13: ## Executes the testscript for testing cobbler in a docker container on Debian 13.
 	./docker/debs/build-and-install-debs.sh deb13 docker/debs/Debian_13/Debian13.dockerfile

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -906,12 +906,9 @@ class Collection(Generic[ITEM]):
                         add_result(key, indx_val, result)
                 else:
                     if result_len > 0:
-                        indx_set: Set[ITEM] = {self.listing[x] for x in indx_val}
-                        result_set = set(result) & indx_set
-                        if len(result_set) == 0:
+                        result = [item for item in result if item.uid in indx_val]
+                        if len(result) == 0:
                             found = False
-                        else:
-                            result = list(result_set)
                     elif found:
                         for obj_name in indx_val:
                             add_result(key, obj_name, result)

--- a/cobbler/data/config/cobbler/settings.yaml
+++ b/cobbler/data/config/cobbler/settings.yaml
@@ -725,13 +725,25 @@ memory_indexes:
       name:
         nonunique: false
         disabled: false
+      parent:
+        property: "get_parent"
+        nonunique: true
+        disabled: false
     profile_group:
       name:
         nonunique: false
         disabled: false
+      parent:
+        property: "get_parent"
+        nonunique: true
+        disabled: false
     system_group:
       name:
         nonunique: false
+        disabled: false
+      parent:
+        property: "get_parent"
+        nonunique: true
         disabled: false
     template:
       name:

--- a/cobbler/data/config/cobbler/settings.yaml
+++ b/cobbler/data/config/cobbler/settings.yaml
@@ -733,3 +733,10 @@ memory_indexes:
       name:
         nonunique: false
         disabled: false
+    template:
+      name:
+        nonunique: false
+        disabled: false
+      tags:
+        nonunique: true
+        disabled: false

--- a/cobbler/data/config/cobbler/settings.yaml
+++ b/cobbler/data/config/cobbler/settings.yaml
@@ -732,6 +732,9 @@ memory_indexes:
         property: "get_parent"
         nonunique: true
         disabled: false
+      members:
+        nonunique: true
+        disabled: false
     profile_group:
       name:
         nonunique: false
@@ -740,12 +743,18 @@ memory_indexes:
         property: "get_parent"
         nonunique: true
         disabled: false
+      members:
+        nonunique: true
+        disabled: false
     system_group:
       name:
         nonunique: false
         disabled: false
       parent:
         property: "get_parent"
+        nonunique: true
+        disabled: false
+      members:
         nonunique: true
         disabled: false
     template:

--- a/cobbler/data/config/cobbler/settings.yaml
+++ b/cobbler/data/config/cobbler/settings.yaml
@@ -709,6 +709,9 @@ memory_indexes:
         name:
             nonunique: true
             disabled: false
+        system_uid:
+            nonunique: true
+            disabled: false
         mac_address:
             nonunique: *allow_duplicate_macs
             disabled: *allow_duplicate_macs

--- a/cobbler/items/abstract/base_item.py
+++ b/cobbler/items/abstract/base_item.py
@@ -150,6 +150,22 @@ class BaseItem(ABC):
         if self._uid == "":
             self._uid = uuid.uuid4().hex
 
+    def __setattr__(self, name: str, value: Any):
+        """
+        Intercepting an attempt to assign a value to an attribute.
+
+        :name: The attribute name.
+        :value: The attribute value.
+        """
+        if (
+            BaseItem._is_dict_key(name)
+            and self._has_initialized
+            and hasattr(self, name)
+            and value != getattr(self, name)
+        ):
+            self.clean_cache(name)
+        super().__setattr__(name, value)
+
     def __eq__(self, other: Any) -> bool:
         """
         Comparison based on the uid for our items.

--- a/cobbler/items/abstract/bootable_item.py
+++ b/cobbler/items/abstract/bootable_item.py
@@ -106,7 +106,7 @@ V2.8.5:
 
 import pprint
 from abc import ABC
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, List, Type, TypeVar, Union, cast
 
 from cobbler import enums, utils
 from cobbler.items.abstract.inheritable_item import InheritableItem
@@ -166,22 +166,6 @@ class BootableItem(InheritableItem, ABC):
 
         if not self._has_initialized:
             self._has_initialized = True
-
-    def __setattr__(self, name: str, value: Any):
-        """
-        Intercepting an attempt to assign a value to an attribute.
-
-        :name: The attribute name.
-        :value: The attribute value.
-        """
-        if (
-            BootableItem._is_dict_key(name)
-            and self._has_initialized
-            and hasattr(self, name)
-            and value != getattr(self, name)
-        ):
-            self.clean_cache(name)
-        super().__setattr__(name, value)
 
     def __common_resolve(self, property_name: List[str]):
         property_name_copy = property_name.copy()
@@ -607,27 +591,3 @@ class BootableItem(InheritableItem, ABC):
                             for ancestor_name in attr_val:
                                 deserialize_ancestor(ancestor_item_type, ancestor_name)
         self.from_dict(item_dict)
-
-    def _clean_dict_cache(self, name: Optional[str]):
-        """
-        Clearing the Item dict cache.
-
-        :param name: The name of Item attribute or None.
-        """
-        if not self.api.settings().cache_enabled:
-            return
-
-        if name is not None and self._inmemory:
-            attr = getattr(type(self), name[1:])
-            if (
-                isinstance(attr, (InheritableProperty, InheritableDictProperty))
-                and self.api.get_items(self.COLLECTION_TYPE).listing.get(self.uid)
-                is not None
-            ):
-                # Invalidating "resolved" caches
-                for dep_item in self.tree_walk(name):
-                    self.logger.info(dep_item.cache.get_dict_cache(True))
-                    dep_item.cache.set_dict_cache(None, True)
-
-        # Invalidating the cache of the object itself.
-        self.cache.clean_dict_cache()

--- a/cobbler/items/abstract/inheritable_item.py
+++ b/cobbler/items/abstract/inheritable_item.py
@@ -24,9 +24,15 @@ if TYPE_CHECKING:
     from cobbler.items.system import System
     from cobbler.settings import Settings
 
+    InheritableDictProperty = property
+    InheritableProperty = property
     LazyProperty = property
 else:
-    from cobbler.decorator import LazyProperty
+    from cobbler.decorator import (
+        InheritableDictProperty,
+        InheritableProperty,
+        LazyProperty,
+    )
 
 
 class HierarchyItem(NamedTuple):
@@ -348,7 +354,7 @@ class InheritableItem(BaseItem, ABC):
 
         :getter: An empty list in case of items which don't have logical children.
         """
-        if self.COLLECTION_TYPE not in ["profile", "menu"]:
+        if "parent" not in self.api.get_items(self.COLLECTION_TYPE).indexes:
             return []
 
         results: Optional[List["InheritableItem"]] = self.api.find_items(  # type: ignore
@@ -376,6 +382,30 @@ class InheritableItem(BaseItem, ABC):
                 results.extend(child.tree_walk(attribute_name))
 
         return results
+
+    def _clean_dict_cache(self, name: Optional[str]):
+        """
+        Clearing the Item dict cache.
+
+        :param name: The name of Item attribute or None.
+        """
+        if not self.api.settings().cache_enabled:
+            return
+
+        if name is not None and self._inmemory:
+            attr = getattr(type(self), name[1:])
+            if (
+                isinstance(attr, (InheritableProperty, InheritableDictProperty))
+                and self.api.get_items(self.COLLECTION_TYPE).listing.get(self.uid)
+                is not None
+            ):
+                # Invalidating "resolved" caches
+                for dep_item in self.tree_walk(name):
+                    self.logger.info(dep_item.cache.get_dict_cache(True))
+                    dep_item.cache.set_dict_cache(None, True)
+
+        # Invalidating the cache of the object itself.
+        self.cache.clean_dict_cache()
 
     @property
     def descendants(self) -> List["InheritableItem"]:

--- a/cobbler/items/abstract/inheritable_item.py
+++ b/cobbler/items/abstract/inheritable_item.py
@@ -401,7 +401,6 @@ class InheritableItem(BaseItem, ABC):
             ):
                 # Invalidating "resolved" caches
                 for dep_item in self.tree_walk(name):
-                    self.logger.info(dep_item.cache.get_dict_cache(True))
                     dep_item.cache.set_dict_cache(None, True)
 
         # Invalidating the cache of the object itself.

--- a/cobbler/items/abstract/item_group.py
+++ b/cobbler/items/abstract/item_group.py
@@ -132,4 +132,8 @@ class ItemGroup(InheritableItem, ABC):
                 member, str
             ):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise TypeError("All members must be of type string")
+        old_members = self._members
         self._members = value
+        self.api.get_items(self.COLLECTION_TYPE).update_index_value(
+            self, "members", old_members, value
+        )

--- a/cobbler/items/network_interface.py
+++ b/cobbler/items/network_interface.py
@@ -612,7 +612,11 @@ class NetworkInterface(BaseItem):
 
         :param system_name: The new system_name.
         """
+        old_system_uid = self._system_uid
         self._system_uid = system_uid
+        self.api.network_interfaces().update_index_value(
+            self, "system_uid", old_system_uid, system_uid
+        )
 
     @property
     def system(self) -> "System":

--- a/cobbler/items/options/dns.py
+++ b/cobbler/items/options/dns.py
@@ -7,7 +7,7 @@ names (CNAMEs). The module ensures proper validation and uniqueness of DNS names
 inheritance and lazy property evaluation.
 """
 
-from typing import TYPE_CHECKING, Any, List, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Union
 
 from cobbler import validate
 from cobbler.items.options.base import ItemOption
@@ -132,9 +132,8 @@ class DNSInterfaceOption(ItemOption["NetworkInterface"]):
         dns_name = validate.hostname(dns_name)
         if dns_name != "" and not self._api.settings().allow_duplicate_hostnames:
             # FIXME: Better querying for ItemOption structs
-            matched = self._api.find_network_interface(
-                return_list=True, dns=f"name={dns_name}"
-            )
+            dedup_kwargs: Dict[str, Any] = {"dns.name": dns_name}
+            matched = self._api.find_network_interface(return_list=True, **dedup_kwargs)
             if matched is None:
                 matched = []
             if not isinstance(matched, list):  # type: ignore

--- a/cobbler/items/options/ip.py
+++ b/cobbler/items/options/ip.py
@@ -3,7 +3,7 @@ This module provides option classes for managing IP-related settings for network
 """
 
 from ipaddress import AddressValueError
-from typing import TYPE_CHECKING, Any, List
+from typing import TYPE_CHECKING, Any, Dict, List
 
 from cobbler import utils, validate
 from cobbler.items.options.base import ItemOption
@@ -120,9 +120,8 @@ class IPv4Option(IPOption):
             return
         address = validate.ipv4_address(address)
         if address != "" and not self._api.settings().allow_duplicate_ips:
-            matched = self._api.find_network_interface(
-                return_list=True, ipv4=f"address={address}"
-            )
+            dedup_kwargs: Dict[str, Any] = {"ipv4.address": address}
+            matched = self._api.find_network_interface(return_list=True, **dedup_kwargs)
             if matched is None:
                 matched = []
             if not isinstance(matched, list):
@@ -203,9 +202,8 @@ class IPv6Option(IPOption):
             return
         address = validate.ipv6_address(address)
         if address != "" and not self._api.settings().allow_duplicate_ips:
-            matched = self._api.find_network_interface(
-                return_list=True, ipv6=f"address={address}"
-            )
+            dedup_kwargs: Dict[str, Any] = {"ipv6.address": address}
+            matched = self._api.find_network_interface(return_list=True, **dedup_kwargs)
             if matched is None:
                 matched = []
             if not isinstance(matched, list):

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -123,9 +123,9 @@ class _InTftpdManager(TftpManagerModule):
         """
         if not menu_items:
             menu_items = self.api.tftpgen.get_menu_items()
-        self.api.tftpgen.write_all_system_files(system, menu_items)
+        meta_blended = self.api.tftpgen.write_all_system_files(system, menu_items)
         # generate any templates listed in the distro
-        self.api.tftpgen.write_templates(system)
+        self.api.tftpgen.write_templates(system, blended=meta_blended)
         return 0
 
     def add_single_distro(self, distro: "Distro") -> None:

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -357,6 +357,10 @@ class Settings:
             "system_group": {
                 "name": {"nonunique": False, "disabled": False},
             },
+            "template": {
+                "name": {"nonunique": False, "disabled": False},
+                "tags": {"nonunique": True, "disabled": False},
+            },
         }
 
     @property

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -312,6 +312,7 @@ class Settings:
             },
             "network_interface": {
                 "name": {"nonunique": True, "disabled": False},
+                "system_uid": {"nonunique": True, "disabled": False},
                 "mac_address": {
                     "nonunique": self.allow_duplicate_macs,
                     "disabled": self.allow_duplicate_macs,

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -350,12 +350,27 @@ class Settings:
             },
             "distro_group": {
                 "name": {"nonunique": False, "disabled": False},
+                "parent": {
+                    "property": "get_parent",
+                    "nonunique": True,
+                    "disabled": False,
+                },
             },
             "profile_group": {
                 "name": {"nonunique": False, "disabled": False},
+                "parent": {
+                    "property": "get_parent",
+                    "nonunique": True,
+                    "disabled": False,
+                },
             },
             "system_group": {
                 "name": {"nonunique": False, "disabled": False},
+                "parent": {
+                    "property": "get_parent",
+                    "nonunique": True,
+                    "disabled": False,
+                },
             },
             "template": {
                 "name": {"nonunique": False, "disabled": False},

--- a/cobbler/settings/__init__.py
+++ b/cobbler/settings/__init__.py
@@ -356,6 +356,7 @@ class Settings:
                     "nonunique": True,
                     "disabled": False,
                 },
+                "members": {"nonunique": True, "disabled": False},
             },
             "profile_group": {
                 "name": {"nonunique": False, "disabled": False},
@@ -364,6 +365,7 @@ class Settings:
                     "nonunique": True,
                     "disabled": False,
                 },
+                "members": {"nonunique": True, "disabled": False},
             },
             "system_group": {
                 "name": {"nonunique": False, "disabled": False},
@@ -372,6 +374,7 @@ class Settings:
                     "nonunique": True,
                     "disabled": False,
                 },
+                "members": {"nonunique": True, "disabled": False},
             },
             "template": {
                 "name": {"nonunique": False, "disabled": False},

--- a/cobbler/settings/migrations/V4_0_0.py
+++ b/cobbler/settings/migrations/V4_0_0.py
@@ -364,6 +364,11 @@ schema = Schema(
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,
                 },
+                Optional("members"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
             },
             Optional("profile_group"): {
                 Optional("name"): {
@@ -376,6 +381,11 @@ schema = Schema(
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,
                 },
+                Optional("members"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
             },
             Optional("system_group"): {
                 Optional("name"): {
@@ -384,6 +394,11 @@ schema = Schema(
                     Optional("disabled"): bool,
                 },
                 Optional("parent"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("members"): {
                     Optional("property"): str,
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,

--- a/cobbler/settings/migrations/V4_0_0.py
+++ b/cobbler/settings/migrations/V4_0_0.py
@@ -369,6 +369,18 @@ schema = Schema(
                     Optional("disabled"): bool,
                 },
             },
+            Optional("template"): {
+                Optional("name"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("tags"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+            },
         },
     },  # type: ignore
     ignore_extra_keys=False,

--- a/cobbler/settings/migrations/V4_0_0.py
+++ b/cobbler/settings/migrations/V4_0_0.py
@@ -354,6 +354,11 @@ schema = Schema(
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,
                 },
+                Optional("parent"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
             },
             Optional("profile_group"): {
                 Optional("name"): {
@@ -361,9 +366,19 @@ schema = Schema(
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,
                 },
+                Optional("parent"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
             },
             Optional("system_group"): {
                 Optional("name"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
+                Optional("parent"): {
                     Optional("property"): str,
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,

--- a/cobbler/settings/migrations/V4_0_0.py
+++ b/cobbler/settings/migrations/V4_0_0.py
@@ -271,6 +271,11 @@ schema = Schema(
                     Optional("nonunique"): bool,
                     Optional("disabled"): bool,
                 },
+                Optional("system_uid"): {
+                    Optional("property"): str,
+                    Optional("nonunique"): bool,
+                    Optional("disabled"): bool,
+                },
                 Optional("mac_address"): {
                     Optional("property"): str,
                     Optional("nonunique"): bool,

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -324,8 +324,11 @@ class TFTPGen:
         )
 
     def write_all_system_files(
-        self, system: "System", menu_items: Dict[str, Union[str, Dict[str, str]]]
-    ) -> None:
+        self,
+        system: "System",
+        menu_items: Dict[str, Union[str, Dict[str, str]]],
+        meta_blended: Optional[Dict[str, Any]] = None,
+    ) -> Optional[Dict[str, Any]]:
         """
         Writes all files for tftp for a given system with the menu items handed to this method. The system must have a
         profile attached. Otherwise this method throws an error.
@@ -345,6 +348,11 @@ class TFTPGen:
 
         :param system: The system to generate files for.
         :param menu_items: The list of labels that are used for displaying the menu entry.
+        :param meta_blended: A pre-computed ``utils.blender(self.api, False, system)`` result to reuse
+                              instead of recomputing it, for callers that already have one.
+        :return: The ``utils.blender(self.api, False, system)`` result used to generate these files
+                 (``None`` for S390/S390x systems, which use a separate code path that doesn't need it),
+                 so callers that also need it (e.g. for :meth:`write_templates`) can reuse it.
         This method is also responsible for removing stale boot loader artefacts when support for PXE/GRUB is disabled
         or management is no longer supported for the system.
         """
@@ -372,7 +380,7 @@ class TFTPGen:
         # hack: s390 generates files per system not per interface
         if distro is not None and distro.arch in (enums.Archs.S390, enums.Archs.S390X):
             self._write_all_system_files_s390(distro, profile, image, system)  # type: ignore
-            return
+            return None
 
         boot_loaders = list(system.boot_loaders)
         pxe_enabled = enums.BootLoader.PXE in boot_loaders
@@ -441,6 +449,12 @@ class TFTPGen:
                     filesystem_helpers.rmfile(grub_path)
                 continue
 
+            # Computed lazily (once, on first actual need) rather than unconditionally above, so that
+            # systems skipped by the checks above (unsupported arch, management not supported) never
+            # pay for it.
+            if meta_blended is None:
+                meta_blended = utils.blender(self.api, False, system)
+
             if image is None:
                 if pxe_path:
                     if pxe_enabled:
@@ -451,6 +465,7 @@ class TFTPGen:
                             distro,
                             working_arch,
                             metadata=pxe_metadata,  # type: ignore
+                            meta_blended=meta_blended,
                         )
                     else:
                         filesystem_helpers.rmfile(pxe_path)
@@ -463,6 +478,7 @@ class TFTPGen:
                             distro,
                             working_arch,
                             bootloader_format=enums.BootLoader.GRUB,
+                            meta_blended=meta_blended,
                         )
                         if grub_name is not None:
                             grub_targets.append(grub_name)
@@ -479,6 +495,7 @@ class TFTPGen:
                             working_arch,
                             image=image,
                             metadata=pxe_metadata,  # type: ignore
+                            meta_blended=meta_blended,
                         )
                     else:
                         filesystem_helpers.rmfile(pxe_path)
@@ -495,6 +512,8 @@ class TFTPGen:
                     system.name,
                     os_error,
                 )
+
+        return meta_blended
 
     def _generate_system_file_s390x(
         self,
@@ -1197,6 +1216,7 @@ class TFTPGen:
         image: Optional["Image"] = None,
         metadata: Optional[Dict[str, Union[str, Dict[str, str]]]] = None,
         bootloader_format: enums.BootLoader = enums.BootLoader.PXE,
+        meta_blended: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
         Write a configuration file for the bootloader(s).
@@ -1215,6 +1235,8 @@ class TFTPGen:
         :param image: If you want to be able to deploy an image, supply this parameter.
         :param metadata: Pass additional parameters to the ones being collected during the method.
         :param bootloader_format: Can be any of those returned by utils.get_supported_system_boot_loaders().
+        :param meta_blended: A pre-computed ``utils.blender(self.api, False, system|profile|image)`` result
+                              to reuse instead of recomputing it, for callers that already have one.
         :return: The generated file-content for the required item.
         """
 
@@ -1256,11 +1278,11 @@ class TFTPGen:
         # just some random variables
         buffer = ""
 
-        self.build_kernel(metadata, system, profile, distro, image, bootloader_format)  # type: ignore
+        self.build_kernel(metadata, system, profile, distro, image, bootloader_format, meta_blended=meta_blended)  # type: ignore
 
         # generate the kernel options and append line:
         kernel_options = self.build_kernel_options(
-            system, profile, distro, image, arch  # type: ignore
+            system, profile, distro, image, arch, blended=meta_blended  # type: ignore
         )
         metadata["kernel_options"] = kernel_options
 
@@ -1361,6 +1383,7 @@ class TFTPGen:
         distro: "Distro",
         image: Optional["Image"] = None,
         boot_loader: str = "pxe",
+        meta_blended: Optional[Dict[str, Any]] = None,
     ):
         """
         Generates kernel and initrd metadata.
@@ -1372,6 +1395,8 @@ class TFTPGen:
                        the templates.
         :param image: If you want to be able to deploy an image, supply this parameter.
         :param boot_loader: Can be any of those returned by utils.get_supported_system_boot_loaders().
+        :param meta_blended: A pre-computed ``utils.blender(self.api, False, system|profile|image)`` result
+                              to reuse instead of recomputing it, for callers that already have one.
         """
         kernel_path: Optional[str] = None
         initrd_path: Optional[str] = None
@@ -1379,14 +1404,15 @@ class TFTPGen:
 
         # ---
 
-        if system:
-            meta_blended = utils.blender(self.api, False, system)
-        elif profile:
-            meta_blended = utils.blender(self.api, False, profile)
-        elif image:
-            meta_blended = utils.blender(self.api, False, image)
-        else:
-            meta_blended = {}
+        if meta_blended is None:
+            if system:
+                meta_blended = utils.blender(self.api, False, system)
+            elif profile:
+                meta_blended = utils.blender(self.api, False, profile)
+            elif image:
+                meta_blended = utils.blender(self.api, False, image)
+            else:
+                meta_blended = {}
         # Derive the flattened view from the already-computed tree instead of walking it again with
         # remove_dicts=True - the two blender() calls only ever differed in this final step. flatten()
         # only returns None for non-dict input, which dict(meta_blended) never is.
@@ -1458,6 +1484,7 @@ class TFTPGen:
         distro: Optional["Distro"],
         image: Optional["Image"],
         arch: enums.Archs,
+        blended: Optional[Dict[str, Any]] = None,
     ) -> str:
         """
         Builds the full kernel options line.
@@ -1467,13 +1494,29 @@ class TFTPGen:
         :param distro: Although the profile contains the distribution please specify it explicitly here.
         :param image: The image to generate the kernel options for.
         :param arch: The processor architecture to generate the kernel options for.
+        :param blended: A pre-computed ``utils.blender(self.api, False, system|profile|image)`` result
+                        to reuse instead of recomputing it, for callers that already have one.
         :return: The generated kernel line options.
         """
 
         management_interface = None
         management_mac = None
+        if blended is None:
+            if system is not None:
+                blended = utils.blender(self.api, False, system)
+            elif profile is not None:
+                blended = utils.blender(self.api, False, profile)
+            elif image is not None:
+                blended = utils.blender(self.api, False, image)
+            else:
+                raise ValueError("Impossible to find object for kernel options")
+        else:
+            # Copy since append_line.render() below mutates its dict argument in place (flatten() +
+            # autoinstall_meta merge), and a caller-supplied dict may be shared with other consumers
+            # of the same blender() result.
+            blended = dict(blended)
+
         if system is not None:
-            blended = utils.blender(self.api, False, system)
             # find the first management interface
             try:
                 for intf in system.interfaces.keys():
@@ -1485,12 +1528,6 @@ class TFTPGen:
             except Exception:
                 # just skip this then
                 pass
-        elif profile is not None:
-            blended = utils.blender(self.api, False, profile)
-        elif image is not None:
-            blended = utils.blender(self.api, False, image)
-        else:
-            raise ValueError("Impossible to find object for kernel options")
 
         append_line = kernel_command_line.KernelCommandLine(self.api)
         kopts: Dict[str, Any] = blended.get("kernel_options", {})
@@ -1702,6 +1739,7 @@ class TFTPGen:
         obj: "BootableItem",
         write_file: bool = False,
         path: Optional[str] = None,
+        blended: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, str]:
         """
         A semi-generic function that will take an object with a template_files dict {source:destiation}, and generate a
@@ -1711,6 +1749,8 @@ class TFTPGen:
         :param obj: The object to write the template files for.
         :param write_file: If the generated template should be written to the disk.
         :param path: TODO: A useless parameter?
+        :param blended: A pre-computed ``utils.blender(self.api, False, obj)`` result to reuse instead
+                        of recomputing it, for callers that already have one for this same object.
         :return: A dict of the destination file names (after variable substitution is done) and the data in the file.
         """
         self.logger.info("Writing template files for %s", obj.name)
@@ -1722,7 +1762,15 @@ class TFTPGen:
         except Exception:
             return results
 
-        blended = utils.blender(self.api, False, obj)
+        if not templates:
+            return results
+
+        if blended is None:
+            blended = utils.blender(self.api, False, obj)
+        else:
+            # Copy since this function mutates `blended` (pop()/update() below) and a caller-supplied
+            # dict may be shared with other consumers of the same blender() result.
+            blended = dict(blended)
 
         if obj.COLLECTION_TYPE == "distro":  # type: ignore
             if re.search("esxi[567]", obj.os_version) is not None:  # type: ignore

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     from cobbler.items.distro import Distro
     from cobbler.items.image import Image
     from cobbler.items.menu import Menu
+    from cobbler.items.network_interface import NetworkInterface
     from cobbler.items.profile import Profile
     from cobbler.items.system import System
     from cobbler.items.template import Template
@@ -2251,18 +2252,133 @@ class TFTPGen:
                 return self._read_chunk(initrd_path, offset, size)
         return None
 
+    def _systems_from_interfaces(
+        self, interfaces: Optional[Union[List["NetworkInterface"], "NetworkInterface"]]
+    ) -> List["System"]:
+        """
+        Resolve the systems owning the given network interface(s) via the already-indexed
+        ``system_uid`` -> item lookup (an O(1) dict-get per interface).
+        """
+        if interfaces is None:
+            return []
+        if not isinstance(interfaces, list):
+            interfaces = [interfaces]
+        systems: List["System"] = []
+        for interface in interfaces:
+            system = self.api.systems().listing.get(interface.system_uid)
+            if system is not None:
+                systems.append(system)
+        return systems
+
+    def _systems_by_mac(self, mac_address: str) -> List["System"]:
+        interfaces = self.api.find_network_interface(
+            return_list=True, mac_address=mac_address
+        )
+        return self._systems_from_interfaces(interfaces)
+
+    def _systems_by_ip(self, ip_address: str) -> List["System"]:
+        kwargs: Dict[str, Any] = {"ipv4.address": ip_address}
+        interfaces = self.api.find_network_interface(return_list=True, **kwargs)
+        return self._systems_from_interfaces(interfaces)
+
+    def _find_system_for_config_filename(
+        self, filename: str, loader: enums.BootLoader
+    ) -> Optional["System"]:
+        """
+        Best-effort O(1)/O(bucket-size) resolution of the system whose :meth:`System.get_config_filename`
+        would produce ``filename``, by reverse-parsing it into a candidate MAC/IP/literal name and doing a
+        targeted, already-indexed lookup - instead of scanning every system.
+
+        Every candidate is verified by recomputing ``get_config_filename()`` and comparing it against the
+        requested filename, so this can never return a wrong system. Returns ``None`` (letting the caller
+        fall back to a full scan) whenever no verified candidate can be found, e.g. when the relevant index
+        is disabled because ``allow_duplicate_macs``/``allow_duplicate_ips`` is enabled - this keeps the
+        function purely a fast path, never a source of incorrect results.
+        """
+        candidates: List["System"] = []
+
+        if filename == "default":
+            default_system = self.api.find_system(return_list=False, name="default")
+            if default_system is not None and not isinstance(default_system, list):
+                candidates.append(default_system)
+        elif loader == enums.BootLoader.PXE and filename.startswith("01-"):
+            candidates.extend(
+                self._systems_by_mac(filename[len("01-") :].replace("-", ":"))
+            )
+        elif loader == enums.BootLoader.GRUB and re.fullmatch(
+            r"[0-9a-f]{2}(:[0-9a-f]{2})+", filename
+        ):
+            candidates.extend(self._systems_by_mac(filename))
+        elif re.fullmatch(r"[0-9A-F]{8}", filename):
+            try:
+                candidates.extend(self._systems_by_ip(utils.hex_to_ip(filename)))
+            except ValueError:
+                pass
+
+        if not candidates:
+            # Either no shape matched, or a shape matched but had no owner (e.g. a system literally
+            # named like an IP-hex/MAC string) - a literal system name is always the final fallback in
+            # get_config_filename() itself, so try it here too before giving up.
+            literal = self.api.find_system(return_list=False, name=filename)
+            if literal is not None and not isinstance(literal, list):
+                candidates.append(literal)
+
+        for candidate in candidates:
+            for interface_name in candidate.interfaces:
+                if (
+                    candidate.get_config_filename(
+                        interface=interface_name, loader=loader
+                    )
+                    == filename
+                ):
+                    return candidate
+        return None
+
+    def _find_system_for_tftp_path(self, path: pathlib.Path) -> Optional["System"]:
+        """
+        Reverse-parse a requested TFTP config-file path into the loader/filename shapes
+        :meth:`generate_system_file` recognizes, and resolve the owning system via
+        :meth:`_find_system_for_config_filename`. Returns ``None`` for any path shape not recognized here
+        (e.g. the caller falls back to a full scan).
+        """
+        parts = path.parts
+        if len(parts) == 3 and parts[1] == "pxelinux.cfg":
+            return self._find_system_for_config_filename(parts[2], enums.BootLoader.PXE)
+        if len(parts) == 4 and parts[1] == "esxi" and parts[2] == "pxelinux.cfg":
+            return self._find_system_for_config_filename(parts[3], enums.BootLoader.PXE)
+        if len(parts) == 4 and parts[1] == "grub" and parts[2] == "system":
+            return self._find_system_for_config_filename(
+                parts[3], enums.BootLoader.GRUB
+            )
+        if (
+            len(parts) == 5
+            and parts[1] == "esxi"
+            and parts[2] == "system"
+            and parts[4] == "boot.cfg"
+        ):
+            candidate = self.api.find_system(return_list=False, name=parts[3])
+            if candidate is not None and not isinstance(candidate, list):
+                return candidate
+        return None
+
     def _generate_tftp_config_file(
         self, path: pathlib.Path, offset: int, size: int
     ) -> Optional[Tuple[bytes, int]]:
         metadata = self.get_menu_items()
-        # TODO: This iterates through all systems for each request. Can this be optimized?
         contents = None
-        for system in self.api.systems():
-            if not system.is_management_supported():
-                continue
-            contents = self.generate_system_file(system, path, metadata)
-            if contents is not None:
-                break
+        candidate = self._find_system_for_tftp_path(path)
+        if candidate is not None and candidate.is_management_supported():
+            contents = self.generate_system_file(candidate, path, metadata)
+        if contents is None:
+            # Fast path above found nothing (unrecognized path shape, no verified candidate, or the
+            # relevant index disabled by allow_duplicate_macs/allow_duplicate_ips) - fall back to the
+            # full scan. Correctness never depends on the fast path succeeding.
+            for system in self.api.systems():
+                if not system.is_management_supported():
+                    continue
+                contents = self.generate_system_file(system, path, metadata)
+                if contents is not None:
+                    break
         if contents is None:
             contents = self.generate_pxe_menu(path, metadata)
         if contents is not None:

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1380,17 +1380,17 @@ class TFTPGen:
         # ---
 
         if system:
-            blended = utils.blender(self.api, True, system)
             meta_blended = utils.blender(self.api, False, system)
         elif profile:
-            blended = utils.blender(self.api, True, profile)
             meta_blended = utils.blender(self.api, False, profile)
         elif image:
-            blended = utils.blender(self.api, True, image)
             meta_blended = utils.blender(self.api, False, image)
         else:
-            blended = {}
             meta_blended = {}
+        # Derive the flattened view from the already-computed tree instead of walking it again with
+        # remove_dicts=True - the two blender() calls only ever differed in this final step. flatten()
+        # only returns None for non-dict input, which dict(meta_blended) never is.
+        blended = cast(Dict[str, Any], utils.flatten(dict(meta_blended)))
 
         autoinstall_meta = meta_blended.get("autoinstall_meta", {})
         metadata.update(blended)

--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -183,6 +183,19 @@ def get_host_ip(ip_address: str, shorten: bool = True) -> str:
     return pretty[0:-cutoff]
 
 
+def hex_to_ip(hex_str: str) -> str:
+    """
+    Inverse of ``get_host_ip()`` for the unshortened (single-address, i.e. non-CIDR) case: decode an
+    8-character hexadecimal string back into its dotted-quad IPv4 address.
+
+    :param hex_str: An 8-character hexadecimal string, as produced by ``get_host_ip()``/``pretty_hex()``
+                    for a bare (non-CIDR) IPv4 address.
+    :return: The decoded dotted-quad IPv4 address.
+    :raises ValueError: If ``hex_str`` is not a valid hexadecimal string.
+    """
+    return str(IPAddress(int(hex_str, 16)))
+
+
 def _IP(ip_address: Union[str, IPAddress]) -> IPAddress:
     """
     Returns a netaddr.IP object representing an ip.

--- a/docker/develop/scripts/profile-flamegraph.sh
+++ b/docker/develop/scripts/profile-flamegraph.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Records a py-spy flamegraph for a pytest invocation, meant to be run inside the
+# dev container (see docker/tests/compose.yml / CLAUDE.md).
+#
+# Usage:
+#   ./docker/develop/scripts/profile-flamegraph.sh <output.svg> <pytest-args...>
+#
+# Example (single-shot, no pytest-benchmark repetition, one iteration/round):
+#   COBBLER_PERFORMANCE_TEST_GET_AUTOINSTALL_ITERATIONS=1 \
+#     ./docker/develop/scripts/profile-flamegraph.sh \
+#     /code/profile-get-autoinstall-profile.svg \
+#     --benchmark-only "tests/performance/get_autoinstall_test.py::test_get_autoinstall[False-profile]"
+#
+# py-spy is a sampling profiler: it attaches to the pytest process it spawns and
+# periodically records the Python call stack, with negligible overhead on the
+# profiled code. No source changes or instrumentation are required.
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+    echo "Usage: $0 <output.svg> <pytest-args...>" >&2
+    exit 1
+fi
+
+OUTPUT="$1"
+shift
+
+if ! command -v py-spy >/dev/null 2>&1; then
+    echo "py-spy not found, installing..."
+    pip install --break-system-packages py-spy
+fi
+
+cd /code
+py-spy record --rate 200 --output "$OUTPUT" -- python3 -m pytest "$@"
+
+echo "Flamegraph written to $OUTPUT"

--- a/tests/cobbler_collections/distro_group_collection_test.py
+++ b/tests/cobbler_collections/distro_group_collection_test.py
@@ -244,7 +244,7 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(distro_group_collection.indexes) == 2
+    assert len(distro_group_collection.indexes) == 3
     assert len(distro_group_collection.indexes["name"]) == 0
 
 

--- a/tests/cobbler_collections/distro_group_collection_test.py
+++ b/tests/cobbler_collections/distro_group_collection_test.py
@@ -244,7 +244,7 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(distro_group_collection.indexes) == 1
+    assert len(distro_group_collection.indexes) == 2
     assert len(distro_group_collection.indexes["name"]) == 0
 
 

--- a/tests/cobbler_collections/network_interface_collection_test.py
+++ b/tests/cobbler_collections/network_interface_collection_test.py
@@ -362,8 +362,9 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(network_interface_collection.indexes) == 5
+    assert len(network_interface_collection.indexes) == 6
     assert len(network_interface_collection.indexes["name"]) == 0
+    assert len(network_interface_collection.indexes["system_uid"]) == 0
     assert len(network_interface_collection.indexes["dns.name"]) == 0
     assert len(network_interface_collection.indexes["ipv4.address"]) == 0
     assert len(network_interface_collection.indexes["ipv6.address"]) == 0

--- a/tests/cobbler_collections/profile_group_collection_test.py
+++ b/tests/cobbler_collections/profile_group_collection_test.py
@@ -243,7 +243,7 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(profile_group_collection.indexes) == 1
+    assert len(profile_group_collection.indexes) == 2
     assert len(profile_group_collection.indexes["name"]) == 0
 
 

--- a/tests/cobbler_collections/profile_group_collection_test.py
+++ b/tests/cobbler_collections/profile_group_collection_test.py
@@ -243,7 +243,7 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(profile_group_collection.indexes) == 2
+    assert len(profile_group_collection.indexes) == 3
     assert len(profile_group_collection.indexes["name"]) == 0
 
 

--- a/tests/cobbler_collections/system_group_collection_test.py
+++ b/tests/cobbler_collections/system_group_collection_test.py
@@ -243,7 +243,7 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(system_group_collection.indexes) == 1
+    assert len(system_group_collection.indexes) == 2
     assert len(system_group_collection.indexes["name"]) == 0
 
 

--- a/tests/cobbler_collections/system_group_collection_test.py
+++ b/tests/cobbler_collections/system_group_collection_test.py
@@ -243,7 +243,7 @@ def test_indexes(
     # Arrange
 
     # Assert
-    assert len(system_group_collection.indexes) == 2
+    assert len(system_group_collection.indexes) == 3
     assert len(system_group_collection.indexes["name"]) == 0
 
 

--- a/tests/integration/data/test_svc_settings/expected_settings.json
+++ b/tests/integration/data/test_svc_settings/expected_settings.json
@@ -385,17 +385,32 @@
             "name": {
                 "nonunique": false,
                 "disabled": false
+            },
+            "parent": {
+                "property": "get_parent",
+                "nonunique": true,
+                "disabled": false
             }
         },
         "profile_group": {
             "name": {
                 "nonunique": false,
                 "disabled": false
+            },
+            "parent": {
+                "property": "get_parent",
+                "nonunique": true,
+                "disabled": false
             }
         },
         "system_group": {
             "name": {
                 "nonunique": false,
+                "disabled": false
+            },
+            "parent": {
+                "property": "get_parent",
+                "nonunique": true,
                 "disabled": false
             }
         },

--- a/tests/integration/data/test_svc_settings/expected_settings.json
+++ b/tests/integration/data/test_svc_settings/expected_settings.json
@@ -318,6 +318,10 @@
                 "nonunique": true,
                 "disabled": false
             },
+            "system_uid": {
+                "nonunique": true,
+                "disabled": false
+            },
             "mac_address": {
                 "nonunique": false,
                 "disabled": false

--- a/tests/integration/data/test_svc_settings/expected_settings.json
+++ b/tests/integration/data/test_svc_settings/expected_settings.json
@@ -398,6 +398,16 @@
                 "nonunique": false,
                 "disabled": false
             }
+        },
+        "template": {
+            "name": {
+                "nonunique": false,
+                "disabled": false
+            },
+            "tags": {
+                "nonunique": true,
+                "disabled": false
+            }
         }
     }
 }

--- a/tests/integration/data/test_svc_settings/expected_settings.json
+++ b/tests/integration/data/test_svc_settings/expected_settings.json
@@ -394,6 +394,10 @@
                 "property": "get_parent",
                 "nonunique": true,
                 "disabled": false
+            },
+            "members": {
+                "nonunique": true,
+                "disabled": false
             }
         },
         "profile_group": {
@@ -405,6 +409,10 @@
                 "property": "get_parent",
                 "nonunique": true,
                 "disabled": false
+            },
+            "members": {
+                "nonunique": true,
+                "disabled": false
             }
         },
         "system_group": {
@@ -414,6 +422,10 @@
             },
             "parent": {
                 "property": "get_parent",
+                "nonunique": true,
+                "disabled": false
+            },
+            "members": {
                 "nonunique": true,
                 "disabled": false
             }

--- a/tests/items/cache_test.py
+++ b/tests/items/cache_test.py
@@ -11,7 +11,9 @@ from cobbler.api import CobblerAPI
 from cobbler.cexceptions import CX
 from cobbler.items.abstract.base_item import BaseItem
 from cobbler.items.abstract.bootable_item import BootableItem
+from cobbler.items.abstract.inheritable_item import InheritableItem
 from cobbler.items.distro import Distro
+from cobbler.items.distro_group import DistroGroup
 from cobbler.items.image import Image
 from cobbler.items.menu import Menu
 from cobbler.items.profile import Profile
@@ -516,7 +518,7 @@ def test_dict_cache_edit_invalidate(
             obj.to_dict(resolved=False)
             obj.to_dict(resolved=True)
         remain_objs = set(objs) - set(dep)
-        if isinstance(obj_test, BootableItem):
+        if isinstance(obj_test, InheritableItem):
             remain_objs.remove(obj_test)
             obj_test.owners = "test"  # type: ignore[method-assign]
             if (
@@ -549,6 +551,7 @@ def test_dict_cache_edit_invalidate(
     objs.append(test_repo1)
     test_repo2 = Repo(cobbler_api)
     test_repo2.name = "test_repo2"  # type: ignore[method-assign]
+    test_repo2.parent = test_repo1.uid  # type: ignore[method-assign]
     cobbler_api.add_repo(test_repo2)
     objs.append(test_repo2)
     test_menu1 = Menu(cobbler_api)
@@ -650,6 +653,55 @@ def test_dict_cache_edit_invalidate(
     )
     with expected_exception:
         cobbler_api.clean_items_cache(True)  # type: ignore
+
+
+@pytest.mark.parametrize(
+    "cache_enabled,expected_exception,expected_output",
+    [
+        (True, does_not_raise(), True),
+        (False, does_not_raise(), False),
+    ],
+)
+def test_dict_cache_edit_invalidate_item_group_descendant(
+    cobbler_api: CobblerAPI,
+    cache_enabled: bool,
+    expected_exception: Any,
+    expected_output: bool,
+):
+    """
+    Test to verify that editing an inheritable property invalidates the resolved dict cache of
+    descendants for item types that extend InheritableItem directly rather than through
+    BootableItem (DistroGroup/ProfileGroup/SystemGroup, via ItemGroup). ``children()`` used to be
+    hardcoded to only support the "profile" and "menu" collection types, which silently made
+    ``tree_walk()``-based descendant cache invalidation a no-op for every other item type.
+    """
+    # Arrange
+    cobbler_api.settings().cache_enabled = cache_enabled
+    parent_group = DistroGroup(cobbler_api)
+    parent_group.name = "test_parent_distro_group"  # type: ignore[method-assign]
+    cobbler_api.add_distro_group(parent_group)
+    child_group = DistroGroup(cobbler_api)
+    child_group.name = "test_child_distro_group"  # type: ignore[method-assign]
+    child_group.parent = parent_group.uid  # type: ignore[method-assign]
+    cobbler_api.add_distro_group(child_group)
+
+    with expected_exception:
+        parent_group.to_dict(resolved=True)
+        parent_group.to_dict(resolved=False)
+        child_group.to_dict(resolved=True)
+        child_group.to_dict(resolved=False)
+
+        # Act
+        parent_group.owners = "test"  # type: ignore[method-assign]
+
+        # Assert
+        result = (
+            parent_group.cache.get_dict_cache(True) is None
+            and parent_group.cache.get_dict_cache(False) is None
+            and child_group.cache.get_dict_cache(True) is None
+            and child_group.cache.get_dict_cache(False) is not None
+        )
+        assert result == expected_output
 
 
 @pytest.mark.parametrize(

--- a/tests/items/inheritable_item_test.py
+++ b/tests/items/inheritable_item_test.py
@@ -3,7 +3,7 @@ Test module that asserts that generic Cobbler InheritableItem functionality is w
 """
 
 import logging
-from typing import Any, Callable, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 
 import pytest
 
@@ -17,6 +17,9 @@ from cobbler.items.repo import Repo
 from cobbler.items.system import System
 
 from tests.conftest import does_not_raise
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
 
 logger = logging.getLogger()
 
@@ -223,6 +226,35 @@ def test_tree_walk(cobbler_api: CobblerAPI):
 
     # Assert
     assert result == []
+
+
+def test_clean_dict_cache_does_not_log_resolved_descendant_cache(
+    mocker: "MockerFixture",
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Any,
+):
+    """
+    Assert that invalidating descendant "resolved" caches for an InheritableProperty edit does not log
+    each descendant's full resolved cache dict. That call served no diagnostic purpose (no message, just
+    the raw value) and unconditionally evaluates/formats a potentially large dict per descendant, on
+    every inheritable-property edit under cache_enabled=True - a real cost at scale that has nothing to
+    do with the cache invalidation itself.
+    """
+    # Arrange
+    cobbler_api.settings().cache_enabled = True
+    test_distro = create_distro()
+    parent_profile: Profile = create_profile(
+        distro_uid=test_distro.uid, name="test_clean_dict_cache_parent"
+    )
+    create_profile(profile_uid=parent_profile.uid, name="test_clean_dict_cache_child")
+    logger_info_spy = mocker.spy(logging.Logger, "info")
+
+    # Act
+    parent_profile.owners = ["test_owner"]
+
+    # Assert
+    logger_info_spy.assert_not_called()
 
 
 def test_grab_tree(cobbler_api: CobblerAPI):

--- a/tests/items/item_group_test.py
+++ b/tests/items/item_group_test.py
@@ -17,6 +17,8 @@ class DummyItemGroup(ItemGroup):
     A concrete dummy class to instantiate the abstract ItemGroup class for testing.
     """
 
+    COLLECTION_TYPE = "distro_group"
+
     def __init__(self, api: CobblerAPI, **kwargs: Any):
         super().__init__(api, **kwargs)
 

--- a/tests/performance/__init__.py
+++ b/tests/performance/__init__.py
@@ -242,26 +242,31 @@ class CobblerTree:
         """
         Method that removes all menus.
         """
-        while len(api.menus()) > 0:
-            api.menus().remove(
-                list(api.menus())[0],
-                recursive=True,
-                with_triggers=False,
-                with_sync=False,
-            )
+        # Snapshot the listing once instead of calling list(api.menus()) - which rebuilds the
+        # whole remaining listing - on every loop iteration (that was O(n^2) for n menus). Items
+        # already cascaded away by an earlier recursive removal are skipped via the listing check.
+        for test_item in list(api.menus()):
+            if test_item.uid in api.menus().listing:
+                api.menus().remove(
+                    test_item,
+                    recursive=True,
+                    with_triggers=False,
+                    with_sync=False,
+                )
 
     @staticmethod
     def remove_profiles(api: CobblerAPI):
         """
         Method that removes all profiles.
         """
-        while len(api.profiles()) > 0:
-            api.profiles().remove(
-                list(api.profiles())[0],
-                recursive=True,
-                with_triggers=False,
-                with_sync=False,
-            )
+        for test_item in list(api.profiles()):
+            if test_item.uid in api.profiles().listing:
+                api.profiles().remove(
+                    test_item,
+                    recursive=True,
+                    with_triggers=False,
+                    with_sync=False,
+                )
 
     @staticmethod
     def remove_images(api: CobblerAPI):

--- a/tests/performance/item_remove_test.py
+++ b/tests/performance/item_remove_test.py
@@ -68,10 +68,12 @@ def test_item_remove(
         return (cobbler_api, what), {}
 
     def item_remove(api: CobblerAPI, what: str):
-        while len(api.get_items(what)) > 0:
-            api.remove_item(
-                what, list(api.get_items(what))[0], recursive=True, with_sync=False
-            )
+        # Snapshot the listing once instead of calling list(api.get_items(what)) - which rebuilds
+        # the whole remaining listing - on every loop iteration (that was O(n^2) for n items).
+        # Items already cascaded away by an earlier recursive removal are skipped via the check.
+        for test_item in list(api.get_items(what)):
+            if test_item.uid in api.get_items(what).listing:
+                api.remove_item(what, test_item, recursive=True, with_sync=False)
 
     # Arrange
     cobbler_api.settings().cache_enabled = cache_enabled

--- a/tests/performance/start_test.py
+++ b/tests/performance/start_test.py
@@ -11,6 +11,7 @@ from pytest_benchmark.fixture import (  # type: ignore[reportMissingTypeStubs,im
 )
 
 from cobbler.api import CobblerAPI
+from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.items.distro import Distro
 
 from tests.performance import CobblerTree
@@ -50,8 +51,10 @@ def test_start(
 
     def start_cobbler():
         # pylint: disable=protected-access,unused-variable
-        CobblerAPI.__shared_state = {}  # type: ignore[reportPrivateUsage]
-        CobblerAPI.__has_loaded = False  # type: ignore[reportPrivateUsage]
+        CollectionManager._CollectionManager__shared_state.clear()  # type: ignore[reportPrivateUsage]
+        CollectionManager.has_loaded = False
+        CobblerAPI._CobblerAPI__shared_state.clear()  # type: ignore[reportPrivateUsage]
+        CobblerAPI._CobblerAPI__has_loaded = False  # type: ignore[reportPrivateUsage]
         api = CobblerAPI()  # type: ignore[reportUnusedVariable]
 
     # Arrange

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -11,7 +11,7 @@ from unittest.mock import PropertyMock
 
 import pytest
 
-from cobbler import enums, tftpgen
+from cobbler import enums, tftpgen, utils
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
 from cobbler.items.image import Image
@@ -487,6 +487,31 @@ def test_build_kernel(mocker: "MockerFixture", cobbler_api: CobblerAPI):
 
     # Assert
     assert False
+
+
+def test_build_kernel_blender_call_count(
+    mocker: "MockerFixture",
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Any,
+):
+    """
+    Test that build_kernel() only walks the object tree once (a single utils.blender() call) instead
+    of once per remove_dicts value.
+    """
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_system: System = create_system(profile_uid=test_profile.uid)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    blender_spy = mocker.spy(utils, "blender")
+
+    # Act
+    test_gen.build_kernel({}, test_system, test_profile, test_distro, None, "pxe")
+
+    # Assert
+    assert blender_spy.call_count == 1
 
 
 def test_build_kernel_options_profile(

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -209,6 +209,70 @@ def test_write_all_system_files(
     assert mock_os_symlink.call_count == expected_symlink
 
 
+def test_write_all_system_files_blender_call_count(
+    mocker: "MockerFixture",
+    setup_test_write_all_system_files: Tuple[System, tftpgen.TFTPGen],
+):
+    """
+    Test that write_all_system_files() computes utils.blender() exactly once for the whole system,
+    regardless of how many interfaces/boot loaders end up being written, and returns that result so
+    callers (e.g. write_templates()) can reuse it instead of recomputing it.
+    """
+    # Arrange
+    test_system, test_gen = setup_test_write_all_system_files
+    # is_management_supported() requires a MAC/IP on at least one interface; without one,
+    # write_all_system_files() never reaches the point where it needs blender() at all.
+    test_system.interfaces["default"].mac_address = "random"
+    blender_spy = mocker.spy(utils, "blender")
+
+    # Act
+    meta_blended = test_gen.write_all_system_files(test_system, {})
+
+    # Assert
+    assert blender_spy.call_count == 1
+    assert meta_blended is not None
+
+
+def test_write_templates_reuses_supplied_blended(
+    mocker: "MockerFixture",
+    setup_test_write_all_system_files: Tuple[System, tftpgen.TFTPGen],
+):
+    """
+    Test that write_templates() does not call utils.blender() again when a caller already supplies one,
+    even when the object has template_files to render.
+    """
+    # Arrange
+    test_system, test_gen = setup_test_write_all_system_files
+    test_system.template_files = {"/nonexistent/source": "/nonexistent/dest"}
+    blended = utils.blender(test_gen.api, False, test_system)
+    blender_spy = mocker.spy(utils, "blender")
+
+    # Act
+    test_gen.write_templates(test_system, blended=blended)
+
+    # Assert
+    assert blender_spy.call_count == 0
+
+
+def test_write_templates_skips_blender_without_templates(
+    mocker: "MockerFixture",
+    setup_test_write_all_system_files: Tuple[System, tftpgen.TFTPGen],
+):
+    """
+    Test that write_templates() does not call utils.blender() at all when the object has no
+    template_files to render.
+    """
+    # Arrange
+    test_system, test_gen = setup_test_write_all_system_files
+    blender_spy = mocker.spy(utils, "blender")
+
+    # Act
+    test_gen.write_templates(test_system)
+
+    # Assert
+    assert blender_spy.call_count == 0
+
+
 def test_write_all_system_files_removes_unused_pxe_files(
     mocker: "MockerFixture",
     setup_test_write_all_system_files: Tuple[System, tftpgen.TFTPGen],

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -908,3 +908,331 @@ def test_write_bootcfg_file(
     # Assert
     assert result == expected_result
     assert pathlib.Path("/srv/tftpboot/esxi/example.txt").is_file()
+
+
+@pytest.fixture(name="tftp_lookup_profile")
+def fixture_tftp_lookup_profile(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[str, bool], Distro],
+    create_profile: Callable[..., Profile],
+) -> Profile:
+    """
+    Setup fixture providing a shared distro/profile for building systems used in the
+    _find_system_for_config_filename()/_find_system_for_tftp_path() tests below.
+    """
+    test_distro = create_distro("test_tftp_lookup_distro", True)
+    return create_profile(distro_uid=test_distro.uid, name="test_tftp_lookup_profile")
+
+
+def _add_tftp_lookup_system(
+    cobbler_api: CobblerAPI,
+    profile: Profile,
+    name: str,
+    mac_address: Union[str, None] = None,
+    ipv4_address: Union[str, None] = None,
+) -> System:
+    """
+    Create+add a system (with a "default" interface) for the _find_system_for_config_filename() tests.
+    """
+    system = cobbler_api.new_system()
+    system.name = name  # type: ignore[method-assign]
+    system.profile = profile.uid  # type: ignore[method-assign]
+    cobbler_api.add_system(system)
+    interface = cobbler_api.new_network_interface(system_uid=system.uid, name="default")
+    cobbler_api.add_network_interface(interface)
+    if mac_address is not None:
+        interface.mac_address = mac_address  # type: ignore[method-assign]
+    if ipv4_address is not None:
+        interface.ipv4.address = ipv4_address  # type: ignore[method-assign]
+    return system
+
+
+def test_find_system_for_config_filename_pxe_mac(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that a PXE-format MAC filename resolves to the system owning that MAC.
+    """
+    # Arrange
+    cobbler_api.settings().allow_duplicate_macs = False
+    system = _add_tftp_lookup_system(
+        cobbler_api,
+        tftp_lookup_profile,
+        "pxe_mac_system",
+        mac_address="AA:BB:CC:DD:EE:FF",
+    )
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    # pylint: disable-next=protected-access
+    result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+        "01-aa-bb-cc-dd-ee-ff", enums.BootLoader.PXE
+    )
+
+    # Assert
+    assert result is not None
+    assert result.uid == system.uid
+
+
+def test_find_system_for_config_filename_grub_mac(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that a GRUB-format MAC filename resolves to the system owning that MAC.
+    """
+    # Arrange
+    cobbler_api.settings().allow_duplicate_macs = False
+    system = _add_tftp_lookup_system(
+        cobbler_api,
+        tftp_lookup_profile,
+        "grub_mac_system",
+        mac_address="AA:BB:CC:DD:EE:00",
+    )
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    # pylint: disable-next=protected-access
+    result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+        "aa:bb:cc:dd:ee:00", enums.BootLoader.GRUB
+    )
+
+    # Assert
+    assert result is not None
+    assert result.uid == system.uid
+
+
+def test_find_system_for_config_filename_ip_hex(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that an IP-derived hex filename resolves to the system owning that IP.
+    """
+    # Arrange
+    cobbler_api.settings().allow_duplicate_ips = False
+    system = _add_tftp_lookup_system(
+        cobbler_api, tftp_lookup_profile, "ip_hex_system", ipv4_address="10.0.0.5"
+    )
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    # pylint: disable-next=protected-access
+    result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+        utils.get_host_ip("10.0.0.5"), enums.BootLoader.PXE
+    )
+
+    # Assert
+    assert result is not None
+    assert result.uid == system.uid
+
+
+def test_find_system_for_config_filename_literal_name(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that a system with neither MAC nor IP falls back to a literal name lookup.
+    """
+    # Arrange
+    system = _add_tftp_lookup_system(
+        cobbler_api, tftp_lookup_profile, "literal_name_system"
+    )
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    # pylint: disable-next=protected-access
+    result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+        "literal_name_system", enums.BootLoader.PXE
+    )
+
+    # Assert
+    assert result is not None
+    assert result.uid == system.uid
+
+
+def test_find_system_for_config_filename_default(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that the reserved "default" system name resolves via the literal "default" filename.
+    """
+    # Arrange
+    system = _add_tftp_lookup_system(cobbler_api, tftp_lookup_profile, "default")
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    # pylint: disable-next=protected-access
+    result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+        "default", enums.BootLoader.PXE
+    )
+
+    # Assert
+    assert result is not None
+    assert result.uid == system.uid
+
+
+def test_find_system_for_config_filename_no_match(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that a filename with no matching system returns None (letting the caller fall back to a
+    full scan), for each of the recognized filename shapes.
+    """
+    # Arrange
+    _add_tftp_lookup_system(
+        cobbler_api,
+        tftp_lookup_profile,
+        "unrelated_system",
+        mac_address="11:22:33:44:55:66",
+    )
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act / Assert
+    # pylint: disable=protected-access
+    assert (
+        test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+            "01-de-ad-be-ef-00-00", enums.BootLoader.PXE
+        )
+        is None
+    )
+    assert (
+        test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+            "DEADBEEF", enums.BootLoader.PXE
+        )
+        is None
+    )
+    assert (
+        test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+            "nonexistent_system_name", enums.BootLoader.PXE
+        )
+        is None
+    )
+
+
+def test_find_system_for_config_filename_ambiguous_hex_name_not_misresolved(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that a system literally named like an 8-hex-character IP filename (but with no matching IP)
+    is not incorrectly matched via the IP-hex branch - the round-trip verification must reject it.
+    """
+    # Arrange
+    _add_tftp_lookup_system(cobbler_api, tftp_lookup_profile, "DEADBEEF")
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    # pylint: disable-next=protected-access
+    result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+        "DEADBEEF", enums.BootLoader.PXE
+    )
+
+    # Assert: falls through to the literal-name branch (uppercase hex doesn't match the lowercase-hex
+    # PXE-MAC/GRUB-MAC shapes, and the IP-hex branch decodes to an IP with no owner), not a false match.
+    assert result is not None
+    assert result.name == "DEADBEEF"
+
+
+@pytest.mark.parametrize("loader", [enums.BootLoader.PXE, enums.BootLoader.GRUB])
+def test_find_system_for_config_filename_roundtrip(
+    cobbler_api: CobblerAPI, tftp_lookup_profile: Profile, loader: enums.BootLoader
+):
+    """
+    Property test: for a representative set of systems, resolving the filename that
+    get_config_filename() itself produces must return that same system, for both loaders.
+    """
+    # Arrange
+    cobbler_api.settings().allow_duplicate_macs = False
+    cobbler_api.settings().allow_duplicate_ips = False
+    systems = [
+        _add_tftp_lookup_system(
+            cobbler_api,
+            tftp_lookup_profile,
+            "roundtrip_mac",
+            mac_address="AA:BB:CC:DD:EE:01",
+        ),
+        _add_tftp_lookup_system(
+            cobbler_api, tftp_lookup_profile, "roundtrip_ip", ipv4_address="10.0.0.6"
+        ),
+        _add_tftp_lookup_system(cobbler_api, tftp_lookup_profile, "roundtrip_literal"),
+    ]
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act / Assert
+    for system in systems:
+        filename = system.get_config_filename(interface="default", loader=loader)
+        if filename is None:
+            continue
+        # pylint: disable-next=protected-access
+        result = test_gen._find_system_for_config_filename(  # type: ignore[reportPrivateUsage]
+            filename, loader
+        )
+        assert result is not None
+        assert result.uid == system.uid
+
+
+def test_find_system_for_tftp_path_dispatch(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI
+):
+    """
+    Test that _find_system_for_tftp_path() dispatches each recognized path shape to
+    _find_system_for_config_filename() with the correct filename/loader, and returns None for anything
+    else (letting the caller fall back to a full scan).
+    """
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    mock_lookup = mocker.patch.object(
+        test_gen, "_find_system_for_config_filename", return_value=None
+    )
+
+    # Act / Assert
+    test_gen._find_system_for_tftp_path(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/pxelinux.cfg/01-aa-bb-cc-dd-ee-ff")
+    )
+    mock_lookup.assert_called_with("01-aa-bb-cc-dd-ee-ff", enums.BootLoader.PXE)
+
+    test_gen._find_system_for_tftp_path(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/esxi/pxelinux.cfg/01-aa-bb-cc-dd-ee-ff")
+    )
+    mock_lookup.assert_called_with("01-aa-bb-cc-dd-ee-ff", enums.BootLoader.PXE)
+
+    test_gen._find_system_for_tftp_path(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/grub/system/aa:bb:cc:dd:ee:ff")
+    )
+    mock_lookup.assert_called_with("aa:bb:cc:dd:ee:ff", enums.BootLoader.GRUB)
+
+    assert (
+        test_gen._find_system_for_tftp_path(  # type: ignore[reportPrivateUsage]
+            pathlib.Path("/some/unrelated/path")
+        )
+        is None
+    )
+
+
+def test_generate_tftp_file_uses_fast_path(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI, tftp_lookup_profile: Profile
+):
+    """
+    Test that generate_tftp_file() resolves a PXE config request via the fast, indexed lookup instead
+    of iterating every system, and produces the same content generate_system_file() would directly.
+    """
+    # Arrange
+    cobbler_api.settings().allow_duplicate_macs = False
+    system = _add_tftp_lookup_system(
+        cobbler_api,
+        tftp_lookup_profile,
+        "fast_path_system",
+        mac_address="AA:BB:CC:DD:EE:02",
+    )
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    path = pathlib.Path("/pxelinux.cfg/01-aa-bb-cc-dd-ee-02")
+    metadata = test_gen.get_menu_items()
+    expected = test_gen.generate_system_file(system, path, metadata)
+    generate_system_file_spy = mocker.spy(test_gen, "generate_system_file")
+
+    # Act
+    content, _length = test_gen.generate_tftp_file(path, 0, 10_000)
+
+    # Assert
+    assert expected is not None
+    assert content == expected.encode("UTF-8")
+    # Exactly one call (for the resolved candidate) - if the fast path had failed and fallen back to
+    # the full scan, this would be called once per system up to and including the match.
+    assert generate_system_file_spy.call_count == 1

--- a/tests/utils/utils_test.py
+++ b/tests/utils/utils_test.py
@@ -74,6 +74,29 @@ def test_get_host_ip():
     assert result == "0A000001"
 
 
+def test_hex_to_ip():
+    # Arrange
+
+    # Act
+    result = utils.hex_to_ip("0A000001")
+
+    # Assert
+    assert result == "10.0.0.1"
+
+
+@pytest.mark.parametrize(
+    "ip_address", ["10.0.0.1", "192.168.1.254", "0.0.0.0", "255.255.255.255"]
+)
+def test_hex_to_ip_get_host_ip_roundtrip(ip_address: str):
+    # Arrange
+
+    # Act
+    result = utils.hex_to_ip(utils.get_host_ip(ip_address))
+
+    # Assert
+    assert result == ip_address
+
+
 @pytest.mark.parametrize(
     "testvalue,expected_result", [("10.0.0.1", True), ("Test", False)]
 )


### PR DESCRIPTION
## Linked Items

Related to #3999 

## Description

This PR aims to fix the current performance regressions that are easily recognisable by looking at the performance testsuite results in the CI. Currently, the following fixes have been applied:

- Cache invalidation for Inheritable Items now works as expected.
- Templates are now caching names and tags.
- Network Interfaces are now caching `system_uid`'s.
- `ItemGroup`s are now caching `member`'s.

## Behaviour changes

None.

## Category

This is related to a:

- [ ] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [x] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 