### PR TITLE
Add dynamic cobbler-tftp module

### DIFF
--- a/.benchmarks/Linux-CPython-3.11-64bit/0003_ae988679c51f7710a1b17ba8171331cf3fbe344a_20260805_091219.json
+++ b/.benchmarks/Linux-CPython-3.11-64bit/0003_ae988679c51f7710a1b17ba8171331cf3fbe344a_20260805_091219.json
@@ -1,0 +1,10215 @@
+{
+    "machine_info": {
+        "node": "115e71c75299",
+        "processor": "x86_64",
+        "machine": "x86_64",
+        "python_compiler": "GCC",
+        "python_implementation": "CPython",
+        "python_implementation_version": "3.13.14",
+        "python_version": "3.13.14",
+        "python_build": [
+            "main",
+            "Jul 17 2026 10:06:46"
+        ],
+        "release": "6.4.0-dirty",
+        "system": "Linux",
+        "cpu": {
+            "python_version": "3.13.14.final.0 (64 bit)",
+            "cpuinfo_version": [
+                9,
+                0,
+                0
+            ],
+            "cpuinfo_version_string": "9.0.0",
+            "arch": "X86_64",
+            "bits": 64,
+            "count": 4,
+            "arch_string_raw": "x86_64",
+            "vendor_id_raw": "AuthenticAMD",
+            "brand_raw": "AMD EPYC",
+            "hz_advertised_friendly": "4.2919 GHz",
+            "hz_actual_friendly": "4.2919 GHz",
+            "hz_advertised": [
+                4291928000,
+                0
+            ],
+            "hz_actual": [
+                4291928000,
+                0
+            ],
+            "model": 68,
+            "family": 26,
+            "flags": [
+                "3dnowprefetch",
+                "abm",
+                "adx",
+                "aes",
+                "apic",
+                "arat",
+                "avx",
+                "avx2",
+                "avx512_bf16",
+                "avx512_bitalg",
+                "avx512_vbmi2",
+                "avx512_vnni",
+                "avx512_vp2intersect",
+                "avx512_vpopcntdq",
+                "avx512bitalg",
+                "avx512bw",
+                "avx512cd",
+                "avx512dq",
+                "avx512f",
+                "avx512ifma",
+                "avx512vbmi",
+                "avx512vbmi2",
+                "avx512vl",
+                "avx512vnni",
+                "avx512vpopcntdq",
+                "avx_vnni",
+                "bmi1",
+                "bmi2",
+                "clflush",
+                "clflushopt",
+                "clwb",
+                "clzero",
+                "cmov",
+                "cmp_legacy",
+                "constant_tsc",
+                "cpuid",
+                "cr8_legacy",
+                "cx16",
+                "cx8",
+                "de",
+                "erms",
+                "f16c",
+                "flush_l1d",
+                "flushbyasid",
+                "fma",
+                "fpu",
+                "fsgsbase",
+                "fsrm",
+                "fxsr",
+                "fxsr_opt",
+                "gfni",
+                "ht",
+                "hypervisor",
+                "ibpb",
+                "ibrs",
+                "invpcid",
+                "lahf_lm",
+                "lbrv",
+                "lm",
+                "mca",
+                "mce",
+                "misalignsse",
+                "mmx",
+                "mmxext",
+                "movbe",
+                "movdir64b",
+                "movdiri",
+                "msr",
+                "mtrr",
+                "nonstop_tsc",
+                "nopl",
+                "npt",
+                "nrip_save",
+                "nx",
+                "ospke",
+                "osvw",
+                "osxsave",
+                "pae",
+                "pat",
+                "pausefilter",
+                "pclmulqdq",
+                "pdpe1gb",
+                "perfctr_core",
+                "pfthreshold",
+                "pge",
+                "pku",
+                "pni",
+                "popcnt",
+                "pse",
+                "pse36",
+                "rdpid",
+                "rdrand",
+                "rdrnd",
+                "rdseed",
+                "rdtscp",
+                "rep_good",
+                "sep",
+                "sha",
+                "sha_ni",
+                "smap",
+                "smep",
+                "ssbd",
+                "sse",
+                "sse2",
+                "sse4_1",
+                "sse4_2",
+                "sse4a",
+                "ssse3",
+                "stibp",
+                "svm",
+                "syscall",
+                "topoext",
+                "tsc",
+                "tsc_adjust",
+                "tsc_deadline_timer",
+                "tsc_known_freq",
+                "tsc_scale",
+                "tscdeadline",
+                "umip",
+                "v_vmsave_vmload",
+                "vaes",
+                "vgif",
+                "vmcb_clean",
+                "vme",
+                "vmmcall",
+                "vnmi",
+                "vpclmulqdq",
+                "wbnoinvd",
+                "x2apic",
+                "xgetbv1",
+                "xsave",
+                "xsavec",
+                "xsaveerptr",
+                "xsaveopt",
+                "xsaves"
+            ],
+            "l3_cache_size": 1048576,
+            "l2_cache_size": 4194304,
+            "l1_data_cache_size": 196608,
+            "l1_instruction_cache_size": 131072,
+            "l2_cache_line_size": 1024,
+            "l2_cache_associativity": 8
+        }
+    },
+    "commit_info": {
+        "id": "ae988679c51f7710a1b17ba8171331cf3fbe344a",
+        "time": "2026-08-05T11:06:51+02:00",
+        "author_time": "2026-08-05T11:06:51+02:00",
+        "dirty": false,
+        "project": "cobbler",
+        "branch": "main"
+    },
+    "benchmarks": [
+        {
+            "group": null,
+            "name": "test_deserialize[False-False]",
+            "fullname": "tests/performance/deserialize_test.py::test_deserialize[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.38326252148000095,
+                "max": 0.4119676789199957,
+                "mean": 0.39949526224400006,
+                "stddev": 0.009288051419428388,
+                "rounds": 10,
+                "median": 0.40054463137999846,
+                "iqr": 0.015047422039997427,
+                "q1": 0.3920010078400037,
+                "q3": 0.4070484298800011,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.38326252148000095,
+                "hd15iqr": 0.4119676789199957,
+                "ops": 2.503158596632441,
+                "total": 3.9949526224400005,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_deserialize[True-False]",
+            "fullname": "tests/performance/deserialize_test.py::test_deserialize[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3940629368000009,
+                "max": 0.41075382911999897,
+                "mean": 0.40253453419600055,
+                "stddev": 0.005925663909757418,
+                "rounds": 10,
+                "median": 0.40281700237999984,
+                "iqr": 0.010355860040003773,
+                "q1": 0.3966861397599996,
+                "q3": 0.4070419998000034,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.3940629368000009,
+                "hd15iqr": 0.41075382911999897,
+                "ops": 2.4842589021519426,
+                "total": 4.025345341960006,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_deserialize[False-True]",
+            "fullname": "tests/performance/deserialize_test.py::test_deserialize[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3940147339199984,
+                "max": 0.4098481161200016,
+                "mean": 0.40196461573199943,
+                "stddev": 0.005441651242400853,
+                "rounds": 10,
+                "median": 0.40218281354000057,
+                "iqr": 0.009602480999997165,
+                "q1": 0.39639070040000207,
+                "q3": 0.40599318139999924,
+                "iqr_outliers": 0,
+                "stddev_outliers": 5,
+                "outliers": "5;0",
+                "ld15iqr": 0.3940147339199984,
+                "hd15iqr": 0.4098481161200016,
+                "ops": 2.4877811649638506,
+                "total": 4.019646157319994,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_deserialize[True-True]",
+            "fullname": "tests/performance/deserialize_test.py::test_deserialize[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.39611071079999877,
+                "max": 0.4106110743199997,
+                "mean": 0.40301437422000075,
+                "stddev": 0.005056300047463615,
+                "rounds": 10,
+                "median": 0.40322230461999875,
+                "iqr": 0.008879329559999816,
+                "q1": 0.39826751867999977,
+                "q3": 0.4071468482399996,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.39611071079999877,
+                "hd15iqr": 0.4106110743199997,
+                "ops": 2.4813010750185103,
+                "total": 4.030143742200007,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_get_autoinstall[False-profile]",
+            "fullname": "tests/performance/get_autoinstall_test.py::test_get_autoinstall[False-profile]",
+            "params": {
+                "cache_enabled": false,
+                "what": "profile"
+            },
+            "param": "False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.3163999150000336,
+                "max": 2.403981665499998,
+                "mean": 2.3388485085500066,
+                "stddev": 0.02447395840915242,
+                "rounds": 10,
+                "median": 2.334162107750018,
+                "iqr": 0.012290316000019175,
+                "q1": 2.3269430164999676,
+                "q3": 2.3392333324999868,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 2.3163999150000336,
+                "hd15iqr": 2.403981665499998,
+                "ops": 0.42756082591256,
+                "total": 23.388485085500065,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_get_autoinstall[False-system]",
+            "fullname": "tests/performance/get_autoinstall_test.py::test_get_autoinstall[False-system]",
+            "params": {
+                "cache_enabled": false,
+                "what": "system"
+            },
+            "param": "False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.032534399500037,
+                "max": 4.0754775810000865,
+                "mean": 4.053758724149998,
+                "stddev": 0.014765205807056576,
+                "rounds": 10,
+                "median": 4.05811969749999,
+                "iqr": 0.027279097500127136,
+                "q1": 4.036726378499907,
+                "q3": 4.064005476000034,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 4.032534399500037,
+                "hd15iqr": 4.0754775810000865,
+                "ops": 0.24668463715972205,
+                "total": 40.53758724149998,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_get_autoinstall[True-profile]",
+            "fullname": "tests/performance/get_autoinstall_test.py::test_get_autoinstall[True-profile]",
+            "params": {
+                "cache_enabled": true,
+                "what": "profile"
+            },
+            "param": "True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.334980566000013,
+                "max": 1.66698328450002,
+                "mean": 1.3732367379500032,
+                "stddev": 0.10332806786103982,
+                "rounds": 10,
+                "median": 1.3408870165000621,
+                "iqr": 0.006913938000025155,
+                "q1": 1.3368345970000064,
+                "q3": 1.3437485350000316,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.334980566000013,
+                "hd15iqr": 1.66698328450002,
+                "ops": 0.728206559265827,
+                "total": 13.732367379500033,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_get_autoinstall[True-system]",
+            "fullname": "tests/performance/get_autoinstall_test.py::test_get_autoinstall[True-system]",
+            "params": {
+                "cache_enabled": true,
+                "what": "system"
+            },
+            "param": "True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.727467774000047,
+                "max": 2.5428034015000094,
+                "mean": 1.8158849582999892,
+                "stddev": 0.25543713619765074,
+                "rounds": 10,
+                "median": 1.7363110492499914,
+                "iqr": 0.004377933000000667,
+                "q1": 1.7332968759999403,
+                "q3": 1.737674808999941,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 1.727467774000047,
+                "hd15iqr": 2.5428034015000094,
+                "ops": 0.550695678946638,
+                "total": 18.158849582999892,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_repos_create[cache_enabled0]",
+            "fullname": "tests/performance/item_add_test.py::test_repos_create[cache_enabled0]",
+            "params": {
+                "cache_enabled": [
+                    false
+                ]
+            },
+            "param": "cache_enabled0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0035909709999941697,
+                "max": 0.004014136000023427,
+                "mean": 0.0037189803999808646,
+                "stddev": 0.00012002989681719453,
+                "rounds": 10,
+                "median": 0.003673495999919396,
+                "iqr": 0.00011702899973897729,
+                "q1": 0.003665912000087701,
+                "q3": 0.0037829409998266783,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.0035909709999941697,
+                "hd15iqr": 0.004014136000023427,
+                "ops": 268.8909035404288,
+                "total": 0.037189803999808646,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_repos_create[cache_enabled1]",
+            "fullname": "tests/performance/item_add_test.py::test_repos_create[cache_enabled1]",
+            "params": {
+                "cache_enabled": [
+                    true
+                ]
+            },
+            "param": "cache_enabled1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0035712039998543332,
+                "max": 0.003851790999988225,
+                "mean": 0.0036995188999753735,
+                "stddev": 9.960905025950695e-05,
+                "rounds": 10,
+                "median": 0.0036599150000711234,
+                "iqr": 0.00017965699976230098,
+                "q1": 0.0036408250000476983,
+                "q3": 0.0038204819998099993,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.0035712039998543332,
+                "hd15iqr": 0.003851790999988225,
+                "ops": 270.30541728186785,
+                "total": 0.036995188999753736,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_distros_create[cache_enabled0]",
+            "fullname": "tests/performance/item_add_test.py::test_distros_create[cache_enabled0]",
+            "params": {
+                "cache_enabled": [
+                    false
+                ]
+            },
+            "param": "cache_enabled0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003992864999872836,
+                "max": 0.004599292999955651,
+                "mean": 0.004126337900015642,
+                "stddev": 0.00018155801052527988,
+                "rounds": 10,
+                "median": 0.004055413000060071,
+                "iqr": 0.00011442400000305497,
+                "q1": 0.004033982999999353,
+                "q3": 0.004148407000002408,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.003992864999872836,
+                "hd15iqr": 0.004599292999955651,
+                "ops": 242.3456401852619,
+                "total": 0.04126337900015642,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_distros_create[cache_enabled1]",
+            "fullname": "tests/performance/item_add_test.py::test_distros_create[cache_enabled1]",
+            "params": {
+                "cache_enabled": [
+                    true
+                ]
+            },
+            "param": "cache_enabled1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003982415999871591,
+                "max": 0.004277509999838003,
+                "mean": 0.00407032060002166,
+                "stddev": 0.00010258273437037927,
+                "rounds": 10,
+                "median": 0.0040205620000506315,
+                "iqr": 0.00011602700010371336,
+                "q1": 0.004006290999996054,
+                "q3": 0.004122318000099767,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.003982415999871591,
+                "hd15iqr": 0.004277509999838003,
+                "ops": 245.68089304677343,
+                "total": 0.040703206000216596,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_menus_create[cache_enabled0]",
+            "fullname": "tests/performance/item_add_test.py::test_menus_create[cache_enabled0]",
+            "params": {
+                "cache_enabled": [
+                    false
+                ]
+            },
+            "param": "cache_enabled0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.010366629999907673,
+                "max": 0.01364563500010263,
+                "mean": 0.01080897830001959,
+                "stddev": 0.0010087052558439209,
+                "rounds": 10,
+                "median": 0.010427323500039165,
+                "iqr": 0.0002704080000057729,
+                "q1": 0.010408739000013156,
+                "q3": 0.01067914700001893,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.010366629999907673,
+                "hd15iqr": 0.01364563500010263,
+                "ops": 92.5156820786834,
+                "total": 0.1080897830001959,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_menus_create[cache_enabled1]",
+            "fullname": "tests/performance/item_add_test.py::test_menus_create[cache_enabled1]",
+            "params": {
+                "cache_enabled": [
+                    true
+                ]
+            },
+            "param": "cache_enabled1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.008893664999959583,
+                "max": 0.009387993000018469,
+                "mean": 0.009003173299970513,
+                "stddev": 0.00014146576253508273,
+                "rounds": 10,
+                "median": 0.00897770249991936,
+                "iqr": 7.250600015140662e-05,
+                "q1": 0.008931384999868897,
+                "q3": 0.009003891000020303,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.008893664999959583,
+                "hd15iqr": 0.009387993000018469,
+                "ops": 111.0719483766102,
+                "total": 0.09003173299970513,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profiles_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_profiles_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3819930539998495,
+                "max": 0.3873860170001535,
+                "mean": 0.3851029742000492,
+                "stddev": 0.0018853313530714927,
+                "rounds": 10,
+                "median": 0.3855671675000849,
+                "iqr": 0.002406176999784293,
+                "q1": 0.38392785500013815,
+                "q3": 0.38633403199992244,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.3819930539998495,
+                "hd15iqr": 0.3873860170001535,
+                "ops": 2.596708067698617,
+                "total": 3.8510297420004918,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profiles_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_profiles_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.37396281899987116,
+                "max": 0.49230996599999344,
+                "mean": 0.3967454957999962,
+                "stddev": 0.03451833739559037,
+                "rounds": 10,
+                "median": 0.3913655664999851,
+                "iqr": 0.016004292999923564,
+                "q1": 0.3757176530000379,
+                "q3": 0.39172194599996146,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.37396281899987116,
+                "hd15iqr": 0.49230996599999344,
+                "ops": 2.520507505658265,
+                "total": 3.967454957999962,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profiles_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_profiles_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3952239200000349,
+                "max": 0.5006185429999732,
+                "mean": 0.40950875160003763,
+                "stddev": 0.03214158451142497,
+                "rounds": 10,
+                "median": 0.40013244850001684,
+                "iqr": 0.006116220000194517,
+                "q1": 0.3970100530000309,
+                "q3": 0.4031262730002254,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.3952239200000349,
+                "hd15iqr": 0.5006185429999732,
+                "ops": 2.441950254036789,
+                "total": 4.095087516000376,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profiles_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_profiles_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.37543649500003085,
+                "max": 0.46465963200012084,
+                "mean": 0.39559201659999416,
+                "stddev": 0.02577383095363931,
+                "rounds": 10,
+                "median": 0.3917122229998995,
+                "iqr": 0.019615662999967753,
+                "q1": 0.3769986570000583,
+                "q3": 0.39661432000002605,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.37543649500003085,
+                "hd15iqr": 0.46465963200012084,
+                "ops": 2.5278568778883055,
+                "total": 3.9559201659999417,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_images_create[cache_enabled0]",
+            "fullname": "tests/performance/item_add_test.py::test_images_create[cache_enabled0]",
+            "params": {
+                "cache_enabled": [
+                    false
+                ]
+            },
+            "param": "cache_enabled0",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0035019540000575944,
+                "max": 0.003771378999999797,
+                "mean": 0.00358925560001353,
+                "stddev": 9.842808361378429e-05,
+                "rounds": 10,
+                "median": 0.0035498739999866302,
+                "iqr": 7.978999997249048e-05,
+                "q1": 0.0035251169999810372,
+                "q3": 0.0036049069999535277,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0035019540000575944,
+                "hd15iqr": 0.0037605590000566735,
+                "ops": 278.6093027189901,
+                "total": 0.0358925560001353,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_images_create[cache_enabled1]",
+            "fullname": "tests/performance/item_add_test.py::test_images_create[cache_enabled1]",
+            "params": {
+                "cache_enabled": [
+                    true
+                ]
+            },
+            "param": "cache_enabled1",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0034845010000026377,
+                "max": 0.0036859199999526027,
+                "mean": 0.00355070150001211,
+                "stddev": 6.789652728645986e-05,
+                "rounds": 10,
+                "median": 0.0035283135000554466,
+                "iqr": 9.599000009075098e-05,
+                "q1": 0.00349719499990897,
+                "q3": 0.003593184999999721,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0034845010000026377,
+                "hd15iqr": 0.0036859199999526027,
+                "ops": 281.6344882825519,
+                "total": 0.0355070150001211,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_systems_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_systems_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.398704442999815,
+                "max": 0.40462534799985406,
+                "mean": 0.40152620129997557,
+                "stddev": 0.0021345102355709816,
+                "rounds": 10,
+                "median": 0.4014786060000688,
+                "iqr": 0.0035290650000661117,
+                "q1": 0.39964028999997936,
+                "q3": 0.40316935500004547,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.398704442999815,
+                "hd15iqr": 0.40462534799985406,
+                "ops": 2.4904974986997463,
+                "total": 4.015262012999756,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_systems_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_systems_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.40410655400000906,
+                "max": 0.4822678049999922,
+                "mean": 0.42463262149999537,
+                "stddev": 0.0210915758762972,
+                "rounds": 10,
+                "median": 0.4208421990000488,
+                "iqr": 0.0012824479999835603,
+                "q1": 0.42049697099992045,
+                "q3": 0.421779418999904,
+                "iqr_outliers": 3,
+                "stddev_outliers": 1,
+                "outliers": "1;3",
+                "ld15iqr": 0.42049697099992045,
+                "hd15iqr": 0.4822678049999922,
+                "ops": 2.3549768655727523,
+                "total": 4.246326214999954,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_systems_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_systems_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.41981864800004587,
+                "max": 0.5204622019998624,
+                "mean": 0.4330606223999894,
+                "stddev": 0.0308425346793876,
+                "rounds": 10,
+                "median": 0.425002599499976,
+                "iqr": 0.005533797999987655,
+                "q1": 0.42050808199996936,
+                "q3": 0.426041879999957,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.41981864800004587,
+                "hd15iqr": 0.5204622019998624,
+                "ops": 2.309145528997939,
+                "total": 4.330606223999894,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_systems_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_systems_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.42609657200000584,
+                "max": 0.538702652999973,
+                "mean": 0.4391121540000086,
+                "stddev": 0.035010560417150095,
+                "rounds": 10,
+                "median": 0.4285800845000267,
+                "iqr": 0.0018264679999902,
+                "q1": 0.42736858100010977,
+                "q3": 0.42919504900009997,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.42609657200000584,
+                "hd15iqr": 0.538702652999973,
+                "ops": 2.277322526581627,
+                "total": 4.391121540000086,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_system_groups_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_system_groups_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029233669999939593,
+                "max": 0.003046700000140845,
+                "mean": 0.00298472499998752,
+                "stddev": 4.466629716943083e-05,
+                "rounds": 10,
+                "median": 0.002998052999942047,
+                "iqr": 7.341799982896191e-05,
+                "q1": 0.0029416820000278676,
+                "q3": 0.0030150999998568295,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.0029233669999939593,
+                "hd15iqr": 0.003046700000140845,
+                "ops": 335.03924147255816,
+                "total": 0.029847249999875203,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_system_groups_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_system_groups_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029397579999113077,
+                "max": 0.003084479999870382,
+                "mean": 0.0030035412000188446,
+                "stddev": 4.609391010352631e-05,
+                "rounds": 10,
+                "median": 0.002994366500047363,
+                "iqr": 2.703999984987604e-05,
+                "q1": 0.00298566500009656,
+                "q3": 0.003012704999946436,
+                "iqr_outliers": 3,
+                "stddev_outliers": 4,
+                "outliers": "4;3",
+                "ld15iqr": 0.002955799000119441,
+                "hd15iqr": 0.0030765750000227854,
+                "ops": 332.940330565043,
+                "total": 0.030035412000188444,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_system_groups_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_system_groups_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0028841440000633156,
+                "max": 0.0031186139999590523,
+                "mean": 0.0029693550999809306,
+                "stddev": 6.720525623612424e-05,
+                "rounds": 10,
+                "median": 0.002946856999983538,
+                "iqr": 6.535299985443999e-05,
+                "q1": 0.002928928000073938,
+                "q3": 0.002994280999928378,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.0028841440000633156,
+                "hd15iqr": 0.0031186139999590523,
+                "ops": 336.7734630345903,
+                "total": 0.029693550999809304,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_system_groups_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_system_groups_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029383950000010373,
+                "max": 0.003112433000069359,
+                "mean": 0.0029889599999705753,
+                "stddev": 5.3727293189689265e-05,
+                "rounds": 10,
+                "median": 0.002987658500046564,
+                "iqr": 6.758599988643255e-05,
+                "q1": 0.0029396190000170463,
+                "q3": 0.003007204999903479,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0029383950000010373,
+                "hd15iqr": 0.003112433000069359,
+                "ops": 334.56453080999563,
+                "total": 0.02988959999970575,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profile_groups_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_profile_groups_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029110150001088186,
+                "max": 0.0030651740000848804,
+                "mean": 0.0029763992999960465,
+                "stddev": 5.189337010306318e-05,
+                "rounds": 10,
+                "median": 0.002973852499962959,
+                "iqr": 6.210700007613923e-05,
+                "q1": 0.0029339769998841803,
+                "q3": 0.0029960839999603195,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.0029110150001088186,
+                "hd15iqr": 0.0030651740000848804,
+                "ops": 335.97642628169154,
+                "total": 0.029763992999960465,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profile_groups_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_profile_groups_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002927245000137191,
+                "max": 0.003076275000012174,
+                "mean": 0.0030049990999486908,
+                "stddev": 5.738294569666148e-05,
+                "rounds": 10,
+                "median": 0.0030075964998559357,
+                "iqr": 0.00010605799980112351,
+                "q1": 0.002952062000076694,
+                "q3": 0.0030581199998778175,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.002927245000137191,
+                "hd15iqr": 0.003076275000012174,
+                "ops": 332.7788018362716,
+                "total": 0.03004999099948691,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profile_groups_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_profile_groups_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0028947040000275592,
+                "max": 0.0031158790000063163,
+                "mean": 0.002980461900006048,
+                "stddev": 7.172081136800143e-05,
+                "rounds": 10,
+                "median": 0.0029734769999549826,
+                "iqr": 0.0001176809998924,
+                "q1": 0.002916655000035462,
+                "q3": 0.003034335999927862,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0028947040000275592,
+                "hd15iqr": 0.0031158790000063163,
+                "ops": 335.51846443598913,
+                "total": 0.029804619000060484,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_profile_groups_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_profile_groups_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029521120000026713,
+                "max": 0.003102403999946546,
+                "mean": 0.003010180799947193,
+                "stddev": 4.562510652292789e-05,
+                "rounds": 10,
+                "median": 0.0030023709998658887,
+                "iqr": 6.0292999933153624e-05,
+                "q1": 0.002972840999973414,
+                "q3": 0.0030331339999065676,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0029521120000026713,
+                "hd15iqr": 0.003102403999946546,
+                "ops": 332.2059591960532,
+                "total": 0.03010180799947193,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_distro_groups_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_distro_groups_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002919239999982892,
+                "max": 0.0031094569999368105,
+                "mean": 0.0029951945999982855,
+                "stddev": 6.871355300786325e-05,
+                "rounds": 10,
+                "median": 0.0029797285001222917,
+                "iqr": 6.980099988140864e-05,
+                "q1": 0.0029486050000286923,
+                "q3": 0.003018405999910101,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.002919239999982892,
+                "hd15iqr": 0.0031094569999368105,
+                "ops": 333.8681232934155,
+                "total": 0.029951945999982854,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_distro_groups_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_distro_groups_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029377450000538374,
+                "max": 0.0030862330002037197,
+                "mean": 0.00301414000002751,
+                "stddev": 4.8782948767770296e-05,
+                "rounds": 10,
+                "median": 0.00300398900003529,
+                "iqr": 6.812800006628095e-05,
+                "q1": 0.0029820879999533645,
+                "q3": 0.0030502160000196454,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.0029377450000538374,
+                "hd15iqr": 0.0030862330002037197,
+                "ops": 331.76959265026613,
+                "total": 0.030141400000275098,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_distro_groups_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_distro_groups_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0028894439999476162,
+                "max": 0.00306162700007917,
+                "mean": 0.0029661530000339555,
+                "stddev": 5.713737473042332e-05,
+                "rounds": 10,
+                "median": 0.0029578925000350864,
+                "iqr": 8.105300003080629e-05,
+                "q1": 0.0029175560000567202,
+                "q3": 0.0029986090000875265,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.0028894439999476162,
+                "hd15iqr": 0.00306162700007917,
+                "ops": 337.1370256317029,
+                "total": 0.029661530000339553,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_distro_groups_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_distro_groups_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029316929999367858,
+                "max": 0.0031144359998052096,
+                "mean": 0.003004217299985612,
+                "stddev": 6.370599847593e-05,
+                "rounds": 10,
+                "median": 0.002995828500047537,
+                "iqr": 7.938900012049999e-05,
+                "q1": 0.0029437659998166055,
+                "q3": 0.0030231549999371055,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.0029316929999367858,
+                "hd15iqr": 0.0031144359998052096,
+                "ops": 332.86540224796295,
+                "total": 0.03004217299985612,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_network_interfaces_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_network_interfaces_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3320094360001349,
+                "max": 0.33471632700002374,
+                "mean": 0.33376398540001445,
+                "stddev": 0.0009416769090934627,
+                "rounds": 10,
+                "median": 0.33415427700003875,
+                "iqr": 0.0007301309999547811,
+                "q1": 0.3335798739999518,
+                "q3": 0.3343100049999066,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.3335798739999518,
+                "hd15iqr": 0.33471632700002374,
+                "ops": 2.9961291323912764,
+                "total": 3.3376398540001446,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_network_interfaces_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_network_interfaces_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3229176689999349,
+                "max": 0.42726641900003415,
+                "mean": 0.3423093423999717,
+                "stddev": 0.030260834679812967,
+                "rounds": 10,
+                "median": 0.3353429535000032,
+                "iqr": 0.0007174360000590241,
+                "q1": 0.33503477499994005,
+                "q3": 0.3357522109999991,
+                "iqr_outliers": 3,
+                "stddev_outliers": 1,
+                "outliers": "1;3",
+                "ld15iqr": 0.33503477499994005,
+                "hd15iqr": 0.42726641900003415,
+                "ops": 2.9213342323317284,
+                "total": 3.423093423999717,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_network_interfaces_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_network_interfaces_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3207732240000496,
+                "max": 0.3219812310001089,
+                "mean": 0.32131835170002887,
+                "stddev": 0.0004162440654665605,
+                "rounds": 10,
+                "median": 0.3213145544999634,
+                "iqr": 0.0007199319998107967,
+                "q1": 0.32094482500019694,
+                "q3": 0.32166475700000774,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.3207732240000496,
+                "hd15iqr": 0.3219812310001089,
+                "ops": 3.112178295168038,
+                "total": 3.2131835170002887,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_network_interfaces_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_network_interfaces_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.3232740879998346,
+                "max": 0.42219681300002776,
+                "mean": 0.3375713946000133,
+                "stddev": 0.030138491754856327,
+                "rounds": 10,
+                "median": 0.3267490859999498,
+                "iqr": 0.011222275999898557,
+                "q1": 0.32530480000013995,
+                "q3": 0.3365270760000385,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.3232740879998346,
+                "hd15iqr": 0.42219681300002776,
+                "ops": 2.9623363116560726,
+                "total": 3.3757139460001326,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_all_items_create[False-False]",
+            "fullname": "tests/performance/item_add_test.py::test_all_items_create[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.8121813770001154,
+                "max": 0.9486974989999908,
+                "mean": 0.8511768247000419,
+                "stddev": 0.05399595224426506,
+                "rounds": 10,
+                "median": 0.8286941695000678,
+                "iqr": 0.04307719300027202,
+                "q1": 0.8134702759998618,
+                "q3": 0.8565474690001338,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.8121813770001154,
+                "hd15iqr": 0.9483458400000018,
+                "ops": 1.1748440171082009,
+                "total": 8.511768247000418,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_all_items_create[True-False]",
+            "fullname": "tests/performance/item_add_test.py::test_all_items_create[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.8146559619999607,
+                "max": 0.9517439979999835,
+                "mean": 0.8506817203999845,
+                "stddev": 0.049521763465112105,
+                "rounds": 10,
+                "median": 0.833356100499941,
+                "iqr": 0.03417869800000517,
+                "q1": 0.8158340239999688,
+                "q3": 0.850012721999974,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.8146559619999607,
+                "hd15iqr": 0.9270161710001048,
+                "ops": 1.1755277867376852,
+                "total": 8.506817203999844,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_all_items_create[False-True]",
+            "fullname": "tests/performance/item_add_test.py::test_all_items_create[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.8124101060000157,
+                "max": 1.038036553999973,
+                "mean": 0.8735394159999942,
+                "stddev": 0.06496828509579478,
+                "rounds": 10,
+                "median": 0.8480761125000527,
+                "iqr": 0.0255711509998946,
+                "q1": 0.8464933160000783,
+                "q3": 0.8720644669999729,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.8124101060000157,
+                "hd15iqr": 0.9288657019999391,
+                "ops": 1.1447680341421556,
+                "total": 8.735394159999942,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_all_items_create[True-True]",
+            "fullname": "tests/performance/item_add_test.py::test_all_items_create[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.8095245689999047,
+                "max": 0.9633229940000092,
+                "mean": 0.8644172581999555,
+                "stddev": 0.04448565173108491,
+                "rounds": 10,
+                "median": 0.8486071539999784,
+                "iqr": 0.01580111099997339,
+                "q1": 0.8466776420000315,
+                "q3": 0.8624787530000049,
+                "iqr_outliers": 3,
+                "stddev_outliers": 3,
+                "outliers": "3;3",
+                "ld15iqr": 0.8444607510000424,
+                "hd15iqr": 0.9221265719997973,
+                "ops": 1.1568487215102334,
+                "total": 8.644172581999555,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-repo]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-repo]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "repo"
+            },
+            "param": "False-False-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004586248999885356,
+                "max": 0.004941626000118049,
+                "mean": 0.004716344299981756,
+                "stddev": 0.0001276995913313884,
+                "rounds": 10,
+                "median": 0.0046635590000505545,
+                "iqr": 0.00020335199974397256,
+                "q1": 0.004622117000053549,
+                "q3": 0.004825468999797522,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.004586248999885356,
+                "hd15iqr": 0.004941626000118049,
+                "ops": 212.02862564632278,
+                "total": 0.04716344299981756,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-distro]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-distro]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro"
+            },
+            "param": "False-False-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004732063000119524,
+                "max": 0.005064446000005773,
+                "mean": 0.0048429227999804425,
+                "stddev": 0.00010982788702361564,
+                "rounds": 10,
+                "median": 0.004802379500006282,
+                "iqr": 5.710699997507618e-05,
+                "q1": 0.004786434999914491,
+                "q3": 0.004843541999889567,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.004732063000119524,
+                "hd15iqr": 0.005018960999905175,
+                "ops": 206.4868760666675,
+                "total": 0.048429227999804425,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-menu]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-menu]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "menu"
+            },
+            "param": "False-False-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.011680625999815675,
+                "max": 0.012812731999929383,
+                "mean": 0.011934412999994492,
+                "stddev": 0.00033987933809577253,
+                "rounds": 10,
+                "median": 0.01178798800003733,
+                "iqr": 0.000315443000090454,
+                "q1": 0.011763642000005348,
+                "q3": 0.012079085000095802,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.011680625999815675,
+                "hd15iqr": 0.012812731999929383,
+                "ops": 83.79130167528655,
+                "total": 0.11934412999994493,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-profile]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-profile]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile"
+            },
+            "param": "False-False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5654509940000025,
+                "max": 0.6692132729999685,
+                "mean": 0.5884070519999796,
+                "stddev": 0.03795539635203657,
+                "rounds": 10,
+                "median": 0.5718343460000597,
+                "iqr": 0.003935646999707387,
+                "q1": 0.5703338800001347,
+                "q3": 0.5742695269998421,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.5654509940000025,
+                "hd15iqr": 0.6502207300000009,
+                "ops": 1.699503764615035,
+                "total": 5.884070519999796,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-image]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-image]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "image"
+            },
+            "param": "False-False-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.005513109000048644,
+                "max": 0.006953483000188498,
+                "mean": 0.005961596600013763,
+                "stddev": 0.00048720080155491773,
+                "rounds": 10,
+                "median": 0.005746932499960167,
+                "iqr": 0.0003990989998783334,
+                "q1": 0.00567092500000399,
+                "q3": 0.0060700239998823236,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.005513109000048644,
+                "hd15iqr": 0.00672449300009248,
+                "ops": 167.74029963679382,
+                "total": 0.05961596600013763,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-system]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-system]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system"
+            },
+            "param": "False-False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5795157760001075,
+                "max": 0.582751498999869,
+                "mean": 0.5804204460000164,
+                "stddev": 0.0011110693965666997,
+                "rounds": 10,
+                "median": 0.579951744500022,
+                "iqr": 0.0012462690001484589,
+                "q1": 0.5796378649999951,
+                "q3": 0.5808841340001436,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.5795157760001075,
+                "hd15iqr": 0.582751498999869,
+                "ops": 1.7228889969185746,
+                "total": 5.8042044600001645,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-network_interface]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-network_interface]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "network_interface"
+            },
+            "param": "False-False-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.43344127999989723,
+                "max": 0.5268956190000154,
+                "mean": 0.4440512776000105,
+                "stddev": 0.02913452741282775,
+                "rounds": 10,
+                "median": 0.43483882850000555,
+                "iqr": 0.0010759399999642483,
+                "q1": 0.4340903380000327,
+                "q3": 0.43516627799999696,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.43344127999989723,
+                "hd15iqr": 0.4379639200001293,
+                "ops": 2.2519921694736644,
+                "total": 4.440512776000105,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-distro_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-distro_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro_group"
+            },
+            "param": "False-False-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0035531999999420805,
+                "max": 0.003860826999925848,
+                "mean": 0.003662144399982026,
+                "stddev": 0.00010997833867882916,
+                "rounds": 10,
+                "median": 0.003624173500043071,
+                "iqr": 0.0001325499999893509,
+                "q1": 0.0035822239999561134,
+                "q3": 0.0037147739999454643,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0035531999999420805,
+                "hd15iqr": 0.003860826999925848,
+                "ops": 273.06405503969427,
+                "total": 0.03662144399982026,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-profile_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-profile_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile_group"
+            },
+            "param": "False-False-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003573878999986846,
+                "max": 0.003881896999928358,
+                "mean": 0.0036454322000054164,
+                "stddev": 8.687852370419213e-05,
+                "rounds": 10,
+                "median": 0.0036212779999686973,
+                "iqr": 3.672900015772029e-05,
+                "q1": 0.003607973000043785,
+                "q3": 0.003644702000201505,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.003573878999986846,
+                "hd15iqr": 0.003881896999928358,
+                "ops": 274.3158959309446,
+                "total": 0.03645432200005416,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-False-system_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-False-system_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system_group"
+            },
+            "param": "False-False-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0035773150000295573,
+                "max": 0.0039048300000104064,
+                "mean": 0.0036677266999959103,
+                "stddev": 0.00011735291937187046,
+                "rounds": 10,
+                "median": 0.003612535999991451,
+                "iqr": 4.329100011091214e-05,
+                "q1": 0.0036114089998591226,
+                "q3": 0.0036546999999700347,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0035773150000295573,
+                "hd15iqr": 0.0038688520000960125,
+                "ops": 272.6484500606643,
+                "total": 0.0366772669999591,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-repo]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-repo]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "repo"
+            },
+            "param": "True-False-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004839023999920755,
+                "max": 0.0059088010000323266,
+                "mean": 0.005027880100010406,
+                "stddev": 0.0003189871837341289,
+                "rounds": 10,
+                "median": 0.004920220500025607,
+                "iqr": 0.00012189900007797405,
+                "q1": 0.00487410000005184,
+                "q3": 0.004995999000129814,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.004839023999920755,
+                "hd15iqr": 0.0059088010000323266,
+                "ops": 198.89097991774509,
+                "total": 0.05027880100010407,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-distro]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-distro]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro"
+            },
+            "param": "True-False-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004932920000101149,
+                "max": 0.006130407999989984,
+                "mean": 0.005183106699996642,
+                "stddev": 0.0003594017779433171,
+                "rounds": 10,
+                "median": 0.005054157500126166,
+                "iqr": 0.0003108139999312698,
+                "q1": 0.00497451799992632,
+                "q3": 0.00528533199985759,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.004932920000101149,
+                "hd15iqr": 0.006130407999989984,
+                "ops": 192.93448078169948,
+                "total": 0.051831066999966424,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-menu]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-menu]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "menu"
+            },
+            "param": "True-False-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.012377014000094277,
+                "max": 0.01286864600001536,
+                "mean": 0.012504011100031676,
+                "stddev": 0.00014949746146805982,
+                "rounds": 10,
+                "median": 0.012450010500060671,
+                "iqr": 0.00010929499990197655,
+                "q1": 0.0124260160000631,
+                "q3": 0.012535310999965077,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.012377014000094277,
+                "hd15iqr": 0.01286864600001536,
+                "ops": 79.97433719468361,
+                "total": 0.12504011100031676,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-profile]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-profile]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile"
+            },
+            "param": "True-False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5707745360000445,
+                "max": 0.6871432200000527,
+                "mean": 0.5961452928000199,
+                "stddev": 0.04299247985839959,
+                "rounds": 10,
+                "median": 0.5791835270000547,
+                "iqr": 0.0091660860000502,
+                "q1": 0.5722227549999843,
+                "q3": 0.5813888410000345,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.5707745360000445,
+                "hd15iqr": 0.666527139999971,
+                "ops": 1.6774434220609629,
+                "total": 5.961452928000199,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-image]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-image]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "image"
+            },
+            "param": "True-False-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00545335700007854,
+                "max": 0.005863676999979361,
+                "mean": 0.005547121899985541,
+                "stddev": 0.00011902527392502259,
+                "rounds": 10,
+                "median": 0.0055212645000892735,
+                "iqr": 7.480999988729309e-05,
+                "q1": 0.005476711000028445,
+                "q3": 0.005551520999915738,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00545335700007854,
+                "hd15iqr": 0.005863676999979361,
+                "ops": 180.27366588114938,
+                "total": 0.05547121899985541,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-system]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-system]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system"
+            },
+            "param": "True-False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5937365700001465,
+                "max": 0.7332783330000439,
+                "mean": 0.6199197274999733,
+                "stddev": 0.047199588989731776,
+                "rounds": 10,
+                "median": 0.5987353694999911,
+                "iqr": 0.0067248230000132025,
+                "q1": 0.5968771059999654,
+                "q3": 0.6036019289999786,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.5937365700001465,
+                "hd15iqr": 0.6784148960000493,
+                "ops": 1.6131120782892703,
+                "total": 6.199197274999733,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-network_interface]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-network_interface]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "network_interface"
+            },
+            "param": "True-False-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4210078200001135,
+                "max": 0.5814234059998853,
+                "mean": 0.4549772954999753,
+                "stddev": 0.04545766460839602,
+                "rounds": 10,
+                "median": 0.4457258904999435,
+                "iqr": 0.002232261000244762,
+                "q1": 0.44471973099985007,
+                "q3": 0.44695199200009483,
+                "iqr_outliers": 3,
+                "stddev_outliers": 1,
+                "outliers": "1;3",
+                "ld15iqr": 0.44471973099985007,
+                "hd15iqr": 0.5814234059998853,
+                "ops": 2.19791187360481,
+                "total": 4.549772954999753,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-distro_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-distro_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro_group"
+            },
+            "param": "True-False-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0034759850000227743,
+                "max": 0.003911822999953074,
+                "mean": 0.0036962966999681155,
+                "stddev": 0.00011054039216087121,
+                "rounds": 10,
+                "median": 0.0036891204998710236,
+                "iqr": 5.999199993311777e-05,
+                "q1": 0.0036542699999699835,
+                "q3": 0.0037142619999031012,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.003652375999990909,
+                "hd15iqr": 0.003911822999953074,
+                "ops": 270.5410526185915,
+                "total": 0.03696296699968116,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-profile_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-profile_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile_group"
+            },
+            "param": "True-False-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003624574000014036,
+                "max": 0.003987455000014961,
+                "mean": 0.003766296800017699,
+                "stddev": 0.0001225307822323662,
+                "rounds": 10,
+                "median": 0.0037162860000989895,
+                "iqr": 0.0001487090000864555,
+                "q1": 0.0036911990000589867,
+                "q3": 0.003839908000145442,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.003624574000014036,
+                "hd15iqr": 0.003987455000014961,
+                "ops": 265.512797609392,
+                "total": 0.03766296800017699,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-False-system_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-False-system_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system_group"
+            },
+            "param": "True-False-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003659088999938831,
+                "max": 0.0041250839999520394,
+                "mean": 0.003848077399948124,
+                "stddev": 0.00018107771784016332,
+                "rounds": 10,
+                "median": 0.0037772504998656586,
+                "iqr": 0.00034075999997185136,
+                "q1": 0.003704472999970676,
+                "q3": 0.004045232999942527,
+                "iqr_outliers": 0,
+                "stddev_outliers": 5,
+                "outliers": "5;0",
+                "ld15iqr": 0.003659088999938831,
+                "hd15iqr": 0.0041250839999520394,
+                "ops": 259.87003276323935,
+                "total": 0.038480773999481244,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-repo]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-repo]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "repo"
+            },
+            "param": "False-True-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004528560000153448,
+                "max": 0.005567852000012863,
+                "mean": 0.004971049300024788,
+                "stddev": 0.000407279556265255,
+                "rounds": 10,
+                "median": 0.004830001499954051,
+                "iqr": 0.0007110240001111379,
+                "q1": 0.004606397000088691,
+                "q3": 0.005317421000199829,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.004528560000153448,
+                "hd15iqr": 0.005567852000012863,
+                "ops": 201.16477219306867,
+                "total": 0.04971049300024788,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-distro]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-distro]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro"
+            },
+            "param": "False-True-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004654988000083904,
+                "max": 0.005037616999970851,
+                "mean": 0.004789877500047624,
+                "stddev": 0.00010975930660565841,
+                "rounds": 10,
+                "median": 0.004750577499976316,
+                "iqr": 8.557000001019333e-05,
+                "q1": 0.004730289999997694,
+                "q3": 0.004815860000007888,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 0.004654988000083904,
+                "hd15iqr": 0.005037616999970851,
+                "ops": 208.77360642105305,
+                "total": 0.047898775000476235,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-menu]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-menu]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "menu"
+            },
+            "param": "False-True-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.011718598000015845,
+                "max": 0.012151440000025104,
+                "mean": 0.011846820499977184,
+                "stddev": 0.00013656552942240032,
+                "rounds": 10,
+                "median": 0.011810279999963313,
+                "iqr": 6.855900005575677e-05,
+                "q1": 0.011767298999984632,
+                "q3": 0.011835858000040389,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.011718598000015845,
+                "hd15iqr": 0.012028650000047492,
+                "ops": 84.41083411383889,
+                "total": 0.11846820499977184,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-profile]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-profile]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile"
+            },
+            "param": "False-True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5644120039999052,
+                "max": 0.6718849569999747,
+                "mean": 0.5885894434999728,
+                "stddev": 0.040101907803397216,
+                "rounds": 10,
+                "median": 0.567658022000046,
+                "iqr": 0.023203516999956264,
+                "q1": 0.567220344999896,
+                "q3": 0.5904238619998523,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.5644120039999052,
+                "hd15iqr": 0.6540216359999249,
+                "ops": 1.6989771241115477,
+                "total": 5.885894434999727,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-image]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-image]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "image"
+            },
+            "param": "False-True-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.005456402000163507,
+                "max": 0.006492428000001382,
+                "mean": 0.005630445200017676,
+                "stddev": 0.0003169543631092611,
+                "rounds": 10,
+                "median": 0.005511189999992894,
+                "iqr": 0.00011947300004067074,
+                "q1": 0.005478093999954581,
+                "q3": 0.0055975669999952515,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.005456402000163507,
+                "hd15iqr": 0.006492428000001382,
+                "ops": 177.60584900051256,
+                "total": 0.05630445200017675,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-system]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-system]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system"
+            },
+            "param": "False-True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.558767448000026,
+                "max": 0.7500608159998592,
+                "mean": 0.589518128599957,
+                "stddev": 0.061525582411080054,
+                "rounds": 10,
+                "median": 0.5600595074998864,
+                "iqr": 0.0329180109997651,
+                "q1": 0.5597512750000533,
+                "q3": 0.5926692859998184,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.558767448000026,
+                "hd15iqr": 0.7500608159998592,
+                "ops": 1.6963006759010006,
+                "total": 5.89518128599957,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-network_interface]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-network_interface]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "network_interface"
+            },
+            "param": "False-True-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.41480385499994554,
+                "max": 0.4550802899998416,
+                "mean": 0.4204892658999597,
+                "stddev": 0.01225172051196871,
+                "rounds": 10,
+                "median": 0.41666669149992686,
+                "iqr": 0.0017163719999189198,
+                "q1": 0.4156352649999917,
+                "q3": 0.4173516369999106,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.41480385499994554,
+                "hd15iqr": 0.42038081400005467,
+                "ops": 2.378181992017637,
+                "total": 4.204892658999597,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-distro_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-distro_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro_group"
+            },
+            "param": "False-True-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003418277000037051,
+                "max": 0.0044929440000487375,
+                "mean": 0.003606985700025689,
+                "stddev": 0.00032635714161112766,
+                "rounds": 10,
+                "median": 0.0034740460000648454,
+                "iqr": 0.0002398010003616946,
+                "q1": 0.003445045999797003,
+                "q3": 0.0036848470001586975,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.003418277000037051,
+                "hd15iqr": 0.0044929440000487375,
+                "ops": 277.2398016418191,
+                "total": 0.03606985700025689,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-profile_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-profile_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile_group"
+            },
+            "param": "False-True-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003416904000005161,
+                "max": 0.0037469940000391944,
+                "mean": 0.0035247937999884015,
+                "stddev": 0.00010388823784160163,
+                "rounds": 10,
+                "median": 0.003490437500090593,
+                "iqr": 5.340099983186519e-05,
+                "q1": 0.0034670780000851664,
+                "q3": 0.0035204789999170316,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.003416904000005161,
+                "hd15iqr": 0.0036757299999408133,
+                "ops": 283.7045389728303,
+                "total": 0.035247937999884016,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[False-True-system_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[False-True-system_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system_group"
+            },
+            "param": "False-True-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003413416999819674,
+                "max": 0.0036728649999986374,
+                "mean": 0.0034836143999655176,
+                "stddev": 7.19816492821991e-05,
+                "rounds": 10,
+                "median": 0.0034698885000352675,
+                "iqr": 2.83819999822299e-05,
+                "q1": 0.003456488999972862,
+                "q3": 0.003484870999955092,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.00342162299989468,
+                "hd15iqr": 0.0036728649999986374,
+                "ops": 287.05817727986727,
+                "total": 0.03483614399965518,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-repo]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-repo]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "repo"
+            },
+            "param": "True-True-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00469471200017324,
+                "max": 0.005700800999875355,
+                "mean": 0.0050016576999723835,
+                "stddev": 0.0003788791131377251,
+                "rounds": 10,
+                "median": 0.004868448499905753,
+                "iqr": 0.0002806780003083986,
+                "q1": 0.004742711999824678,
+                "q3": 0.005023390000133077,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.00469471200017324,
+                "hd15iqr": 0.00568708599985257,
+                "ops": 199.93371397757215,
+                "total": 0.05001657699972384,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-distro]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-distro]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro"
+            },
+            "param": "True-True-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.004759584999874278,
+                "max": 0.00549874200009981,
+                "mean": 0.005033666300005279,
+                "stddev": 0.00022897116498714424,
+                "rounds": 10,
+                "median": 0.005041303499979222,
+                "iqr": 0.00031051199994180934,
+                "q1": 0.00485631700007616,
+                "q3": 0.0051668290000179695,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.004759584999874278,
+                "hd15iqr": 0.00549874200009981,
+                "ops": 198.6623547132934,
+                "total": 0.050336663000052795,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-menu]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-menu]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "menu"
+            },
+            "param": "True-True-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.01237801499996749,
+                "max": 0.01380576600013228,
+                "mean": 0.012752901099997872,
+                "stddev": 0.00042533106440202975,
+                "rounds": 10,
+                "median": 0.01264323299994885,
+                "iqr": 0.00013140700002622907,
+                "q1": 0.012564225000005536,
+                "q3": 0.012695632000031765,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.01237801499996749,
+                "hd15iqr": 0.01313964499991016,
+                "ops": 78.41353054954429,
+                "total": 0.1275290109999787,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-profile]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-profile]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile"
+            },
+            "param": "True-True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5693046370001866,
+                "max": 0.6524169330000404,
+                "mean": 0.5789604962000567,
+                "stddev": 0.02583169550442352,
+                "rounds": 10,
+                "median": 0.5708140860001549,
+                "iqr": 0.0011268460000337654,
+                "q1": 0.5701615559999027,
+                "q3": 0.5712884019999365,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.5693046370001866,
+                "hd15iqr": 0.5732591109999703,
+                "ops": 1.7272335618118846,
+                "total": 5.789604962000567,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-image]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-image]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "image"
+            },
+            "param": "True-True-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.005382254000096509,
+                "max": 0.0065888990000075864,
+                "mean": 0.005610959800014826,
+                "stddev": 0.0003571986167937244,
+                "rounds": 10,
+                "median": 0.005495666499996332,
+                "iqr": 0.00010142999985873757,
+                "q1": 0.0054389900001297065,
+                "q3": 0.005540419999988444,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.005382254000096509,
+                "hd15iqr": 0.005739504000075613,
+                "ops": 178.22262779308414,
+                "total": 0.05610959800014825,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-system]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-system]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system"
+            },
+            "param": "True-True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.5737886150000122,
+                "max": 0.7123596349999843,
+                "mean": 0.6060576641000125,
+                "stddev": 0.05445812339284291,
+                "rounds": 10,
+                "median": 0.582309870500012,
+                "iqr": 0.015334856000208674,
+                "q1": 0.5748950919999061,
+                "q3": 0.5902299480001147,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.5737886150000122,
+                "hd15iqr": 0.7049964630000431,
+                "ops": 1.650008009526596,
+                "total": 6.060576641000125,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-network_interface]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-network_interface]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "network_interface"
+            },
+            "param": "True-True-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4282790289998957,
+                "max": 0.5525484429999779,
+                "mean": 0.44155731499995454,
+                "stddev": 0.03900719140189624,
+                "rounds": 10,
+                "median": 0.429239472499944,
+                "iqr": 0.0018638079998254398,
+                "q1": 0.4283963200000471,
+                "q3": 0.43026012799987257,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.4282790289998957,
+                "hd15iqr": 0.5525484429999779,
+                "ops": 2.264711660365321,
+                "total": 4.415573149999545,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-distro_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-distro_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro_group"
+            },
+            "param": "True-True-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003506943000047613,
+                "max": 0.0038714769998478005,
+                "mean": 0.003606135299992275,
+                "stddev": 0.000128097007630588,
+                "rounds": 10,
+                "median": 0.003556226000114293,
+                "iqr": 5.512400002771756e-05,
+                "q1": 0.0035336529999767663,
+                "q3": 0.003588777000004484,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.003506943000047613,
+                "hd15iqr": 0.00381455100000494,
+                "ops": 277.30518042463416,
+                "total": 0.03606135299992275,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-profile_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-profile_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile_group"
+            },
+            "param": "True-True-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.003516961999821433,
+                "max": 0.003839137000113624,
+                "mean": 0.0035970852999980705,
+                "stddev": 9.722532549688418e-05,
+                "rounds": 10,
+                "median": 0.0035749104999922565,
+                "iqr": 7.404000007227296e-05,
+                "q1": 0.0035315289999289234,
+                "q3": 0.0036055690000011964,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.003516961999821433,
+                "hd15iqr": 0.003839137000113624,
+                "ops": 278.00285970436573,
+                "total": 0.03597085299998071,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_copy[True-True-system_group]",
+            "fullname": "tests/performance/item_copy_test.py::test_item_copy[True-True-system_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system_group"
+            },
+            "param": "True-True-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0035939759998200316,
+                "max": 0.003890563000140901,
+                "mean": 0.003695900599996094,
+                "stddev": 9.77354564543654e-05,
+                "rounds": 10,
+                "median": 0.003662950500029183,
+                "iqr": 9.442600003239932e-05,
+                "q1": 0.0036369879999256227,
+                "q3": 0.003731413999958022,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 0.0035939759998200316,
+                "hd15iqr": 0.003890563000140901,
+                "ops": 270.5700472575093,
+                "total": 0.03695900599996094,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-repo-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-repo-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "repo",
+                "inherit_property": false
+            },
+            "param": "False-False-repo-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.7045959993993164e-05,
+                "max": 1.834724000218557e-05,
+                "mean": 1.7617792000237387e-05,
+                "stddev": 4.2866515947591145e-07,
+                "rounds": 10,
+                "median": 1.755516000230273e-05,
+                "iqr": 6.403600036719577e-07,
+                "q1": 1.7377039994244116e-05,
+                "q3": 1.8017399997916073e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 1.7045959993993164e-05,
+                "hd15iqr": 1.834724000218557e-05,
+                "ops": 56760.80180686239,
+                "total": 0.00017617792000237386,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-repo-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-repo-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "repo",
+                "inherit_property": true
+            },
+            "param": "False-False-repo-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.911892000061925e-05,
+                "max": 7.472508000319066e-05,
+                "mean": 7.15859760011881e-05,
+                "stddev": 1.3583224829688465e-06,
+                "rounds": 10,
+                "median": 7.150261999868234e-05,
+                "iqr": 5.766400045103962e-07,
+                "q1": 7.12485599979118e-05,
+                "q3": 7.18252000024222e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 7.104740000613675e-05,
+                "hd15iqr": 7.472508000319066e-05,
+                "ops": 13969.216540169868,
+                "total": 0.000715859760011881,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-distro-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-distro-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro",
+                "inherit_property": false
+            },
+            "param": "False-False-distro-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.9087040000158597e-05,
+                "max": 2.1076759994684836e-05,
+                "mean": 1.9670719998430288e-05,
+                "stddev": 7.231182371957383e-07,
+                "rounds": 10,
+                "median": 1.9306039998809865e-05,
+                "iqr": 1.285640000787679e-06,
+                "q1": 1.91843999982666e-05,
+                "q3": 2.047003999905428e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 1.9087040000158597e-05,
+                "hd15iqr": 2.1076759994684836e-05,
+                "ops": 50836.98004342492,
+                "total": 0.00019670719998430287,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-distro-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-distro-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro",
+                "inherit_property": true
+            },
+            "param": "False-False-distro-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.590967999931308e-05,
+                "max": 8.076840000285301e-05,
+                "mean": 7.677595599852794e-05,
+                "stddev": 1.419419304452712e-06,
+                "rounds": 10,
+                "median": 7.639317999746708e-05,
+                "iqr": 3.582400040613693e-07,
+                "q1": 7.616979999511386e-05,
+                "q3": 7.652803999917523e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 7.590967999931308e-05,
+                "hd15iqr": 8.076840000285301e-05,
+                "ops": 13024.91108048428,
+                "total": 0.0007677595599852793,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-menu-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-menu-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "menu",
+                "inherit_property": false
+            },
+            "param": "False-False-menu-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.737051999654795e-05,
+                "max": 5.0723599997581914e-05,
+                "mean": 4.830787999981112e-05,
+                "stddev": 1.051310583372127e-06,
+                "rounds": 10,
+                "median": 4.80018999951426e-05,
+                "iqr": 9.000799946079445e-07,
+                "q1": 4.756812000778155e-05,
+                "q3": 4.846820000238949e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 4.737051999654795e-05,
+                "hd15iqr": 5.0723599997581914e-05,
+                "ops": 20700.556513842253,
+                "total": 0.0004830787999981112,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-menu-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-menu-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "menu",
+                "inherit_property": true
+            },
+            "param": "False-False-menu-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00020406063999871548,
+                "max": 0.00021763175999694795,
+                "mean": 0.00020710809999854973,
+                "stddev": 3.911295290052133e-06,
+                "rounds": 10,
+                "median": 0.0002066192599977512,
+                "iqr": 2.7627600047708256e-06,
+                "q1": 0.00020460607999666535,
+                "q3": 0.00020736884000143618,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00020406063999871548,
+                "hd15iqr": 0.00021763175999694795,
+                "ops": 4828.396378543391,
+                "total": 0.0020710809999854975,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-profile-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-profile-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile",
+                "inherit_property": false
+            },
+            "param": "False-False-profile-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0016923472399957972,
+                "max": 0.001723325359998853,
+                "mean": 0.0017048021519995018,
+                "stddev": 1.0439274789802354e-05,
+                "rounds": 10,
+                "median": 0.0017013873999985663,
+                "iqr": 1.149476000136926e-05,
+                "q1": 0.0016979236800034414,
+                "q3": 0.0017094184400048107,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.0016923472399957972,
+                "hd15iqr": 0.001723325359998853,
+                "ops": 586.5783304104441,
+                "total": 0.01704802151999502,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-profile-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-profile-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile",
+                "inherit_property": true
+            },
+            "param": "False-False-profile-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00677764916000342,
+                "max": 0.007368369640007586,
+                "mean": 0.006857538680001198,
+                "stddev": 0.00017991307893067097,
+                "rounds": 10,
+                "median": 0.006802084819996708,
+                "iqr": 2.1181800002522885e-05,
+                "q1": 0.006791788079999606,
+                "q3": 0.006812969880002129,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00677764916000342,
+                "hd15iqr": 0.007368369640007586,
+                "ops": 145.82491571156916,
+                "total": 0.06857538680001199,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-image-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-image-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "image",
+                "inherit_property": false
+            },
+            "param": "False-False-image-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.9018080001842465e-05,
+                "max": 2.0754959996338586e-05,
+                "mean": 1.9686635999278224e-05,
+                "stddev": 6.245773829483598e-07,
+                "rounds": 10,
+                "median": 1.937380000072153e-05,
+                "iqr": 1.124919990616035e-06,
+                "q1": 1.920644000165339e-05,
+                "q3": 2.0331359992269426e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 1.9018080001842465e-05,
+                "hd15iqr": 2.0754959996338586e-05,
+                "ops": 50795.88000899002,
+                "total": 0.00019686635999278224,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-image-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-image-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "image",
+                "inherit_property": true
+            },
+            "param": "False-False-image-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.634371999301948e-05,
+                "max": 8.144288000039524e-05,
+                "mean": 7.720125199739414e-05,
+                "stddev": 1.5155682840025242e-06,
+                "rounds": 10,
+                "median": 7.672323999941e-05,
+                "iqr": 5.370000053517288e-07,
+                "q1": 7.654891999663959e-05,
+                "q3": 7.708592000199132e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 7.634371999301948e-05,
+                "hd15iqr": 8.144288000039524e-05,
+                "ops": 12953.157806738085,
+                "total": 0.0007720125199739414,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-system-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-system-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system",
+                "inherit_property": false
+            },
+            "param": "False-False-system-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0018807396400006837,
+                "max": 0.0019139504000031593,
+                "mean": 0.0018929278960004012,
+                "stddev": 1.0934337015877942e-05,
+                "rounds": 10,
+                "median": 0.0018909332000021095,
+                "iqr": 7.30688000658117e-06,
+                "q1": 0.0018854977999944822,
+                "q3": 0.0018928046800010634,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.0018807396400006837,
+                "hd15iqr": 0.0019103660800010402,
+                "ops": 528.2821401242576,
+                "total": 0.01892927896000401,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-system-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-system-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system",
+                "inherit_property": true
+            },
+            "param": "False-False-system-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.007548761040006866,
+                "max": 0.012810304240001642,
+                "mean": 0.008090828439998404,
+                "stddev": 0.0016582855919754999,
+                "rounds": 10,
+                "median": 0.007567826439999408,
+                "iqr": 2.0843919992331005e-05,
+                "q1": 0.007559769720000986,
+                "q3": 0.007580613639993317,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.007548761040006866,
+                "hd15iqr": 0.012810304240001642,
+                "ops": 123.59673764139254,
+                "total": 0.08090828439998404,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-network_interface-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-network_interface-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "network_interface",
+                "inherit_property": false
+            },
+            "param": "False-False-network_interface-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.001522151720000693,
+                "max": 0.0015455893200032732,
+                "mean": 0.0015300962759993127,
+                "stddev": 6.6597696267585806e-06,
+                "rounds": 10,
+                "median": 0.0015286280800000896,
+                "iqr": 7.57820000217178e-06,
+                "q1": 0.0015254058399932547,
+                "q3": 0.0015329840399954265,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.001522151720000693,
+                "hd15iqr": 0.0015455893200032732,
+                "ops": 653.553646058576,
+                "total": 0.015300962759993127,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-network_interface-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-network_interface-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "network_interface",
+                "inherit_property": true
+            },
+            "param": "False-False-network_interface-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006498122439998042,
+                "max": 0.006627722119992541,
+                "mean": 0.006524734307998188,
+                "stddev": 3.927844576288778e-05,
+                "rounds": 10,
+                "median": 0.006510762959992462,
+                "iqr": 2.1253920003800296e-05,
+                "q1": 0.006499713399998655,
+                "q3": 0.006520967320002455,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.006498122439998042,
+                "hd15iqr": 0.006627722119992541,
+                "ops": 153.26294570710323,
+                "total": 0.06524734307998188,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-distro_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-distro_group-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro_group",
+                "inherit_property": false
+            },
+            "param": "False-False-distro_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.602731999810203e-05,
+                "max": 1.7452359998060274e-05,
+                "mean": 1.640155199856963e-05,
+                "stddev": 4.96307790070273e-07,
+                "rounds": 10,
+                "median": 1.6143719999490714e-05,
+                "iqr": 7.173199992394106e-07,
+                "q1": 1.6062559998317737e-05,
+                "q3": 1.6779879997557147e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 1.602731999810203e-05,
+                "hd15iqr": 1.7452359998060274e-05,
+                "ops": 60969.8399326606,
+                "total": 0.00016401551998569631,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-distro_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-distro_group-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro_group",
+                "inherit_property": true
+            },
+            "param": "False-False-distro_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.503807999251876e-05,
+                "max": 7.036248000076739e-05,
+                "mean": 6.72186559986585e-05,
+                "stddev": 1.4084037387612598e-06,
+                "rounds": 10,
+                "median": 6.744159999925615e-05,
+                "iqr": 8.732400056032854e-07,
+                "q1": 6.67027999952552e-05,
+                "q3": 6.757604000085848e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 6.574259999979404e-05,
+                "hd15iqr": 7.036248000076739e-05,
+                "ops": 14876.822292013056,
+                "total": 0.0006721865599865851,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-profile_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-profile_group-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile_group",
+                "inherit_property": false
+            },
+            "param": "False-False-profile_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.5877000005275478e-05,
+                "max": 1.7695639999146807e-05,
+                "mean": 1.630617200044071e-05,
+                "stddev": 6.004784743735421e-07,
+                "rounds": 10,
+                "median": 1.6065960003288638e-05,
+                "iqr": 3.9636000110476716e-07,
+                "q1": 1.5914679997877102e-05,
+                "q3": 1.631103999898187e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 1.5877000005275478e-05,
+                "hd15iqr": 1.704839999547403e-05,
+                "ops": 61326.471962455245,
+                "total": 0.0001630617200044071,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-profile_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-profile_group-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile_group",
+                "inherit_property": true
+            },
+            "param": "False-False-profile_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.536947999848053e-05,
+                "max": 7.08886799930042e-05,
+                "mean": 6.746940800076117e-05,
+                "stddev": 1.543974571349578e-06,
+                "rounds": 10,
+                "median": 6.722638000155711e-05,
+                "iqr": 1.2815999980375582e-06,
+                "q1": 6.6759320006895e-05,
+                "q3": 6.804092000493255e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 6.536947999848053e-05,
+                "hd15iqr": 7.08886799930042e-05,
+                "ops": 14821.532152597489,
+                "total": 0.0006746940800076117,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-system_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-system_group-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system_group",
+                "inherit_property": false
+            },
+            "param": "False-False-system_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.608499999747437e-05,
+                "max": 1.7355359996145126e-05,
+                "mean": 1.6502215999025793e-05,
+                "stddev": 4.634890931024856e-07,
+                "rounds": 10,
+                "median": 1.6353500000150235e-05,
+                "iqr": 8.59200008562768e-07,
+                "q1": 1.611023999430472e-05,
+                "q3": 1.6969440002867488e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 1.608499999747437e-05,
+                "hd15iqr": 1.7355359996145126e-05,
+                "ops": 60597.922125067016,
+                "total": 0.00016502215999025793,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-False-system_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-False-system_group-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system_group",
+                "inherit_property": true
+            },
+            "param": "False-False-system_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.549015999553376e-05,
+                "max": 6.970123999963107e-05,
+                "mean": 6.718238799840037e-05,
+                "stddev": 1.0592541070490197e-06,
+                "rounds": 10,
+                "median": 6.712397999763197e-05,
+                "iqr": 4.0835999243427285e-07,
+                "q1": 6.693244000416598e-05,
+                "q3": 6.734079999660026e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 6.63369199992303e-05,
+                "hd15iqr": 6.970123999963107e-05,
+                "ops": 14884.853453315922,
+                "total": 0.0006718238799840037,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-repo-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-repo-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "repo",
+                "inherit_property": false
+            },
+            "param": "True-False-repo-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4940400007835705e-05,
+                "max": 2.6897280004050118e-05,
+                "mean": 2.5844151999990572e-05,
+                "stddev": 6.669342173977344e-07,
+                "rounds": 10,
+                "median": 2.579499999683321e-05,
+                "iqr": 1.3312800001585855e-06,
+                "q1": 2.5215360001311637e-05,
+                "q3": 2.6546640001470223e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 5,
+                "outliers": "5;0",
+                "ld15iqr": 2.4940400007835705e-05,
+                "hd15iqr": 2.6897280004050118e-05,
+                "ops": 38693.47309210861,
+                "total": 0.0002584415199999057,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-repo-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-repo-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "repo",
+                "inherit_property": true
+            },
+            "param": "True-False-repo-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 9.663820000241686e-05,
+                "max": 0.0001050119200044719,
+                "mean": 9.800593999898411e-05,
+                "stddev": 2.550308772571066e-06,
+                "rounds": 10,
+                "median": 9.698286000002554e-05,
+                "iqr": 1.372959995933333e-06,
+                "q1": 9.671396000157984e-05,
+                "q3": 9.808691999751317e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 9.663820000241686e-05,
+                "hd15iqr": 0.0001050119200044719,
+                "ops": 10203.463177949883,
+                "total": 0.000980059399989841,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-distro-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-distro-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro",
+                "inherit_property": false
+            },
+            "param": "True-False-distro-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.7438679999249872e-05,
+                "max": 2.9534240002249135e-05,
+                "mean": 2.846482799941441e-05,
+                "stddev": 6.816789059463406e-07,
+                "rounds": 10,
+                "median": 2.8373459999784243e-05,
+                "iqr": 1.1750399971788255e-06,
+                "q1": 2.794844000163721e-05,
+                "q3": 2.9123479998816036e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 2.7438679999249872e-05,
+                "hd15iqr": 2.9534240002249135e-05,
+                "ops": 35131.07474320844,
+                "total": 0.0002846482799941441,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-distro-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-distro-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro",
+                "inherit_property": true
+            },
+            "param": "True-False-distro-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00010490171999663289,
+                "max": 0.00011140552000142634,
+                "mean": 0.00010691428799873392,
+                "stddev": 1.7664596817217749e-06,
+                "rounds": 10,
+                "median": 0.00010643538000294939,
+                "iqr": 1.3205199957155888e-06,
+                "q1": 0.00010598732000289601,
+                "q3": 0.0001073078399986116,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.00010490171999663289,
+                "hd15iqr": 0.00011140552000142634,
+                "ops": 9353.28681244028,
+                "total": 0.0010691428799873392,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-menu-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-menu-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "menu",
+                "inherit_property": false
+            },
+            "param": "True-False-menu-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.123331999537186e-05,
+                "max": 7.458439999936672e-05,
+                "mean": 7.274182399942219e-05,
+                "stddev": 9.540937094894864e-07,
+                "rounds": 10,
+                "median": 7.264796000526986e-05,
+                "iqr": 8.63639997987774e-07,
+                "q1": 7.22408000001451e-05,
+                "q3": 7.310443999813287e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 4,
+                "outliers": "4;1",
+                "ld15iqr": 7.123331999537186e-05,
+                "hd15iqr": 7.458439999936672e-05,
+                "ops": 13747.249450439176,
+                "total": 0.0007274182399942219,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-menu-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-menu-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "menu",
+                "inherit_property": true
+            },
+            "param": "True-False-menu-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0004193816400038486,
+                "max": 0.00045122704000277736,
+                "mean": 0.00042664921200139363,
+                "stddev": 9.338742679601992e-06,
+                "rounds": 10,
+                "median": 0.00042368094000266865,
+                "iqr": 6.637639999098623e-06,
+                "q1": 0.000421360159998585,
+                "q3": 0.0004279977999976836,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0004193816400038486,
+                "hd15iqr": 0.00045122704000277736,
+                "ops": 2343.8458852626068,
+                "total": 0.0042664921200139365,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-profile-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-profile-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile",
+                "inherit_property": false
+            },
+            "param": "True-False-profile-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0024882660799994483,
+                "max": 0.002575104680008735,
+                "mean": 0.0025172533720024147,
+                "stddev": 2.640057010062049e-05,
+                "rounds": 10,
+                "median": 0.0025112081599991147,
+                "iqr": 3.0187839993232185e-05,
+                "q1": 0.0024993448800069017,
+                "q3": 0.002529532720000134,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.0024882660799994483,
+                "hd15iqr": 0.002575104680008735,
+                "ops": 397.25838134622256,
+                "total": 0.02517253372002415,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-profile-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-profile-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile",
+                "inherit_property": true
+            },
+            "param": "True-False-profile-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.013517820760007453,
+                "max": 0.014474535080007627,
+                "mean": 0.013764554276002854,
+                "stddev": 0.00026993027691856456,
+                "rounds": 10,
+                "median": 0.013672879220002869,
+                "iqr": 0.00021814792000441306,
+                "q1": 0.013634670880001067,
+                "q3": 0.01385281880000548,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.013517820760007453,
+                "hd15iqr": 0.014474535080007627,
+                "ops": 72.65037283069903,
+                "total": 0.13764554276002855,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-image-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-image-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "image",
+                "inherit_property": false
+            },
+            "param": "True-False-image-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.763188000244554e-05,
+                "max": 2.9486559997167204e-05,
+                "mean": 2.845782000076724e-05,
+                "stddev": 6.786629213254592e-07,
+                "rounds": 10,
+                "median": 2.8241620002518174e-05,
+                "iqr": 1.257960002476468e-06,
+                "q1": 2.785227999993367e-05,
+                "q3": 2.9110240002410138e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 2.763188000244554e-05,
+                "hd15iqr": 2.9486559997167204e-05,
+                "ops": 35139.72609191566,
+                "total": 0.00028457820000767244,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-image-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-image-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "image",
+                "inherit_property": true
+            },
+            "param": "True-False-image-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00010804800000187242,
+                "max": 0.00011377795999578666,
+                "mean": 0.00010999835599704966,
+                "stddev": 1.7401475197724186e-06,
+                "rounds": 10,
+                "median": 0.00010924685999270878,
+                "iqr": 2.1893199937039813e-06,
+                "q1": 0.00010882388000027276,
+                "q3": 0.00011101319999397674,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.00010804800000187242,
+                "hd15iqr": 0.00011377795999578666,
+                "ops": 9091.04496095216,
+                "total": 0.0010999835599704965,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-system-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-system-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system",
+                "inherit_property": false
+            },
+            "param": "True-False-system-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002749444760002007,
+                "max": 0.0028092213600029938,
+                "mean": 0.0027796536920022845,
+                "stddev": 1.7537719713786918e-05,
+                "rounds": 10,
+                "median": 0.0027840930000002117,
+                "iqr": 1.3439239992294339e-05,
+                "q1": 0.0027736646000084877,
+                "q3": 0.002787103840000782,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.002753975240002546,
+                "hd15iqr": 0.0028092213600029938,
+                "ops": 359.7570455906916,
+                "total": 0.027796536920022846,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-system-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-system-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system",
+                "inherit_property": true
+            },
+            "param": "True-False-system-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.010493631879999157,
+                "max": 0.016242238919994635,
+                "mean": 0.011120890959999087,
+                "stddev": 0.001800320694703293,
+                "rounds": 10,
+                "median": 0.010553705620000072,
+                "iqr": 8.978655999271681e-05,
+                "q1": 0.01050462608000089,
+                "q3": 0.010594412639993606,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.010493631879999157,
+                "hd15iqr": 0.016242238919994635,
+                "ops": 89.92085288821877,
+                "total": 0.11120890959999087,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-network_interface-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-network_interface-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "network_interface",
+                "inherit_property": false
+            },
+            "param": "True-False-network_interface-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0017724203200032208,
+                "max": 0.0017918579999968642,
+                "mean": 0.0017789687800004686,
+                "stddev": 5.4716441000877735e-06,
+                "rounds": 10,
+                "median": 0.0017778382999995301,
+                "iqr": 4.993759994249619e-06,
+                "q1": 0.0017760090800038597,
+                "q3": 0.0017810028399981093,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.0017724203200032208,
+                "hd15iqr": 0.0017918579999968642,
+                "ops": 562.1234117440423,
+                "total": 0.017789687800004686,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-network_interface-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-network_interface-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "network_interface",
+                "inherit_property": true
+            },
+            "param": "True-False-network_interface-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006807717199999388,
+                "max": 0.006882833400004529,
+                "mean": 0.00684002655599943,
+                "stddev": 2.5726298433546156e-05,
+                "rounds": 10,
+                "median": 0.006847177659997214,
+                "iqr": 4.3683599997166624e-05,
+                "q1": 0.006814263480000591,
+                "q3": 0.006857947079997757,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.006807717199999388,
+                "hd15iqr": 0.006882833400004529,
+                "ops": 146.19826280102578,
+                "total": 0.0684002655599943,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-distro_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-distro_group-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro_group",
+                "inherit_property": false
+            },
+            "param": "True-False-distro_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4134919995049133e-05,
+                "max": 2.6157080001212307e-05,
+                "mean": 2.5102319998950408e-05,
+                "stddev": 6.773928522146073e-07,
+                "rounds": 10,
+                "median": 2.5007340000229305e-05,
+                "iqr": 1.0002399994846215e-06,
+                "q1": 2.4582159994679387e-05,
+                "q3": 2.5582399994164008e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 2.4134919995049133e-05,
+                "hd15iqr": 2.6157080001212307e-05,
+                "ops": 39836.95531097574,
+                "total": 0.0002510231999895041,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-distro_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-distro_group-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro_group",
+                "inherit_property": true
+            },
+            "param": "True-False-distro_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0001317625199953909,
+                "max": 0.00014129324000350607,
+                "mean": 0.00013499813999897015,
+                "stddev": 2.7633622859972034e-06,
+                "rounds": 10,
+                "median": 0.00013463091999710742,
+                "iqr": 2.537560003474927e-06,
+                "q1": 0.00013346855999770923,
+                "q3": 0.00013600612000118416,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 0.0001317625199953909,
+                "hd15iqr": 0.00014129324000350607,
+                "ops": 7407.509466483232,
+                "total": 0.0013499813999897014,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-profile_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-profile_group-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile_group",
+                "inherit_property": false
+            },
+            "param": "True-False-profile_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.369204000387981e-05,
+                "max": 2.5927879996743285e-05,
+                "mean": 2.4610555999061034e-05,
+                "stddev": 8.175328080256017e-07,
+                "rounds": 10,
+                "median": 2.440602000206127e-05,
+                "iqr": 1.5160400016611703e-06,
+                "q1": 2.3853559996496186e-05,
+                "q3": 2.5369599998157356e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 2.369204000387981e-05,
+                "hd15iqr": 2.5927879996743285e-05,
+                "ops": 40632.97066665836,
+                "total": 0.00024610555999061035,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-profile_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-profile_group-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile_group",
+                "inherit_property": true
+            },
+            "param": "True-False-profile_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00013194407999435497,
+                "max": 0.00014272471999902337,
+                "mean": 0.00013532670399854396,
+                "stddev": 3.0503216824338837e-06,
+                "rounds": 10,
+                "median": 0.0001346661799971116,
+                "iqr": 2.1997600106260582e-06,
+                "q1": 0.00013374823999583895,
+                "q3": 0.000135948000006465,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.00013194407999435497,
+                "hd15iqr": 0.00014272471999902337,
+                "ops": 7389.52453915348,
+                "total": 0.0013532670399854397,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-system_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-system_group-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system_group",
+                "inherit_property": false
+            },
+            "param": "True-False-system_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4353279995921185e-05,
+                "max": 2.572508000412199e-05,
+                "mean": 2.4948300000687594e-05,
+                "stddev": 5.195805402247981e-07,
+                "rounds": 10,
+                "median": 2.4785920004433137e-05,
+                "iqr": 1.007919991025119e-06,
+                "q1": 2.4540040003557804e-05,
+                "q3": 2.5547959994582923e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 2.4353279995921185e-05,
+                "hd15iqr": 2.572508000412199e-05,
+                "ops": 40082.891418350715,
+                "total": 0.00024948300000687595,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-False-system_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-False-system_group-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system_group",
+                "inherit_property": true
+            },
+            "param": "True-False-system_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.000133542679996026,
+                "max": 0.00014524623999932374,
+                "mean": 0.00013689016399894173,
+                "stddev": 3.3069922094593446e-06,
+                "rounds": 10,
+                "median": 0.0001366012399967076,
+                "iqr": 2.8833999931521183e-06,
+                "q1": 0.00013467080000737042,
+                "q3": 0.00013755420000052254,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.000133542679996026,
+                "hd15iqr": 0.00014524623999932374,
+                "ops": 7305.126758469884,
+                "total": 0.0013689016399894172,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-repo-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-repo-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "repo",
+                "inherit_property": false
+            },
+            "param": "False-True-repo-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.6691319997335087e-05,
+                "max": 1.894999999421998e-05,
+                "mean": 1.7078579997360067e-05,
+                "stddev": 7.28478052173307e-07,
+                "rounds": 10,
+                "median": 1.6751859998294095e-05,
+                "iqr": 2.256400057376617e-07,
+                "q1": 1.672015999247378e-05,
+                "q3": 1.6945799998211442e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 1.6691319997335087e-05,
+                "hd15iqr": 1.7734919993017684e-05,
+                "ops": 58552.877355996556,
+                "total": 0.00017078579997360067,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-repo-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-repo-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "repo",
+                "inherit_property": true
+            },
+            "param": "False-True-repo-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.923316000211344e-05,
+                "max": 7.584035999570915e-05,
+                "mean": 7.143361199996434e-05,
+                "stddev": 1.8397635409318974e-06,
+                "rounds": 10,
+                "median": 7.126578000224982e-05,
+                "iqr": 9.521599986328462e-07,
+                "q1": 7.06317999993189e-05,
+                "q3": 7.158395999795175e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 6.923316000211344e-05,
+                "hd15iqr": 7.584035999570915e-05,
+                "ops": 13999.012117719865,
+                "total": 0.0007143361199996435,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-distro-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-distro-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro",
+                "inherit_property": false
+            },
+            "param": "False-True-distro-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.9256120003774414e-05,
+                "max": 2.0639960002881707e-05,
+                "mean": 1.9833188001030066e-05,
+                "stddev": 5.970957165886502e-07,
+                "rounds": 10,
+                "median": 1.950200000010227e-05,
+                "iqr": 1.1252799959038396e-06,
+                "q1": 1.934431999870867e-05,
+                "q3": 2.046959999461251e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 1.9256120003774414e-05,
+                "hd15iqr": 2.0639960002881707e-05,
+                "ops": 50420.53753274882,
+                "total": 0.00019833188001030066,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-distro-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-distro-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro",
+                "inherit_property": true
+            },
+            "param": "False-True-distro-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.474072000150044e-05,
+                "max": 7.885480000368262e-05,
+                "mean": 7.656563999898936e-05,
+                "stddev": 1.2895091875419044e-06,
+                "rounds": 10,
+                "median": 7.625631999871985e-05,
+                "iqr": 3.4823999158106907e-07,
+                "q1": 7.609004000187269e-05,
+                "q3": 7.643827999345376e-05,
+                "iqr_outliers": 3,
+                "stddev_outliers": 3,
+                "outliers": "3;3",
+                "ld15iqr": 7.566643999780354e-05,
+                "hd15iqr": 7.878947999415687e-05,
+                "ops": 13060.688841799009,
+                "total": 0.0007656563999898935,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-menu-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-menu-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "menu",
+                "inherit_property": false
+            },
+            "param": "False-True-menu-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 4.679463999309519e-05,
+                "max": 5.014291999941634e-05,
+                "mean": 4.7823324001001314e-05,
+                "stddev": 9.420246029229716e-07,
+                "rounds": 10,
+                "median": 4.747150000184774e-05,
+                "iqr": 9.016400053951673e-07,
+                "q1": 4.7337280002466286e-05,
+                "q3": 4.823892000786145e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 4.679463999309519e-05,
+                "hd15iqr": 5.014291999941634e-05,
+                "ops": 20910.29891563084,
+                "total": 0.0004782332400100131,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-menu-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-menu-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "menu",
+                "inherit_property": true
+            },
+            "param": "False-True-menu-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00020335172000159217,
+                "max": 0.00021734920000199054,
+                "mean": 0.00020655650000026072,
+                "stddev": 3.979801942239396e-06,
+                "rounds": 10,
+                "median": 0.0002055534600003739,
+                "iqr": 1.8025999997917065e-06,
+                "q1": 0.00020451872000194272,
+                "q3": 0.00020632132000173443,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00020335172000159217,
+                "hd15iqr": 0.00021734920000199054,
+                "ops": 4841.290397536451,
+                "total": 0.002065565000002607,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-profile-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-profile-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile",
+                "inherit_property": false
+            },
+            "param": "False-True-profile-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0016903258399997866,
+                "max": 0.0017084438400070212,
+                "mean": 0.0016992736600013813,
+                "stddev": 5.9074236842111e-06,
+                "rounds": 10,
+                "median": 0.0016999566999993476,
+                "iqr": 1.0934919991995983e-05,
+                "q1": 0.0016928493600062212,
+                "q3": 0.0017037842799982172,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.0016903258399997866,
+                "hd15iqr": 0.0017084438400070212,
+                "ops": 588.4867302652046,
+                "total": 0.016992736600013814,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-profile-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-profile-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile",
+                "inherit_property": true
+            },
+            "param": "False-True-profile-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006755536840000786,
+                "max": 0.007324776200002816,
+                "mean": 0.006836541432001468,
+                "stddev": 0.00017215851630786818,
+                "rounds": 10,
+                "median": 0.006789311460001954,
+                "iqr": 1.6292599993902868e-05,
+                "q1": 0.0067779052400055665,
+                "q3": 0.006794197839999469,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.006755536840000786,
+                "hd15iqr": 0.007324776200002816,
+                "ops": 146.27279157836387,
+                "total": 0.06836541432001468,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-image-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-image-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "image",
+                "inherit_property": false
+            },
+            "param": "False-True-image-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.9058159996347967e-05,
+                "max": 2.049488000011479e-05,
+                "mean": 1.957658400078799e-05,
+                "stddev": 5.763567341735971e-07,
+                "rounds": 10,
+                "median": 1.928457999838429e-05,
+                "iqr": 9.533599950373193e-07,
+                "q1": 1.908304000608041e-05,
+                "q3": 2.0036400001117728e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 1.9058159996347967e-05,
+                "hd15iqr": 2.049488000011479e-05,
+                "ops": 51081.434838669935,
+                "total": 0.00019576584000787988,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-image-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-image-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "image",
+                "inherit_property": true
+            },
+            "param": "False-True-image-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.444335999934993e-05,
+                "max": 8.214415999646007e-05,
+                "mean": 7.693353200011188e-05,
+                "stddev": 2.149899240204136e-06,
+                "rounds": 10,
+                "median": 7.666352000342158e-05,
+                "iqr": 1.463159997001646e-06,
+                "q1": 7.595256000058725e-05,
+                "q3": 7.74157199975889e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 7.444335999934993e-05,
+                "hd15iqr": 8.214415999646007e-05,
+                "ops": 12998.23333209953,
+                "total": 0.0007693353200011188,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-system-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-system-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system",
+                "inherit_property": false
+            },
+            "param": "False-True-system-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0018829570400066586,
+                "max": 0.0019065753600079915,
+                "mean": 0.0018988938960010273,
+                "stddev": 8.667956459648353e-06,
+                "rounds": 10,
+                "median": 0.001902640759994938,
+                "iqr": 7.446359995810867e-06,
+                "q1": 0.001897519160002048,
+                "q3": 0.0019049655199978588,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.001897519160002048,
+                "hd15iqr": 0.0019065753600079915,
+                "ops": 526.6223679511259,
+                "total": 0.018988938960010273,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-system-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-system-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system",
+                "inherit_property": true
+            },
+            "param": "False-True-system-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.007522299359998215,
+                "max": 0.012826895799998966,
+                "mean": 0.008105945299997074,
+                "stddev": 0.001658943648184051,
+                "rounds": 10,
+                "median": 0.0075885403399979625,
+                "iqr": 2.346964000025757e-05,
+                "q1": 0.007575476399997569,
+                "q3": 0.007598946039997827,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.007573024999992413,
+                "hd15iqr": 0.012826895799998966,
+                "ops": 123.36624082577524,
+                "total": 0.08105945299997075,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-network_interface-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-network_interface-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "network_interface",
+                "inherit_property": false
+            },
+            "param": "False-True-network_interface-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0015195308000056683,
+                "max": 0.0015411121199940681,
+                "mean": 0.0015282177559993214,
+                "stddev": 7.36366619445087e-06,
+                "rounds": 10,
+                "median": 0.0015259783200008315,
+                "iqr": 1.0532959995543942e-05,
+                "q1": 0.0015227436399982252,
+                "q3": 0.0015332765999937692,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.0015195308000056683,
+                "hd15iqr": 0.0015411121199940681,
+                "ops": 654.3570090546991,
+                "total": 0.015282177559993216,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-network_interface-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-network_interface-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "network_interface",
+                "inherit_property": true
+            },
+            "param": "False-True-network_interface-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006527035120006986,
+                "max": 0.006605027519999567,
+                "mean": 0.006554416195998784,
+                "stddev": 2.9576132275716215e-05,
+                "rounds": 10,
+                "median": 0.006543274399996335,
+                "iqr": 3.825580000011569e-05,
+                "q1": 0.006532296599998517,
+                "q3": 0.006570552399998633,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.006527035120006986,
+                "hd15iqr": 0.006605027519999567,
+                "ops": 152.5688894474631,
+                "total": 0.06554416195998783,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-distro_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-distro_group-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro_group",
+                "inherit_property": false
+            },
+            "param": "False-True-distro_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.608300000043528e-05,
+                "max": 1.8073960000037914e-05,
+                "mean": 1.64055119985278e-05,
+                "stddev": 6.246555164530966e-07,
+                "rounds": 10,
+                "median": 1.614409999547206e-05,
+                "iqr": 2.139999924111184e-07,
+                "q1": 1.6108640002130413e-05,
+                "q3": 1.632263999454153e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 1.608300000043528e-05,
+                "hd15iqr": 1.680032000876963e-05,
+                "ops": 60955.12289343595,
+                "total": 0.00016405511998527798,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-distro_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-distro_group-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro_group",
+                "inherit_property": true
+            },
+            "param": "False-True-distro_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.497680000393302e-05,
+                "max": 7.182604000263381e-05,
+                "mean": 6.74591960005273e-05,
+                "stddev": 1.7589808427596539e-06,
+                "rounds": 10,
+                "median": 6.717967999975372e-05,
+                "iqr": 1.2944399986736227e-06,
+                "q1": 6.663268000011158e-05,
+                "q3": 6.79271199987852e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 6.497680000393302e-05,
+                "hd15iqr": 7.182604000263381e-05,
+                "ops": 14823.775842098436,
+                "total": 0.000674591960005273,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-profile_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-profile_group-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile_group",
+                "inherit_property": false
+            },
+            "param": "False-True-profile_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.587660000041069e-05,
+                "max": 1.7489640003987007e-05,
+                "mean": 1.6454484000860246e-05,
+                "stddev": 4.7005825286536954e-07,
+                "rounds": 10,
+                "median": 1.6252900004474213e-05,
+                "iqr": 5.867200070497336e-07,
+                "q1": 1.622203999431804e-05,
+                "q3": 1.6808760001367773e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 1.587660000041069e-05,
+                "hd15iqr": 1.7489640003987007e-05,
+                "ops": 60773.70763785237,
+                "total": 0.00016454484000860247,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-profile_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-profile_group-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile_group",
+                "inherit_property": true
+            },
+            "param": "False-True-profile_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.543243999658443e-05,
+                "max": 7.007992000580998e-05,
+                "mean": 6.719757599967125e-05,
+                "stddev": 1.2430177508747724e-06,
+                "rounds": 10,
+                "median": 6.709393999699387e-05,
+                "iqr": 4.937199992127809e-07,
+                "q1": 6.701260000227193e-05,
+                "q3": 6.750632000148472e-05,
+                "iqr_outliers": 3,
+                "stddev_outliers": 3,
+                "outliers": "3;3",
+                "ld15iqr": 6.701260000227193e-05,
+                "hd15iqr": 7.007992000580998e-05,
+                "ops": 14881.489177599089,
+                "total": 0.0006719757599967125,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-system_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-system_group-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system_group",
+                "inherit_property": false
+            },
+            "param": "False-True-system_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.6158359994733473e-05,
+                "max": 1.724916000057419e-05,
+                "mean": 1.6577311999753873e-05,
+                "stddev": 4.203982050510642e-07,
+                "rounds": 10,
+                "median": 1.647211999625142e-05,
+                "iqr": 7.894799909990977e-07,
+                "q1": 1.619360000404413e-05,
+                "q3": 1.6983079995043226e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 1.6158359994733473e-05,
+                "hd15iqr": 1.724916000057419e-05,
+                "ops": 60323.41069618809,
+                "total": 0.00016577311999753873,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[False-True-system_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[False-True-system_group-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system_group",
+                "inherit_property": true
+            },
+            "param": "False-True-system_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 6.475232000411779e-05,
+                "max": 6.957339999644319e-05,
+                "mean": 6.68679919999704e-05,
+                "stddev": 1.2932060578099408e-06,
+                "rounds": 10,
+                "median": 6.698913999571232e-05,
+                "iqr": 9.654000041336996e-07,
+                "q1": 6.627439999647322e-05,
+                "q3": 6.723980000060692e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 6.556144000569475e-05,
+                "hd15iqr": 6.957339999644319e-05,
+                "ops": 14954.838183273736,
+                "total": 0.000668679919999704,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-repo-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-repo-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "repo",
+                "inherit_property": false
+            },
+            "param": "True-True-repo-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4688359999345267e-05,
+                "max": 2.7320879999024326e-05,
+                "mean": 2.5535539999509638e-05,
+                "stddev": 8.03026252586781e-07,
+                "rounds": 10,
+                "median": 2.5343579995933396e-05,
+                "iqr": 5.121199956192873e-07,
+                "q1": 2.5150840001515463e-05,
+                "q3": 2.566295999713475e-05,
+                "iqr_outliers": 2,
+                "stddev_outliers": 4,
+                "outliers": "4;2",
+                "ld15iqr": 2.4688359999345267e-05,
+                "hd15iqr": 2.644084000166913e-05,
+                "ops": 39161.106442988996,
+                "total": 0.00025535539999509637,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-repo-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-repo-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "repo",
+                "inherit_property": true
+            },
+            "param": "True-True-repo-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 9.653559999605932e-05,
+                "max": 0.00010441080000418879,
+                "mean": 9.821981600089202e-05,
+                "stddev": 2.433636916420287e-06,
+                "rounds": 10,
+                "median": 9.717421999994258e-05,
+                "iqr": 2.5868800003081566e-06,
+                "q1": 9.677164000095218e-05,
+                "q3": 9.935852000126033e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 9.653559999605932e-05,
+                "hd15iqr": 0.00010441080000418879,
+                "ops": 10181.244892486035,
+                "total": 0.0009821981600089203,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-distro-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-distro-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro",
+                "inherit_property": false
+            },
+            "param": "True-True-distro-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.7661920003083652e-05,
+                "max": 2.947051999399264e-05,
+                "mean": 2.8417976000127965e-05,
+                "stddev": 6.251849621841536e-07,
+                "rounds": 10,
+                "median": 2.83454200007327e-05,
+                "iqr": 1.1749999976018411e-06,
+                "q1": 2.7818600001410234e-05,
+                "q3": 2.8993599999012075e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 2.7661920003083652e-05,
+                "hd15iqr": 2.947051999399264e-05,
+                "ops": 35188.99445884172,
+                "total": 0.00028417976000127965,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-distro-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-distro-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro",
+                "inherit_property": true
+            },
+            "param": "True-True-distro-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00010456228000293777,
+                "max": 0.00011180187999343616,
+                "mean": 0.00010605805199975294,
+                "stddev": 2.1223260488974945e-06,
+                "rounds": 10,
+                "median": 0.00010530845999710437,
+                "iqr": 1.4054399980523066e-06,
+                "q1": 0.00010489932000382396,
+                "q3": 0.00010630476000187627,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00010456228000293777,
+                "hd15iqr": 0.00011180187999343616,
+                "ops": 9428.798484836676,
+                "total": 0.0010605805199975294,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-menu-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-menu-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "menu",
+                "inherit_property": false
+            },
+            "param": "True-True-menu-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 7.138399999348621e-05,
+                "max": 7.518395999795757e-05,
+                "mean": 7.269450800049526e-05,
+                "stddev": 1.0736531728898458e-06,
+                "rounds": 10,
+                "median": 7.271912000305746e-05,
+                "iqr": 1.205479993586774e-06,
+                "q1": 7.192500000201107e-05,
+                "q3": 7.313047999559785e-05,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 7.138399999348621e-05,
+                "hd15iqr": 7.518395999795757e-05,
+                "ops": 13756.197373165895,
+                "total": 0.0007269450800049526,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-menu-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-menu-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "menu",
+                "inherit_property": true
+            },
+            "param": "True-True-menu-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0004230770000049233,
+                "max": 0.00045755731999634006,
+                "mean": 0.00042907175999880564,
+                "stddev": 1.0265691327467621e-05,
+                "rounds": 10,
+                "median": 0.0004257363599981545,
+                "iqr": 5.176480008230991e-06,
+                "q1": 0.0004237759199986613,
+                "q3": 0.00042895240000689227,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0004230770000049233,
+                "hd15iqr": 0.00045755731999634006,
+                "ops": 2330.6124831025554,
+                "total": 0.004290717599988056,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-profile-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-profile-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile",
+                "inherit_property": false
+            },
+            "param": "True-True-profile-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0024329867200049192,
+                "max": 0.002509987679995902,
+                "mean": 0.0024815829759991174,
+                "stddev": 3.026556464001322e-05,
+                "rounds": 10,
+                "median": 0.0024937423600067633,
+                "iqr": 6.188019999171963e-05,
+                "q1": 0.0024420998000005056,
+                "q3": 0.0025039799999922252,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.0024329867200049192,
+                "hd15iqr": 0.002509987679995902,
+                "ops": 402.9685928988077,
+                "total": 0.024815829759991175,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-profile-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-profile-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile",
+                "inherit_property": true
+            },
+            "param": "True-True-profile-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.013591629319998902,
+                "max": 0.014791015559994776,
+                "mean": 0.013814305943998989,
+                "stddev": 0.0003542310544387372,
+                "rounds": 10,
+                "median": 0.013724929720001455,
+                "iqr": 0.00014617519999774245,
+                "q1": 0.013617794439996942,
+                "q3": 0.013763969639994685,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.013591629319998902,
+                "hd15iqr": 0.014791015559994776,
+                "ops": 72.38872543100187,
+                "total": 0.1381430594399899,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-image-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-image-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "image",
+                "inherit_property": false
+            },
+            "param": "True-True-image-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.775652000309492e-05,
+                "max": 2.9575520002254053e-05,
+                "mean": 2.845441600038612e-05,
+                "stddev": 7.011880195749564e-07,
+                "rounds": 10,
+                "median": 2.8242819998922643e-05,
+                "iqr": 1.241159998244258e-06,
+                "q1": 2.7825440001834066e-05,
+                "q3": 2.9066600000078324e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 2.775652000309492e-05,
+                "hd15iqr": 2.9575520002254053e-05,
+                "ops": 35143.92985561293,
+                "total": 0.0002845441600038612,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-image-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-image-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "image",
+                "inherit_property": true
+            },
+            "param": "True-True-image-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00010562348000348721,
+                "max": 0.00011480628000754223,
+                "mean": 0.00010799600800237386,
+                "stddev": 2.6360300423253256e-06,
+                "rounds": 10,
+                "median": 0.00010698482000407239,
+                "iqr": 2.3127599979488926e-06,
+                "q1": 0.00010649392000232183,
+                "q3": 0.00010880668000027072,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.00010562348000348721,
+                "hd15iqr": 0.00011480628000754223,
+                "ops": 9259.601521363818,
+                "total": 0.0010799600800237385,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-system-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-system-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system",
+                "inherit_property": false
+            },
+            "param": "True-True-system-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002738314279995393,
+                "max": 0.0027832033599952412,
+                "mean": 0.002764045531998818,
+                "stddev": 1.585277773233555e-05,
+                "rounds": 10,
+                "median": 0.0027683560600007696,
+                "iqr": 2.732691998971878e-05,
+                "q1": 0.002749207920005574,
+                "q3": 0.0027765348399952927,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.002738314279995393,
+                "hd15iqr": 0.0027832033599952412,
+                "ops": 361.78854089890865,
+                "total": 0.027640455319988176,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-system-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-system-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system",
+                "inherit_property": true
+            },
+            "param": "True-True-system-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.01051486291999936,
+                "max": 0.015889930000003005,
+                "mean": 0.011103272292000838,
+                "stddev": 0.0016821575707662406,
+                "rounds": 10,
+                "median": 0.010574521879998428,
+                "iqr": 5.570540000007784e-05,
+                "q1": 0.010550422040005288,
+                "q3": 0.010606127440005365,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.01051486291999936,
+                "hd15iqr": 0.015889930000003005,
+                "ops": 90.06353926134307,
+                "total": 0.11103272292000838,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-network_interface-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-network_interface-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "network_interface",
+                "inherit_property": false
+            },
+            "param": "True-True-network_interface-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0017635789199994178,
+                "max": 0.0017894090400022832,
+                "mean": 0.0017745038359998943,
+                "stddev": 7.0278590096340736e-06,
+                "rounds": 10,
+                "median": 0.0017743793999989066,
+                "iqr": 8.51400000101421e-06,
+                "q1": 0.001768902519997937,
+                "q3": 0.0017774165199989512,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0017635789199994178,
+                "hd15iqr": 0.0017894090400022832,
+                "ops": 563.5378068577246,
+                "total": 0.017745038359998945,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-network_interface-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-network_interface-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "network_interface",
+                "inherit_property": true
+            },
+            "param": "True-True-network_interface-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006807723600004465,
+                "max": 0.006833269159997144,
+                "mean": 0.006824978679998822,
+                "stddev": 7.597042768743494e-06,
+                "rounds": 10,
+                "median": 0.006824940520000383,
+                "iqr": 1.0476480001670938e-05,
+                "q1": 0.006821913039993887,
+                "q3": 0.006832389519995558,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.006807723600004465,
+                "hd15iqr": 0.006833269159997144,
+                "ops": 146.5206042226307,
+                "total": 0.06824978679998822,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-distro_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-distro_group-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro_group",
+                "inherit_property": false
+            },
+            "param": "True-True-distro_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.3764999996274126e-05,
+                "max": 2.6381520001450554e-05,
+                "mean": 2.480304399978195e-05,
+                "stddev": 7.634857155402434e-07,
+                "rounds": 10,
+                "median": 2.4584359998698346e-05,
+                "iqr": 8.407599943893734e-07,
+                "q1": 2.4316080007338315e-05,
+                "q3": 2.515684000172769e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 2.3764999996274126e-05,
+                "hd15iqr": 2.6381520001450554e-05,
+                "ops": 40317.63198133226,
+                "total": 0.0002480304399978195,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-distro_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-distro_group-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro_group",
+                "inherit_property": true
+            },
+            "param": "True-True-distro_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00012931711999954133,
+                "max": 0.00014075660000344213,
+                "mean": 0.00013354291600171564,
+                "stddev": 3.057091055711595e-06,
+                "rounds": 10,
+                "median": 0.00013321888000064063,
+                "iqr": 2.0065999979124183e-06,
+                "q1": 0.00013170040000659355,
+                "q3": 0.00013370700000450597,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.00012931711999954133,
+                "hd15iqr": 0.00014075660000344213,
+                "ops": 7488.2294766362065,
+                "total": 0.0013354291600171564,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-profile_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-profile_group-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile_group",
+                "inherit_property": false
+            },
+            "param": "True-True-profile_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4011880004763952e-05,
+                "max": 2.5697040000522976e-05,
+                "mean": 2.4763644000813655e-05,
+                "stddev": 5.630172251198617e-07,
+                "rounds": 10,
+                "median": 2.459073999943939e-05,
+                "iqr": 9.80680006250623e-07,
+                "q1": 2.4322839999513234e-05,
+                "q3": 2.5303520005763857e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 2.4011880004763952e-05,
+                "hd15iqr": 2.5697040000522976e-05,
+                "ops": 40381.779029255275,
+                "total": 0.00024763644000813656,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-profile_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-profile_group-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile_group",
+                "inherit_property": true
+            },
+            "param": "True-True-profile_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.00013198295999245602,
+                "max": 0.00013792287999422114,
+                "mean": 0.00013500547199873835,
+                "stddev": 1.6767047411744324e-06,
+                "rounds": 10,
+                "median": 0.00013540378000016063,
+                "iqr": 2.0767200021509704e-06,
+                "q1": 0.00013358795999920403,
+                "q3": 0.000135664680001355,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.00013198295999245602,
+                "hd15iqr": 0.00013792287999422114,
+                "ops": 7407.1071727325625,
+                "total": 0.0013500547199873836,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-system_group-False]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-system_group-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system_group",
+                "inherit_property": false
+            },
+            "param": "True-True-system_group-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 2.4160960001609056e-05,
+                "max": 2.5684199999886915e-05,
+                "mean": 2.4875856000107888e-05,
+                "stddev": 5.250118806833509e-07,
+                "rounds": 10,
+                "median": 2.4694359999557492e-05,
+                "iqr": 9.249599952454442e-07,
+                "q1": 2.4542840001231526e-05,
+                "q3": 2.546779999647697e-05,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 2.4160960001609056e-05,
+                "hd15iqr": 2.5684199999886915e-05,
+                "ops": 40199.62167314616,
+                "total": 0.0002487585600010789,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_edit[True-True-system_group-True]",
+            "fullname": "tests/performance/item_edit_test.py::test_item_edit[True-True-system_group-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system_group",
+                "inherit_property": true
+            },
+            "param": "True-True-system_group-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0001329271200029325,
+                "max": 0.00014294556000095328,
+                "mean": 0.00013593172800119646,
+                "stddev": 2.9828979030846478e-06,
+                "rounds": 10,
+                "median": 0.00013550616000429727,
+                "iqr": 3.875239990520647e-06,
+                "q1": 0.00013350384000659687,
+                "q3": 0.00013737907999711752,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.0001329271200029325,
+                "hd15iqr": 0.00014294556000095328,
+                "ops": 7356.63420677767,
+                "total": 0.0013593172800119646,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-repo]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-repo]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "repo"
+            },
+            "param": "False-False-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0023332700000082696,
+                "max": 0.0026139359999888256,
+                "mean": 0.0024010881000549487,
+                "stddev": 9.34155020886904e-05,
+                "rounds": 10,
+                "median": 0.0023661915000730005,
+                "iqr": 3.1498999987888965e-05,
+                "q1": 0.002352917000052912,
+                "q3": 0.002384416000040801,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0023332700000082696,
+                "hd15iqr": 0.0025288870001531905,
+                "ops": 416.4778460136948,
+                "total": 0.02401088100054949,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-distro]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-distro]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro"
+            },
+            "param": "False-False-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.45023161800008893,
+                "max": 0.45256554899992807,
+                "mean": 0.45109478940000824,
+                "stddev": 0.0008435108467325315,
+                "rounds": 10,
+                "median": 0.450840686499987,
+                "iqr": 0.0015511620001689153,
+                "q1": 0.4502861399998892,
+                "q3": 0.4518373020000581,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.45023161800008893,
+                "hd15iqr": 0.45256554899992807,
+                "ops": 2.2168289758568904,
+                "total": 4.510947894000083,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-menu]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-menu]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "menu"
+            },
+            "param": "False-False-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.6520831160000853,
+                "max": 0.6879955700001119,
+                "mean": 0.6657505053000022,
+                "stddev": 0.015804143011148002,
+                "rounds": 10,
+                "median": 0.6545754144998455,
+                "iqr": 0.029504184000188616,
+                "q1": 0.6532248399998934,
+                "q3": 0.6827290240000821,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.6520831160000853,
+                "hd15iqr": 0.6879955700001119,
+                "ops": 1.5020641997851392,
+                "total": 6.657505053000023,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-profile]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-profile]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile"
+            },
+            "param": "False-False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4295111920000636,
+                "max": 0.44391785600009825,
+                "mean": 0.43277460130004786,
+                "stddev": 0.005028358223205825,
+                "rounds": 10,
+                "median": 0.43043639900008657,
+                "iqr": 0.0012481030000799365,
+                "q1": 0.430322144999991,
+                "q3": 0.43157024800007093,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.4295111920000636,
+                "hd15iqr": 0.44031192700003885,
+                "ops": 2.3106716452306033,
+                "total": 4.327746013000478,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-image]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-image]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "image"
+            },
+            "param": "False-False-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.21784591200002978,
+                "max": 0.2227969570001278,
+                "mean": 0.21866451010005222,
+                "stddev": 0.001485298953995027,
+                "rounds": 10,
+                "median": 0.21814050050011247,
+                "iqr": 0.0005759210000633175,
+                "q1": 0.21793994899985591,
+                "q3": 0.21851586999991923,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.21784591200002978,
+                "hd15iqr": 0.2227969570001278,
+                "ops": 4.573215834350255,
+                "total": 2.186645101000522,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-system]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-system]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system"
+            },
+            "param": "False-False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.43219713400003457,
+                "max": 0.43332402000010006,
+                "mean": 0.4327896806000126,
+                "stddev": 0.00034677370082530673,
+                "rounds": 10,
+                "median": 0.43269221850005124,
+                "iqr": 0.0005969000001186942,
+                "q1": 0.43258671599983245,
+                "q3": 0.43318361599995114,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.43219713400003457,
+                "hd15iqr": 0.43332402000010006,
+                "ops": 2.3105911365853644,
+                "total": 4.327896806000126,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-network_interface]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-network_interface]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "network_interface"
+            },
+            "param": "False-False-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.2072619749999376,
+                "max": 0.20899685199992746,
+                "mean": 0.20804343969998626,
+                "stddev": 0.0006271246133515263,
+                "rounds": 10,
+                "median": 0.2079305849999855,
+                "iqr": 0.0009898679998059379,
+                "q1": 0.20762522700010777,
+                "q3": 0.2086150949999137,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.2072619749999376,
+                "hd15iqr": 0.20899685199992746,
+                "ops": 4.806688456228529,
+                "total": 2.0804343969998627,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-distro_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-distro_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro_group"
+            },
+            "param": "False-False-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022221910001007927,
+                "max": 0.002405805999842414,
+                "mean": 0.002270203600005516,
+                "stddev": 5.657941179819044e-05,
+                "rounds": 10,
+                "median": 0.002257933500004583,
+                "iqr": 3.569699993022368e-05,
+                "q1": 0.0022304870001335075,
+                "q3": 0.0022661840000637312,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0022221910001007927,
+                "hd15iqr": 0.002328641000076459,
+                "ops": 440.48912617245884,
+                "total": 0.02270203600005516,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-profile_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-profile_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile_group"
+            },
+            "param": "False-False-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002216971000052581,
+                "max": 0.0024127389999648585,
+                "mean": 0.0022695283000302878,
+                "stddev": 7.447811060930838e-05,
+                "rounds": 10,
+                "median": 0.0022378760000947295,
+                "iqr": 4.033499999422929e-05,
+                "q1": 0.0022237450000375247,
+                "q3": 0.002264080000031754,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.002216971000052581,
+                "hd15iqr": 0.0024035620001541247,
+                "ops": 440.62019406704667,
+                "total": 0.02269528300030288,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-False-system_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-False-system_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system_group"
+            },
+            "param": "False-False-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022005710000030376,
+                "max": 0.002412658999901396,
+                "mean": 0.0022528058999796486,
+                "stddev": 6.121023583164091e-05,
+                "rounds": 10,
+                "median": 0.0022386624999626292,
+                "iqr": 5.6334999953833176e-05,
+                "q1": 0.002212173000089024,
+                "q3": 0.002268508000042857,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0022005710000030376,
+                "hd15iqr": 0.002412658999901396,
+                "ops": 443.89088292472684,
+                "total": 0.022528058999796485,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-repo]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-repo]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "repo"
+            },
+            "param": "True-False-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022261890001118445,
+                "max": 0.0033183600000938895,
+                "mean": 0.0023982659000239435,
+                "stddev": 0.0003549846004925542,
+                "rounds": 10,
+                "median": 0.0022507545000962637,
+                "iqr": 5.702699991161353e-05,
+                "q1": 0.002229514999953608,
+                "q3": 0.0022865419998652214,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.0022261890001118445,
+                "hd15iqr": 0.0027075929999682558,
+                "ops": 416.9679433752597,
+                "total": 0.023982659000239437,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-distro]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-distro]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro"
+            },
+            "param": "True-False-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.42994434499996714,
+                "max": 0.4328170989999762,
+                "mean": 0.43130797750000055,
+                "stddev": 0.000994825167837454,
+                "rounds": 10,
+                "median": 0.4311638550000225,
+                "iqr": 0.0018560639998668194,
+                "q1": 0.4305203070000516,
+                "q3": 0.43237637099991844,
+                "iqr_outliers": 0,
+                "stddev_outliers": 5,
+                "outliers": "5;0",
+                "ld15iqr": 0.42994434499996714,
+                "hd15iqr": 0.4328170989999762,
+                "ops": 2.318528875344066,
+                "total": 4.313079775000006,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-menu]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-menu]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "menu"
+            },
+            "param": "True-False-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.6496453600000223,
+                "max": 0.6531080510001175,
+                "mean": 0.6510873251999783,
+                "stddev": 0.0009021258296566493,
+                "rounds": 10,
+                "median": 0.6510037349999038,
+                "iqr": 0.000597410999944259,
+                "q1": 0.6506289270000707,
+                "q3": 0.651226338000015,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.6504861879998316,
+                "hd15iqr": 0.6531080510001175,
+                "ops": 1.5358922855591681,
+                "total": 6.510873251999783,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-profile]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-profile]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile"
+            },
+            "param": "True-False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.42891301999998177,
+                "max": 0.4304860219999682,
+                "mean": 0.4296199678000221,
+                "stddev": 0.0005001836218119219,
+                "rounds": 10,
+                "median": 0.4296159494999756,
+                "iqr": 0.000594615999943926,
+                "q1": 0.4293368759999794,
+                "q3": 0.4299314919999233,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.42891301999998177,
+                "hd15iqr": 0.4304860219999682,
+                "ops": 2.327638552557865,
+                "total": 4.296199678000221,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-image]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-image]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "image"
+            },
+            "param": "True-False-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.21709773799989307,
+                "max": 0.21825981899996805,
+                "mean": 0.2174097436000011,
+                "stddev": 0.0003402227320609474,
+                "rounds": 10,
+                "median": 0.21732454849995975,
+                "iqr": 0.0003182080001806753,
+                "q1": 0.21720338599993738,
+                "q3": 0.21752159400011806,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.21709773799989307,
+                "hd15iqr": 0.21825981899996805,
+                "ops": 4.599609858515996,
+                "total": 2.174097436000011,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-system]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-system]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system"
+            },
+            "param": "True-False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4298220760001641,
+                "max": 0.43292814699998416,
+                "mean": 0.43077402630001416,
+                "stddev": 0.001149391856170792,
+                "rounds": 10,
+                "median": 0.43038736249991416,
+                "iqr": 0.0009126829997967434,
+                "q1": 0.4299568190001537,
+                "q3": 0.43086950199995044,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.4298220760001641,
+                "hd15iqr": 0.43281459400009226,
+                "ops": 2.3214027284540744,
+                "total": 4.307740263000142,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-network_interface]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-network_interface]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "network_interface"
+            },
+            "param": "True-False-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.20696887500002958,
+                "max": 0.20821534399988195,
+                "mean": 0.20737816179998844,
+                "stddev": 0.00041861154780285423,
+                "rounds": 10,
+                "median": 0.20724154649997217,
+                "iqr": 0.0005975120000130119,
+                "q1": 0.20702196399997774,
+                "q3": 0.20761947599999075,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.20696887500002958,
+                "hd15iqr": 0.20821534399988195,
+                "ops": 4.822108515767814,
+                "total": 2.0737816179998845,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-distro_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-distro_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro_group"
+            },
+            "param": "True-False-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0021970239999973273,
+                "max": 0.0024556099999699654,
+                "mean": 0.0022909385000048133,
+                "stddev": 8.831168088639198e-05,
+                "rounds": 10,
+                "median": 0.0022586395000416815,
+                "iqr": 8.363699998881202e-05,
+                "q1": 0.0022324310000385594,
+                "q3": 0.0023160680000273715,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 0.0021970239999973273,
+                "hd15iqr": 0.0024556099999699654,
+                "ops": 436.5023329949272,
+                "total": 0.022909385000048132,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-profile_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-profile_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile_group"
+            },
+            "param": "True-False-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0021942389998912404,
+                "max": 0.002453085000070132,
+                "mean": 0.0022852776000036102,
+                "stddev": 8.729008135928029e-05,
+                "rounds": 10,
+                "median": 0.0022493270000722987,
+                "iqr": 4.775999991579738e-05,
+                "q1": 0.0022403750001558365,
+                "q3": 0.002288135000071634,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.0021942389998912404,
+                "hd15iqr": 0.002433326999835117,
+                "ops": 437.583600346155,
+                "total": 0.0228527760000361,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-False-system_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-False-system_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system_group"
+            },
+            "param": "True-False-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002194499000097494,
+                "max": 0.0024767300001258263,
+                "mean": 0.002282762100048785,
+                "stddev": 9.706802922183508e-05,
+                "rounds": 10,
+                "median": 0.002251170500016997,
+                "iqr": 8.515900003658317e-05,
+                "q1": 0.0022137959999781742,
+                "q3": 0.0022989550000147574,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.002194499000097494,
+                "hd15iqr": 0.002434190000030867,
+                "ops": 438.0657975610463,
+                "total": 0.022827621000487852,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-repo]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-repo]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "repo"
+            },
+            "param": "False-True-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022046290000616864,
+                "max": 0.0024431360000107816,
+                "mean": 0.0022877224000012577,
+                "stddev": 7.567250989046652e-05,
+                "rounds": 10,
+                "median": 0.0022668900001008296,
+                "iqr": 3.1429000046045985e-05,
+                "q1": 0.002246957999886945,
+                "q3": 0.002278386999932991,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.0022046290000616864,
+                "hd15iqr": 0.002405885999905877,
+                "ops": 437.11597176276734,
+                "total": 0.022877224000012575,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-distro]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-distro]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro"
+            },
+            "param": "False-True-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4303440859998773,
+                "max": 0.43244090200005303,
+                "mean": 0.43090874119995987,
+                "stddev": 0.0005988285922549553,
+                "rounds": 10,
+                "median": 0.43079902049998964,
+                "iqr": 0.0005011709999962477,
+                "q1": 0.4305112800000188,
+                "q3": 0.43101245100001506,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.4303440859998773,
+                "hd15iqr": 0.43244090200005303,
+                "ops": 2.320676988856807,
+                "total": 4.309087411999599,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-menu]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-menu]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "menu"
+            },
+            "param": "False-True-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.651183607999883,
+                "max": 0.6537940079999771,
+                "mean": 0.6522757469999988,
+                "stddev": 0.0009216411183701672,
+                "rounds": 10,
+                "median": 0.6519315269999879,
+                "iqr": 0.0011499380000259407,
+                "q1": 0.6518014779999248,
+                "q3": 0.6529514159999508,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.651183607999883,
+                "hd15iqr": 0.6537940079999771,
+                "ops": 1.5330939477656247,
+                "total": 6.522757469999988,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-profile]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-profile]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile"
+            },
+            "param": "False-True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4286786600000596,
+                "max": 0.4327218299999913,
+                "mean": 0.4298657939999885,
+                "stddev": 0.0012289616747801274,
+                "rounds": 10,
+                "median": 0.42957960050000565,
+                "iqr": 0.0009932339999068063,
+                "q1": 0.4289576030000717,
+                "q3": 0.4299508369999785,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.4286786600000596,
+                "hd15iqr": 0.4327218299999913,
+                "ops": 2.326307452134763,
+                "total": 4.2986579399998845,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-image]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-image]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "image"
+            },
+            "param": "False-True-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.21727955899996232,
+                "max": 0.21824237599980734,
+                "mean": 0.21771721259995047,
+                "stddev": 0.00024827883812234783,
+                "rounds": 10,
+                "median": 0.2177205264999884,
+                "iqr": 0.0002293010002176743,
+                "q1": 0.2175961529999313,
+                "q3": 0.21782545400014897,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.21727955899996232,
+                "hd15iqr": 0.21824237599980734,
+                "ops": 4.5931141045677135,
+                "total": 2.1771721259995047,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-system]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-system]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system"
+            },
+            "param": "False-True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.43019542700017155,
+                "max": 0.43267514199988,
+                "mean": 0.4312418191000006,
+                "stddev": 0.000658186011522739,
+                "rounds": 10,
+                "median": 0.4312420664999763,
+                "iqr": 0.000607700999808003,
+                "q1": 0.43088758600015353,
+                "q3": 0.43149528699996154,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.43019542700017155,
+                "hd15iqr": 0.43267514199988,
+                "ops": 2.3188845694209217,
+                "total": 4.312418191000006,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-network_interface]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-network_interface]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "network_interface"
+            },
+            "param": "False-True-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.20728915599988795,
+                "max": 0.2084356979999029,
+                "mean": 0.20792799879995982,
+                "stddev": 0.00036844029183875015,
+                "rounds": 10,
+                "median": 0.20784927649992824,
+                "iqr": 0.0005628260000776208,
+                "q1": 0.20766124400006447,
+                "q3": 0.2082240700001421,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.20728915599988795,
+                "hd15iqr": 0.2084356979999029,
+                "ops": 4.809357112901686,
+                "total": 2.0792799879995982,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-distro_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-distro_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro_group"
+            },
+            "param": "False-True-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022133449999728327,
+                "max": 0.002441292999947109,
+                "mean": 0.0022789878999674327,
+                "stddev": 8.175974721224482e-05,
+                "rounds": 10,
+                "median": 0.002236017499967602,
+                "iqr": 7.696500006204587e-05,
+                "q1": 0.0022235129999899073,
+                "q3": 0.002300478000051953,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.0022133449999728327,
+                "hd15iqr": 0.002441292999947109,
+                "ops": 438.79127221969463,
+                "total": 0.02278987899967433,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-profile_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-profile_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile_group"
+            },
+            "param": "False-True-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002198616999976366,
+                "max": 0.0024866779999683786,
+                "mean": 0.002258568499996727,
+                "stddev": 8.288771463926635e-05,
+                "rounds": 10,
+                "median": 0.002240145000087068,
+                "iqr": 3.964400002587354e-05,
+                "q1": 0.002221048999899722,
+                "q3": 0.0022606929999255954,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.002198616999976366,
+                "hd15iqr": 0.0024866779999683786,
+                "ops": 442.7583223627927,
+                "total": 0.02258568499996727,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[False-True-system_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[False-True-system_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system_group"
+            },
+            "param": "False-True-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022126939998088346,
+                "max": 0.002719736000017292,
+                "mean": 0.002318330900016008,
+                "stddev": 0.0001569669956958168,
+                "rounds": 10,
+                "median": 0.002254962500046531,
+                "iqr": 5.663599995386903e-05,
+                "q1": 0.002237660999981017,
+                "q3": 0.002294296999934886,
+                "iqr_outliers": 2,
+                "stddev_outliers": 1,
+                "outliers": "1;2",
+                "ld15iqr": 0.0022126939998088346,
+                "hd15iqr": 0.0024585850001130893,
+                "ops": 431.3448093165195,
+                "total": 0.02318330900016008,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-repo]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-repo]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "repo"
+            },
+            "param": "True-True-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002199298000050476,
+                "max": 0.0025315519999367098,
+                "mean": 0.002277678500036018,
+                "stddev": 9.440817386790482e-05,
+                "rounds": 10,
+                "median": 0.0022478790000377558,
+                "iqr": 5.005399975743785e-05,
+                "q1": 0.0022320100001707033,
+                "q3": 0.002282063999928141,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.002199298000050476,
+                "hd15iqr": 0.0025315519999367098,
+                "ops": 439.0435261096712,
+                "total": 0.022776785000360178,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-distro]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-distro]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro"
+            },
+            "param": "True-True-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4304256190000615,
+                "max": 0.43385370500004683,
+                "mean": 0.4319870053999466,
+                "stddev": 0.0013102816888284107,
+                "rounds": 10,
+                "median": 0.4313236349998988,
+                "iqr": 0.002432174999967174,
+                "q1": 0.4308859139998731,
+                "q3": 0.43331808899984026,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.4304256190000615,
+                "hd15iqr": 0.43385370500004683,
+                "ops": 2.3148844467536005,
+                "total": 4.319870053999466,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-menu]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-menu]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "menu"
+            },
+            "param": "True-True-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.6543326390001312,
+                "max": 0.6673518190000323,
+                "mean": 0.6618561560000444,
+                "stddev": 0.0031714996542625295,
+                "rounds": 10,
+                "median": 0.6620005430000901,
+                "iqr": 0.0012922360001539346,
+                "q1": 0.6616353069998695,
+                "q3": 0.6629275430000234,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.6610833710001316,
+                "hd15iqr": 0.6673518190000323,
+                "ops": 1.5109023175723593,
+                "total": 6.618561560000444,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-profile]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-profile]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile"
+            },
+            "param": "True-True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.43615234899993993,
+                "max": 0.4564065299998674,
+                "mean": 0.45106575399995563,
+                "stddev": 0.007854339808568398,
+                "rounds": 10,
+                "median": 0.4545303629998898,
+                "iqr": 0.0039969330000531045,
+                "q1": 0.45156724499997836,
+                "q3": 0.45556417800003146,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.45156724499997836,
+                "hd15iqr": 0.4564065299998674,
+                "ops": 2.216971674600015,
+                "total": 4.510657539999556,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-image]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-image]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "image"
+            },
+            "param": "True-True-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.21720937800000684,
+                "max": 0.23482092699987334,
+                "mean": 0.2222871452999698,
+                "stddev": 0.007367628614474261,
+                "rounds": 10,
+                "median": 0.2180607960000316,
+                "iqr": 0.013563902999976563,
+                "q1": 0.21744132200001332,
+                "q3": 0.23100522499998988,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.21720937800000684,
+                "hd15iqr": 0.23482092699987334,
+                "ops": 4.498685691655854,
+                "total": 2.222871452999698,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-system]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-system]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system"
+            },
+            "param": "True-True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.42973028300002625,
+                "max": 0.43900926199989954,
+                "mean": 0.4317394312999795,
+                "stddev": 0.0027884939588106276,
+                "rounds": 10,
+                "median": 0.43090712299988354,
+                "iqr": 0.0023854080000091926,
+                "q1": 0.4299937680000312,
+                "q3": 0.4323791760000404,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.42973028300002625,
+                "hd15iqr": 0.43900926199989954,
+                "ops": 2.3162118803672205,
+                "total": 4.317394312999795,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-network_interface]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-network_interface]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "network_interface"
+            },
+            "param": "True-True-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.21058750700012752,
+                "max": 0.21285690700005944,
+                "mean": 0.2114044364000165,
+                "stddev": 0.0007243063469060979,
+                "rounds": 10,
+                "median": 0.2111645799999451,
+                "iqr": 0.0010579759998563532,
+                "q1": 0.21090666600002805,
+                "q3": 0.2119646419998844,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.21058750700012752,
+                "hd15iqr": 0.21285690700005944,
+                "ops": 4.730269700243253,
+                "total": 2.114044364000165,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-distro_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-distro_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro_group"
+            },
+            "param": "True-True-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002220649000037156,
+                "max": 0.0024953039999218163,
+                "mean": 0.0022813694999967993,
+                "stddev": 7.880150862650213e-05,
+                "rounds": 10,
+                "median": 0.002259456499928092,
+                "iqr": 3.592799998841656e-05,
+                "q1": 0.0022451039999396016,
+                "q3": 0.002281031999928018,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.002220649000037156,
+                "hd15iqr": 0.0024953039999218163,
+                "ops": 438.33320292982046,
+                "total": 0.022813694999967993,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-profile_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-profile_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile_group"
+            },
+            "param": "True-True-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022370589999809454,
+                "max": 0.0024845839998306474,
+                "mean": 0.002323197099940444,
+                "stddev": 8.187985947062315e-05,
+                "rounds": 10,
+                "median": 0.002293289999897752,
+                "iqr": 6.0322000081214355e-05,
+                "q1": 0.002270732999932079,
+                "q3": 0.0023310550000132935,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.0022370589999809454,
+                "hd15iqr": 0.002452885000138849,
+                "ops": 430.4413086714147,
+                "total": 0.02323197099940444,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_remove[True-True-system_group]",
+            "fullname": "tests/performance/item_remove_test.py::test_item_remove[True-True-system_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system_group"
+            },
+            "param": "True-True-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022344449998854543,
+                "max": 0.0024874799998997332,
+                "mean": 0.0022851057999787373,
+                "stddev": 7.473407101902837e-05,
+                "rounds": 10,
+                "median": 0.0022626974999866434,
+                "iqr": 4.820100002689287e-05,
+                "q1": 0.0022438220000822184,
+                "q3": 0.0022920230001091113,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0022344449998854543,
+                "hd15iqr": 0.0024874799998997332,
+                "ops": 437.6164989863073,
+                "total": 0.022851057999787372,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-repo]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-repo]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "repo"
+            },
+            "param": "False-False-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0024538370000755094,
+                "max": 0.0027272800000446296,
+                "mean": 0.0025184745999922596,
+                "stddev": 9.274844491700835e-05,
+                "rounds": 10,
+                "median": 0.002477966500009643,
+                "iqr": 4.9342999773216434e-05,
+                "q1": 0.0024655280001297797,
+                "q3": 0.002514870999902996,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0024538370000755094,
+                "hd15iqr": 0.0026479200000721903,
+                "ops": 397.06574765656694,
+                "total": 0.025184745999922598,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-distro]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-distro]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro"
+            },
+            "param": "False-False-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0029379150000750087,
+                "max": 0.003683112999851801,
+                "mean": 0.003106641599993054,
+                "stddev": 0.00024641436389805056,
+                "rounds": 10,
+                "median": 0.00298448700004883,
+                "iqr": 0.0003228259997740679,
+                "q1": 0.002947203000076115,
+                "q3": 0.003270028999850183,
+                "iqr_outliers": 0,
+                "stddev_outliers": 1,
+                "outliers": "1;0",
+                "ld15iqr": 0.0029379150000750087,
+                "hd15iqr": 0.003683112999851801,
+                "ops": 321.8910092500647,
+                "total": 0.03106641599993054,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-menu]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-menu]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "menu"
+            },
+            "param": "False-False-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006543943999986368,
+                "max": 0.0068687130001308105,
+                "mean": 0.006617414800007282,
+                "stddev": 9.706948034545207e-05,
+                "rounds": 10,
+                "median": 0.006579100500061941,
+                "iqr": 8.222400015256426e-05,
+                "q1": 0.006560404999845559,
+                "q3": 0.006642628999998124,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.006543943999986368,
+                "hd15iqr": 0.0068687130001308105,
+                "ops": 151.1164148269653,
+                "total": 0.06617414800007282,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-profile]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-profile]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile"
+            },
+            "param": "False-False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.25222216199995273,
+                "max": 0.33796770100002504,
+                "mean": 0.26584066120003624,
+                "stddev": 0.026229077724029704,
+                "rounds": 10,
+                "median": 0.25395360700008496,
+                "iqr": 0.015310279000004812,
+                "q1": 0.252683308000087,
+                "q3": 0.2679935870000918,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.25222216199995273,
+                "hd15iqr": 0.33796770100002504,
+                "ops": 3.7616517935438525,
+                "total": 2.6584066120003627,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-image]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-image]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "image"
+            },
+            "param": "False-False-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0028996730000017124,
+                "max": 0.0032469249999849126,
+                "mean": 0.0029876111999556088,
+                "stddev": 0.00011398124920130337,
+                "rounds": 10,
+                "median": 0.0029536345000451547,
+                "iqr": 6.077499983803136e-05,
+                "q1": 0.0029057140000077197,
+                "q3": 0.002966488999845751,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0028996730000017124,
+                "hd15iqr": 0.0031386619998556853,
+                "ops": 334.7155747758806,
+                "total": 0.029876111999556088,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-system]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-system]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system"
+            },
+            "param": "False-False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.24879328599990913,
+                "max": 0.2651903050000328,
+                "mean": 0.25678784380002073,
+                "stddev": 0.00779422113209642,
+                "rounds": 10,
+                "median": 0.25620447250003053,
+                "iqr": 0.014968878999980006,
+                "q1": 0.24939795099999174,
+                "q3": 0.26436682999997174,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.24879328599990913,
+                "hd15iqr": 0.2651903050000328,
+                "ops": 3.8942653406084613,
+                "total": 2.567878438000207,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-network_interface]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-network_interface]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "network_interface"
+            },
+            "param": "False-False-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.2232432839998637,
+                "max": 0.22603453299984722,
+                "mean": 0.2241053751999516,
+                "stddev": 0.0008610672475481113,
+                "rounds": 10,
+                "median": 0.22383184900002107,
+                "iqr": 0.0011268450000443408,
+                "q1": 0.22341760099993735,
+                "q3": 0.2245444459999817,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.2232432839998637,
+                "hd15iqr": 0.22603453299984722,
+                "ops": 4.462186590160003,
+                "total": 2.241053751999516,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-distro_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-distro_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "distro_group"
+            },
+            "param": "False-False-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0020890220000637783,
+                "max": 0.0030936780001411535,
+                "mean": 0.002263349800045944,
+                "stddev": 0.00030884901520663905,
+                "rounds": 10,
+                "median": 0.002127342999983739,
+                "iqr": 0.0002295409999533149,
+                "q1": 0.002117575000056604,
+                "q3": 0.002347116000009919,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0020890220000637783,
+                "hd15iqr": 0.0030936780001411535,
+                "ops": 441.8230005718519,
+                "total": 0.02263349800045944,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-profile_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-profile_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "profile_group"
+            },
+            "param": "False-False-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0020817679999254324,
+                "max": 0.002302762999988772,
+                "mean": 0.0021366479000107575,
+                "stddev": 6.452777181787022e-05,
+                "rounds": 10,
+                "median": 0.002114980500095953,
+                "iqr": 5.921100000705337e-05,
+                "q1": 0.002096404999974766,
+                "q3": 0.002155615999981819,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0020817679999254324,
+                "hd15iqr": 0.002302762999988772,
+                "ops": 468.0228314618264,
+                "total": 0.021366479000107574,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-False-system_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-False-system_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false,
+                "what": "system_group"
+            },
+            "param": "False-False-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0020838319999256782,
+                "max": 0.002363957999932609,
+                "mean": 0.002179943199985246,
+                "stddev": 9.358831068454324e-05,
+                "rounds": 10,
+                "median": 0.002160370499950659,
+                "iqr": 7.744599975012534e-05,
+                "q1": 0.0021095300000979478,
+                "q3": 0.002186975999848073,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.0020838319999256782,
+                "hd15iqr": 0.0023249240000495774,
+                "ops": 458.7275485006986,
+                "total": 0.02179943199985246,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-repo]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-repo]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "repo"
+            },
+            "param": "True-False-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0024561609998272615,
+                "max": 0.002737578999813195,
+                "mean": 0.002539189399976749,
+                "stddev": 0.00010536663483192238,
+                "rounds": 10,
+                "median": 0.0024900140000454485,
+                "iqr": 7.005100019341626e-05,
+                "q1": 0.002484062999883463,
+                "q3": 0.002554114000076879,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0024561609998272615,
+                "hd15iqr": 0.0027284919999601698,
+                "ops": 393.8264707662835,
+                "total": 0.02539189399976749,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-distro]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-distro]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro"
+            },
+            "param": "True-False-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002940801000022475,
+                "max": 0.0031753099999605183,
+                "mean": 0.003006450499992752,
+                "stddev": 7.429861363589845e-05,
+                "rounds": 10,
+                "median": 0.002981621999992967,
+                "iqr": 4.50949999049044e-05,
+                "q1": 0.0029633920000833314,
+                "q3": 0.0030084869999882358,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.002940801000022475,
+                "hd15iqr": 0.00310223299993595,
+                "ops": 332.61814887769174,
+                "total": 0.03006450499992752,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-menu]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-menu]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "menu"
+            },
+            "param": "True-False-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006497155999795723,
+                "max": 0.009999079999943206,
+                "mean": 0.006993611999928362,
+                "stddev": 0.0010677035287682958,
+                "rounds": 10,
+                "median": 0.006632649999914975,
+                "iqr": 0.0003066050001052645,
+                "q1": 0.0065459079999072856,
+                "q3": 0.00685251300001255,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.006497155999795723,
+                "hd15iqr": 0.009999079999943206,
+                "ops": 142.9876292837297,
+                "total": 0.06993611999928362,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-profile]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-profile]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile"
+            },
+            "param": "True-False-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.2387605320000148,
+                "max": 0.36116282200009664,
+                "mean": 0.2524738715999547,
+                "stddev": 0.038199743449738234,
+                "rounds": 10,
+                "median": 0.24062236199995368,
+                "iqr": 0.001335777000122107,
+                "q1": 0.23991019099980804,
+                "q3": 0.24124596799993014,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.2387605320000148,
+                "hd15iqr": 0.36116282200009664,
+                "ops": 3.9608058990932014,
+                "total": 2.524738715999547,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-image]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-image]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "image"
+            },
+            "param": "True-False-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0026410269999814773,
+                "max": 0.002908229000013307,
+                "mean": 0.0027093479999621196,
+                "stddev": 7.598435405074221e-05,
+                "rounds": 10,
+                "median": 0.002692253999953209,
+                "iqr": 6.290900000749389e-05,
+                "q1": 0.0026589209999201557,
+                "q3": 0.0027218299999276496,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0026410269999814773,
+                "hd15iqr": 0.002908229000013307,
+                "ops": 369.0924901540819,
+                "total": 0.027093479999621195,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-system]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-system]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system"
+            },
+            "param": "True-False-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.25454723699999704,
+                "max": 0.3728886030000922,
+                "mean": 0.26787327910001296,
+                "stddev": 0.036938301153035716,
+                "rounds": 10,
+                "median": 0.255610036500002,
+                "iqr": 0.0038595449998410913,
+                "q1": 0.25488224600007925,
+                "q3": 0.25874179099992034,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.25454723699999704,
+                "hd15iqr": 0.3728886030000922,
+                "ops": 3.7331084435138484,
+                "total": 2.6787327910001295,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-network_interface]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-network_interface]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "network_interface"
+            },
+            "param": "True-False-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.22795203300006506,
+                "max": 0.23286776100007955,
+                "mean": 0.23080709260000276,
+                "stddev": 0.001944645376627573,
+                "rounds": 10,
+                "median": 0.23168489549993865,
+                "iqr": 0.0036875620000955678,
+                "q1": 0.22873622499992052,
+                "q3": 0.2324237870000161,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.22795203300006506,
+                "hd15iqr": 0.23286776100007955,
+                "ops": 4.332622488915612,
+                "total": 2.3080709260000276,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-distro_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-distro_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "distro_group"
+            },
+            "param": "True-False-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002150577000065823,
+                "max": 0.002345773000115514,
+                "mean": 0.0022422962000518964,
+                "stddev": 5.1846026025444676e-05,
+                "rounds": 10,
+                "median": 0.0022408865000898004,
+                "iqr": 4.95130000217614e-05,
+                "q1": 0.0022147980000681855,
+                "q3": 0.002264311000089947,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.002150577000065823,
+                "hd15iqr": 0.002345773000115514,
+                "ops": 445.9714109031874,
+                "total": 0.022422962000518964,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-profile_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-profile_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "profile_group"
+            },
+            "param": "True-False-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022152280002956104,
+                "max": 0.0024923089999902004,
+                "mean": 0.0022877194000102464,
+                "stddev": 9.531869321611617e-05,
+                "rounds": 10,
+                "median": 0.0022510204998980043,
+                "iqr": 4.173800016360474e-05,
+                "q1": 0.0022362380000231497,
+                "q3": 0.0022779760001867544,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0022152280002956104,
+                "hd15iqr": 0.002432857000258082,
+                "ops": 437.1165449729198,
+                "total": 0.022877194000102463,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-False-system_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-False-system_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false,
+                "what": "system_group"
+            },
+            "param": "True-False-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022028650000720518,
+                "max": 0.002507426000192936,
+                "mean": 0.0022609420000662796,
+                "stddev": 9.084956503330694e-05,
+                "rounds": 10,
+                "median": 0.002232305000006818,
+                "iqr": 5.9192000207985984e-05,
+                "q1": 0.0022065319999455824,
+                "q3": 0.0022657240001535683,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0022028650000720518,
+                "hd15iqr": 0.002507426000192936,
+                "ops": 442.29352189073626,
+                "total": 0.022609420000662794,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-repo]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-repo]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "repo"
+            },
+            "param": "False-True-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002508939000108512,
+                "max": 0.0028008369999952265,
+                "mean": 0.0025944740998966155,
+                "stddev": 7.962859992221892e-05,
+                "rounds": 10,
+                "median": 0.002566277499681746,
+                "iqr": 3.8221000068006106e-05,
+                "q1": 0.0025620699998398777,
+                "q3": 0.002600290999907884,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.002508939000108512,
+                "hd15iqr": 0.0028008369999952265,
+                "ops": 385.43456650418983,
+                "total": 0.025944740998966154,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-distro]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-distro]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro"
+            },
+            "param": "False-True-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0030209609999474196,
+                "max": 0.003302297999653092,
+                "mean": 0.003100772500010862,
+                "stddev": 0.00010338540473797263,
+                "rounds": 10,
+                "median": 0.0030629044999841426,
+                "iqr": 2.003700001296238e-05,
+                "q1": 0.0030486830000882037,
+                "q3": 0.003068720000101166,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.0030209609999474196,
+                "hd15iqr": 0.0032865600001059647,
+                "ops": 322.5002801709887,
+                "total": 0.03100772500010862,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-menu]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-menu]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "menu"
+            },
+            "param": "False-True-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.006754950999948051,
+                "max": 0.007005790999755845,
+                "mean": 0.006808144099977653,
+                "stddev": 7.811165662662456e-05,
+                "rounds": 10,
+                "median": 0.006775118500172539,
+                "iqr": 5.3129000207263744e-05,
+                "q1": 0.006762744999832648,
+                "q3": 0.006815874000039912,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.006754950999948051,
+                "hd15iqr": 0.007005790999755845,
+                "ops": 146.8829074877076,
+                "total": 0.06808144099977653,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-profile]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-profile]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile"
+            },
+            "param": "False-True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.26032652599997164,
+                "max": 0.2638783830002467,
+                "mean": 0.2612492355000541,
+                "stddev": 0.0010995740340754955,
+                "rounds": 10,
+                "median": 0.26079974850017607,
+                "iqr": 0.0012863140004810703,
+                "q1": 0.2605027969998446,
+                "q3": 0.26178911100032565,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.26032652599997164,
+                "hd15iqr": 0.2638783830002467,
+                "ops": 3.827762397412999,
+                "total": 2.6124923550005406,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-image]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-image]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "image"
+            },
+            "param": "False-True-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0028356930001791625,
+                "max": 0.0031281219999073073,
+                "mean": 0.002912913999944067,
+                "stddev": 8.54810426399487e-05,
+                "rounds": 10,
+                "median": 0.0029020629999649827,
+                "iqr": 6.902899986016564e-05,
+                "q1": 0.0028620130001399957,
+                "q3": 0.0029310420000001614,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0028356930001791625,
+                "hd15iqr": 0.0031281219999073073,
+                "ops": 343.29884096104513,
+                "total": 0.029129139999440667,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-system]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-system]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system"
+            },
+            "param": "False-True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.25419556700035173,
+                "max": 0.2673358830002144,
+                "mean": 0.261693998300052,
+                "stddev": 0.0058636842887201095,
+                "rounds": 10,
+                "median": 0.26505744600012804,
+                "iqr": 0.011983253999915178,
+                "q1": 0.2550512630000412,
+                "q3": 0.2670345169999564,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.25419556700035173,
+                "hd15iqr": 0.2673358830002144,
+                "ops": 3.8212569126381877,
+                "total": 2.6169399830005204,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-network_interface]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-network_interface]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "network_interface"
+            },
+            "param": "False-True-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.22864315999959217,
+                "max": 0.2306895120000263,
+                "mean": 0.22963874649994978,
+                "stddev": 0.0006859804455160019,
+                "rounds": 10,
+                "median": 0.22972046799986856,
+                "iqr": 0.0007755659994472808,
+                "q1": 0.22906054400027642,
+                "q3": 0.2298361099997237,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.22864315999959217,
+                "hd15iqr": 0.2306895120000263,
+                "ops": 4.35466581855871,
+                "total": 2.2963874649994978,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-distro_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-distro_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "distro_group"
+            },
+            "param": "False-True-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0021042599996690114,
+                "max": 0.0023944250001477485,
+                "mean": 0.002219939199994769,
+                "stddev": 8.268548351033405e-05,
+                "rounds": 10,
+                "median": 0.002199864999965939,
+                "iqr": 6.990099973336328e-05,
+                "q1": 0.0021761450002486527,
+                "q3": 0.002246045999982016,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 0.0021042599996690114,
+                "hd15iqr": 0.0023944250001477485,
+                "ops": 450.46278745037534,
+                "total": 0.022199391999947693,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-profile_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-profile_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "profile_group"
+            },
+            "param": "False-True-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0021049709998806065,
+                "max": 0.0024784520001048804,
+                "mean": 0.002203364899924054,
+                "stddev": 0.00011257144273288471,
+                "rounds": 10,
+                "median": 0.00216882099994109,
+                "iqr": 0.00012978299992028042,
+                "q1": 0.002121231999808515,
+                "q3": 0.0022510149997287954,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0021049709998806065,
+                "hd15iqr": 0.0024784520001048804,
+                "ops": 453.8512890145741,
+                "total": 0.02203364899924054,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[False-True-system_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[False-True-system_group]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true,
+                "what": "system_group"
+            },
+            "param": "False-True-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0022003310000400234,
+                "max": 0.0024699270002201956,
+                "mean": 0.0022805621000316022,
+                "stddev": 7.637712708568437e-05,
+                "rounds": 10,
+                "median": 0.002275716999974975,
+                "iqr": 7.744599997749901e-05,
+                "q1": 0.0022216699999262346,
+                "q3": 0.0022991159999037336,
+                "iqr_outliers": 1,
+                "stddev_outliers": 2,
+                "outliers": "2;1",
+                "ld15iqr": 0.0022003310000400234,
+                "hd15iqr": 0.0024699270002201956,
+                "ops": 438.4883884486824,
+                "total": 0.022805621000316023,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-repo]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-repo]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "repo"
+            },
+            "param": "True-True-repo",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002554033999786043,
+                "max": 0.0028437480000320647,
+                "mean": 0.0026664945999527847,
+                "stddev": 9.982145515514515e-05,
+                "rounds": 10,
+                "median": 0.00264594750001379,
+                "iqr": 8.307600000989623e-05,
+                "q1": 0.00260120300026756,
+                "q3": 0.0026842790002774564,
+                "iqr_outliers": 2,
+                "stddev_outliers": 3,
+                "outliers": "3;2",
+                "ld15iqr": 0.002554033999786043,
+                "hd15iqr": 0.0028361639997456223,
+                "ops": 375.02419844304467,
+                "total": 0.026664945999527845,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-distro]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-distro]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro"
+            },
+            "param": "True-True-distro",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0031399540002894355,
+                "max": 0.003668136000214872,
+                "mean": 0.003231434000053923,
+                "stddev": 0.00015538327734147437,
+                "rounds": 10,
+                "median": 0.0031930289999309025,
+                "iqr": 3.872299976137583e-05,
+                "q1": 0.003171313000166265,
+                "q3": 0.0032100359999276407,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0031399540002894355,
+                "hd15iqr": 0.003668136000214872,
+                "ops": 309.46013441194,
+                "total": 0.03231434000053923,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-menu]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-menu]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "menu"
+            },
+            "param": "True-True-menu",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.007025818999863986,
+                "max": 0.007306564999908005,
+                "mean": 0.0071280073999332675,
+                "stddev": 0.00011261725040203841,
+                "rounds": 10,
+                "median": 0.007075296500033801,
+                "iqr": 0.00021591499989881413,
+                "q1": 0.007050494999930379,
+                "q3": 0.007266409999829193,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.007025818999863986,
+                "hd15iqr": 0.007306564999908005,
+                "ops": 140.29166131468412,
+                "total": 0.07128007399933267,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-profile]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-profile]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile"
+            },
+            "param": "True-True-profile",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.2428353310001512,
+                "max": 0.25916864200007694,
+                "mean": 0.2536423249000109,
+                "stddev": 0.005568376097219262,
+                "rounds": 10,
+                "median": 0.254035761500063,
+                "iqr": 0.0047466599999097525,
+                "q1": 0.2535299969999869,
+                "q3": 0.25827665699989666,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.2535299969999869,
+                "hd15iqr": 0.25916864200007694,
+                "ops": 3.942559667020136,
+                "total": 2.5364232490001086,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-image]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-image]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "image"
+            },
+            "param": "True-True-image",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0026426199997331423,
+                "max": 0.0029529530002037063,
+                "mean": 0.002730130800000552,
+                "stddev": 0.0001047952305693089,
+                "rounds": 10,
+                "median": 0.0026885565000611678,
+                "iqr": 1.8123999780073063e-05,
+                "q1": 0.002682015000118554,
+                "q3": 0.002700138999898627,
+                "iqr_outliers": 3,
+                "stddev_outliers": 2,
+                "outliers": "2;3",
+                "ld15iqr": 0.0026735489996099204,
+                "hd15iqr": 0.002897569000197109,
+                "ops": 366.282816925767,
+                "total": 0.02730130800000552,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-system]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-system]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system"
+            },
+            "param": "True-True-system",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.25385226199978206,
+                "max": 0.25929184300002817,
+                "mean": 0.25590306779990896,
+                "stddev": 0.001548676780132642,
+                "rounds": 10,
+                "median": 0.25567052499991405,
+                "iqr": 0.0013443729999380594,
+                "q1": 0.25526894199992967,
+                "q3": 0.2566133149998677,
+                "iqr_outliers": 1,
+                "stddev_outliers": 3,
+                "outliers": "3;1",
+                "ld15iqr": 0.25385226199978206,
+                "hd15iqr": 0.25929184300002817,
+                "ops": 3.9077296282430725,
+                "total": 2.5590306779990897,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-network_interface]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-network_interface]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "network_interface"
+            },
+            "param": "True-True-network_interface",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.22695883799997318,
+                "max": 0.230738133000159,
+                "mean": 0.2283314614000574,
+                "stddev": 0.0011325051964843613,
+                "rounds": 10,
+                "median": 0.22814619749988196,
+                "iqr": 0.0018677959997148719,
+                "q1": 0.2273087060002581,
+                "q3": 0.22917650199997297,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.22695883799997318,
+                "hd15iqr": 0.230738133000159,
+                "ops": 4.3795979488254115,
+                "total": 2.283314614000574,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-distro_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-distro_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "distro_group"
+            },
+            "param": "True-True-distro_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0021207309996498225,
+                "max": 0.002441643000111071,
+                "mean": 0.0021913411999321397,
+                "stddev": 9.757809412590011e-05,
+                "rounds": 10,
+                "median": 0.002151398000023619,
+                "iqr": 8.416799983024248e-05,
+                "q1": 0.002129486999820074,
+                "q3": 0.0022136549996503163,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0021207309996498225,
+                "hd15iqr": 0.002441643000111071,
+                "ops": 456.3415318577351,
+                "total": 0.021913411999321397,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-profile_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-profile_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "profile_group"
+            },
+            "param": "True-True-profile_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.002093159000196465,
+                "max": 0.002356132999921101,
+                "mean": 0.0021728247999362794,
+                "stddev": 9.856156966195812e-05,
+                "rounds": 10,
+                "median": 0.002132823500005543,
+                "iqr": 3.828200033240137e-05,
+                "q1": 0.0021231649998298963,
+                "q3": 0.0021614470001622976,
+                "iqr_outliers": 2,
+                "stddev_outliers": 2,
+                "outliers": "2;2",
+                "ld15iqr": 0.002093159000196465,
+                "hd15iqr": 0.0023544499999843538,
+                "ops": 460.2303876637114,
+                "total": 0.021728247999362793,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_item_rename[True-True-system_group]",
+            "fullname": "tests/performance/item_rename_test.py::test_item_rename[True-True-system_group]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true,
+                "what": "system_group"
+            },
+            "param": "True-True-system_group",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.0021845109999958368,
+                "max": 0.002494091000244225,
+                "mean": 0.0022641890999693715,
+                "stddev": 8.706705398342184e-05,
+                "rounds": 10,
+                "median": 0.002254908000168143,
+                "iqr": 5.5313000302703585e-05,
+                "q1": 0.002217512999777682,
+                "q3": 0.0022728260000803857,
+                "iqr_outliers": 1,
+                "stddev_outliers": 1,
+                "outliers": "1;1",
+                "ld15iqr": 0.0021845109999958368,
+                "hd15iqr": 0.002494091000244225,
+                "ops": 441.65922361057534,
+                "total": 0.022641890999693715,
+                "iterations": 1
+            }
+        },
+        {
+            "group": null,
+            "name": "test_make_pxe_menu[False-False]",
+            "fullname": "tests/performance/make_pxe_menu_test.py::test_make_pxe_menu[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.01007644072000403,
+                "max": 0.010382389040005364,
+                "mean": 0.010185195476002263,
+                "stddev": 9.625950349361812e-05,
+                "rounds": 10,
+                "median": 0.010168641000009302,
+                "iqr": 0.00015519371998379966,
+                "q1": 0.010103027040004235,
+                "q3": 0.010258220759988034,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 0.01007644072000403,
+                "hd15iqr": 0.010382389040005364,
+                "ops": 98.1817189818437,
+                "total": 0.10185195476002264,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_make_pxe_menu[True-False]",
+            "fullname": "tests/performance/make_pxe_menu_test.py::test_make_pxe_menu[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.010054925120002736,
+                "max": 0.010259173720005493,
+                "mean": 0.010160532615998818,
+                "stddev": 6.581069837937386e-05,
+                "rounds": 10,
+                "median": 0.010160204960002375,
+                "iqr": 7.838355999410795e-05,
+                "q1": 0.010108624320000672,
+                "q3": 0.01018700787999478,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.010054925120002736,
+                "hd15iqr": 0.010259173720005493,
+                "ops": 98.42003739305908,
+                "total": 0.10160532615998819,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_make_pxe_menu[False-True]",
+            "fullname": "tests/performance/make_pxe_menu_test.py::test_make_pxe_menu[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.010061126000000514,
+                "max": 0.010217667399992934,
+                "mean": 0.010137453851997633,
+                "stddev": 5.383828812812214e-05,
+                "rounds": 10,
+                "median": 0.010116771819994028,
+                "iqr": 9.160031999272226e-05,
+                "q1": 0.010106688319992826,
+                "q3": 0.010198288639985549,
+                "iqr_outliers": 0,
+                "stddev_outliers": 5,
+                "outliers": "5;0",
+                "ld15iqr": 0.010061126000000514,
+                "hd15iqr": 0.010217667399992934,
+                "ops": 98.6440988634385,
+                "total": 0.10137453851997634,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_make_pxe_menu[True-True]",
+            "fullname": "tests/performance/make_pxe_menu_test.py::test_make_pxe_menu[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.009989525960008905,
+                "max": 0.010195147960002942,
+                "mean": 0.010086312331999579,
+                "stddev": 6.489959189222661e-05,
+                "rounds": 10,
+                "median": 0.010083622199999809,
+                "iqr": 8.466052000585464e-05,
+                "q1": 0.010038893040000402,
+                "q3": 0.010123553560006257,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.009989525960008905,
+                "hd15iqr": 0.010195147960002942,
+                "ops": 99.14426274778596,
+                "total": 0.10086312331999579,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_start[False-False]",
+            "fullname": "tests/performance/start_test.py::test_start[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4427832579599999,
+                "max": 0.4593869225600065,
+                "mean": 0.44925443558799816,
+                "stddev": 0.005941031091546791,
+                "rounds": 10,
+                "median": 0.446869118199993,
+                "iqr": 0.008225423679996291,
+                "q1": 0.4444733585600079,
+                "q3": 0.4526987822400042,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.4427832579599999,
+                "hd15iqr": 0.4593869225600065,
+                "ops": 2.2259101319526624,
+                "total": 4.492544355879982,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_start[True-False]",
+            "fullname": "tests/performance/start_test.py::test_start[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.4234039289999964,
+                "max": 0.4622620797199852,
+                "mean": 0.4470697422479952,
+                "stddev": 0.015899486453773794,
+                "rounds": 10,
+                "median": 0.4551773753799989,
+                "iqr": 0.03131451724000722,
+                "q1": 0.42860823515999075,
+                "q3": 0.45992275239999797,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.4234039289999964,
+                "hd15iqr": 0.4622620797199852,
+                "ops": 2.2367874751972976,
+                "total": 4.470697422479953,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_start[False-True]",
+            "fullname": "tests/performance/start_test.py::test_start[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.44659235627999805,
+                "max": 0.4622722672399868,
+                "mean": 0.45521930290399903,
+                "stddev": 0.005248109903405069,
+                "rounds": 10,
+                "median": 0.4555603306400008,
+                "iqr": 0.007378285440008792,
+                "q1": 0.45158065132000047,
+                "q3": 0.45895893676000926,
+                "iqr_outliers": 0,
+                "stddev_outliers": 4,
+                "outliers": "4;0",
+                "ld15iqr": 0.44659235627999805,
+                "hd15iqr": 0.4622722672399868,
+                "ops": 2.1967434017421037,
+                "total": 4.552193029039991,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_start[True-True]",
+            "fullname": "tests/performance/start_test.py::test_start[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 0.44751059555999745,
+                "max": 0.4639313299599962,
+                "mean": 0.45647527685199746,
+                "stddev": 0.0053832379434571856,
+                "rounds": 10,
+                "median": 0.4566070290599964,
+                "iqr": 0.009115232759995706,
+                "q1": 0.4523913206799989,
+                "q3": 0.4615065534399946,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 0.44751059555999745,
+                "hd15iqr": 0.4639313299599962,
+                "ops": 2.1906991478187527,
+                "total": 4.564752768519974,
+                "iterations": 25
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sync[False-False]",
+            "fullname": "tests/performance/sync_test.py::test_sync[False-False]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": false
+            },
+            "param": "False-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 3.706210216000045,
+                "max": 3.8326604085000326,
+                "mean": 3.7502943039499996,
+                "stddev": 0.03860604355056238,
+                "rounds": 10,
+                "median": 3.737094768750012,
+                "iqr": 0.0538652490001823,
+                "q1": 3.7219825979998404,
+                "q3": 3.7758478470000227,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 3.706210216000045,
+                "hd15iqr": 3.8326604085000326,
+                "ops": 0.2666457400281224,
+                "total": 37.502943039499996,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sync[True-False]",
+            "fullname": "tests/performance/sync_test.py::test_sync[True-False]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": false
+            },
+            "param": "True-False",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.4973814644999948,
+                "max": 1.5280381570000827,
+                "mean": 1.5061312424500328,
+                "stddev": 0.010440409200239191,
+                "rounds": 10,
+                "median": 1.5018896192500506,
+                "iqr": 0.01396592650007733,
+                "q1": 1.498429586499924,
+                "q3": 1.5123955130000013,
+                "iqr_outliers": 0,
+                "stddev_outliers": 2,
+                "outliers": "2;0",
+                "ld15iqr": 1.4973814644999948,
+                "hd15iqr": 1.5280381570000827,
+                "ops": 0.6639527630894196,
+                "total": 15.06131242450033,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sync[False-True]",
+            "fullname": "tests/performance/sync_test.py::test_sync[False-True]",
+            "params": {
+                "cache_enabled": false,
+                "enable_menu": true
+            },
+            "param": "False-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.4939669694999793,
+                "max": 1.5160427094999704,
+                "mean": 1.5084455207000247,
+                "stddev": 0.006842357804461184,
+                "rounds": 10,
+                "median": 1.5101108692500702,
+                "iqr": 0.009940720500026146,
+                "q1": 1.503987379499904,
+                "q3": 1.51392809999993,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 1.4939669694999793,
+                "hd15iqr": 1.5160427094999704,
+                "ops": 0.6629341174588326,
+                "total": 15.084455207000246,
+                "iterations": 2
+            }
+        },
+        {
+            "group": null,
+            "name": "test_sync[True-True]",
+            "fullname": "tests/performance/sync_test.py::test_sync[True-True]",
+            "params": {
+                "cache_enabled": true,
+                "enable_menu": true
+            },
+            "param": "True-True",
+            "extra_info": {},
+            "options": {
+                "disable_gc": false,
+                "timer": "perf_counter",
+                "min_rounds": 5,
+                "max_time": 1.0,
+                "min_time": 5e-06,
+                "warmup": false
+            },
+            "stats": {
+                "min": 1.4939280465000593,
+                "max": 1.5139435639998737,
+                "mean": 1.502012637100006,
+                "stddev": 0.008756389082011816,
+                "rounds": 10,
+                "median": 1.4970543675000272,
+                "iqr": 0.017622535500095182,
+                "q1": 1.4942668324999886,
+                "q3": 1.5118893680000838,
+                "iqr_outliers": 0,
+                "stddev_outliers": 3,
+                "outliers": "3;0",
+                "ld15iqr": 1.4939280465000593,
+                "hd15iqr": 1.5139435639998737,
+                "ops": 0.6657733598904592,
+                "total": 15.02012637100006,
+                "iterations": 2
+            }
+        }
+    ],
+    "datetime": "2026-08-05T09:49:52.960892+00:00",
+    "version": "5.2.3"
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,33 @@ jobs:
       run:  rstcheck -r docs
     - name: Run doc8
       run: doc8 --ignore D001 docs
