### PR TITLE
Add XCP-ng 7.x and 8.x support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,22 @@ updates:
         applies-to: version-updates
         patterns:
           - "*"
+    commit-message:
+      prefix: "build"
+      prefix-development: "chore"
+      include: "scope"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "no changelog"
+    groups:
+      npm:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: "build"
+      prefix-development: "chore"
+      include: "scope"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -120,3 +120,15 @@ jobs:
         uses: isort/isort-action@24d8a7a51d33ca7f36c3f23598dafa33f7071326 # v1.1.1
         with:
           configuration: --check-only --diff --profile=black
+  commitlint:
+    name: commitlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        # https://github.com/actions/checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+      - name: Lint commit messages
+        # https://github.com/wagoid/commitlint-github-action
+        uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ docs/_build
 supervisord.pid
 .claude
 .superpowers/
+
+# Node (commitlint tooling)
+node_modules/

--- a/changelog.d/3980.added
+++ b/changelog.d/3980.added
@@ -1,0 +1,1 @@
+Added support for interactive and automatic network installations of XCP-ng 7.x and 8.x latest releases.

--- a/cobbler/actions/mkloaders.py
+++ b/cobbler/actions/mkloaders.py
@@ -157,6 +157,12 @@ class MkLoaders:
             self.bootloaders_dir.joinpath("pxelinux.0"),
             skip_existing=True,
         )
+        # Make mboot.c32 (needed for XCP-ng PXE boot)
+        symlink(
+            self.syslinux_folder.joinpath("mboot.c32"),
+            self.bootloaders_dir.joinpath("mboot.c32"),
+            skip_existing=True,
+        )
         # Make linux.c32 for syslinux + wimboot
         libcom32_c32_path = self.syslinux_folder.joinpath("libcom32.c32")
         if syslinux_version > 4 and libcom32_c32_path.exists():

--- a/cobbler/autoinstall/generate/xen.py
+++ b/cobbler/autoinstall/generate/xen.py
@@ -1,0 +1,49 @@
+"""
+This module is responsible to generate Xen/XCP-ng answerfiles and metadata.
+"""
+
+from typing import TYPE_CHECKING, Any, Optional
+
+from cobbler import utils
+from cobbler.autoinstall.generate.base import AutoinstallBaseGenerator
+
+if TYPE_CHECKING:
+    from cobbler.items.abstract.bootable_item import BootableItem
+    from cobbler.items.template import Template
+
+
+class XenGenerator(AutoinstallBaseGenerator):
+    """
+    This is the specific implementation to generate files related to a given Xen/XCP-ng installation.
+    """
+
+    def generate_autoinstall(
+        self,
+        obj: "BootableItem",
+        requested_file: "Template",
+        autoinstaller_subfile: str = "",
+    ) -> str:
+        if obj.TYPE_NAME not in ("profile", "system"):  # type: ignore
+            raise ValueError("obj must be either a system or profile!")
+
+        template: Optional["Template"] = obj.autoinstall  # type: ignore
+        if template is None:
+            raise ValueError(f"No template set for object {obj.name}!")
+
+        meta = utils.blender(self.api, False, obj)
+        # make autoinstall_meta metavariable available at top level
+        autoinstall_meta = meta.pop("autoinstall_meta")
+        meta.update(autoinstall_meta)
+
+        meta["kernel_options"] = utils.dict_to_string(meta["kernel_options"])
+        if "kernel_options_post" in meta:
+            meta["kernel_options_post"] = utils.dict_to_string(
+                meta["kernel_options_post"]
+            )
+
+        return self.api.templar.render(template.content, meta, None)  # type: ignore
+
+    def generate_autoinstall_metadata(
+        self, obj: "BootableItem", key: str
+    ) -> Optional[Any]:
+        return None

--- a/cobbler/autoinstall/manager.py
+++ b/cobbler/autoinstall/manager.py
@@ -14,6 +14,7 @@ from cobbler.autoinstall.generate.kickstart import KickstartGenerator
 from cobbler.autoinstall.generate.legacy import LegacyGenerator
 from cobbler.autoinstall.generate.preseed import PreseedGenerator
 from cobbler.autoinstall.generate.windows import WindowsGenerator
+from cobbler.autoinstall.generate.xen import XenGenerator
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
@@ -192,6 +193,8 @@ class AutoInstallationManager:
             return AgamaGenerator(api=self.api)
         elif autoinstaller_type == enums.AutoinstallerType.WINDOWS:
             return WindowsGenerator(api=self.api)
