### PR TITLE
fix(remote): resolve ItemOption-backed fields in get_item_resolved_value

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -158,6 +158,7 @@ from cobbler.items import network_interface, system
 from cobbler.items.abstract import base_item
 from cobbler.items.abstract import bootable_item as item
 from cobbler.items.abstract.inheritable_item import InheritableItem
+from cobbler.items.options import base as options_base
 from cobbler.utils import signatures
 from cobbler.utils.event import CobblerEvent
 from cobbler.utils.thread import CobblerThread
@@ -1058,6 +1059,8 @@ class CobblerXMLRPCInterface:
                     ].to_dict(resolved=True)
                 return interface_return_value
             return self.xmlrpc_hacks(return_value)
+        if isinstance(return_value, options_base.ItemOption):
+            return self.xmlrpc_hacks(return_value.to_dict(resolved=True))
 
         if not isinstance(  # type: ignore
             return_value, (str, int, float, bool, tuple, bytes, bytearray, dict, list)

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -252,6 +252,20 @@ def test_get_random_mac(remote: CobblerXMLRPCInterface, token: str):
             },
             does_not_raise(),
         ),
+        (
+            ["power"],
+            "system",
+            {
+                "address": "",
+                "id": "",
+                "identity_file": "",
+                "options": "",
+                "password": "",
+                "type": "",
+                "user": "",
+            },
+            does_not_raise(),
+        ),
         (["doesnt_exist"], "system", {}, pytest.raises(AttributeError)),
     ],
 )


### PR DESCRIPTION
## Linked Items

Related to #3999 

## Description

get_item_resolved_value() had no XML-RPC conversion branch for raw `ItemOption` instances (PowerOption/DNSOption/TFTPOption/VirtOption), so resolving system.power/dns/tftp/virt raised "Cannot return XML-RPC compliant type". Convert ItemOption values via `to_dict(resolved=True)`, mirroring the existing `NetworkInterface` special case. Adds a regression test case for the "power" field.

This was discovered while cobbler/cobbler-web#644 was being progressed.

## Behaviour changes

See description

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