+  apidoc:
+    name: code-autodoc up to date
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      # https://github.com/actions/checkout
+      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+    - name: Set up Python
+      # https://github.com/actions/setup-python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      with:
+        python-version: "3.11"
+    - name: Install dependencies
+      # Pinned to the exact version docs/code-autodoc/ was generated with - sphinx-apidoc's
+      # output formatting (e.g. automodule option order) isn't stable across versions, so an
+      # unpinned/newer Sphinx here would flag the committed files as stale for no real reason.
+      run: pip install sphinx==8.2.3
+    - name: Regenerate code-autodoc
+      run: make apidoc
+    - name: Check for uncommitted code-autodoc changes
+      run: |
+        if [ -n "$(git status --porcelain -- docs/code-autodoc/)" ]; then
+          echo "::error::docs/code-autodoc/ is out of date. Run 'make apidoc' locally and commit the changes."
+          git status --porcelain -- docs/code-autodoc/
+          git diff -- docs/code-autodoc/
+          exit 1
+        fi
   shellscripts:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/performance_testing.yml
+++ b/.github/workflows/performance_testing.yml
@@ -80,7 +80,7 @@ jobs:
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             docker exec -u 0 -it cobbler bash -c "pytest --benchmark-only --benchmark-autosave tests/performance"
           else