+        elif autoinstaller_type == enums.AutoinstallerType.XEN:
+            return XenGenerator(api=self.api)
         raise ValueError("Unknown template type selected!")
 
     def generate_autoinstall(

--- a/cobbler/data/templates/cheetah/autoinstall/scripts/xcp_post_install.template
+++ b/cobbler/data/templates/cheetah/autoinstall/scripts/xcp_post_install.template
@@ -1,0 +1,2 @@
+#!/bin/bash
+$SNIPPET('built-in-autoinstall_done')

--- a/cobbler/data/templates/cheetah/autoinstall/scripts/xcp_pre_install.template
+++ b/cobbler/data/templates/cheetah/autoinstall/scripts/xcp_pre_install.template
@@ -1,0 +1,2 @@
+#!/bin/sh
+$SNIPPET('built-in-autoinstall_start')

--- a/cobbler/data/templates/cheetah/autoinstall/snippets/network_config_xcp.template
+++ b/cobbler/data/templates/cheetah/autoinstall/snippets/network_config_xcp.template
@@ -1,0 +1,59 @@
+## start of cobbler network_config generated code
+#if $getVar("system_name","") != ""
+    #set ikeys = $interfaces.keys()
+    #import re
+    #for $iname in $ikeys
+        #set $idata    = $interfaces[$iname]
+        #set $mac      = $idata["mac_address"]
+        #set $static   = $idata["static"]
+        #set $ip       = $idata["ipv4"]["address"]
+        #set $netmask  = $idata["ipv4"]["netmask"]
+        #set $type     = $idata["interface_type"]
+        ## Ignore BMC interface
+        #if $type == "bmc"
+            #continue
+        #end if
+        #if $iname != "default":
+            #set $if_id = 'name="' + $iname + '"'
+        #elif $mac != "":
+            #set $if_id = 'hwaddr="' + $mac + '"'
+        #else
+            #set $if_id = 'name="*"'
+        #end if
+        #if $static == True:
+            #if $ip != "":
+  <admin-interface $if_id proto="static">
+   <ipaddr>$ip</ipaddr>
+                #if $netmask != "":
+   <subnet>$netmask</subnet>
+                #else
+   <subnet>255.255.255.0</subnet>
+                #end if
+                #if $gateway != "":
+   <gateway>$gateway</gateway>
+                #end if
+  </admin-interface>
+            #else
+  <admin-interface $if_id proto="dhcp" />
+            #end if
+        #else
+  <admin-interface $if_id proto="dhcp" />
+        #end if
+        #if $name_servers and $name_servers[0] != "":
+            #for $ns in $name_servers
+  <name-server>$ns</name-server>
+            #end for
+        #end if
+        #if $hostname != ""
+  <hostname>$hostname</hostname>
+        #else
+            #set $myhostname = $getVar('name','').replace("_","-")
+  <hostname>$myhostname</hostname>
+        #end if
+    #end for
+#else
+## profile based install so just provide one interface for starters
+#set $myhostname = $getVar('hostname',$getVar('name','cobbler')).replace("_","-")
+  <admin-interface name="*" proto="dhcp" />
+  <hostname>$myhostname</hostname>
+#end if

--- a/cobbler/data/templates/cheetah/autoinstall/xcp_answerfile.xml.template
+++ b/cobbler/data/templates/cheetah/autoinstall/xcp_answerfile.xml.template
@@ -1,0 +1,21 @@
+<?xml version="1.0"?>
+ <installation sr-type="ext" mode="fresh" netinstall-gpg-check="true">
+  <keymap>us</keymap>
+  <timezone>US/Eastern</timezone>
+  <source type="url">$tree/</source>
+  <driver-source type="url">$tree/</driver-source>
+  <primary-disk>sda</primary-disk>
+  <root-password type="hash">$default_password_crypted</root-password>
+  <bootloader location="mbr">grub2</bootloader>
+$SNIPPET('built-in-network_config_xcp')
+  <ntp-server>us.pool.ntp.org</ntp-server>
+  <network-backend>vswitch</network-backend>
+## Figure out if we're automating OS installation for a system or a profile
+#if $getVar('system_name','') != ''
+#set $what = "system"
+#else
+#set $what = "profile"
+#end if
+  <script stage="installation-start" type="url">http://$http_server/cblr/svc/op/script/$what/$name/?script=built-in-xcp_pre_install</script>
+  <script stage="installation-complete" type="url">http://$http_server/cblr/svc/op/script/$what/$name/?script=built-in-xcp_post_install</script>
+ </installation>

--- a/cobbler/data/templates/cheetah/boot_loader_conf/grub.template
+++ b/cobbler/data/templates/cheetah/boot_loader_conf/grub.template
@@ -8,6 +8,14 @@ set default='local'
 #end if
 #end if
 menuentry '$menu_label' --class gnu-linux --class gnu --class os {
+#if $breed == "xen" and $os_version.startswith("xcp")
+  echo 'Loading Xen kernel ...'
+  multiboot2 $initrd_path dom0_mem=max:2048M watchdog dom0_max_vcpus=4 com1=115200,8n1 console=com1,vga
+  echo 'Loading Dom0 kernel ...'
+  module2 $kernel_path $kernel_options
+  echo 'Loading initial ramdisk ...'
+  module2 $img_path/install.img
+#else
   echo 'Loading kernel ...'
   clinux $kernel_path $kernel_options
 #if "wimboot" in $kernel_path
@@ -19,6 +27,7 @@ menuentry '$menu_label' --class gnu-linux --class gnu --class os {
 #if $breed != "windows" or "wimboot" in $kernel_path
   echo 'Loading initial ramdisk ...'
   cinitrd $initrd_path
+#end if
 #end if
   echo '...done'
 }

--- a/cobbler/data/templates/cheetah/boot_loader_conf/pxe.template
+++ b/cobbler/data/templates/cheetah/boot_loader_conf/pxe.template
@@ -27,6 +27,8 @@ LABEL $menu_name
 #end if
 #if $breed == "vmware"
 	append -c $bootcfg_path
+#elif $breed == "xen" and $os_version.startswith("xcp")
+	append $initrd_path dom0_max_vcpus=2 dom0_mem=max:2048M com1=115200,8n1 console=com1,vga --- $img_path/$os.path.basename($kernel) $append_line --- $img_path/install.img
 #elif $breed != "windows" or "wimboot" in $kernel_path
 	$append_line
 #end if

--- a/cobbler/templates/__init__.py
+++ b/cobbler/templates/__init__.py
@@ -84,6 +84,7 @@ TEMPLATE_TAG_MAPPING: Dict[str, Set[enums.ConvertableEnum]] = {
     "sample_esxi6.ks.template": {enums.AutoinstallerType.KICKSTART},
     "sample_esxi7.ks.template": {enums.AutoinstallerType.KICKSTART},
     "sample_legacy.ks.template": {enums.AutoinstallerType.KICKSTART},
+    "xcp_answerfile.xml.template": {enums.AutoinstallerType.XEN},
     "sample_old.seed.template": {enums.AutoinstallerType.PRESEED},
     "sample.ks.template": {enums.AutoinstallerType.KICKSTART},
     "sample.seed.template": {enums.AutoinstallerType.PRESEED},

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -1293,7 +1293,7 @@ class TFTPGen:
             append_line = "append "
         # TODO if cloud-init then add nocloud-net to kernel options
         append_line = f"{append_line}{kernel_options}"
-        if distro and distro.os_version.startswith("xenserver620"):
+        if distro and distro.os_version.startswith(("xenserver620", "xcp")):
             append_line = f"{kernel_options}"
         metadata["append_line"] = append_line
 
@@ -1440,6 +1440,11 @@ class TFTPGen:
             # ESXi: for templating pxe/ipxe, kernel_path is bootloader mboot.c32
             if distro.breed == "vmware" and distro.os_version.startswith("esxi"):
                 kernel_path = os.path.join(img_path, "mboot.c32")
+
+            # XCP-ng: PXE boots via the syslinux mboot.c32 module (symlinked at the tftpboot root),
+            # not a per-distro kernel image.
+            if boot_loader == "pxe" and distro.os_version.startswith("xcp"):
+                kernel_path = "mboot.c32"
 
             if not kernel_path:
                 kernel_path = os.path.join(img_path, os.path.basename(distro.kernel))
@@ -1664,6 +1669,8 @@ class TFTPGen:
                         f"vga --- {img_path}/vmlinuz xencons=hvc console=hvc0 console=tty0 install"
                         f" answerfile={autoinstall_path} --- {img_path}/install.img"
                     )
+                if distro.os_version.startswith("xcp"):
+                    return f" {hkopts} install answerfile={autoinstall_path}"
             elif distro.breed == "powerkvm":
                 append_line.append_key("kssendmac")
                 append_line.append_key_value("kvmp.inst.auto", autoinstall_path)

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    extends: ["@commitlint/config-conventional"],
+    ignores: [(message) => message.includes("dependabot[bot]")],
+    rules: {
+        "body-max-line-length": [2, "always", 120],
+        "footer-max-line-length": [2, "always", 120],
+        "header-max-length": [2, "always", 72],
+    },
+};

--- a/docs/code-autodoc/cobbler.autoinstall.generate.rst
+++ b/docs/code-autodoc/cobbler.autoinstall.generate.rst
@@ -68,6 +68,14 @@ cobbler.autoinstall.generate.windows module
    :show-inheritance:
    :undoc-members:
 
+cobbler.autoinstall.generate.xen module
+---------------------------------------
+
+.. automodule:: cobbler.autoinstall.generate.xen
+   :members:
+   :show-inheritance:
+   :undoc-members:
+
 Module contents
 ---------------
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "cobbler-commit-tooling",
+  "private": true,
+  "description": "Commit message linting tooling for Cobbler (commitlint) - not a published package",
+  "devDependencies": {
+    "@commitlint/cli": "^21.2.1",
+    "@commitlint/config-conventional": "^21.2.0"
+  }
+}

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ if __name__ == "__main__":
             "schema",
             "systemd-python",
             "gunicorn",
