### PR TITLE
Fix DHCP config

### DIFF
--- a/cobbler/items/network_interface.py
+++ b/cobbler/items/network_interface.py
@@ -226,6 +226,44 @@ class NetworkInterface(BaseItem):
             )
 
     @property
+    def name(self) -> str:
+        """
+        The name of the network interface.
+
+        :getter: The name of the object.
+        :setter: See ``BaseItem.name`` - additionally rejects "::" in the name.
+        """
+        return BaseItem.name.fget(self)  # type: ignore[union-attr]
+
+    @name.setter
+    def name(self, name: str) -> None:
+        """
+        The network interface's name.
+
+        Interface names commonly embed a ":" as a separator (e.g. "<system-name>:default") to keep
+        them unique per-system - ``NetworkInterfaces.check_for_duplicate_names()`` only enforces
+        uniqueness within the owning system, not across the whole (global) collection, so this is
+        opt-in, not required. A second, adjacent colon has no such legitimate use and has been
+        observed to reach consumers - e.g. the "host" declaration names ISC dhcpd's
+        ``cobbler/modules/managers/isc.py`` builds from this name - that cannot parse a colon there
+        at all, turning into a hard config-file syntax error instead of a clear validation failure
+        at the source.
+
+        :param name: object name string.
+        :raises TypeError: In case ``name`` was not of type str.
+        :raises ValueError: In case there were disallowed characters in the name, including "::".
+        """
+        if (
+            isinstance(name, str)  # pyright: ignore[reportUnnecessaryIsInstance]
+            and "::" in name
+        ):
+            raise ValueError(
+                f'Invalid characters in name: "{name}" - network interface names must not contain'
+                ' "::"'
+            )
+        BaseItem.name.fset(self, name)  # type: ignore[union-attr]
+
+    @property
     def ipv4(self) -> IPv4Option:
         """
         Returns the IPv4 configuration option for this network interface.

--- a/cobbler/items/network_interface.py
+++ b/cobbler/items/network_interface.py
@@ -375,9 +375,14 @@ class NetworkInterface(BaseItem):
         :param address: MAC address
         :raises CX: In case there a random mac can't be computed
         """
-        if self._mac_address == address:
-            return
         address = validate.mac_address(address)
+        if self._mac_address == address:
+            # Re-setting the address already stored (once normalized - e.g. a
+            # caller sending a different case) must be a no-op. Comparing
+            # against the raw, un-normalized input above would miss this and
+            # fall through to the duplicate check below, which then reports a
+            # false conflict against this very object.
+            return
         if address == "random":
             # FIXME: Pass virt_type of system
             address = utils.get_random_mac(self.api)

--- a/cobbler/modules/managers/isc.py
+++ b/cobbler/modules/managers/isc.py
@@ -185,10 +185,7 @@ class _IscManager(DhcpManagerModule):
             if profile is not None:
                 iface["profile"] = profile.to_dict()  # type: ignore
             if host:
-                if iface_name == "eth0":
-                    iface["name"] = host
-                else:
-                    iface["name"] = f"{host}-{iface_name}"
+                iface["name"] = f"{host}-{iface_name}"
             else:
                 self.generic_entry_cnt += 1
                 iface["name"] = f"generic{self.generic_entry_cnt:d}"

