### PR TITLE
fixes to PR-4001

### DIFF
--- a/autoinstall_snippets/agama_hostname
+++ b/autoinstall_snippets/agama_hostname
@@ -7,7 +7,7 @@
     "static": "$myhostname"
     #end if
 #else
-## profile based install so just provide one interface for starters
+## profile based install
 #set $myhostname = $getVar('hostname',$getVar('name','cobbler')).replace("_","-")
     "static": "$myhostname"
 #end if

--- a/autoinstall_templates/sample_agama.json
+++ b/autoinstall_templates/sample_agama.json
@@ -11,15 +11,12 @@
 $SNIPPET('agama_hostname')
 $SNIPPET('agama_networking')
 
-  "user": {
-    "fullName": "susadmin",
-    "userName": "susadmin",
+  "root": {
     "hashedPassword": true,
     "password": "$default_password_crypted"
   },
 
   "software": {
-    "patterns": ["basesystem"],
     "packages": ["agama-scripts", "sudo"],
     "onlyRequired": false
   },


### PR DESCRIPTION
Follow up to PR #4001 _(thanks for getting that merged)_

I left a few environment-specific configs from my local dev/test that didn't exactly line up with typical cobbler defaults or the Agama reference [page](https://agama-project.github.io/docs/user/reference/profile/software).

One thing I should mention regarding this (and the original commit), the `sample_agama.json` template includes 'agama-scripts' as a package to install, but this package is not available on Leap 16 install media (ISO) so could cause some issues if users do not install from or mirror the online repos appropriately. However, this package is necessary for the Agama first-boot installation scripts, so I decided to leave it in the sample template. I could try to come up with something else if needed, or double-check the cobbler `main` branch functionality and try to align.

Let me know your thoughts.