### PR TITLE
Items: Remove by UID instead of Name

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -19,6 +19,9 @@ V4.0.0 (unreleased)
         * ``input_int``
     * Changed:
         * ```get_random_mac``: Change default `virt_type`` to ``kvm``
+        * ``remove_item`` and all ``remove_<type>`` methods: Require an item handle (object id) instead of the name
+          of the item, matching the contract of ``modify_item``. Clients that only know the name of an item have to
+          retrieve a handle via ``get_item_handle`` or ``get_<type>_handle`` first.
     * Removed:
         * ``xapi_object_edit``: Remove all-in-one edit method for the CLI
 
@@ -1948,7 +1951,7 @@ class CobblerXMLRPCInterface:
     def get_item_handle(self, what: str, name: str, token: Optional[str] = None) -> str:
         """
         Given the name of an object (or other search parameters), return a reference (object id) that can be used with
-        ``modify_*`` functions or ``save_*`` functions to manipulate that object.
+        ``modify_*``, ``save_*``, ``rename_*`` or ``remove_*`` functions to manipulate that object.
 
         :param what: The collection where the item is living in.
         :param name: The name of the item.
@@ -1987,8 +1990,8 @@ class CobblerXMLRPCInterface:
 
     def get_distro_handle(self, name: str):
         """
-        Get a handle for a distribution which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate
-        it.
+        Get a handle for a distribution which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -1997,7 +2000,8 @@ class CobblerXMLRPCInterface:
 
     def get_profile_handle(self, name: str):
         """
-        Get a handle for a profile which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a profile which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2006,7 +2010,8 @@ class CobblerXMLRPCInterface:
 
     def get_system_handle(self, name: str):
         """
-        Get a handle for a system which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a system which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2015,7 +2020,8 @@ class CobblerXMLRPCInterface:
 
     def get_repo_handle(self, name: str):
         """
-        Get a handle for a repository which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a repository which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2024,7 +2030,8 @@ class CobblerXMLRPCInterface:
 
     def get_image_handle(self, name: str):
         """
-        Get a handle for an image which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for an image which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2033,7 +2040,8 @@ class CobblerXMLRPCInterface:
 
     def get_menu_handle(self, name: str):
         """
-        Get a handle for a menu which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a menu which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2042,8 +2050,8 @@ class CobblerXMLRPCInterface:
 
     def get_network_interface_handle(self, name: str):
         """
-        Get a handle for a network interface which allows you to use the functions ``modify_*`` or ``save_*`` to
-        manipulate it.
+        Get a handle for a network interface which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2052,7 +2060,8 @@ class CobblerXMLRPCInterface:
 
     def get_template_handle(self, name: str):
         """
-        Get a handle for a template which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a template which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2061,7 +2070,8 @@ class CobblerXMLRPCInterface:
 
     def get_distro_group_handle(self, name: str):
         """
-        Get a handle for a distro group which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a distro group which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2070,7 +2080,8 @@ class CobblerXMLRPCInterface:
 
     def get_profile_group_handle(self, name: str):
         """
-        Get a handle for a profile group which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a profile group which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2079,7 +2090,8 @@ class CobblerXMLRPCInterface:
 
     def get_system_group_handle(self, name: str):
         """
-        Get a handle for a system group which allows you to use the functions ``modify_*`` or ``save_*`` to manipulate it.
+        Get a handle for a system group which allows you to use the functions ``modify_*``,
+        ``save_*``, ``rename_*`` or ``remove_*`` to manipulate it.
 
         :param name: The name of the item.
         :return: The handle of the desired object.