-            "libcobblersignatures>=0.3.2",
+            "libcobblersignatures>=0.4.0",
             "dataclasses; python_version < '3.7'",
             "importlib-resources; python_version < '3.7'",
         ],

--- a/tests/actions/mkloaders_test.py
+++ b/tests/actions/mkloaders_test.py
@@ -36,10 +36,10 @@ def test_grubimage_run(cobbler_api: CobblerAPI, mocker: "MockerFixture"):
 
     # Assert
     # pylint: disable=no-member
-    # On a full install: 3 common formats, 4 syslinux links and 9 bootloader formats
-    # In our test container we have: shim (2x), ipxe (1x), syslinux v4 (3x) and 3 grubs (4x)
-    # On GH we have: shim (2x), ipxe (1x), syslinux v4 (3x) and 3 grubs (3x)
-    assert mkloaders.symlink.call_count == 9  # type: ignore[reportFunctionMemberAccess]
+    # On a full install: 3 common formats, 5 syslinux links and 9 bootloader formats
+    # In our test container we have: shim (2x), ipxe (1x), syslinux v4 (4x) and 3 grubs (4x)
+    # On GH we have: shim (2x), ipxe (1x), syslinux v4 (4x) and 3 grubs (3x)
+    assert mkloaders.symlink.call_count == 10  # type: ignore[reportFunctionMemberAccess]
     # In our test container we have: x86_64, arm64-efi, i386-efi & i386-pc-pxe
     # On GH we have: x86_64, i386-efi & i386-pc-pxe
     assert mkloaders.mkimage.call_count == 3  # type: ignore[reportFunctionMemberAccess]

