### PR TITLE
Containerisation Sidecar Fixup

### DIFF
--- a/cobbler/data/templates/cheetah/etc/dhcp6.template
+++ b/cobbler/data/templates/cheetah/etc/dhcp6.template
@@ -68,13 +68,13 @@ host $iface.name {
     #end if
     ##
     ## fixed-address6
-    fixed-address6 $iface.ipv6_address;
+    fixed-address6 $iface.ipv6.address;
     ##
     ## host-name
     #if $iface.hostname:
     option host-name "$iface.hostname";
-    #else if $iface.dns_name:
-    option host-name "$iface.dns_name";
+    #else if $iface.dns.name:
+    option host-name "$iface.dns.name";
     #end if
     ##
     ## dhcp6.bootfile-url

--- a/cobbler/modules/managers/bind.py
+++ b/cobbler/modules/managers/bind.py
@@ -11,13 +11,14 @@ import pathlib
 import re
 import socket
 import time
-from typing import TYPE_CHECKING, Dict, Iterable, List, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
 
 from cobbler import enums, utils
 from cobbler.modules.managers import DnsManagerModule
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
+    from cobbler.items.template import Template
 
 
 MANAGER = None
@@ -68,6 +69,35 @@ class _BindManager(DnsManagerModule):
         """
         Not used.
         """
+
+    def __find_named_template(self, tag: str, error_message: str) -> "Template":
+        """
+        Find the active (falling back to default) template for the given tag.
+
+        Mirrors isc.py's "prefer active over default" tie-breaking
+        (cobbler/modules/managers/isc.py's ``_write_config()``) - a plain
+        ``find_template(False, ...)`` has no such preference: it just returns whichever
+        collection-insertion-order match happens to come first, which is always the
+        read-only built-in template rather than any custom, "active"-tagged one an admin
+        registers alongside it.
+
+        :param tag: The ``TemplateTag`` value to search for.
+        :param error_message: Error to raise if neither an active nor a default template
+                               is found.
+        """
+        search_result = self.api.find_template(True, False, tags=tag)
+        if search_result is None or not isinstance(search_result, list):
+            raise TypeError("Search result for named template must be of type list!")
+        named_template: Optional["Template"] = None
+        for template in search_result:
+            if enums.TemplateTag.ACTIVE.value in template.tags:
+                named_template = template
+                break
+            if enums.TemplateTag.DEFAULT.value in template.tags:
+                named_template = template
+        if named_template is None:
+            raise ValueError(error_message)
+        return named_template
 
     @staticmethod
     def __expand_ipv6(address: str) -> str:
@@ -308,11 +338,10 @@ zone "{arpa}." {{
 """
             metadata.zone_include = metadata.zone_include + txt
 
-        search_result = self.api.find_template(
-            False, False, tags=enums.TemplateTag.NAMED_PRIMARY.value
+        search_result = self.__find_named_template(
+            enums.TemplateTag.NAMED_PRIMARY.value,
+            "Could not location primary named template.",
         )
-        if search_result is None or isinstance(search_result, list):
-            raise ValueError("Could not location primary named template.")
 
         self.logger.info("generating %s", settings_file)
         self.api.templar.render(search_result.content, metadata.__dict__, settings_file)
@@ -366,11 +395,10 @@ zone "{arpa}." {{
             metadata.zone_include = metadata.zone_include + txt
             metadata.bind_master = self.settings.bind_master
 
-        search_result = self.api.find_template(
-            False, False, tags=enums.TemplateTag.NAMED_SECONDARY.value
+        search_result = self.__find_named_template(
+            enums.TemplateTag.NAMED_SECONDARY.value,
+            "Could not location secondary named template.",
         )
-        if search_result is None or isinstance(search_result, list):
-            raise ValueError("Could not location secondary named template.")
 
         self.logger.info("generating %s", settings_file)
         self.api.templar.render(search_result.content, metadata.__dict__, settings_file)
@@ -527,11 +555,10 @@ zone "{arpa}." {{
         forward = self.__forward_zones()
         reverse = self.__reverse_zones()
 
-        search_result = self.api.find_template(
-            False, False, tags=enums.TemplateTag.NAMED_ZONE_DEFAULT.value
+        search_result = self.__find_named_template(
+            enums.TemplateTag.NAMED_ZONE_DEFAULT.value,
+            "Could not locate default zone named template.",
         )
-        if search_result is None or isinstance(search_result, list):
-            raise ValueError("Could not locate default zone named template.")
 
         zonefileprefix = self.settings.bind_chroot_path + self.zonefile_base
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -31,6 +31,9 @@ services:
       - source: cobbler-settings
         target: /etc/cobbler/settings.yaml
         mode: 0640
+      - source: cobbler-logging-config
+        target: /etc/cobbler/logging_config.conf
+        mode: 0644
     volumes:
       - cobbler-etc:/etc/cobbler:z
       - cobbler-var-lib:/var/lib/cobbler:z

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -41,6 +41,7 @@ services:
       - cobbler-tftproot:/srv/tftpboot:z
       - cobbler-dhcp-config:/etc/cobbler-dhcp:z
       - cobbler-dns-config:/etc/cobbler-dns:z
+      - cobbler-dns-zones:/var/lib/named:z
       - type: bind
         source: ${COBBLER_DISTRO_SOURCE_DIR:-./distro-sources}
         target: /srv/distro-sources

--- a/compose.yml
+++ b/compose.yml
@@ -28,6 +28,9 @@ services:
       - source: cobbler-settings
         target: /etc/cobbler/settings.yaml
         mode: 0640
+      - source: cobbler-logging-config
+        target: /etc/cobbler/logging_config.conf
+        mode: 0644
     volumes:
       - cobbler-etc:/etc/cobbler:z
       - cobbler-var-lib:/var/lib/cobbler:z

--- a/compose.yml
+++ b/compose.yml
@@ -38,6 +38,7 @@ services:
       - cobbler-tftproot:/srv/tftpboot:z
       - cobbler-dhcp-config:/etc/cobbler-dhcp:z
       - cobbler-dns-config:/etc/cobbler-dns:z
+      - cobbler-dns-zones:/var/lib/named:z
       - type: bind
         source: ${COBBLER_DISTRO_SOURCE_DIR:-./distro-sources}
         target: /srv/distro-sources

--- a/docker/compose/base.yml
+++ b/docker/compose/base.yml
@@ -15,6 +15,7 @@ volumes:
   cobbler-tftproot:
   cobbler-dhcp-config:
   cobbler-dns-config:
+  cobbler-dns-zones:
 
 configs:
   cobbler-settings:
@@ -22,6 +23,7 @@ configs:
       tftpboot_location: "/srv/tftpboot"
       webdir: "/srv/www/cobbler"
       manage_tftpd: false
+      bind_zonefile_path: "/var/lib/named"
 
       modules:
         authentication:

--- a/docker/compose/base.yml
+++ b/docker/compose/base.yml
@@ -49,6 +49,36 @@ configs:
         serializers:
           module: "serializers.file"
 
+  # Overrides the RPM-shipped /etc/cobbler/logging_config.conf for the "cobblerd" service: raises
+  # handler_stdout to DEBUG (root logger is already DEBUG) so debug-level output actually reaches
+  # "docker compose logs cobblerd" instead of being filtered out by the handler, and drops the FileHandler
+  # entirely -- containers log to stdout, not to a file that would silently accumulate inside the container
+  # (or need its own volume/rotation) at /var/log/cobbler/cobbler.log.
+  cobbler-logging-config:
+    content: |
+      [loggers]
+      keys=root
+
+      [handlers]
+      keys=stdout
+
+      [formatters]
+      keys=stdout
+
+      [logger_root]
+      level=DEBUG
+      handlers=stdout
+
+      [handler_stdout]
+      class=StreamHandler
+      level=DEBUG
+      formatter=stdout
+      args=(sys.stdout,)
+
+      [formatter_stdout]
+      format=%(levelname)s | %(message)s
+      class=logging.Formatter
+
 services:
   traefik:
     image: traefik:v3.6

--- a/docker/compose/dns.dev.yml
+++ b/docker/compose/dns.dev.yml
@@ -11,6 +11,7 @@ services:
       dockerfile: docker/images/dns/Dockerfile
     volumes:
       - cobbler-dns-config:/etc/cobbler-dns:ro,z
+      - cobbler-dns-zones:/var/lib/named:ro,z
     networks:
       - cobbler
     depends_on:

--- a/docker/compose/dns.yml
+++ b/docker/compose/dns.yml
@@ -9,6 +9,7 @@ services:
     image: ghcr.io/cobbler/cobbler-dns:latest
     volumes:
       - cobbler-dns-config:/etc/cobbler-dns:ro,z
+      - cobbler-dns-zones:/var/lib/named:ro,z
     networks:
       - cobbler
     depends_on:

--- a/docker/images/cobblerd/Dockerfile
+++ b/docker/images/cobblerd/Dockerfile
@@ -74,11 +74,15 @@ RUN zypper --no-gpg-checks install --no-recommends -y /tmp/rpms/cobbler-[0-9]*.n
 # /srv/tftpboot: tftproot (openSUSE packaging convention for cobbler.spec's %tftpboot_dir; follow
 #   whatever "tftpboot_location" is set to in the mounted settings.yaml).
 RUN mkdir -p /etc/cobbler /srv/www/cobbler /var/lib/cobbler /srv/tftpboot
-# /etc/dhcpd.conf, /etc/named.conf: this image never installs dhcp-server/bind (DHCP/DNS run in the
-# separate "dhcp"/"dns" sidecar containers -- see docker/images/dhcp/Dockerfile, docker/images/dns/
-# Dockerfile), but cobbler/modules/managers/isc.py and bind.py still open() these exact, hardcoded paths
-# for writing whenever manage_dhcp/manage_dns is enabled -- and compose.yml/compose.dev.yml needs to
-# share whatever lands there with the "dhcp"/"dns" sidecars via a volume.
+# /etc/dhcpd.conf, /etc/dhcpd6.conf, /etc/named.conf: this image never installs dhcp-server/bind
+# (DHCP/DNS run in the separate "dhcp"/"dns" sidecar containers -- see docker/images/dhcp/Dockerfile,
+# docker/images/dns/Dockerfile), but cobbler/modules/managers/isc.py and bind.py still open() these
+# exact, hardcoded paths for writing whenever manage_dhcp_v4/manage_dhcp_v6/manage_dns is enabled --
+# and compose.yml/compose.dev.yml needs to share whatever lands there with the "dhcp"/"dns" sidecars
+# via a volume. dhcpconf_location() resolves protocol=V6 to "/etc/dhcpd6.conf" on this image's distro
+# family (see cobbler/utils/dhcpconf_location()'s "dist == \"suse\"" branch) -- without a symlink for
+# it too, a v6 sync silently writes straight to this container's own ephemeral filesystem instead of
+# the shared volume, never reaching the "dhcp" sidecar.
 #
 # Mounting a named volume directly onto a path that's a plain file (rather than a directory) relies on
 # Docker's "seed a fresh volume from the image's own content at that mount point" feature -- which is a
@@ -88,11 +92,12 @@ RUN mkdir -p /etc/cobbler /srv/www/cobbler /var/lib/cobbler /srv/tftpboot
 # works). Sidestep the whole class of problem: share a plain *directory* per service instead (Docker's
 # directory-volume case is unambiguous and robust everywhere) and symlink the exact file path isc.py/
 # bind.py expect into it. open() transparently follows symlinks, so no cobbler source changes are
-# needed -- dhcpconf_location()/namedconf_location() still resolve to "/etc/dhcpd.conf"/"/etc/named.conf"
-# exactly as before. The "dhcp"/"dns" sidecar images set up the identical symlink so both sides of each
-# shared volume agree on where the real file actually lives.
+# needed -- dhcpconf_location()/namedconf_location() still resolve to "/etc/dhcpd.conf"/
+# "/etc/dhcpd6.conf"/"/etc/named.conf" exactly as before. The "dhcp"/"dns" sidecar images set up the
+# identical symlink so both sides of each shared volume agree on where the real file actually lives.
 RUN mkdir -p /etc/cobbler-dhcp /etc/cobbler-dns && \
     ln -s /etc/cobbler-dhcp/dhcpd.conf /etc/dhcpd.conf && \
+    ln -s /etc/cobbler-dhcp/dhcpd6.conf /etc/dhcpd6.conf && \
     ln -s /etc/cobbler-dns/named.conf /etc/named.conf
 VOLUME ["/etc/cobbler", "/srv/www/cobbler", "/var/lib/cobbler", "/srv/tftpboot", "/etc/cobbler-dhcp", "/etc/cobbler-dns"]
 

--- a/docs/user-guide/docker-deployment.rst
+++ b/docs/user-guide/docker-deployment.rst
@@ -310,6 +310,15 @@ mounted directly onto a path that is a plain file in the image -- confirmed outr
 fails unconditionally) on at least one real Docker Engine build, regardless of whether that file is empty or has
 real content. Mounting onto a directory instead is the unambiguous, universally-supported case.
 
+``named.conf`` alone isn't enough for the ``dns`` sidecar to actually serve anything, though: ``bind.py`` also
+renders the zone files it references to ``bind_zonefile_path`` (``/var/lib/named`` by default), a directory
+separate from ``/etc/cobbler-dns``. The ``cobbler-dns-zones`` volume, mounted at ``/var/lib/named`` on both
+``cobblerd`` (read-write) and the ``dns`` sidecar (read-only), carries that zone data across -- the same
+plain-directory-volume approach as ``cobbler-dns-config``, without needing a symlink trick since
+``/var/lib/named`` is already a directory in both images, not a single file. ``docker/compose/base.yml`` also
+pins ``bind_zonefile_path: "/var/lib/named"`` explicitly in the ``cobbler-settings`` config so it can't silently
+drift out of sync with this mount path.
+
 The ``dhcp`` sidecar additionally runs with ``network_mode: host`` instead of joining the ``cobbler`` bridge
 network like everything else in the stack -- ISC ``dhcpd`` needs real L2 broadcast visibility to serve DHCP
 clients, which a NAT'd bridge network does not provide. The ``dns`` sidecar has no such requirement and stays


### PR DESCRIPTION
## Linked Items

Follow-up PR for #4045 

## Description

This PR is an accumulation of bug fixes that were discovered during the work on openSUSE/orthos2#404. The reason why this PR must be merged already is the bug fix for `bind.py`; it fixes the issue that the `active` tag was ignored on a template object, leading to an insertion order preferred pick of the templates.

## Behaviour changes

None

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [x] No tests required 