@@ -2160,29 +2172,31 @@ class CobblerXMLRPCInterface:
         return list(results)
 
     def remove_item(
-        self, what: str, name: str, token: str, recursive: bool = True
+        self, what: str, object_id: str, token: str, recursive: bool = True
     ) -> bool:
         """
         Deletes an item from a collection.
-        Note that this requires the name of the distro, not an item handle.
+        Note that this requires an item handle (object id), not the name of the item. Callers that only know the name
+        of an item have to retrieve a handle via ``get_item_handle`` or the type specific ``get_<type>_handle`` first.
 
         :param what: The item type of the item to remove.
-        :param name: The name of the item to remove.
+        :param object_id: The id of the object which shall be removed.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
         self._log(
-            f"remove_item ({what}, recursive={recursive})", name=name, token=token
+            f"remove_item ({what}, recursive={recursive})",
+            object_id=object_id,
+            token=token,
         )
-        obj_handle = self.get_item_handle(what, name, token)
         try:
-            obj = cast(InheritableItem, self.__get_object(obj_handle, token))
+            obj = cast(InheritableItem, self.__get_object(object_id, token))
         except ValueError:
             return False
         self.check_access(token, f"remove_{what}", obj.name)
         if token in self.transactions:
-            self.transactions[token][obj_handle] = TransactionTuple(
+            self.transactions[token][object_id] = TransactionTuple(
                 what, obj, True, obj.mtime, obj.uid, []
             )
             if recursive:
@@ -2197,142 +2211,146 @@ class CobblerXMLRPCInterface:
                     )
 
             return True
-        if obj_handle in self.unsaved_items:
-            self.unsaved_items.pop(obj_handle)
+        if object_id in self.unsaved_items:
+            self.unsaved_items.pop(object_id)
             return True
         self.api.remove_item(
-            what, name, delete=True, with_triggers=True, recursive=recursive
+            what, obj, delete=True, with_triggers=True, recursive=recursive
         )
         return True
 
-    def remove_distro(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_distro(self, object_id: str, token: str, recursive: bool = True) -> bool:
         """
         Deletes a distribution from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("distro", name, token, recursive)
+        return self.remove_item("distro", object_id, token, recursive)
 