--- a/tests/special_cases/built_in_scripts_test.py
+++ b/tests/special_cases/built_in_scripts_test.py
@@ -2,7 +2,7 @@
 Test module for built-in scripts in Cobbler.
 """
 
-from typing import Callable
+from typing import Callable, List
 
 from cobbler.api import CobblerAPI
 from cobbler.items.distro import Distro
@@ -96,6 +96,58 @@ def test_built_in_preseed_nochroot_late_default(
         "",
     ]
     template = "built-in-preseed_nochroot_late_default"
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+
+    # Act
+    result = cobbler_api.generate_script(test_profile.name, None, template)
+
+    # Assert
+    assert result == "\n".join(expected_result)
+
+
+def test_built_in_xcp_pre_install(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    Test to verify the built-in xcp_pre_install script generation.
+    """
+    # Arrange
+    expected_result: List[str] = [
+        "#!/bin/sh",
+        "",
+        'wget "http://192.168.1.1/cblr/svc/op/trig/mode/pre/profile/test_built_in_xcp_pre_install" -O /dev/null',
+        "",
+    ]
+    template = "built-in-xcp_pre_install"
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+
+    # Act
+    result = cobbler_api.generate_script(test_profile.name, None, template)
+
+    # Assert
+    assert result == "\n".join(expected_result)
+
+
+def test_built_in_xcp_post_install(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    Test to verify the built-in xcp_post_install script generation.
+    """
+    # Arrange
+    expected_result: List[str] = [
+        "#!/bin/bash",
+        "",
+        'wget "http://192.168.1.1/cblr/svc/op/trig/mode/post/profile/test_built_in_xcp_post_install" -O /dev/null',
+        "",
+    ]
+    template = "built-in-xcp_post_install"
     test_distro = create_distro()
     test_profile = create_profile(test_distro.uid)
 

--- a/tests/special_cases/built_in_snippets_test.py
+++ b/tests/special_cases/built_in_snippets_test.py
@@ -832,3 +832,46 @@ def test_built_in_redhat_register(cobbler_api: CobblerAPI):
 
     # Assert
     assert result == "\n".join(expected_result)
+
+
+def test_built_in_network_config_xcp(cobbler_api: CobblerAPI):
+    """
+    Test to verify the functionality of the built-in network_config_xcp snippet.
+    """
+    # Arrange
+    expected_result: List[str] = [
+        '  <admin-interface hwaddr="aa:bb:cc:dd:ee:ff" proto="static">',
+        "   <ipaddr>192.168.1.10</ipaddr>",
+        "   <subnet>255.255.255.0</subnet>",
+        "  </admin-interface>",
+        "  <hostname></hostname>",
+        "",
+    ]
+    target_template = cobbler_api.find_template(
+        False, False, name="built-in-network_config_xcp"
+    )
+    if target_template is None or isinstance(target_template, list):
+        pytest.fail("Target template not found!")
+    meta: Dict[str, Any] = {
+        "system_name": "test_name",
+        "hostname": "",
+        "gateway": "",
+        "name_servers": [],
+        "interfaces": {
+            "default": {
+                "mac_address": "aa:bb:cc:dd:ee:ff",
+                "static": True,
+                "ipv4": {
+                    "address": "192.168.1.10",
+                    "netmask": "255.255.255.0",
+                },
+                "interface_type": "",
+            }
+        },
+    }
+
+    # Act
+    result = cobbler_api.templar.render(target_template.content, meta, None)
+
+    # Assert
+    assert result == "\n".join(expected_result)

--- a/tests/special_cases/built_in_templates_xcp_test.py
+++ b/tests/special_cases/built_in_templates_xcp_test.py
@@ -1,0 +1,40 @@
+"""
+Test module to extensively verify the built-in XCP-ng Answerfile Template.
+"""
+
+from typing import Callable
+
+import pytest
+
+from cobbler.api import CobblerAPI
+from cobbler.autoinstall.manager import AutoInstallationManager
+from cobbler.items.distro import Distro
+from cobbler.items.profile import Profile
+
+
+def test_built_in_xcp_answerfile_xml(
+    cobbler_api: CobblerAPI,
+    autoinstall_manager: AutoInstallationManager,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+):
+    """
+    Test to verify the built-in XCP-ng answerfile XML template.
+    """
+    # Arrange
+    target_template = cobbler_api.find_template(
+        False, False, name="built-in-xcp_answerfile.xml"
+    )
+    if target_template is None or isinstance(target_template, list):
+        pytest.fail("Could not find built-in template!")
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_profile.autoinstall = target_template
+
+    # Act
+    result = autoinstall_manager.generate_autoinstall(test_profile, target_template)
+
+    # Assert
+    # TODO: Extend assertion
+    assert isinstance(result, str)
+    assert "<installation" in result

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -683,6 +683,12 @@ def test_build_kernel_options_system(
             "append /images/test_build_kernel_options_autoinstall/xen.gz dom0_max_vcpus=2 dom0_mem=752M com1=115200,8n1 console=com1,vga --- /images/test_build_kernel_options_autoinstall/vmlinuz xencons=hvc console=hvc0 console=tty0 install answerfile=http://192.168.1.1/cblr/svc/op/autoinstall/system/test_build_kernel_options_autoinstall/file/built-in-answerfile.xml --- /images/test_build_kernel_options_autoinstall/install.img",
         ),
         (
+            "xen",
+            "xcp82",
+            "built-in-xcp_answerfile.xml",
+            "  install answerfile=http://192.168.1.1/cblr/svc/op/autoinstall/system/test_build_kernel_options_autoinstall/file/built-in-xcp_answerfile.xml",
+        ),
+        (
             "powerkvm",
             "",
             "built-in-powerkvm.ks",


### PR DESCRIPTION
## Linked Items

Fixes #3980

Forward port of #3981

## Description

This PR adds XCP-ng 7.x and 8.x support. Furthermore, it starts enforcing conventional commits as other repos in the Cobbler org already do.

## Behaviour changes

Old: Newer XCP-ng releases can't be recognised by Cobbler

New: XCP-ng 7.x and 8.x releases are recognized by Cobbler

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
