### PR TITLE
fix: close cobblerd restart race in integration test fixtures

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -54,6 +54,35 @@ def fixture_restart_cobbler() -> Callable[[], None]:
     return _restart_cobbler
 
 
+def wait_for_cobblerd(
+    remote: Any, timeout: float = 30.0, interval: float = 0.5
+) -> None:
+    """
+    Poll cobblerd's XML-RPC endpoint until it responds.
+
+    The process manager (e.g. supervisord) only guarantees that the cobblerd process didn't immediately die after a
+    restart, not that it has finished initializing and bound its XML-RPC listener. Callers that talk to cobblerd
+    right after restarting it can otherwise lose a race and see a 503 from the reverse proxy.
+
+    :param remote: An XML-RPC client pointed at cobblerd's endpoint.
+    :param timeout: How long to keep retrying before giving up, in seconds.
+    :param interval: How long to wait between retries, in seconds.
+    :raises TimeoutError: If cobblerd is still unreachable once ``timeout`` has elapsed.
+    """
+    deadline = time.monotonic() + timeout
+    last_error: BaseException = TimeoutError("no attempt was made")
+    while time.monotonic() < deadline:
+        try:
+            remote.ping()
+            return
+        except (OSError, xmlrpc.client.ProtocolError) as error:
+            last_error = error
+            time.sleep(interval)
+    raise TimeoutError(
+        f"cobblerd's XML-RPC endpoint did not become reachable within {timeout}s"
+    ) from last_error
+
+
 @pytest.fixture(name="reset_cobbler", autouse=True)
 def fixture_reset_cobbler(
     restart_cobbler: Callable[[], None],
@@ -62,6 +91,10 @@ def fixture_reset_cobbler(
     Fixture to reset Cobbler after each test.
     """
     restart_cobbler()
+    try:
+        wait_for_cobblerd(xmlrpc.client.ServerProxy("http://localhost/cobbler_api"))
+    except TimeoutError as error:
+        pytest.fail(str(error))
     yield
 
 

--- a/tests/integration/conftest_test.py
+++ b/tests/integration/conftest_test.py
@@ -1,0 +1,34 @@
+"""
+Tests for helpers defined in the integration test conftest module.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+
+from tests.integration.conftest import wait_for_cobblerd
+
+
+def test_wait_for_cobblerd_returns_once_ping_succeeds() -> None:
+    """
+    Test that "wait_for_cobblerd" retries through transient connection failures - the state right after a cobblerd
+    restart, before it has bound its XML-RPC listener - and returns as soon as a ping succeeds.
+    """
+    remote = Mock()
+    remote.ping.side_effect = [ConnectionRefusedError(), ConnectionRefusedError(), True]
+
+    wait_for_cobblerd(remote, timeout=5, interval=0)
+
+    assert remote.ping.call_count == 3
+
+
+def test_wait_for_cobblerd_raises_timeout_if_never_reachable() -> None:
+    """
+    Test that "wait_for_cobblerd" gives up and raises "TimeoutError" if cobblerd never becomes reachable, instead
+    of retrying forever.
+    """
+    remote = Mock()
+    remote.ping.side_effect = ConnectionRefusedError("connection refused")
+
+    with pytest.raises(TimeoutError):
+        wait_for_cobblerd(remote, timeout=0.05, interval=0.01)


### PR DESCRIPTION
## Linked Items

None

## Description

The autouse reset_cobbler fixture restarted cobblerd before every integration test and immediately logged in over XML-RPC. supervisord's startProcess only confirms the process survived startsecs (1s), not that cobblerd finished initializing and bound its listener, so under load (e.g. right after a heavy buildiso run) the login could hit Apache before cobblerd was ready and get a 503, failing the next test's setup. Poll cobblerd's ping() with a timeout after restarting it instead of assuming it's immediately ready.

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
