### PR TITLE
fix(item-group): validate members reference existing items

### DIFF
--- a/cobbler/items/abstract/item_group.py
+++ b/cobbler/items/abstract/item_group.py
@@ -124,6 +124,8 @@ class ItemGroup(InheritableItem, ABC):
         Set the members of this item group.
 
         :param value: A list of string uids representing the members of the group.
+        :raises TypeError: In case ``value`` is not a list or one of its entries is not a string.
+        :raises ValueError: In case one of the given uids does not reference an existing item.
         """
         if not isinstance(value, list):  # pyright: ignore[reportUnnecessaryIsInstance]
             raise TypeError("members must be a list")
@@ -132,6 +134,14 @@ class ItemGroup(InheritableItem, ABC):
                 member, str
             ):  # pyright: ignore[reportUnnecessaryIsInstance]
                 raise TypeError("All members must be of type string")
+        referenced_type = self.COLLECTION_TYPE.removesuffix("_group")
+        referenced_collection = self.api.get_items(referenced_type)
+        for member in value:
+            if referenced_collection.find(uid=member) is None:
+                raise ValueError(
+                    f'members references uid "{member}" which is not an existing '
+                    f'"{referenced_type}" item'
+                )
         old_members = self._members
         self._members = value
         self.api.get_items(self.COLLECTION_TYPE).update_index_value(

--- a/tests/cobbler_collections/profile_group_collection_test.py
+++ b/tests/cobbler_collections/profile_group_collection_test.py
@@ -11,6 +11,8 @@ from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import profile_group
 from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.items import profile_group as item_profile_group
+from cobbler.items.distro import Distro
+from cobbler.items.profile import Profile
 
 
 @pytest.fixture(name="profile_group_collection")
@@ -33,14 +35,19 @@ def test_obj_create(collection_mgr: CollectionManager):
 
 
 def test_profile_group_collection_factory_produce(
-    cobbler_api: CobblerAPI, collection_mgr: CollectionManager
+    cobbler_api: CobblerAPI,
+    collection_mgr: CollectionManager,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[..., Profile],
 ):
     collection = profile_group.ProfileGroups(collection_mgr)
-    item_dict = {"name": "test_group", "members": ["profile1"]}
+    test_distro = create_distro("test_profile_group_collection_factory_produce")
+    test_profile = create_profile(distro_uid=test_distro.uid)
+    item_dict = {"name": "test_group", "members": [test_profile.uid]}
     item = collection.factory_produce(cobbler_api, item_dict)
     assert isinstance(item, item_profile_group.ProfileGroup)
     assert getattr(item, "name") == "test_group"
-    assert getattr(item, "members") == ["profile1"]
+    assert getattr(item, "members") == [test_profile.uid]
 
 
 def test_get(

--- a/tests/cobbler_collections/system_group_collection_test.py
+++ b/tests/cobbler_collections/system_group_collection_test.py
@@ -11,6 +11,9 @@ from cobbler.cexceptions import CX
 from cobbler.cobbler_collections import system_group
 from cobbler.cobbler_collections.manager import CollectionManager
 from cobbler.items import system_group as item_system_group
+from cobbler.items.distro import Distro
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
 
 
 @pytest.fixture(name="system_group_collection")
@@ -33,14 +36,21 @@ def test_obj_create(collection_mgr: CollectionManager):
 
 
 def test_system_group_collection_factory_produce(
-    cobbler_api: CobblerAPI, collection_mgr: CollectionManager
+    cobbler_api: CobblerAPI,
+    collection_mgr: CollectionManager,
+    create_distro: Callable[[str], Distro],
+    create_profile: Callable[..., Profile],
+    create_system: Callable[..., System],
 ):
     collection = system_group.SystemGroups(collection_mgr)
-    item_dict = {"name": "test_group", "members": ["system1"]}
+    test_distro = create_distro("test_system_group_collection_factory_produce")
+    test_profile = create_profile(distro_uid=test_distro.uid)
+    test_system = create_system(profile_uid=test_profile.uid)
+    item_dict = {"name": "test_group", "members": [test_system.uid]}
     item = collection.factory_produce(cobbler_api, item_dict)
     assert isinstance(item, item_system_group.SystemGroup)
     assert getattr(item, "name") == "test_group"
-    assert getattr(item, "members") == ["system1"]
+    assert getattr(item, "members") == [test_system.uid]
 
 
 def test_get(

--- a/tests/items/item_group_test.py
+++ b/tests/items/item_group_test.py
@@ -2,7 +2,7 @@
 Tests for the ItemGroup abstract class.
 """
 
