### PR TITLE
fix: replace bare except with except Exception in utils

### DIFF
--- a/cobbler/utils/__init__.py
+++ b/cobbler/utils/__init__.py
@@ -413,7 +413,7 @@ def read_file_contents(
             with open(file_location, encoding="UTF-8") as file_fd:
                 data = file_fd.read()
             return data
-        except:
+        except Exception:
             log_exc()
             raise
 


### PR DESCRIPTION

### Summary

`cobbler/utils/__init__.py` `grab_file_contents()` has a bare `except:` that
logs and re-raises. A bare except also intercepts
`KeyboardInterrupt`/`SystemExit` before re-raising, which is unnecessary and
hides intent.

Replace with `except Exception:` — behavior is identical (the handler always
logs and re-raises), but only expected exceptions are intercepted.

### Verification

- `python -m py_compile cobbler/utils/__init__.py` → OK
- `grep -c "except:" cobbler/utils/__init__.py` → 0 remaining bare handlers

### Files changed

- `cobbler/utils/__init__.py` (1 line)