--- a/tests/cobbler_collections/network_interface_collection_test.py
+++ b/tests/cobbler_collections/network_interface_collection_test.py
@@ -285,6 +285,42 @@ def test_duplicate_add(
         network_interface_collection.add(item2, check_for_duplicate_names=True)
 
 
+def test_duplicate_name_allowed_across_systems(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], distro.Distro],
+    create_profile: Callable[[str], profile.Profile],
+    create_system: Callable[..., system.System],
+    network_interface_collection: network_interfaces.NetworkInterfaces,
+):
+    """
+    Test that a Network Interface name only needs to be unique within its owning system, not
+    across the whole collection - two different systems may each have an interface with the same
+    name, even with check_for_duplicate_names explicitly enabled. Contrast with test_duplicate_add,
+    which rejects the same name reused *within* one system.
+    """
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_system_1 = create_system(
+        test_profile.uid, name="test_duplicate_name_allowed_across_systems_1"
+    )
+    test_system_2 = create_system(
+        test_profile.uid, name="test_duplicate_name_allowed_across_systems_2"
+    )
+    name = "duplicate_name_across_systems"
+    item1 = cobbler_api.new_network_interface(system_uid=test_system_1.uid, name=name)
+    item2 = cobbler_api.new_network_interface(system_uid=test_system_2.uid, name=name)
+
+    # Act
+    network_interface_collection.add(item1, check_for_duplicate_names=True)
+    network_interface_collection.add(item2, check_for_duplicate_names=True)
+
+    # Assert
+    assert item1.uid in network_interface_collection.listing
+    assert item2.uid in network_interface_collection.listing
+    assert network_interface_collection.indexes["name"][name] == {item1.uid, item2.uid}
+
+
 def test_remove(
     cobbler_api: CobblerAPI,
     create_distro: Callable[[], distro.Distro],

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -388,6 +388,32 @@ def test_mac_address(
         assert interface.mac_address == expected_result
 
 
+def test_mac_address_reset_same_value_different_case(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Any,
+):
+    """
+    Re-setting a network interface's mac_address to the value it already has
+    - just in a different case - must be a no-op, not a false "duplicate"
+    conflict against itself. Callers (e.g. Orthos2) may not send the address
+    in the same case Cobbler normalizes and stores it in.
+    """
+    # Arrange
+    distro = create_distro()
+    profile = create_profile(distro.uid)
+    system: System = create_system(profile.uid)
+    system.interfaces["default"].mac_address = "aa:bb:cc:dd:ee:ff"
+    cobbler_api.add_system(system)
+
+    # Act
+    system.interfaces["default"].mac_address = "AA:BB:CC:DD:EE:FF"
+
+    # Assert
+    assert system.interfaces["default"].mac_address == "aa:bb:cc:dd:ee:ff"
+
+
 def test_netmask(cobbler_api: CobblerAPI):
     """
     Test to verify that the netmask property of NetworkInterface works as expected.

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -265,6 +265,42 @@ def test_management(
 
 
 @pytest.mark.parametrize(
+    "input_name,expected_result,expected_exception",
+    [
+        ("", "", does_not_raise()),
+        ("default", "default", does_not_raise()),
+        # A single colon is a common, opt-in "<system-name>:<label>" separator (see
+        # NetworkInterfaces.check_for_duplicate_names(), which only enforces uniqueness within the
+        # owning system) and must keep working.
+        ("host.example.org:default", "host.example.org:default", does_not_raise()),
+        ("host.example.org::default", "", pytest.raises(ValueError)),
+        ("::", "", pytest.raises(ValueError)),
+        (0, "", pytest.raises(TypeError)),
+    ],
+)
+def test_name(
+    cobbler_api: CobblerAPI,
+    input_name: Any,
+    expected_result: str,
+    expected_exception: Any,
+):
+    """
+    Test to verify that the name property of NetworkInterface rejects "::", while still allowing a
+    single colon (used as a "<system-name>:<label>" separator).
+    """
+    # Arrange
+    interface = NetworkInterface(cobbler_api, "")
+
+    # Act
+    with expected_exception:
+        interface.name = input_name
+
+        # Assert
+        assert isinstance(interface.name, str)
+        assert interface.name == expected_result
+
+
+@pytest.mark.parametrize(
     "input_dns_name,expected_result,expected_exception",
     [
         ("", "", does_not_raise()),


### PR DESCRIPTION
## Linked Items

This is a follow-up for #4050 

## Description

This PR is a fix, so no invalid interface names can be set.

## Behaviour changes

Old: Network Interfaces with double colons crashed `dhcpd`

New: Double colons are rejected for Network Interfaces

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
