### PR TITLE
XML-RPC: Switch to object ID for get_item

### DIFF
--- a/cobbler/actions/replicate.py
+++ b/cobbler/actions/replicate.py
@@ -216,7 +216,8 @@ class Replicate:
             for distro in self.must_include["distro"]:
                 if self.must_include["distro"][distro] == 1:
                     self.logger.info("Rsyncing distro %s", distro)
-                    target = self.remote.get_distro(distro)
+                    distro_handle = self.remote.get_distro_handle(distro)
+                    target = self.remote.get_distro(distro_handle)
                     if not isinstance(target, dict):
                         raise TypeError(
                             "Remote server passed unexpected data for distro"

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -22,6 +22,9 @@ V4.0.0 (unreleased)
         * ``remove_item`` and all ``remove_<type>`` methods: Require an item handle (object id) instead of the name
           of the item, matching the contract of ``modify_item``. Clients that only know the name of an item have to
           retrieve a handle via ``get_item_handle`` or ``get_<type>_handle`` first.
+        * ``get_item`` and all ``get_<type>`` methods: Require an item handle (object id) instead of the name
+          of the item, matching the contract of ``modify_item``. Clients that only know the name of an item have to
+          retrieve a handle via ``get_item_handle`` or ``get_<type>_handle`` first.
     * Removed:
         * ``xapi_object_edit``: Remove all-in-one edit method for the CLI
 
@@ -1105,25 +1108,26 @@ class CobblerXMLRPCInterface:
     def get_item(
         self,
         what: str,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
     ):
         """
         Returns a dict describing a given object.
+        Note that this requires an item handle (object id), not the name of the item. Callers that only know the name
+        of an item have to retrieve a handle via ``get_item_handle`` or the type specific ``get_<type>_handle`` first.
 
         :param what: "distro", "profile", "system", "image", "repo", etc
-        :param name: the object name to retrieve
+        :param object_id: The id of the object which shall be retrieved.
         :param flatten: reduce dicts to string representations (True/False)
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
         :return: The item or None.
         """
-        self._log(f"get_item({what},{name})")
-        item_handle = self.get_item_handle(what, name, token=token)
+        self._log(f"get_item({what})", object_id=object_id, token=token)
         try:
-            requested_item = self.__get_object(item_handle, token=token)
+            requested_item = self.__get_object(object_id, token=token)
         except ValueError:
             return self.xmlrpc_hacks(None)
         requested_item_dict = requested_item.to_dict(resolved=resolved)
@@ -1133,7 +1137,7 @@ class CobblerXMLRPCInterface:
 
     def get_distro(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1142,7 +1146,7 @@ class CobblerXMLRPCInterface:
         """
         Get a distribution.
 
-        :param name: The name of the distribution to get.
+        :param object_id: The id of the distribution to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1151,12 +1155,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "distro", name, flatten=flatten, resolved=resolved, token=token
+            "distro", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_profile(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1165,7 +1169,7 @@ class CobblerXMLRPCInterface:
         """
         Get a profile.
 
-        :param name: The name of the profile to get.
+        :param object_id: The id of the profile to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1174,12 +1178,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "profile", name, flatten=flatten, resolved=resolved, token=token
+            "profile", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_system(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1188,7 +1192,7 @@ class CobblerXMLRPCInterface:
         """
         Get a system.
 
-        :param name: The name of the system to get.
+        :param object_id: The id of the system to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1197,12 +1201,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "system", name, flatten=flatten, resolved=resolved, token=token
+            "system", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_repo(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1211,7 +1215,7 @@ class CobblerXMLRPCInterface:
         """
         Get a repository.
 
-        :param name: The name of the repository to get.
+        :param object_id: The id of the repository to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1220,12 +1224,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "repo", name, flatten=flatten, resolved=resolved, token=token
+            "repo", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_image(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1234,7 +1238,7 @@ class CobblerXMLRPCInterface:
         """
         Get an image.
 
-        :param name: The name of the image to get.
+        :param object_id: The id of the image to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1243,12 +1247,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "image", name, flatten=flatten, resolved=resolved, token=token
+            "image", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_menu(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1257,7 +1261,7 @@ class CobblerXMLRPCInterface:
         """
         Get a menu.
 
-        :param name: The name of the file to get.
+        :param object_id: The id of the menu to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1266,12 +1270,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "menu", name, flatten=flatten, resolved=resolved, token=token
+            "menu", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_network_interface(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1280,7 +1284,7 @@ class CobblerXMLRPCInterface:
         """
         Get a network interface.
 
-        :param name: The name of the network interface to get.
+        :param object_id: The id of the network interface to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1289,12 +1293,16 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "network_interface", name, flatten=flatten, resolved=resolved, token=token
+            "network_interface",
+            object_id,
+            flatten=flatten,
+            resolved=resolved,
+            token=token,
         )
 
     def get_template(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1303,7 +1311,7 @@ class CobblerXMLRPCInterface:
         """
         Get a template.
 
-        :param name: The name of the template to get.
+        :param object_id: The id of the template to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1312,12 +1320,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "template", name, flatten=flatten, resolved=resolved, token=token
+            "template", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_distro_group(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1326,7 +1334,7 @@ class CobblerXMLRPCInterface:
         """
         Get a distro group.
 
-        :param name: The name of the distro group to get.
+        :param object_id: The id of the distro group to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1335,12 +1343,12 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "distro_group", name, flatten=flatten, resolved=resolved, token=token
+            "distro_group", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_profile_group(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1349,7 +1357,7 @@ class CobblerXMLRPCInterface:
         """
         Get a profile group.
 
-        :param name: The name of the profile group to get.
+        :param object_id: The id of the profile group to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1358,12 +1366,16 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "profile_group", name, flatten=flatten, resolved=resolved, token=token
+            "profile_group",
+            object_id,
+            flatten=flatten,
+            resolved=resolved,
+            token=token,
         )
 
     def get_system_group(
         self,
-        name: str,
+        object_id: str,
         flatten: bool = False,
         resolved: bool = False,
         token: Optional[str] = None,
@@ -1372,7 +1384,7 @@ class CobblerXMLRPCInterface:
         """
         Get a system group.
 
-        :param name: The name of the system group to get.
+        :param object_id: The id of the system group to get.
         :param flatten: If the item should be flattened.
         :param resolved: If this is True, Cobbler will resolve the values to its final form, rather than give you the
                          objects raw value.
@@ -1381,7 +1393,7 @@ class CobblerXMLRPCInterface:
         :return: The item or None.
         """
         return self.get_item(
-            "system_group", name, flatten=flatten, resolved=resolved, token=token
+            "system_group", object_id, flatten=flatten, resolved=resolved, token=token
         )
 
     def get_template_content(self, uid: str, token: Optional[str] = None) -> str:

--- a/cobbler/services/files.py
+++ b/cobbler/services/files.py
@@ -103,7 +103,8 @@ def resolve_source_tree_path(distro_name: str) -> Optional[str]:
 
     remote = _build_remote()
     try:
-        data = remote.get_distro(distro_name)
+        distro_handle = remote.get_distro_handle(distro_name)
+        data = remote.get_distro(distro_handle)
     except (xmlrpc.client.Fault, xmlrpc.client.ProtocolError, OSError):
         data = None
 

--- a/tests/integration/settings_cli_test.py
+++ b/tests/integration/settings_cli_test.py
@@ -137,7 +137,8 @@ def test_settings_cli_migrate_from_2_8_5(
     restart_cobbler()
 
     # Assert - Boot loaders should be preserved after migration.
-    assert remote.get_distro("fake", False, False, token).get("boot_loaders") == [  # type: ignore
+    distro_handle = remote.get_distro_handle("fake")
+    assert remote.get_distro(distro_handle, False, False, token).get("boot_loaders") == [  # type: ignore
         "<<inherit>>"
     ]
 

--- a/tests/services/files_test.py
+++ b/tests/services/files_test.py
@@ -436,9 +436,13 @@ def test_metadata_cache_reuses_lookup_within_ttl(
     root_b.mkdir()
     (root_b / "f.txt").write_text("b")
 
-    def fake_get_distro(name: str) -> Dict[str, Any]:
-        return _distro_dict(str(root_a) if name == "distro-a" else str(root_b))
+    def fake_get_distro(handle: str) -> Dict[str, Any]:
+        return _distro_dict(str(root_a) if handle == "distro-a" else str(root_b))
 
+    def fake_get_distro_handle(name: str) -> str:
+        return name
+
+    stub_remote.get_distro_handle.side_effect = fake_get_distro_handle
     stub_remote.get_distro.side_effect = fake_get_distro
 
     resp1, body1 = _call(_environ("/tree/distro-a/f.txt"))

--- a/tests/xmlrpcapi/distro_group_test.py
+++ b/tests/xmlrpcapi/distro_group_test.py
@@ -45,7 +45,7 @@ def test_modify_save_and_get_distro_group(remote: CobblerXMLRPCInterface, token:
     remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
-    group = remote.get_distro_group("test_distro_group", token=token)
+    group = remote.get_distro_group(handle, token=token)
 
     # Assert
     assert group is not None
@@ -130,7 +130,7 @@ def test_remove_distro_group(remote: CobblerXMLRPCInterface, token: str):
 
     # Assert
     assert result is True
-    group = remote.get_distro_group("test_distro_group_to_remove", token=token)
+    group = remote.get_distro_group(handle, token=token)
     assert group == "~"
 
 

--- a/tests/xmlrpcapi/distro_test.py
+++ b/tests/xmlrpcapi/distro_test.py
@@ -114,7 +114,8 @@ def test_get_distro(remote: CobblerXMLRPCInterface, fk_initrd: str, fk_kernel: s
     # Arrange --> Done in fixture
 
     # Act
-    distro = remote.get_distro("testdistro0")
+    distro_handle = remote.get_distro_handle("testdistro0")
+    distro = remote.get_distro(distro_handle)
 
     # Assert
     assert distro.get("name") == "testdistro0"  # type: ignore

--- a/tests/xmlrpcapi/image_test.py
+++ b/tests/xmlrpcapi/image_test.py
@@ -47,7 +47,7 @@ class TestImage:
         test_image = create_image()
 
         # Act
-        result_image = remote.get_image(test_image.name)
+        result_image = remote.get_image(test_image.uid)
 
         # Assert
         assert result_image.get("name") == test_image.name  # type: ignore[reportUnknownMemberType]

--- a/tests/xmlrpcapi/item_test.py
+++ b/tests/xmlrpcapi/item_test.py
@@ -18,7 +18,8 @@ def test_get_item_resolved(
     # Arrange --> Done in fixture
 
     # Act
-    distro = remote.get_item("distro", "testdistro0", resolved=True)
+    distro_handle = remote.get_distro_handle("testdistro0")
+    distro = remote.get_item("distro", distro_handle, resolved=True)
 
     # Assert
     assert distro.get("name") == "testdistro0"  # type: ignore

--- a/tests/xmlrpcapi/menu_test.py
+++ b/tests/xmlrpcapi/menu_test.py
@@ -93,7 +93,8 @@ class TestMenu:
         # Arrange --> Done in fixture
 
         # Act
-        menu = remote.get_menu("testmenu0")
+        menu_uid = remote.get_menu_handle("testmenu0")
+        menu = remote.get_menu(menu_uid)
 
         # Assert
         assert menu.get("name") == "testmenu0"  # type: ignore[reportUnknownMemberType]

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -687,7 +687,7 @@ def test_save_distro_with_triggers_false(
 
     # Assert
     assert result is True
-    assert remote.get_distro("testdistro_notriggers", False, False, token) is not None
+    assert remote.get_distro(distro, False, False, token) is not None
 
 
 @pytest.mark.integration

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -313,11 +313,11 @@ def test_get_item_resolved_value(
         test_network_interface_handle, True, True, "new", token
     )
     if checked_object == "distro":
-        test_item = remote.get_distro(name_distro, token=token)
+        test_item = remote.get_distro(distro_uid, token=token)
     elif checked_object == "profile":
-        test_item = remote.get_profile(name_profile, token=token)
+        test_item = remote.get_profile(profile_uid, token=token)
     elif checked_object == "system":
-        test_item = remote.get_system(name_system, token=token)
+        test_item = remote.get_system(test_system_handle, token=token)
     else:
         raise ValueError("checked_object has wrong value")
 
@@ -436,3 +436,79 @@ def test_remove_item_with_name_instead_of_handle(
 
     # Cleanup
     assert remote.remove_distro(distro_uid, token, False) is True
+
+
+def test_get_item_with_duplicate_names(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Verify that an item can be retrieved via its handle even if its name is not globally unique.
+
+    Network interface names are only unique per system, so two systems may both own an interface called "eth0". Since
+    ``get_network_interface`` takes an object id, the caller can address exactly one of them.
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+    distro_uid = create_distro(
+        "testdistro_get_duplicate_names", "x86_64", "suse", path_kernel, path_initrd
+    )
+    profile_uid = create_profile("testprofile_get_duplicate_names", distro_uid, "")
+    system_uids = [
+        create_system(f"testsystem_get_duplicate_names{i}", profile_uid)
+        for i in range(2)
+    ]
+    interface_uids: List[str] = []
+    for i, system_uid in enumerate(system_uids):
+        interface_handle = remote.new_network_interface(system_uid, token)
+        remote.modify_network_interface(interface_handle, ["name"], "eth0", token)
+        remote.modify_network_interface(
+            interface_handle, ["mac_address"], f"aa:bb:cc:dd:ee:0{i}", token
+        )
+        remote.save_network_interface(interface_handle, True, True, "new", token)
+        interface_uids.append(interface_handle)
+
+    # The name alone is ambiguous, so a handle has to be obtained via a more specific search.
+    with pytest.raises(CX):
+        remote.get_network_interface_handle("eth0")
+
+    # Act & Assert
+    first_interface = remote.get_network_interface(interface_uids[0], token=token)
+    assert isinstance(first_interface, dict)
+    assert first_interface.get("mac_address") == "aa:bb:cc:dd:ee:00"
+
+    second_interface = remote.get_network_interface(interface_uids[1], token=token)
+    assert isinstance(second_interface, dict)
+    assert second_interface.get("mac_address") == "aa:bb:cc:dd:ee:01"
+
+
+def test_get_item_with_name_instead_of_handle(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Verify that passing a name instead of an object id to ``get_item``/``get_<type>`` does not return the object.
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+    distro_name = "testdistro_get_name_instead_of_handle"
+    distro_uid = create_distro(distro_name, "x86_64", "suse", path_kernel, path_initrd)
+
+    # Act & Assert
+    assert remote.get_distro(distro_name) == "~"
+    assert remote.get_item("distro", distro_name) == "~"
+    assert remote.get_distro(distro_uid).get("name") == distro_name  # type: ignore

--- a/tests/xmlrpcapi/profile_group_test.py
+++ b/tests/xmlrpcapi/profile_group_test.py
@@ -45,7 +45,7 @@ def test_modify_save_and_get_profile_group(remote: CobblerXMLRPCInterface, token
     remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
-    group = remote.get_profile_group("test_profile_group", token=token)
+    group = remote.get_profile_group(handle, token=token)
 
     # Assert
     assert group is not None
@@ -130,7 +130,7 @@ def test_remove_profile_group(remote: CobblerXMLRPCInterface, token: str):
 
     # Assert
     assert result is True
-    group = remote.get_profile_group("test_profile_group_to_remove", token=token)
+    group = remote.get_profile_group(handle, token=token)
     assert group == "~"
 
 

--- a/tests/xmlrpcapi/profile_test.py
+++ b/tests/xmlrpcapi/profile_test.py
@@ -205,7 +205,8 @@ def test_get_profile(remote: CobblerXMLRPCInterface):
     distro_uid = remote.get_distro_handle("testdistro0")
 
     # Act
-    profile = remote.get_profile("testprofile0")
+    profile_uid = remote.get_profile_handle("testprofile0")
+    profile = remote.get_profile(profile_uid)
 
     # Assert
     assert profile.get("name") == "testprofile0"  # type: ignore

--- a/tests/xmlrpcapi/repo_test.py
+++ b/tests/xmlrpcapi/repo_test.py
@@ -69,7 +69,8 @@ class TestRepo:
         # Arrange --> Done in fixture
 
         # Act
-        repo = remote.get_repo("testrepo0")
+        repo_uid = remote.get_repo_handle("testrepo0")
+        repo = remote.get_repo(repo_uid)
 
         # Assert
         assert repo.get("name") == "testrepo0"  # type: ignore

--- a/tests/xmlrpcapi/system_group_test.py
+++ b/tests/xmlrpcapi/system_group_test.py
@@ -45,7 +45,7 @@ def test_modify_save_and_get_system_group(remote: CobblerXMLRPCInterface, token:
     remote.save_system_group(handle, True, True, "new", token)
 
     # Act
-    group = remote.get_system_group("test_system_group", token=token)
+    group = remote.get_system_group(handle, token=token)
 
     # Assert
     assert group is not None
@@ -130,7 +130,7 @@ def test_remove_system_group(remote: CobblerXMLRPCInterface, token: str):
 
     # Assert
     assert result is True
-    group = remote.get_system_group("test_system_group_to_remove", token=token)
+    group = remote.get_system_group(handle, token=token)
     assert group == "~"
 
 

--- a/tests/xmlrpcapi/transaction_test.py
+++ b/tests/xmlrpcapi/transaction_test.py
@@ -68,19 +68,17 @@ def test_modify_profile(
 
     # changes are visible inside the transaction identified by the token
     assert (
-        cast(Dict[Any, Any], remote.get_profile("testprofile0", token=token))["comment"]
+        cast(Dict[Any, Any], remote.get_profile(profile, token=token))["comment"]
         == "test comment"
     )
 
     # changes are not visible until commit
     assert (
-        cast(Dict[Any, Any], remote.get_profile("testprofile0"))["comment"]
-        != "test comment"
+        cast(Dict[Any, Any], remote.get_profile(profile))["comment"] != "test comment"
     )
     assert remote.transaction_commit(token)
     assert (
-        cast(Dict[Any, Any], remote.get_profile("testprofile0"))["comment"]
-        == "test comment"
+        cast(Dict[Any, Any], remote.get_profile(profile))["comment"] == "test comment"
     )
 
 
@@ -269,19 +267,19 @@ def test_parent_profile_recursive(remote: CobblerXMLRPCInterface, token: str):
     assert remote.save_profile(profile3, True, True, "bypass", token)
 
     # Act
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile0"))["depth"] == 1
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile1"))["depth"] == 2
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile2"))["depth"] == 3
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile3"))["depth"] == 4
+    assert cast(Dict[Any, Any], remote.get_profile(profile_uid))["depth"] == 1
+    assert cast(Dict[Any, Any], remote.get_profile(profile1))["depth"] == 2
+    assert cast(Dict[Any, Any], remote.get_profile(profile2))["depth"] == 3
+    assert cast(Dict[Any, Any], remote.get_profile(profile3))["depth"] == 4
 
     assert remote.modify_profile(profile2, ["parent"], profile_uid, token)
     assert remote.save_profile(profile2, True, True, "bypass", token)
 
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile0"))["depth"] == 1
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile1"))["depth"] == 2
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile2"))["depth"] == 2
+    assert cast(Dict[Any, Any], remote.get_profile(profile_uid))["depth"] == 1
+    assert cast(Dict[Any, Any], remote.get_profile(profile1))["depth"] == 2
+    assert cast(Dict[Any, Any], remote.get_profile(profile2))["depth"] == 2
     #   this seems to be a bug
-    #   assert cast(Dict[Any, Any], remote.get_profile("testprofile3"))["depth"] == 3
+    #   assert cast(Dict[Any, Any], remote.get_profile(profile3))["depth"] == 3
 
     assert remote.remove_profile(profile_uid, token)
 
@@ -407,8 +405,7 @@ def test_conflict2(remote: CobblerXMLRPCInterface, token: str, token2: str):
 
     # result of the successfully commited transaction - comment is set
     assert (
-        cast(Dict[Any, Any], remote.get_profile("testprofile0"))["comment"]
-        == "test comment"
+        cast(Dict[Any, Any], remote.get_profile(profile))["comment"] == "test comment"
     )
 
 
@@ -481,15 +478,9 @@ def test_modify_distro(
 
     assert remote.get_distro_handle("testdistro0") == distro
 
-    assert (
-        cast(Dict[Any, Any], remote.get_distro("testdistro0"))["comment"]
-        != "test comment"
-    )
+    assert cast(Dict[Any, Any], remote.get_distro(distro))["comment"] != "test comment"
     assert remote.transaction_commit(token)
-    assert (
-        cast(Dict[Any, Any], remote.get_distro("testdistro0"))["comment"]
-        == "test comment"
-    )
+    assert cast(Dict[Any, Any], remote.get_distro(distro))["comment"] == "test comment"
 
 
 @pytest.mark.usefixtures(
@@ -626,7 +617,7 @@ def test_reparent_and_remove_distro(
     assert remote.get_item_handle("distro", "testdistro0") == "~"
     assert remote.get_item_handle("distro", "testdistro1") != "~"
     assert remote.get_item_handle("profile", "testprofile0") != "~"
-    assert cast(Dict[Any, Any], remote.get_profile("testprofile0"))["distro"] == distro
+    assert cast(Dict[Any, Any], remote.get_profile(profile))["distro"] == distro
 
     assert remote.get_item_handle("profile", "testsubprofile0") != "~"
     assert remote.get_item_handle("profile", "testsubprofile1") != "~"


### PR DESCRIPTION
## Linked Items

None

Related to #3999

## Description

`get_item` and all `get_<type>` XML-RPC methods used to take the name of the item and resolve it via `get_item_handle`, the same defect `remove_item` had before commit 408bf8706f93fef2ccaccc31a97d0c27ba6ec0b9: names are not globally unique - a `NetworkInterface` name is only unique per system - so the lookup could raise an ambiguous match error and the caller had no way to address a specific item.

Change the contract to match `modify_item`/`remove_item`, which already take an explicit `object_id` and resolve it via `__get_object`. `get_item` now does the same and no longer performs any name resolution itself. Callers that only know the name have to obtain a handle via `get_item_handle`/`get_<type>_handle` first; callers that need to disambiguate can obtain the handle from `find_<type>` instead.

Also fix the two in-tree callers that only knew a distro name (`cobbler/actions/replicate.py`, `cobbler/services/files.py`) to resolve a handle via `get_distro_handle` first.

BREAKING CHANGE: `get_item` and all `get_<type>` XML-RPC methods require an item handle (object id) instead of a name. Passing a name now returns "~" (not found).

## Behaviour changes

Old: Network Interfaces cannot be retrieved individually if two of the same name exist.

New: Objects are retrieved via object ID

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
