### PR TITLE
Avoid shared inodes for yum repodata after cobbler hardlink

### DIFF
--- a/cobbler/actions/hardlink.py
+++ b/cobbler/actions/hardlink.py
@@ -10,6 +10,9 @@ Hard links Cobbler content together to save space.
 
 import logging
 import os
+import shutil
+import stat
+import tempfile
 from typing import TYPE_CHECKING
 
 from cobbler import utils
@@ -73,4 +76,46 @@ class HardLinker:
             f"{self.webdir}/distro_mirror",
             f"{self.webdir}/repo_mirror",
         ]
-        return utils.subprocess_call(hardlink_cmd.copy(), shell=False)
+        result = utils.subprocess_call(hardlink_cmd.copy(), shell=False)
+        self._break_repodata_hardlinks()
+        return result
+
+    def _break_repodata_hardlinks(self) -> None:
+        """
+        Replace hardlinked yum repository metadata files with private copies.
+        """
+        for mirror_dir in ["distro_mirror", "repo_mirror"]:
+            mirror_path = os.path.join(self.webdir, mirror_dir)
+            if not os.path.isdir(mirror_path):
+                continue
+            for root, _, files in os.walk(mirror_path):
+                if os.path.basename(root) != "repodata":
+                    continue
+                for filename in files:
+                    self._break_hardlink(os.path.join(root, filename))
+
+    def _break_hardlink(self, file_path: str) -> None:
+        """
+        Replace a hardlinked regular file with a private inode.
+        """
+        stat_result = os.stat(file_path, follow_symlinks=False)
+        if not stat.S_ISREG(stat_result.st_mode) or stat_result.st_nlink <= 1:
+            return
+
+        tmp_path = ""
+        try:
+            with tempfile.NamedTemporaryFile(
+                dir=os.path.dirname(file_path),
+                prefix=f".{os.path.basename(file_path)}.",
+                delete=False,
+            ) as tmp_file:
+                tmp_path = tmp_file.name
+            shutil.copy2(file_path, tmp_path)
+            try:
+                os.chown(tmp_path, stat_result.st_uid, stat_result.st_gid)
+            except PermissionError:
+                pass
+            os.replace(tmp_path, file_path)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                os.unlink(tmp_path)

