### PR TITLE
Use package-owned EFI loader paths for Red Hat shim discovery

### DIFF
--- a/cobbler/cobblerd/distro_options.py
+++ b/cobbler/cobblerd/distro_options.py
@@ -111,9 +111,9 @@ def get_distro_options() -> DistroOptions:
         distro_options.webrootconfig = pathlib.Path("/etc/httpd")
         distro_options.tftproot = pathlib.Path("/var/lib/tftpboot")
         distro_options.bind_zonefiles = pathlib.Path("/var/named")
-        distro_options.shim_folder = r"/boot/efi/EFI/*/"
+        distro_options.shim_folder = r"/usr/share/efi/*/"
         distro_options.shim_file = r"shim[a-zA-Z0-9]*\.efi"
-        distro_options.secure_grub_folder = r"/boot/efi/EFI/*/"
+        distro_options.secure_grub_folder = r"/usr/share/efi/*/"
         distro_options.secure_grub_file = r"grub\.efi"
         distro_options.grub_mod_folder = pathlib.Path("/usr/lib/grub")
     elif distro == "suse":

--- a/tests/cobblerd/distro_options_test.py
+++ b/tests/cobblerd/distro_options_test.py
@@ -1,0 +1,14 @@
+from pytest_mock import MockerFixture
+
+from cobbler.cobblerd.distro_options import get_distro_options
+
+
+def test_redhat_efi_loader_folders_use_package_paths(mocker: MockerFixture):
+    mocker.patch("cobbler.cobblerd.distro_options.get_family", return_value="redhat")
+
+    result = get_distro_options()
+
+    assert result.shim_folder == r"/usr/share/efi/*/"
+    assert result.secure_grub_folder == r"/usr/share/efi/*/"
+    assert "/boot/efi" not in result.shim_folder
+    assert "/boot/efi" not in result.secure_grub_folder


### PR DESCRIPTION
On Red Hat-family systems, generated cobblerd setup defaults currently point `bootloaders_shim_folder` and `secure_boot_grub_folder` at `/boot/efi/EFI/*/`.

On UEFI systems with SELinux enforcing, that location is the mounted EFI System Partition labeled `dosfs_t`. `cobblerd_t` is denied directory and file access there, so `mkloaders` cannot see `shim.efi` through the glob-based `find_file()` lookup and reports it missing even when the file exists.

The generic settings default already avoids this by scanning package-owned EFI loader locations under `/usr/share/efi/*/` instead of the ESP.

This changes only the Red Hat branch of `get_distro_options()` so generated settings use `/usr/share/efi/*/` for shim and secure GRUB discovery, while preserving the existing Red Hat filename regexes for shim variants.

A focused unit test patches `cobbler.cobblerd.distro_options.get_family` to `redhat` and asserts the generated shim and secure GRUB folders no longer point at `/boot/efi`.

Fixes #3878.