-    def remove_profile(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_profile(
+        self, object_id: str, token: str, recursive: bool = True
+    ) -> bool:
         """
         Deletes a profile from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("profile", name, token, recursive)
+        return self.remove_item("profile", object_id, token, recursive)
 
-    def remove_system(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_system(self, object_id: str, token: str, recursive: bool = True) -> bool:
         """
         Deletes a system from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("system", name, token, recursive)
+        return self.remove_item("system", object_id, token, recursive)
 
-    def remove_repo(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_repo(self, object_id: str, token: str, recursive: bool = True) -> bool:
         """
         Deletes a repository from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("repo", name, token, recursive)
+        return self.remove_item("repo", object_id, token, recursive)
 
-    def remove_image(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_image(self, object_id: str, token: str, recursive: bool = True) -> bool:
         """
         Deletes an image from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("image", name, token, recursive)
+        return self.remove_item("image", object_id, token, recursive)
 
-    def remove_menu(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_menu(self, object_id: str, token: str, recursive: bool = True) -> bool:
         """
         Deletes a menu from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("menu", name, token, recursive)
+        return self.remove_item("menu", object_id, token, recursive)
 
     def remove_network_interface(
-        self, name: str, token: str, recursive: bool = True
+        self, object_id: str, token: str, recursive: bool = True
     ) -> bool:
         """
         Deletes a network interface from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("network_interface", name, token, recursive)
+        return self.remove_item("network_interface", object_id, token, recursive)
 
-    def remove_template(self, name: str, token: str, recursive: bool = True) -> bool:
+    def remove_template(
+        self, object_id: str, token: str, recursive: bool = True
+    ) -> bool:
         """
         Deletes a template from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("template", name, token, recursive)
+        return self.remove_item("template", object_id, token, recursive)
 
     def remove_distro_group(
-        self, name: str, token: str, recursive: bool = True
+        self, object_id: str, token: str, recursive: bool = True
     ) -> bool:
         """
         Deletes a distro group from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("distro_group", name, token, recursive)
+        return self.remove_item("distro_group", object_id, token, recursive)
 
     def remove_profile_group(
-        self, name: str, token: str, recursive: bool = True
+        self, object_id: str, token: str, recursive: bool = True
     ) -> bool:
         """
         Deletes a profile group from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("profile_group", name, token, recursive)
+        return self.remove_item("profile_group", object_id, token, recursive)
 
     def remove_system_group(
-        self, name: str, token: str, recursive: bool = True
+        self, object_id: str, token: str, recursive: bool = True
     ) -> bool:
         """
         Deletes a system group from Cobbler.
 
-        :param name: The name of the item to remove.
+        :param object_id: The id of the item to remove.
         :param token: The API-token obtained via the login() method.
         :param recursive: If items which are depending on this one should be erased too.
         :return: True if the action was successful.
         """
-        return self.remove_item("system_group", name, token, recursive)
+        return self.remove_item("system_group", object_id, token, recursive)
 
     def copy_item(
         self, what: str, object_id: str, newname: str, token: Optional[str] = None

--- a/tests/integration/basic_test.py
+++ b/tests/integration/basic_test.py
@@ -99,7 +99,7 @@ def test_basic_distro_add_remove(
     assert len(remote.get_item_names("distro")) == len(distro_names)
     # 3. Remove distros
     for name in distro_names:
-        remote.remove_distro(name, token)
+        remote.remove_distro(remote.get_distro_handle(name), token)
 
     # Assert
     assert len(remote.get_item_names("distro")) == 0
@@ -334,7 +334,7 @@ def test_basic_profile_add_remove(
 
     # Act - Remove Profiles
     for i in range(1, 3):
-        remote.remove_profile(f"fake-{i}", token, True)
+        remote.remove_profile(remote.get_profile_handle(f"fake-{i}"), token, True)
 
     # Assert - Assert Profiles deleted
     profile_names = remote.get_item_names("profile")
@@ -423,7 +423,7 @@ def test_basic_system_add_remove(
 
     # Act - Remove systems
     for i in range(1, 4):
-        remote.remove_system(f"testbed-{i}", token)
+        remote.remove_system(remote.get_system_handle(f"testbed-{i}"), token)
 
     # Assert - No systems present
     assert len(remote.get_item_names("system")) == 0

--- a/tests/xmlrpcapi/conftest.py
+++ b/tests/xmlrpcapi/conftest.py
@@ -97,7 +97,7 @@ def remove_distro(remote: CobblerXMLRPCInterface, token: str):
     """
 
     def _remove_distro(name: str):
-        remote.remove_distro(name, token)
+        remote.remove_distro(remote.get_distro_handle(name), token)
 
     return _remove_distro
 
@@ -128,7 +128,7 @@ def remove_profile(remote: CobblerXMLRPCInterface, token: str):
     """
 
     def _remove_profile(name: str):
-        remote.remove_profile(name, token)
+        remote.remove_profile(remote.get_profile_handle(name), token)
 
     return _remove_profile
 
@@ -156,7 +156,7 @@ def remove_system(remote: CobblerXMLRPCInterface, token: str):
     """
 
     def _remove_system(name: str):
-        remote.remove_system(name, token)
+        remote.remove_system(remote.get_system_handle(name), token)
 
     return _remove_system
 
@@ -209,7 +209,7 @@ def remove_repo(remote: CobblerXMLRPCInterface, token: str):
     """
 
     def _remove_repo(name: str):
-        remote.remove_repo(name, token)
+        remote.remove_repo(remote.get_repo_handle(name), token)
 
     return _remove_repo
 
@@ -239,7 +239,7 @@ def remove_menu(remote: CobblerXMLRPCInterface, token: str):
     """
 
     def _remove_menu(name: str):
-        remote.remove_menu(name, token)
+        remote.remove_menu(remote.get_menu_handle(name), token)
 
     return _remove_menu
 

--- a/tests/xmlrpcapi/distro_group_test.py
+++ b/tests/xmlrpcapi/distro_group_test.py
@@ -126,7 +126,7 @@ def test_remove_distro_group(remote: CobblerXMLRPCInterface, token: str):
     remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
-    result = remote.remove_distro_group("test_distro_group_to_remove", token)
+    result = remote.remove_distro_group(handle, token)
 
     # Assert
     assert result is True

--- a/tests/xmlrpcapi/distro_test.py
+++ b/tests/xmlrpcapi/distro_test.py
@@ -167,7 +167,7 @@ def test_copy_distro(remote: CobblerXMLRPCInterface, token: str):
     assert result
 
     # Cleanup --> Plus fixture
-    remote.remove_distro("testdistrocopy", token)
+    remote.remove_distro(remote.get_distro_handle("testdistrocopy"), token)
 
 
 @pytest.mark.usefixtures("create_testdistro")
@@ -185,7 +185,7 @@ def test_rename_distro(remote: CobblerXMLRPCInterface, token: str):
     assert result
 
     # Cleanup
-    remote.remove_distro("testdistro1", token)
+    remote.remove_distro(distro, token)
 
 
 def test_remove_distro(
@@ -207,10 +207,10 @@ def test_remove_distro(
     folder = create_kernel_initrd(fk_kernel, fk_initrd)
     kernel_path = os.path.join(folder, fk_kernel)
     initrd_path = os.path.join(folder, fk_initrd)
-    create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
+    distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
 
     # Act
-    result = remote.remove_distro(distro_name, token)  # type: ignore
+    result = remote.remove_distro(distro_handle, token)  # type: ignore
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/image_test.py
+++ b/tests/xmlrpcapi/image_test.py
@@ -122,7 +122,7 @@ class TestImage:
         test_image = create_image()
 
         # Act
-        result = remote.remove_image(test_image.name, token)
+        result = remote.remove_image(test_image.uid, token)
 
         # Assert
         assert result

--- a/tests/xmlrpcapi/item_test.py
+++ b/tests/xmlrpcapi/item_test.py
@@ -40,7 +40,7 @@ def test_remove_item(remote: CobblerXMLRPCInterface, token: str):
     remote.modify_menu(test_menu, ["display_name"], "testmenu0", token)
 
     # Act
-    result = remote.remove_menu("testmenu0", token, True)  # type: ignore
+    result = remote.remove_menu(test_menu, token, True)  # type: ignore
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/menu_test.py
+++ b/tests/xmlrpcapi/menu_test.py
@@ -30,7 +30,7 @@ def remove_menu(remote: CobblerXMLRPCInterface, token: str):
     :param token: The token to authenticate against the remote object.
     """
     yield
-    remote.remove_menu("testmenu0", token)
+    remote.remove_menu(remote.get_menu_handle("testmenu0"), token)
 
 
 class TestMenu:
@@ -58,7 +58,7 @@ class TestMenu:
 
         new_menus = remote.get_menus(token)
         assert len(new_menus) == len(menus) + 1
-        remote.remove_menu("testsubmenu0", token, False)
+        remote.remove_menu(submenu, token, False)
 
     def test_create_menu(self, remote: CobblerXMLRPCInterface, token: str):
         """
@@ -127,7 +127,7 @@ class TestMenu:
         assert remote.copy_menu(menu, "testmenucopy", token)
 
         # Cleanup
-        remote.remove_menu("testmenucopy", token)
+        remote.remove_menu(remote.get_menu_handle("testmenucopy"), token)
 
     @pytest.mark.usefixtures("create_menu")
     def test_rename_menu(self, remote: CobblerXMLRPCInterface, token: str):
@@ -145,7 +145,7 @@ class TestMenu:
         assert result
 
         # Cleanup
-        remote.remove_menu("testmenu1", token)
+        remote.remove_menu(menu, token)
 
     @pytest.mark.usefixtures("create_menu")
     def test_remove_menu(self, remote: CobblerXMLRPCInterface, token: str):
@@ -156,7 +156,7 @@ class TestMenu:
         # Arrange --> Done in fixture
 
         # Act
-        result = remote.remove_menu("testmenu0", token)
+        result = remote.remove_menu(remote.get_menu_handle("testmenu0"), token)
 
         # Assert
         assert result

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -9,6 +9,7 @@ from typing import Any, Callable, Dict, List, Union
 
 import pytest
 
+from cobbler.cexceptions import CX
 from cobbler.remote import CobblerXMLRPCInterface
 
 from tests.conftest import does_not_raise
@@ -344,3 +345,94 @@ def test_get_item_resolved_value(
             assert profile_uid == result
         else:
             assert expected_result == result
+
+
+def test_remove_item_with_duplicate_names(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Verify that an item can be removed via its handle even if its name is not globally unique.
+
+    Network interface names are only unique per system, so two systems may both own an interface called "eth0". Since
+    ``remove_network_interface`` takes an object id, the caller can address exactly one of them.
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+    distro_uid = create_distro(
+        "testdistro_duplicate_names", "x86_64", "suse", path_kernel, path_initrd
+    )
+    profile_uid = create_profile("testprofile_duplicate_names", distro_uid, "")
+    system_uids = [
+        create_system(f"testsystem_duplicate_names{i}", profile_uid) for i in range(2)
+    ]
+    for system_uid in system_uids:
+        interface_handle = remote.new_network_interface(system_uid, token)
+        remote.modify_network_interface(interface_handle, ["name"], "eth0", token)
+        remote.save_network_interface(interface_handle, True, True, "new", token)
+
+    # The name alone is ambiguous, so a handle has to be obtained via a more specific search.
+    with pytest.raises(CX):
+        remote.get_network_interface_handle("eth0")
+    interfaces = remote.find_network_interface(
+        {"system_uid": system_uids[0], "name": "eth0"}, expand=True, token=token
+    )
+    assert len(interfaces) == 1
+    interface_uid = interfaces[0]["uid"]
+
+    # Act
+    result = remote.remove_network_interface(interface_uid, token, False)
+
+    # Assert
+    assert result is True
+    assert (
+        remote.find_network_interface(
+            {"system_uid": system_uids[0], "name": "eth0"}, token=token
+        )
+        == []
+    )
+    assert (
+        len(
+            remote.find_network_interface(
+                {"system_uid": system_uids[1], "name": "eth0"}, token=token
+            )
+        )
+        == 1
+    )
+
+
+def test_remove_item_with_name_instead_of_handle(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Verify that passing a name instead of an object id to ``remove_*`` does not remove anything.
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+    distro_name = "testdistro_name_instead_of_handle"
+    distro_uid = create_distro(distro_name, "x86_64", "suse", path_kernel, path_initrd)
+
+    # Act
+    result = remote.remove_distro(distro_name, token, False)
+
+    # Assert
+    assert result is False
+    assert remote.get_distro_handle(distro_name) == distro_uid
+
+    # Cleanup
+    assert remote.remove_distro(distro_uid, token, False) is True

--- a/tests/xmlrpcapi/profile_group_test.py
+++ b/tests/xmlrpcapi/profile_group_test.py
@@ -126,7 +126,7 @@ def test_remove_profile_group(remote: CobblerXMLRPCInterface, token: str):
     remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
-    result = remote.remove_profile_group("test_profile_group_to_remove", token)
+    result = remote.remove_profile_group(handle, token)
 
     # Assert
     assert result is True

--- a/tests/xmlrpcapi/profile_test.py
+++ b/tests/xmlrpcapi/profile_test.py
@@ -276,7 +276,7 @@ def test_copy_profile(remote: CobblerXMLRPCInterface, token: str):
     assert result
 
     # Cleanup
-    remote.remove_profile("testprofilecopy", token)
+    remote.remove_profile(remote.get_profile_handle("testprofilecopy"), token)
 
 
 @pytest.mark.usefixtures(
@@ -299,7 +299,7 @@ def test_rename_profile(remote: CobblerXMLRPCInterface, token: str):
     assert result
 
     # Cleanup
-    remote.remove_profile("testprofile1", token)
+    remote.remove_profile(profile, token)
 
 
 def test_remove_profile(
@@ -327,10 +327,10 @@ def test_remove_profile(
     kernel_path = os.path.join(folder, fk_kernel)
     initrd_path = os.path.join(folder, fk_initrd)
     distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
-    create_profile(profile_name, distro_handle, "")  # type: ignore
+    profile_handle = create_profile(profile_name, distro_handle, "")  # type: ignore
 
     # Act
-    result_profile_remove = remote.remove_profile(profile_name, token)  # type: ignore
+    result_profile_remove = remote.remove_profile(profile_handle, token)  # type: ignore
 
     # Assert
     assert result_profile_remove

--- a/tests/xmlrpcapi/repo_test.py
+++ b/tests/xmlrpcapi/repo_test.py
@@ -126,7 +126,7 @@ class TestRepo:
         # Arrange --> Done in fixture
 
         # Act
-        result = remote.remove_repo("testrepo0", token)
+        result = remote.remove_repo(remote.get_repo_handle("testrepo0"), token)
 
         # Assert
         assert result

--- a/tests/xmlrpcapi/system_group_test.py
+++ b/tests/xmlrpcapi/system_group_test.py
@@ -126,7 +126,7 @@ def test_remove_system_group(remote: CobblerXMLRPCInterface, token: str):
     remote.save_system_group(handle, True, True, "new", token)
 
     # Act
-    result = remote.remove_system_group("test_system_group_to_remove", token)
+    result = remote.remove_system_group(handle, token)
 
     # Assert
     assert result is True

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -240,10 +240,10 @@ def test_remove_system(
     initrd_path = os.path.join(folder, fk_initrd)
     distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
     profile_handle = create_profile(profile_name, distro_handle, "")  # type: ignore
-    create_system(system_name, profile_handle)  # type: ignore
+    system_handle = create_system(system_name, profile_handle)  # type: ignore
 
     # Act
-    result = remote.remove_system(system_name, token)  # type: ignore
+    result = remote.remove_system(system_handle, token)  # type: ignore
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/transaction_test.py
+++ b/tests/xmlrpcapi/transaction_test.py
@@ -4,7 +4,7 @@ Tests that validate the functionality of XML-RPC API transactions.
 
 import logging
 import os
-from typing import Any, Callable, Dict, cast
+from typing import Any, Callable, Dict, List, cast
 
 import pytest
 
@@ -190,7 +190,7 @@ def test_remove_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
     assert remote.get_item_handle("profile", "testsubprofile1") != "~"
 
     remote.transaction_begin(token)
-    assert remote.remove_profile("testprofile0", token)
+    assert remote.remove_profile(profile_uid, token)
 
     # profiles are visible outside of transaction until commit
     assert remote.get_item_handle("profile", "testprofile0") != "~"
@@ -226,16 +226,18 @@ def test_create_profiles(
 
     # Act
     remote.transaction_begin(token)
+    profile_uids: List[str] = []
     for i in range(50):
         profile = remote.new_profile(token)
         remote.modify_profile(profile, ["name"], f"testprofile{i}", token)
         remote.modify_profile(profile, ["distro"], distro_uid, token)
         remote.save_profile(profile, True, True, "bypass", token)
+        profile_uids.append(profile)
     assert remote.transaction_commit(token)
 
     remote.transaction_begin(token)
-    for i in range(50):
-        remote.remove_profile(f"testprofile{i}", token)
+    for profile_uid in profile_uids:
+        remote.remove_profile(profile_uid, token)
     assert remote.transaction_commit(token)
 
 
@@ -281,7 +283,7 @@ def test_parent_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
     #   this seems to be a bug
     #   assert cast(Dict[Any, Any], remote.get_profile("testprofile3"))["depth"] == 3
 
-    assert remote.remove_profile("testprofile0", token)
+    assert remote.remove_profile(profile_uid, token)
 
 
 @pytest.mark.usefixtures(
@@ -320,7 +322,7 @@ def test_reparent_and_delete_profile(remote: CobblerXMLRPCInterface, token: str)
     assert remote.modify_profile(subprofile1, ["parent"], profile1, token)
     assert remote.save_profile(subprofile1, True, True, "bypass", token)
 
-    assert remote.remove_profile("testprofile0", token)
+    assert remote.remove_profile(profile_uid, token)
 
     # the transaction is not visible without the token
     assert remote.get_item_handle("profile", "testprofile0") != "~"
@@ -340,7 +342,7 @@ def test_reparent_and_delete_profile(remote: CobblerXMLRPCInterface, token: str)
     assert remote.get_item_handle("profile", "testsubprofile1") == "~"
 
     # cleanup
-    assert remote.remove_profile("testprofile1", token)
+    assert remote.remove_profile(profile1, token)
 
 
 @pytest.mark.usefixtures(
@@ -362,7 +364,7 @@ def test_conflict(remote: CobblerXMLRPCInterface, token: str, token2: str):
 
     # delete the original profile before the transaction is finished
     remote.transaction_begin(token2)
-    assert remote.remove_profile("testprofile0", token2)
+    assert remote.remove_profile(profile, token2)
 
     # the first commit is successful
     assert remote.transaction_commit(token2)
@@ -394,7 +396,7 @@ def test_conflict2(remote: CobblerXMLRPCInterface, token: str, token2: str):
 
     # delete the original profile before the transaction is finished
     remote.transaction_begin(token2)
-    assert remote.remove_profile("testprofile0", token2)
+    assert remote.remove_profile(profile, token2)
 
     # the first commit is successful
     assert remote.transaction_commit(token)
@@ -501,6 +503,7 @@ def test_remove_distro_recursive(remote: CobblerXMLRPCInterface, token: str):
     """
 
     # Arrange
+    distro_uid = remote.get_distro_handle("testdistro0")
     profile_uid = remote.get_profile_handle("testprofile0")
     remote.transaction_begin(token)
 
@@ -523,7 +526,7 @@ def test_remove_distro_recursive(remote: CobblerXMLRPCInterface, token: str):
     assert remote.get_item_handle("profile", "testsubprofile1") != "~"
 
     remote.transaction_begin(token)
-    assert remote.remove_distro("testdistro0", token)
+    assert remote.remove_distro(distro_uid, token)
 
     # distro and profiles are visible outside of transaction until commit
     assert remote.get_item_handle("distro", "testdistro0") != "~"
@@ -563,6 +566,7 @@ def test_reparent_and_remove_distro(
     """
 
     # Arrange
+    old_distro_uid = remote.get_distro_handle("testdistro0")
     remote.transaction_begin(token)
     profile_uid = remote.get_item_handle("profile", "testprofile0", token)
     logger.info("profile_uid: %s", profile_uid)
@@ -600,7 +604,7 @@ def test_reparent_and_remove_distro(
     profile = remote.get_item_handle("profile", "testprofile0", token)
     assert remote.modify_profile(profile, ["distro"], distro, token)
     assert remote.save_profile(profile, True, True, "new", token)
-    assert remote.remove_distro("testdistro0", token)
+    assert remote.remove_distro(old_distro_uid, token)
 
     # distro and profiles are visible outside of transaction until commit
     assert remote.get_item_handle("distro", "testdistro0") != "~"


### PR DESCRIPTION
## Linked Items

Related to #3999 

## Description

`remove_item` and all `remove_<type>` XML-RPC methods used to take the name of the item. Names are not globally unique - a `NetworkInterface` name is only unique per system - so `get_item_handle` could raise an ambiguous match error and the caller had no way to address a specific item.

Change the contract to match `modify_item`, which already takes an explicit `object_id` and resolves it via `__get_object`. `remove_item` now does the same and no longer performs any name resolution itself. Callers that only know the name have to obtain a handle via `get_item_handle`/`get_<type>_handle` first; callers that need to disambiguate can obtain the handle from `find_<type>` instead.

Also pass the resolved object instead of a string to `api.remove_item`, so the removal does not perform a second, redundant lookup by name.

`get_item_handle` itself is unchanged; only its docstring and the docstrings of the per-type `get_<type>_handle` wrappers are extended to mention the `rename_*` and `remove_*` families.

## Behaviour changes

Old: Network Interfaces with duplicate names could not be removed.

New: Network Interfaces can be removed if their UID is known.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [x] Refactoring
- [ ] Miscellaneous

## Tests

- [ ] Unit-Tests were created
- [ ] System-Tests were created
- [x] Code is already covered by Unit-Tests
- [x] Code is already covered by System-Tests
- [ ] No tests required 