-from typing import Any, List, Type
+from typing import Any, Callable, List, Type
 
 import pytest
 
@@ -10,6 +10,7 @@ from cobbler import enums
 from cobbler.api import CobblerAPI
 from cobbler.items.abstract.base_item import BaseItem
 from cobbler.items.abstract.item_group import ItemGroup
+from cobbler.items.distro import Distro
 
 
 class DummyItemGroup(ItemGroup):
@@ -45,12 +46,16 @@ def test_members_initialization(cobbler_api: CobblerAPI):
     assert getattr(group, "members") == []
 
 
-def test_members_setter_valid(cobbler_api: CobblerAPI):
+def test_members_setter_valid(
+    cobbler_api: CobblerAPI, create_distro: Callable[[str], Distro]
+):
     """
     Test that the members setter works with a valid list of strings.
     """
     group = DummyItemGroup(api=cobbler_api)
-    valid_members = ["member1", "member2"]
+    distro1 = create_distro("test_members_setter_valid_1")
+    distro2 = create_distro("test_members_setter_valid_2")
+    valid_members = [distro1.uid, distro2.uid]
     setattr(group, "members", valid_members)
     assert getattr(group, "members") == valid_members
 
@@ -73,10 +78,36 @@ def test_members_setter_invalid_member_type(cobbler_api: CobblerAPI):
         setattr(group, "members", ["member1", 123])
 
 
-def test_from_dict_initialization(cobbler_api: CobblerAPI):
+def test_from_dict_initialization(
+    cobbler_api: CobblerAPI, create_distro: Callable[[str], Distro]
+):
     """
     Test that passing a dict to __init__ correctly sets members via from_dict.
     """
     # Note: In from_dict, the keys correspond to properties.
-    group = DummyItemGroup(api=cobbler_api, members=["m1", "m2"])
-    assert getattr(group, "members") == ["m1", "m2"]
+    distro1 = create_distro("test_from_dict_initialization_1")
+    distro2 = create_distro("test_from_dict_initialization_2")
+    group = DummyItemGroup(api=cobbler_api, members=[distro1.uid, distro2.uid])
+    assert getattr(group, "members") == [distro1.uid, distro2.uid]
+
+
+def test_members_setter_nonexistent_uid_raises(cobbler_api: CobblerAPI):
+    """
+    Test that the members setter raises a ValueError if a uid does not reference an
+    existing item.
+    """
+    group = DummyItemGroup(api=cobbler_api)
+    with pytest.raises(ValueError, match="not an existing"):
+        setattr(group, "members", ["does-not-exist"])
+
+
+def test_members_setter_existing_uid_succeeds(
+    cobbler_api: CobblerAPI, create_distro: Callable[[str], Distro]
+):
+    """
+    Test that the members setter accepts a uid that references an existing item.
+    """
+    group = DummyItemGroup(api=cobbler_api)
+    distro1 = create_distro("test_members_setter_existing_uid_succeeds")
+    setattr(group, "members", [distro1.uid])
+    assert getattr(group, "members") == [distro1.uid]


### PR DESCRIPTION
## Linked Items

Related to #3999

## Description

Validates that all members of a given group are part of the target collection.

## Behaviour changes

Old: The setter only validated that the members were valid strings.

New: The setter now validates that the string is a uid and that there is an item existing with that uid.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