--- a/tests/actions/hardlink_test.py
+++ b/tests/actions/hardlink_test.py
@@ -2,6 +2,8 @@
 Module to test the "cobbler hardlink" functionallity.
 """
 
+import os
+from pathlib import Path
 from typing import List
 
 import pytest
@@ -100,6 +102,14 @@ def test_run(
     # Arrange
     mocker.patch("cobbler.utils.get_family", return_value=mock_family)
     mock_subprocess_call = mocker.patch("cobbler.utils.subprocess_call", return_value=0)
+    mock_break_repodata_hardlinks = mocker.patch.object(
+        hardlink.HardLinker, "_break_repodata_hardlinks", autospec=True
+    )
+    mock_manager = mocker.Mock()
+    mock_manager.attach_mock(mock_subprocess_call, "subprocess_call")
+    mock_manager.attach_mock(
+        mock_break_repodata_hardlinks, "break_repodata_hardlinks"
+    )
     hardlink_obj = hardlink.HardLinker(cobbler_api)
     hardlink_obj.webdir = "/srv/www/cobbler"
     expected_calls = [
@@ -115,9 +125,79 @@ def test_run(
             shell=False,
         ),
     ]
+    expected_manager_calls = [
+        mocker.call.subprocess_call(expected_hardlink_cmd, shell=False),
+        mocker.call.subprocess_call(
+            [
+                "/usr/bin/hardlink",
+                "-c",
+                "-v",
+                "/srv/www/cobbler/distro_mirror",
+                "/srv/www/cobbler/repo_mirror",
+            ],
+            shell=False,
+        ),
+        mocker.call.break_repodata_hardlinks(hardlink_obj),
+    ]
 
     # Act
     hardlink_obj.run()
 
     # Assert
     assert mock_subprocess_call.mock_calls == expected_calls
+    assert mock_manager.mock_calls == expected_manager_calls
+
+
+def test_break_repodata_hardlinks_replaces_repodata_files(tmp_path: Path):
+    """
+    Assert that hardlinked files inside repodata directories get private inodes.
+    """
+    # Arrange
+    repo1_repodata = tmp_path / "repo_mirror" / "repo1" / "repodata"
+    repo2_repodata = tmp_path / "repo_mirror" / "repo2" / "repodata"
+    repo1_repodata.mkdir(parents=True)
+    repo2_repodata.mkdir(parents=True)
+    repo1_file = repo1_repodata / "repomd.xml"
+    repo2_file = repo2_repodata / "repomd.xml"
+    repo1_file.write_text("<repomd />")
+    os.link(repo1_file, repo2_file)
+    hardlink_obj = hardlink.HardLinker.__new__(hardlink.HardLinker)
+    hardlink_obj.webdir = str(tmp_path)
+
+    # Act
+    hardlink_obj._break_repodata_hardlinks()
+
+    # Assert
+    repo1_stat = repo1_file.stat()
+    repo2_stat = repo2_file.stat()
+    assert repo1_stat.st_ino != repo2_stat.st_ino
+    assert repo1_stat.st_nlink == 1
+    assert repo2_stat.st_nlink == 1
+    assert repo1_file.read_text() == repo2_file.read_text()
+
+
+def test_break_repodata_hardlinks_leaves_other_hardlinks(tmp_path: Path):
+    """
+    Assert that hardlinked files outside repodata directories stay hardlinked.
+    """
+    # Arrange
+    repo1_packages = tmp_path / "repo_mirror" / "repo1" / "Packages"
+    repo2_packages = tmp_path / "repo_mirror" / "repo2" / "Packages"
+    repo1_packages.mkdir(parents=True)
+    repo2_packages.mkdir(parents=True)
+    repo1_file = repo1_packages / "package.rpm"
+    repo2_file = repo2_packages / "package.rpm"
+    repo1_file.write_text("rpm")
+    os.link(repo1_file, repo2_file)
+    hardlink_obj = hardlink.HardLinker.__new__(hardlink.HardLinker)
+    hardlink_obj.webdir = str(tmp_path)
+
+    # Act
+    hardlink_obj._break_repodata_hardlinks()
+
+    # Assert
+    repo1_stat = repo1_file.stat()
+    repo2_stat = repo2_file.stat()
+    assert repo1_stat.st_ino == repo2_stat.st_ino
+    assert repo1_stat.st_nlink == 2
+    assert repo2_stat.st_nlink == 2


### PR DESCRIPTION
Issue #3481 reports that `cobbler hardlink` can corrupt yum repository metadata by hardlinking identical files under separate `repodata` directories.

Root cause: the existing implementation runs the system `hardlink` binary across the full `distro_mirror` and `repo_mirror` trees. Because repository metadata directories are not excluded, files such as `repomd.xml` and metadata databases can become shared inodes across logically separate repositories. Later sync operations can mutate or replace metadata through one path while another repository still observes the linked inode/content, leaving repodata inconsistent with its package payload.

This change keeps the existing portable `hardlink` subprocess calls, then adds post-processing in `HardLinker` that:

- walks `distro_mirror` and `repo_mirror`
- finds directories named `repodata`
- replaces regular files with link count greater than one using a same-directory temporary copy and `os.replace`
- preserves file metadata as much as practical with standard library APIs

This avoids depending on distro-specific `hardlink` exclude flags and limits the behavior change to yum repository metadata.

Files modified:

- `cobbler/actions/hardlink.py`
- `tests/actions/hardlink_test.py`

`ruff check cobbler/actions/hardlink.py tests/actions/hardlink_test.py` reports no new findings on the changed files.
Ran `pytest -x` locally with no new failures.