-            docker exec -u 0 -it cobbler bash -c "pytest --benchmark-only --benchmark-autosave --benchmark-compare=\"0002\" --benchmark-group-by=name --benchmark-compare-fail=\"mean:10%\" tests/performance"
+            docker exec -u 0 -it cobbler bash -c "pytest --benchmark-only --benchmark-autosave --benchmark-compare=\"0003\" --benchmark-group-by=name --benchmark-compare-fail=\"mean:10%\" tests/performance"
           fi
       - name: Stop and remove the container
         if: always()

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,11 @@ doc: ## Creates the documentation with sphinx in html form.
 	@echo "creating: documentation"
 	@cd docs; make html > /dev/null 2>&1
 
+apidoc: ## Regenerates the docs/code-autodoc folder from the current source tree using sphinx-apidoc.
+	@echo "regenerating: code-autodoc"
+	@rm -f docs/code-autodoc/*
+	@cd docs; sphinx-apidoc --no-toc -o code-autodoc ../cobbler
+
 man: ## Creates documentation and man pages using Sphinx
 	@if python3 -c "from importlib.metadata import version; from sys import exit; exit(0 if tuple(int(p) for p in version('setuptools_scm').split('.')[:2]) >= (8, 2) else 1)" 2>/dev/null; then \
 		python3 -m setuptools_scm --force-write-version-files > /dev/null; \

--- a/changelog.d/4039.added
+++ b/changelog.d/4039.added
@@ -1,0 +1,1 @@
+Added an optional "dynamic_tftp" TFTP manager that serves TFTP content on demand instead of copying it to the TFTP root, for use with a separate server such as cobbler-tftp

--- a/cobbler/actions/check.py
+++ b/cobbler/actions/check.py
@@ -72,6 +72,11 @@ class CobblerCheck:
             self.check_tftpd_dir(status)
         elif mode == "tftpd_py":
             self.check_ctftpd_dir(status)
+        elif mode == "dynamic_tftp" and self.settings.manage_tftpd:
+            status.append(
+                "manage_tftpd is enabled but the 'dynamic_tftp' TFTP manager is selected; disable "
+                "manage_tftpd since cobbler-tftp manages its own service independently of Cobbler."
+            )
 
         self.check_service(status, "cobblerd")
 

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -373,7 +373,7 @@ class CobblerSync:
 
         :param name: The name of the image.
         """
-        self.api.tftpgen.copy_single_image_files(image_obj)
+        self.tftpd.add_single_image(image_obj)
         kids = self.api.find_system(return_list=True, image=image_obj.name)
         if not isinstance(kids, list):
             raise ValueError("Expected to get list of profiles from search!")

--- a/cobbler/modules/managers/__init__.py
+++ b/cobbler/modules/managers/__init__.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, List
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.items.distro import Distro
+    from cobbler.items.image import Image
     from cobbler.items.system import System
 
 
@@ -195,4 +196,15 @@ class TftpManagerModule(ManagerModule):
         distribution.
 
         :param distro: The distribution object to add.
+        """
+
+    @abstractmethod
+    def add_single_image(self, image: "Image") -> None:
+        """
+        Add a single image to the TFTP configuration.
+
+        This method should be implemented by subclasses to update TFTP boot files and configuration for the specified
+        image.
+
+        :param image: The image object to add.
         """

--- a/cobbler/modules/managers/dynamic_tftp.py
+++ b/cobbler/modules/managers/dynamic_tftp.py
@@ -1,0 +1,142 @@
+"""
+This is some of the code behind 'cobbler sync' when TFTP content is served dynamically (e.g. by the separate
+cobbler-tftp daemon) instead of being materialized into the TFTP root directory.
+"""
+
+# SPDX-License-Identifier: GPL-2.0-or-later
+
+from typing import TYPE_CHECKING, Dict, List, Optional, Union
+
+from cobbler.modules.managers import TftpManagerModule
+
+if TYPE_CHECKING:
+    from cobbler.api import CobblerAPI
+    from cobbler.items.distro import Distro
+    from cobbler.items.image import Image
+    from cobbler.items.system import System
+
+
+MANAGER = None
+
+
+def register() -> str:
+    """
+    The mandatory Cobbler module registration hook.
+    """
+    return "manage"
+
+
+class _DynamicTftpManager(TftpManagerModule):
+    @staticmethod
+    def what() -> str:
+        """
+        Static method to identify the manager.
+
+        :return: Always "dynamic_tftp".
+        """
+        return "dynamic_tftp"
+
+    def __init__(self, api: "CobblerAPI"):
+        super().__init__(api)
+
+    def write_boot_files(self) -> int:
+        """
+        No-op: bootable files referenced by ``template_files`` are served on demand by
+        :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`, so nothing needs to be written to the TFTP root.
+
+        :return: Always ``0``.
+        """
+        self.logger.info(
+            "dynamic TFTP manager selected, skipping write_boot_files: "
+            "boot files are served on demand instead"
+        )
+        return 0
+
+    def sync_single_system(
+        self,
+        system: "System",
+        menu_items: Optional[Dict[str, Union[str, Dict[str, str]]]] = None,
+    ) -> int:
+        """
+        No-op: per-system PXE/GRUB configuration is rendered on demand by
+        :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`, so nothing needs to be written to the TFTP root.
+
+        :param system: The system that would have been synced.
+        :param menu_items: Unused.
+        """
+        del system, menu_items  # unused
+        self.logger.info(
+            "dynamic TFTP manager selected, skipping sync_single_system: "
+            "system configuration is generated on demand instead"
+        )
+        return 0
+
+    def add_single_distro(self, distro: "Distro") -> None:
+        """
+        No-op: distro kernel/initrd files are served on demand by
+        :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`, so nothing needs to be copied into the TFTP root.
+
+        :param distro: The distro that would have been added.
+        """
+        del distro  # unused
+        self.logger.info(
+            "dynamic TFTP manager selected, skipping add_single_distro: "
+            "distro files are served on demand instead"
+        )
+
+    def add_single_image(self, image: "Image") -> None:
+        """
+        No-op: image files are served on demand by :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`, so nothing
+        needs to be copied into the TFTP root.
+
+        :param image: The image that would have been added.
+        """
+        del image  # unused
+        self.logger.info(
+            "dynamic TFTP manager selected, skipping add_single_image: "
+            "image files are served on demand instead"
+        )
+
+    def sync_systems(self, systems: List[str], verbose: bool = True) -> None:
+        """
+        No-op: system configuration is rendered on demand by
+        :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`, so nothing needs to be written to the TFTP root.
+
+        :param systems: Unused.
+        :param verbose: Unused.
+        """
+        del systems, verbose  # unused
+        self.logger.info(
+            "dynamic TFTP manager selected, skipping sync_systems: "
+            "system configuration is generated on demand instead"
+        )
+
+    def sync(self) -> int:
+        """
+        No-op: bootloaders, distro kernels/initrds, images and per-system configuration are all served on demand by
+        :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`/:meth:`cobbler.api.CobblerAPI.get_tftp_file`, so nothing
+        needs to be materialized into the TFTP root.
+
+        :return: Always ``0``.
+        """
+        self.logger.info(
+            "dynamic TFTP manager selected, skipping sync: "
+            "TFTP content is served on demand instead of being copied to the TFTP root"
+        )
+        return 0
+
+
+def get_manager(api: "CobblerAPI") -> _DynamicTftpManager:
+    """
+    Creates a manager object to manage TFTP content that is served dynamically instead of being copied into the
+    TFTP root.
+
+    :param api: The API which holds all information in the current Cobbler instance.
+    :return: The object to manage the server with.
+    """
+    # Singleton used, therefore ignoring 'global'
+    global MANAGER  # pylint: disable=global-statement
+
+    if not MANAGER:
+        MANAGER = _DynamicTftpManager(api)  # type: ignore
+    return MANAGER

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -17,6 +17,7 @@ from cobbler.utils import filesystem_helpers
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.items.distro import Distro
+    from cobbler.items.image import Image
     from cobbler.items.system import System
 
 
@@ -136,6 +137,14 @@ class _InTftpdManager(TftpManagerModule):
         """
         self.api.tftpgen.copy_single_distro_files(distro, self.bootloc, False)
         self.write_boot_files_distro(distro)
+
+    def add_single_image(self, image: "Image") -> None:
+        """
+        Add a single image to the TFTP configuration.
+
+        :param image: The image object to add.
+        """
+        self.api.tftpgen.copy_single_image_files(image)
 
     def sync_systems(self, systems: List[str], verbose: bool = True) -> None:
         """

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -2215,6 +2215,36 @@ class TFTPGen:
             file_size = fd.seek(0, os.SEEK_END)
             return data, file_size
 
+    def _get_bundled_grub_file(
+        self, path: pathlib.Path, offset: int, size: int
+    ) -> Optional[Tuple[bytes, int]]:
+        """
+        Serve Cobbler's embedded, hardcoded default GRUB configuration (the same files
+        :meth:`copy_static_grub_files` would otherwise write to the TFTP root) straight from the Python package
+        resources, without requiring anything to be copied to disk first.
+
+        :param path: Normalized absolute path to the file.
+        :param offset: Offset of the requested chunk in the file.
+        :param size: Size of the requested chunk in the file.
+        :return: The requested chunk and the length of the whole file, or ``None`` if ``path`` doesn't refer to one
+                 of the bundled default GRUB files.
+        """
+        relative_path = str(path).strip("/")
+        resource_files = cast("Traversable", files("cobbler.data.config.grub"))
+        if relative_path == "grub.cfg":
+            resource = resource_files.joinpath("grub.cfg")
+        elif relative_path.startswith("grub/"):
+            resource = resource_files.joinpath("grub").joinpath(
+                relative_path[len("grub/") :]
+            )
+        else:
+            return None
+        try:
+            content = resource.read_bytes()
+        except FileNotFoundError:
+            return None
+        return content[offset : offset + size], len(content)
+
     def _get_static_tftp_file(
         self, path: pathlib.Path, offset: int, size: int
     ) -> Optional[Tuple[bytes, int]]:
@@ -2231,7 +2261,7 @@ class TFTPGen:
                     size,
                 )
             except FileNotFoundError:
-                return None
+                return self._get_bundled_grub_file(path, offset, size)
 
     def _get_distro_tftp_file(
         self, path: pathlib.Path, offset: int, size: int

--- a/docs/cobbler-conf/settings-yaml.rst
+++ b/docs/cobbler-conf/settings-yaml.rst
@@ -1167,12 +1167,16 @@ tftpd
 module
 ------
 
-Chooses the TFTP management engine if ``manage_tftpd`` is enabled in ``/etc/cobbler/settings.yaml``, which is **on** by
-default.
+Chooses the TFTP management engine. For ``managers.in_tftpd`` this only takes effect if ``manage_tftpd`` is enabled
+in ``/etc/cobbler/settings.yaml``, which is **on** by default.
 
 Choices:
 
 - managers.in_tftpd -- default, uses the system's TFTP server
+- managers.dynamic_tftp -- serves all TFTP content on demand instead of copying it into the TFTP root, for use with
+  a separate dynamic TFTP server (e.g. `cobbler-tftp <https://github.com/cobbler/cobbler-tftp>`_) that calls back
+  into Cobbler's XML-RPC API for every request. Requires ``manage_tftpd`` to be **disabled**, since that separate
+  server manages its own service. See :ref:`the TFTP user guide <tftp-directory>` for details.
 
 default: ``managers.in_tftpd``
 

--- a/docs/code-autodoc/cobbler.actions.buildiso.rst
+++ b/docs/code-autodoc/cobbler.actions.buildiso.rst
@@ -9,29 +9,29 @@ cobbler.actions.buildiso.append\_line module
 
 .. automodule:: cobbler.actions.buildiso.append_line
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.buildiso.netboot module
 ---------------------------------------
 
 .. automodule:: cobbler.actions.buildiso.netboot
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.buildiso.standalone module
 ------------------------------------------
 
 .. automodule:: cobbler.actions.buildiso.standalone
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.actions.buildiso
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.actions.rst
+++ b/docs/code-autodoc/cobbler.actions.rst
@@ -17,85 +17,85 @@ cobbler.actions.acl module
 
 .. automodule:: cobbler.actions.acl
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.check module
 ----------------------------
 
 .. automodule:: cobbler.actions.check
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.hardlink module
 -------------------------------
 
 .. automodule:: cobbler.actions.hardlink
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.importer module
 -------------------------------
 
 .. automodule:: cobbler.actions.importer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.log module
 --------------------------
 
 .. automodule:: cobbler.actions.log
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.mkloaders module
 --------------------------------
 
 .. automodule:: cobbler.actions.mkloaders
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.replicate module
 --------------------------------
 
 .. automodule:: cobbler.actions.replicate
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.reposync module
 -------------------------------
 
 .. automodule:: cobbler.actions.reposync
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.status module
 -----------------------------
 
 .. automodule:: cobbler.actions.status
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.actions.sync module
 ---------------------------
 
 .. automodule:: cobbler.actions.sync
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.actions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.autoinstall.generate.rst
+++ b/docs/code-autodoc/cobbler.autoinstall.generate.rst
@@ -9,69 +9,69 @@ cobbler.autoinstall.generate.agama module
 
 .. automodule:: cobbler.autoinstall.generate.agama
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.autoyast module
 --------------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.autoyast
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.base module
 ----------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.base
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.cloud\_init module
 -----------------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.cloud_init
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.kickstart module
 ---------------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.kickstart
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.legacy module
 ------------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.legacy
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.preseed module
 -------------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.preseed
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.autoinstall.generate.windows module
 -------------------------------------------
 
 .. automodule:: cobbler.autoinstall.generate.windows
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.autoinstall.generate
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.autoinstall.rst
+++ b/docs/code-autodoc/cobbler.autoinstall.rst
@@ -17,13 +17,13 @@ cobbler.autoinstall.manager module
 
 .. automodule:: cobbler.autoinstall.manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.autoinstall
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.cobbler_collections.rst
+++ b/docs/code-autodoc/cobbler.cobbler_collections.rst
@@ -9,109 +9,109 @@ cobbler.cobbler\_collections.collection module
 
 .. automodule:: cobbler.cobbler_collections.collection
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.distro\_group module
 -------------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.distro_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.distros module
 -------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.distros
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.images module
 ------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.images
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.manager module
 -------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.menus module
 -----------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.menus
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.network\_interfaces module
 -------------------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.network_interfaces
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.profile\_group module
 --------------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.profile_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.profiles module
 --------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.profiles
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.repos module
 -----------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.repos
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.system\_group module
 -------------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.system_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.systems module
 -------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.systems
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobbler\_collections.templates module
 ---------------------------------------------
 
 .. automodule:: cobbler.cobbler_collections.templates
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.cobbler_collections
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.cobblerd.rst
+++ b/docs/code-autodoc/cobbler.cobblerd.rst
@@ -9,37 +9,37 @@ cobbler.cobblerd.cli module
 
 .. automodule:: cobbler.cobblerd.cli
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobblerd.daemon module
 ------------------------------
 
 .. automodule:: cobbler.cobblerd.daemon
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobblerd.distro\_options module
 ---------------------------------------
 
 .. automodule:: cobbler.cobblerd.distro_options
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cobblerd.setup module
 -----------------------------
 
 .. automodule:: cobbler.cobblerd.setup
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.cobblerd
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.data.rst
+++ b/docs/code-autodoc/cobbler.data.rst
@@ -6,5 +6,5 @@ Module contents
 
 .. automodule:: cobbler.data
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.items.abstract.rst
+++ b/docs/code-autodoc/cobbler.items.abstract.rst
@@ -9,45 +9,45 @@ cobbler.items.abstract.base\_item module
 
 .. automodule:: cobbler.items.abstract.base_item
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.abstract.bootable\_item module
 --------------------------------------------
 
 .. automodule:: cobbler.items.abstract.bootable_item
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.abstract.inheritable\_item module
 -----------------------------------------------
 
 .. automodule:: cobbler.items.abstract.inheritable_item
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.abstract.item\_cache module
 -----------------------------------------
 
 .. automodule:: cobbler.items.abstract.item_cache
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.abstract.item\_group module
 -----------------------------------------
 
 .. automodule:: cobbler.items.abstract.item_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.items.abstract
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.items.options.rst
+++ b/docs/code-autodoc/cobbler.items.options.rst
@@ -9,69 +9,69 @@ cobbler.items.options.base module
 
 .. automodule:: cobbler.items.options.base
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.dns module
 --------------------------------
 
 .. automodule:: cobbler.items.options.dns
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.ip module
 -------------------------------
 
 .. automodule:: cobbler.items.options.ip
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.package module
 ------------------------------------
 
 .. automodule:: cobbler.items.options.package
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.power module
 ----------------------------------
 
 .. automodule:: cobbler.items.options.power
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.tftp module
 ---------------------------------
 
 .. automodule:: cobbler.items.options.tftp
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.uri module
 --------------------------------
 
 .. automodule:: cobbler.items.options.uri
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.options.virt module
 ---------------------------------
 
 .. automodule:: cobbler.items.options.virt
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.items.options
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.items.rst
+++ b/docs/code-autodoc/cobbler.items.rst
@@ -18,93 +18,93 @@ cobbler.items.distro module
 
 .. automodule:: cobbler.items.distro
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.distro\_group module
 ----------------------------------
 
 .. automodule:: cobbler.items.distro_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.image module
 --------------------------
 
 .. automodule:: cobbler.items.image
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.menu module
 -------------------------
 
 .. automodule:: cobbler.items.menu
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.network\_interface module
 ---------------------------------------
 
 .. automodule:: cobbler.items.network_interface
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.profile module
 ----------------------------
 
 .. automodule:: cobbler.items.profile
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.profile\_group module
 -----------------------------------
 
 .. automodule:: cobbler.items.profile_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.repo module
 -------------------------
 
 .. automodule:: cobbler.items.repo
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.system module
 ---------------------------
 
 .. automodule:: cobbler.items.system
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.system\_group module
 ----------------------------------
 
 .. automodule:: cobbler.items.system_group
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.items.template module
 -----------------------------
 
 .. automodule:: cobbler.items.template
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.items
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.modules.authentication.rst
+++ b/docs/code-autodoc/cobbler.modules.authentication.rst
@@ -9,53 +9,53 @@ cobbler.modules.authentication.configfile module
 
 .. automodule:: cobbler.modules.authentication.configfile
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authentication.denyall module
 ---------------------------------------------
 
 .. automodule:: cobbler.modules.authentication.denyall
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authentication.ldap module
 ------------------------------------------
 
 .. automodule:: cobbler.modules.authentication.ldap
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authentication.pam module
 -----------------------------------------
 
 .. automodule:: cobbler.modules.authentication.pam
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authentication.passthru module
 ----------------------------------------------
 
 .. automodule:: cobbler.modules.authentication.passthru
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authentication.spacewalk module
 -----------------------------------------------
 
 .. automodule:: cobbler.modules.authentication.spacewalk
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.modules.authentication
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.modules.authorization.rst
+++ b/docs/code-autodoc/cobbler.modules.authorization.rst
@@ -9,29 +9,29 @@ cobbler.modules.authorization.allowall module
 
 .. automodule:: cobbler.modules.authorization.allowall
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authorization.configfile module
 -----------------------------------------------
 
 .. automodule:: cobbler.modules.authorization.configfile
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.authorization.ownership module
 ----------------------------------------------
 
 .. automodule:: cobbler.modules.authorization.ownership
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.modules.authorization
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.modules.installation.rst
+++ b/docs/code-autodoc/cobbler.modules.installation.rst
@@ -9,61 +9,61 @@ cobbler.modules.installation.post\_log module
 
 .. automodule:: cobbler.modules.installation.post_log
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.installation.post\_power module
 -----------------------------------------------
 
 .. automodule:: cobbler.modules.installation.post_power
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.installation.post\_puppet module
 ------------------------------------------------
 
 .. automodule:: cobbler.modules.installation.post_puppet
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.installation.post\_report module
 ------------------------------------------------
 
 .. automodule:: cobbler.modules.installation.post_report
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.installation.pre\_clear\_anamon\_logs module
 ------------------------------------------------------------
 
 .. automodule:: cobbler.modules.installation.pre_clear_anamon_logs
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.installation.pre\_log module
 --------------------------------------------
 
 .. automodule:: cobbler.modules.installation.pre_log
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.installation.pre\_puppet module
 -----------------------------------------------
 
 .. automodule:: cobbler.modules.installation.pre_puppet
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.modules.installation
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.modules.managers.rst
+++ b/docs/code-autodoc/cobbler.modules.managers.rst
@@ -9,61 +9,61 @@ cobbler.modules.managers.bind module
 
 .. automodule:: cobbler.modules.managers.bind
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.managers.dnsmasq module
 ---------------------------------------
 
 .. automodule:: cobbler.modules.managers.dnsmasq
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.managers.genders module
 ---------------------------------------
 
 .. automodule:: cobbler.modules.managers.genders
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.managers.import\_signatures module
 --------------------------------------------------
 
 .. automodule:: cobbler.modules.managers.import_signatures
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.managers.in\_tftpd module
 -----------------------------------------
 
 .. automodule:: cobbler.modules.managers.in_tftpd
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.managers.isc module
 -----------------------------------
 
 .. automodule:: cobbler.modules.managers.isc
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.managers.ndjbdns module
 ---------------------------------------
 
 .. automodule:: cobbler.modules.managers.ndjbdns
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.modules.managers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.modules.managers.rst
+++ b/docs/code-autodoc/cobbler.modules.managers.rst
@@ -20,6 +20,14 @@ cobbler.modules.managers.dnsmasq module
    :show-inheritance:
    :undoc-members:
 
+cobbler.modules.managers.dynamic\_tftp module
+---------------------------------------------
+
+.. automodule:: cobbler.modules.managers.dynamic_tftp
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 cobbler.modules.managers.genders module
 ---------------------------------------
 

--- a/docs/code-autodoc/cobbler.modules.rst
+++ b/docs/code-autodoc/cobbler.modules.rst
@@ -21,45 +21,45 @@ cobbler.modules.nsupdate\_add\_system\_post module
 
 .. automodule:: cobbler.modules.nsupdate_add_system_post
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.nsupdate\_delete\_system\_pre module
 ----------------------------------------------------
 
 .. automodule:: cobbler.modules.nsupdate_delete_system_pre
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.scm\_track module
 ---------------------------------
 
 .. automodule:: cobbler.modules.scm_track
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.sync\_post\_restart\_services module
 ----------------------------------------------------
 
 .. automodule:: cobbler.modules.sync_post_restart_services
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.sync\_post\_wingen module
 -----------------------------------------
 
 .. automodule:: cobbler.modules.sync_post_wingen
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.modules
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.modules.serializers.rst
+++ b/docs/code-autodoc/cobbler.modules.serializers.rst
@@ -9,29 +9,29 @@ cobbler.modules.serializers.file module
 
 .. automodule:: cobbler.modules.serializers.file
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.serializers.mongodb module
 ------------------------------------------
 
 .. automodule:: cobbler.modules.serializers.mongodb
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.modules.serializers.sqlite module
 -----------------------------------------
 
 .. automodule:: cobbler.modules.serializers.sqlite
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.modules.serializers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.rst
+++ b/docs/code-autodoc/cobbler.rst
@@ -26,125 +26,125 @@ cobbler.api module
 
 .. automodule:: cobbler.api
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.cexceptions module
 --------------------------
 
 .. automodule:: cobbler.cexceptions
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.configgen module
 ------------------------
 
 .. automodule:: cobbler.configgen
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.decorator module
 ------------------------
 
 .. automodule:: cobbler.decorator
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.download\_manager module
 --------------------------------
 
 .. automodule:: cobbler.download_manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.enums module
 --------------------
 
 .. automodule:: cobbler.enums
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.grub module
 -------------------
 
 .. automodule:: cobbler.grub
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.module\_loader module
 -----------------------------
 
 .. automodule:: cobbler.module_loader
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.power\_manager module
 -----------------------------
 
 .. automodule:: cobbler.power_manager
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.remote module
 ---------------------
 
 .. automodule:: cobbler.remote
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.serializer module
 -------------------------
 
 .. automodule:: cobbler.serializer
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.services module
 -----------------------
 
 .. automodule:: cobbler.services
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.tftpgen module
 ----------------------
 
 .. automodule:: cobbler.tftpgen
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.validate module
 -----------------------
 
 .. automodule:: cobbler.validate
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.yumgen module
 ---------------------
 
 .. automodule:: cobbler.yumgen
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.settings.migrations.rst
+++ b/docs/code-autodoc/cobbler.settings.migrations.rst
@@ -9,149 +9,149 @@ cobbler.settings.migrations.V2\_8\_5 module
 
 .. automodule:: cobbler.settings.migrations.V2_8_5
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_0\_0 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_0_0
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_0\_1 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_0_1
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_1\_0 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_1_0
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_1\_1 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_1_1
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_1\_2 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_1_2
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_2\_0 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_2_0
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_2\_1 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_2_1
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_0 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_0
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_1 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_1
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_2 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_2
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_3 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_3
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_4 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_4
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_5 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_5
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_6 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_6
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.V3\_3\_7 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V3_3_7
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
-cobbler.settings.migrations.V3\_4\_0 module
+cobbler.settings.migrations.V4\_0\_0 module
 -------------------------------------------
 
 .. automodule:: cobbler.settings.migrations.V4_0_0
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.settings.migrations.helper module
 -----------------------------------------
 
 .. automodule:: cobbler.settings.migrations.helper
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.settings.migrations
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.settings.rst
+++ b/docs/code-autodoc/cobbler.settings.rst
@@ -17,13 +17,13 @@ cobbler.settings.cli module
 
 .. automodule:: cobbler.settings.cli
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.settings
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.templates.rst
+++ b/docs/code-autodoc/cobbler.templates.rst
@@ -9,21 +9,21 @@ cobbler.templates.cheetah module
 
 .. automodule:: cobbler.templates.cheetah
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.templates.jinja module
 ------------------------------
 
 .. automodule:: cobbler.templates.jinja
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.templates
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/code-autodoc/cobbler.utils.rst
+++ b/docs/code-autodoc/cobbler.utils.rst
@@ -9,69 +9,69 @@ cobbler.utils.event module
 
 .. automodule:: cobbler.utils.event
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.filesystem\_helpers module
 ----------------------------------------
 
 .. automodule:: cobbler.utils.filesystem_helpers
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.input\_converters module
 --------------------------------------
 
 .. automodule:: cobbler.utils.input_converters
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.kernel\_command\_line module
 ------------------------------------------
 
 .. automodule:: cobbler.utils.kernel_command_line
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.mtab module
 -------------------------
 
 .. automodule:: cobbler.utils.mtab
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.process\_management module
 ----------------------------------------
 
 .. automodule:: cobbler.utils.process_management
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.signatures module
 -------------------------------
 
 .. automodule:: cobbler.utils.signatures
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 cobbler.utils.thread module
 ---------------------------
 
 .. automodule:: cobbler.utils.thread
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Module contents
 ---------------
 
 .. automodule:: cobbler.utils
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/user-guide/tftp.rst
+++ b/docs/user-guide/tftp.rst
@@ -1,3 +1,5 @@
+.. _tftp-directory:
+
 ******************
 The TFTP Directory
 ******************
@@ -90,3 +92,29 @@ from. Those files should not be touched by Cobbler and should survive even a ``c
 
 .. note:: In case Cobbler is not able to find a MAC for the interface it tries to generate an entry for, it falls back
           first to the IP and finally uses the name if no IP is known to Cobbler.
+
+Dynamic (no-copy) TFTP serving
+###############################
+
+Everything described above is the behaviour of the default ``managers.in_tftpd`` module (see ``modules.tftpd.module``
+in :ref:`settings-ref`), which materializes the TFTP directory on disk so that a normal ``tftpd``/``in.tftpd``
+process can serve it statically.
+
+Cobbler also ships a second module, ``managers.dynamic_tftp``, for use with a separate, stateless TFTP server such as
+`cobbler-tftp <https://github.com/cobbler/cobbler-tftp>`_. Instead of materializing files on disk, that server calls
+back into Cobbler's XML-RPC API (``get_tftp_file``) for every request, and Cobbler resolves the requested path on the
+fly -- reading bootloaders/kernels/initrds/images straight from where they already live, and rendering PXE/GRUB/menu
+configuration in memory.
+
+When ``managers.dynamic_tftp`` is selected:
+
+* None of the "Behaviour" steps above happen. ``cobbler sync`` becomes a no-op with respect to the TFTP directory --
+  no directories are created, no bootloaders/kernels/initrds/images are copied, and no PXE/GRUB configuration files
+  are written to disk.
+* The default ``tftpboot/grub.cfg``/``tftpboot/grub/*`` content is served directly from Cobbler's bundled package
+  data instead of being copied anywhere. To override it with your own default GRUB configuration, drop the replacement
+  file(s) into ``grubconfig_dir`` (``/var/lib/cobbler/grub_config`` by default) -- this directory is always checked
+  before the bundled default, for both the classic and the dynamic module.
+* ``manage_tftpd`` must be set to ``False``. It only controls whether Cobbler manages a local ``in.tftpd``-style
+  service, which does not apply when a separate server like cobbler-tftp is responsible for TFTP. ``cobbler check``
+  warns if both are enabled at once.

--- a/tests/actions/check_test.py
+++ b/tests/actions/check_test.py
@@ -1,0 +1,73 @@
+"""
+Tests that validate the functionality of the module that performs sanity checks on a Cobbler installation
+(the code behind "cobbler check").
+"""
+
+from typing import TYPE_CHECKING
+
+from cobbler.actions import check
+from cobbler.api import CobblerAPI
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+def test_run_warns_on_dynamic_tftp_with_manage_tftpd_enabled(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI
+):
+    """
+    Test that "cobbler check" warns when the 'dynamic_tftp' TFTP manager is selected while manage_tftpd is still
+    enabled, since that combination leaves cobbler-tftp's own service unmanaged/conflicting with Cobbler.
+    """
+    # Arrange
+    cobbler_api.settings().manage_tftpd = True
+    sync_mock = mocker.MagicMock()
+    sync_mock.tftpd.what.return_value = "dynamic_tftp"
+    mocker.patch.object(cobbler_api, "get_sync", return_value=sync_mock)
+    test_check = check.CobblerCheck(cobbler_api)
+
+    # Act
+    status = test_check.run()
+
+    # Assert
+    assert any("dynamic_tftp" in message for message in status)
+
+
+def test_run_does_not_warn_when_manage_tftpd_disabled(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI
+):
+    """
+    Test that no warning is emitted for the 'dynamic_tftp' TFTP manager when manage_tftpd is correctly disabled.
+    """
+    # Arrange
+    cobbler_api.settings().manage_tftpd = False
+    sync_mock = mocker.MagicMock()
+    sync_mock.tftpd.what.return_value = "dynamic_tftp"
+    mocker.patch.object(cobbler_api, "get_sync", return_value=sync_mock)
+    test_check = check.CobblerCheck(cobbler_api)
+
+    # Act
+    status = test_check.run()
+
+    # Assert
+    assert not any("dynamic_tftp" in message for message in status)
+
+
+def test_run_does_not_warn_for_in_tftpd_manager(
+    mocker: "MockerFixture", cobbler_api: CobblerAPI
+):
+    """
+    Test that the new guard doesn't fire for the classic 'in_tftpd' manager, regardless of manage_tftpd.
+    """
+    # Arrange
+    cobbler_api.settings().manage_tftpd = True
+    sync_mock = mocker.MagicMock()
+    sync_mock.tftpd.what.return_value = "in_tftpd"
+    mocker.patch.object(cobbler_api, "get_sync", return_value=sync_mock)
+    test_check = check.CobblerCheck(cobbler_api)
+
+    # Act
+    status = test_check.run()
+
+    # Assert
+    assert not any("dynamic_tftp" in message for message in status)

--- a/tests/module_loader_test.py
+++ b/tests/module_loader_test.py
@@ -182,6 +182,7 @@ def test_get_module_from_file(
             [
                 "cobbler.modules.managers.bind",
                 "cobbler.modules.managers.dnsmasq",
+                "cobbler.modules.managers.dynamic_tftp",
                 "cobbler.modules.managers.in_tftpd",
                 "cobbler.modules.managers.isc",
                 "cobbler.modules.managers.ndjbdns",

--- a/tests/modules/managers/dynamic_tftp_test.py
+++ b/tests/modules/managers/dynamic_tftp_test.py
@@ -1,0 +1,174 @@
+"""
+Tests that validate the functionality of the module that serves TFTP content dynamically (e.g. via cobbler-tftp)
+instead of copying it into the TFTP root.
+"""
+
+from typing import TYPE_CHECKING, Any, Generator
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.modules.managers import dynamic_tftp
+from cobbler.settings import Settings
+from cobbler.tftpgen import TFTPGen
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+@pytest.fixture(name="api_mock_dynamic_tftp")
+def fixture_api_mock_dynamic_tftp(mocker: "MockerFixture") -> CobblerAPI:
+    """
+    Fixture to provide a mocked CobblerAPI instance with necessary attributes for testing the dynamic_tftp manager.
+    """
+    api_mock_dynamic_tftp = mocker.MagicMock(spec=CobblerAPI)
+    settings_mock = mocker.MagicMock(
+        name="dynamic_tftp_setting_mock", spec=Settings, autospec=True
+    )
+    settings_mock.tftpboot_location = "/var/lib/tftpboot"
+    settings_mock.webdir = "/srv/www/cobbler"
+    api_mock_dynamic_tftp.settings.return_value = settings_mock
+    api_mock_dynamic_tftp.distros = mocker.MagicMock(return_value=[])
+    api_mock_dynamic_tftp.profiles = mocker.MagicMock(return_value=[])
+    api_mock_dynamic_tftp.systems = mocker.MagicMock(return_value=[])
+    api_mock_dynamic_tftp.repos = mocker.MagicMock(return_value=[])
+    api_mock_dynamic_tftp.tftpgen = mocker.MagicMock(spec=TFTPGen, autospec=True)
+    return api_mock_dynamic_tftp
+
+
+@pytest.fixture(name="reset_singleton", scope="function", autouse=True)
+def fixture_reset_singleton() -> Generator[Any, Any, Any]:
+    """
+    Fixture to reset the singleton instance of _DynamicTftpManager before and after each test.
+    """
+    dynamic_tftp.MANAGER = None
+    yield
+    dynamic_tftp.MANAGER = None
+
+
+def test_register():
+    """
+    Test the register function to ensure it returns the expected string.
+    """
+    # Arrange & Act
+    result = dynamic_tftp.register()
+
+    # Assert
+    assert result == "manage"
+
+
+def test_manager_what():
+    """
+    Test the what method of the _DynamicTftpManager class to ensure it returns the expected string.
+    """
+    # pylint: disable=protected-access
+    # Arrange & Act & Assert
+    assert dynamic_tftp._DynamicTftpManager.what() == "dynamic_tftp"  # type: ignore[reportPrivateUsage]
+
+
+def test_dynamic_tftp_singleton(mocker: "MockerFixture"):
+    """
+    Test to ensure that the _DynamicTftpManager class implements the singleton pattern correctly.
+    """
+    # Arrange
+    mcollection = mocker.Mock()
+
+    # Act
+    manager_1 = dynamic_tftp.get_manager(mcollection)
+    manager_2 = dynamic_tftp.get_manager(mcollection)
+
+    # Assert
+    assert manager_1 == manager_2
+
+
+def test_manager_write_boot_files(api_mock_dynamic_tftp: CobblerAPI):
+    """
+    Test that write_boot_files is a no-op that doesn't touch tftpgen.
+    """
+    # Arrange
+    manager_obj = dynamic_tftp.get_manager(api_mock_dynamic_tftp)
+    tftpgen_mock = api_mock_dynamic_tftp.tftpgen
+
+    # Act
+    result = manager_obj.write_boot_files()
+
+    # Assert
+    assert result == 0
+    assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+
+
+def test_manager_sync_single_system(api_mock_dynamic_tftp: CobblerAPI):
+    """
+    Test that sync_single_system is a no-op that doesn't touch tftpgen.
+    """
+    # Arrange
+    manager_obj = dynamic_tftp.get_manager(api_mock_dynamic_tftp)
+    tftpgen_mock = api_mock_dynamic_tftp.tftpgen
+
+    # Act
+    result = manager_obj.sync_single_system(None, None)  # type: ignore[reportArgumentType,arg-type]
+
+    # Assert
+    assert result == 0
+    assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+
+
+def test_manager_add_single_distro(api_mock_dynamic_tftp: CobblerAPI):
+    """
+    Test that add_single_distro is a no-op that doesn't touch tftpgen.
+    """
+    # Arrange
+    manager_obj = dynamic_tftp.get_manager(api_mock_dynamic_tftp)
+    tftpgen_mock = api_mock_dynamic_tftp.tftpgen
+
+    # Act
+    manager_obj.add_single_distro(None)  # type: ignore[reportArgumentType,arg-type]
+
+    # Assert
+    assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+
+
+def test_manager_add_single_image(api_mock_dynamic_tftp: CobblerAPI):
+    """
+    Test that add_single_image is a no-op that doesn't touch tftpgen.
+    """
+    # Arrange
+    manager_obj = dynamic_tftp.get_manager(api_mock_dynamic_tftp)
+    tftpgen_mock = api_mock_dynamic_tftp.tftpgen
+
+    # Act
+    manager_obj.add_single_image(None)  # type: ignore[reportArgumentType,arg-type]
+
+    # Assert
+    assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+
+
+def test_manager_sync_systems(api_mock_dynamic_tftp: CobblerAPI):
+    """
+    Test that sync_systems is a no-op that doesn't touch tftpgen.
+    """
+    # Arrange
+    manager_obj = dynamic_tftp.get_manager(api_mock_dynamic_tftp)
+    tftpgen_mock = api_mock_dynamic_tftp.tftpgen
+
+    # Act
+    manager_obj.sync_systems(["t1.example.org"], True)
+
+    # Assert
+    assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]
+
+
+def test_manager_sync(api_mock_dynamic_tftp: CobblerAPI):
+    """
+    Test that sync is a no-op that doesn't touch tftpgen.
+    """
+    # Arrange
+    manager_obj = dynamic_tftp.get_manager(api_mock_dynamic_tftp)
+    tftpgen_mock = api_mock_dynamic_tftp.tftpgen
+
+    # Act
+    result = manager_obj.sync()
+
+    # Assert
+    assert result == 0
+    assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -184,6 +184,22 @@ def test_manager_add_single_distro(mocker: "MockerFixture", api_mock_tftp: Cobbl
     assert manager_obj.write_boot_files_distro.call_count == 1  # type: ignore[reportFunctionMemberAccess,attr-defined]
 
 
+def test_manager_add_single_image(api_mock_tftp: CobblerAPI):
+    """
+    Test to verify the add_single_image method of the InTftpdManager class.
+    """
+    # Arrange
+    manager_obj = in_tftpd.get_manager(api_mock_tftp)
+    tftpgen_mock = api_mock_tftp.tftpgen
+
+    # Act
+    manager_obj.add_single_image(None)  # type: ignore[reportArgumentType,arg-type]
+
+    # Assert
+    # pylint: disable=no-member
+    assert tftpgen_mock.copy_single_image_files.call_count == 1  # type: ignore[reportFunctionMemberAccess,attr-defined]
+
+
 @pytest.mark.parametrize(
     "input_systems, input_verbose, expected_output",
     [(["t1.example.org"], True, "t1.example.org")],

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -1236,3 +1236,130 @@ def test_generate_tftp_file_uses_fast_path(
     # Exactly one call (for the resolved candidate) - if the fast path had failed and fallen back to
     # the full scan, this would be called once per system up to and including the match.
     assert generate_system_file_spy.call_count == 1
+
+
+def test_get_bundled_grub_file_returns_default_grub_cfg(cobbler_api: CobblerAPI):
+    """
+    Test that _get_bundled_grub_file() serves Cobbler's embedded default grub.cfg straight from the package
+    resources, without anything needing to be copied to disk.
+    """
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    expected = (
+        tftpgen.files("cobbler.data.config.grub").joinpath("grub.cfg").read_bytes()
+    )
+
+    # Act
+    content, length = test_gen._get_bundled_grub_file(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/grub.cfg"), 0, 10_000
+    )
+
+    # Assert
+    assert content == expected
+    assert length == len(expected)
+
+
+def test_get_bundled_grub_file_returns_default_grub_subfolder_file(
+    cobbler_api: CobblerAPI,
+):
+    """
+    Test that _get_bundled_grub_file() also serves files bundled under the "grub/" subfolder.
+    """
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    expected = (
+        tftpgen.files("cobbler.data.config.grub")
+        .joinpath("grub")
+        .joinpath("local_efi.cfg")
+        .read_bytes()
+    )
+
+    # Act
+    content, length = test_gen._get_bundled_grub_file(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/grub/local_efi.cfg"), 0, 10_000
+    )
+
+    # Assert
+    assert content == expected
+    assert length == len(expected)
+
+
+def test_get_bundled_grub_file_returns_none_for_unrelated_path(
+    cobbler_api: CobblerAPI,
+):
+    """
+    Test that _get_bundled_grub_file() returns None for paths that aren't part of the bundled default GRUB
+    configuration, so the caller can continue its own fallback/error handling.
+    """
+    # Arrange
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act / Assert
+    assert (
+        test_gen._get_bundled_grub_file(  # type: ignore[reportPrivateUsage]
+            pathlib.Path("/pxelinux.0"), 0, 10_000
+        )
+        is None
+    )
+    assert (
+        test_gen._get_bundled_grub_file(  # type: ignore[reportPrivateUsage]
+            pathlib.Path("/grub/does_not_exist.cfg"), 0, 10_000
+        )
+        is None
+    )
+
+
+def test_get_static_tftp_file_falls_back_to_bundled_grub_cfg(
+    tmp_path: pathlib.Path, cobbler_api: CobblerAPI
+):
+    """
+    Test that _get_static_tftp_file() falls back to the bundled default grub.cfg when it's absent from both
+    bootloaders_dir and grubconfig_dir.
+    """
+    # Arrange
+    cobbler_api.settings().bootloaders_dir = str(tmp_path / "loaders")
+    cobbler_api.settings().grubconfig_dir = str(tmp_path / "grub_config")
+    os.makedirs(cobbler_api.settings().bootloaders_dir)
+    os.makedirs(cobbler_api.settings().grubconfig_dir)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+    expected = (
+        tftpgen.files("cobbler.data.config.grub").joinpath("grub.cfg").read_bytes()
+    )
+
+    # Act
+    result = test_gen._get_static_tftp_file(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/grub.cfg"), 0, 10_000
+    )
+
+    # Assert
+    assert result is not None
+    content, length = result
+    assert content == expected
+    assert length == len(expected)
+
+
+def test_get_static_tftp_file_grubconfig_override_takes_precedence(
+    tmp_path: pathlib.Path, cobbler_api: CobblerAPI
+):
+    """
+    Test that a custom grub.cfg placed in grubconfig_dir is served instead of the bundled default.
+    """
+    # Arrange
+    cobbler_api.settings().bootloaders_dir = str(tmp_path / "loaders")
+    cobbler_api.settings().grubconfig_dir = str(tmp_path / "grub_config")
+    os.makedirs(cobbler_api.settings().bootloaders_dir)
+    os.makedirs(cobbler_api.settings().grubconfig_dir)
+    override_content = b"# custom override grub.cfg\n"
+    (tmp_path / "grub_config" / "grub.cfg").write_bytes(override_content)
+    test_gen = tftpgen.TFTPGen(cobbler_api)
+
+    # Act
+    result = test_gen._get_static_tftp_file(  # type: ignore[reportPrivateUsage]
+        pathlib.Path("/grub.cfg"), 0, 10_000
+    )
+
+    # Assert
+    assert result is not None
+    content, length = result
+    assert content == override_content
+    assert length == len(override_content)


### PR DESCRIPTION
## Linked Items

Fixes #4039

## Description

This PR updates the performance benchmark baseline, adds a `apidocs` target to the `Makefile` (checked inside the CI) and a new module that assumes that cobbler-tftp is used for providing TFTP connectivity (skipping writes to disk for the TFTP-root).

## Behaviour changes

Old: Cobbler wrote potentially thousands of files to disk inside the TFTP-root.

New: Each file is generated on demand via `CobblerAPI.get_tftp_file()`.

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
