### PR TITLE
fix(remote): tie-break find_items sort on duplicate sort-field values

### DIFF
--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -914,6 +914,9 @@ class CobblerXMLRPCInterface:
                 sort_field = sort_field[1:]
                 sort_rev = True
             sort_fields.insert(0, sort_field)
+        # "uid" is a tie-breaker: without it, two items tying on every requested field (e.g. NetworkInterfaces sharing
+        # a name, which is only unique per-system) fall through to comparing ITEM objects directly, raising TypeError.
+        sort_fields.append("uid")
         sortdata = [(x.sort_key(sort_fields), x) for x in data]
         if sort_rev:
             sortdata.sort(reverse=True)

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -490,6 +490,53 @@ def test_get_item_with_duplicate_names(
     assert second_interface.get("mac_address") == "aa:bb:cc:dd:ee:01"
 
 
+def test_find_items_does_not_crash_on_fully_duplicate_names(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+    create_kernel_initrd: Callable[[str, str], str],
+):
+    """
+    Verify that find_<type>/find_items doesn't crash when two or more items tie on every field
+    the results are sorted by.
+
+    Network interface names are only unique per system, so two systems may both own an interface
+    called "eth0" - an unscoped ``find_network_interface({"name": "eth0"})`` then legitimately
+    returns two items with an identical sort key. CobblerXMLRPCInterface.__sort() previously fell
+    back to comparing the ITEM objects themselves once their sort_key() values tied, and ITEM
+    doesn't implement rich comparison, raising "TypeError: '<' not supported between instances of
+    'NetworkInterface' and 'NetworkInterface'".
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    basepath = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(basepath, fk_kernel)
+    path_initrd = os.path.join(basepath, fk_initrd)
+    distro_uid = create_distro(
+        "testdistro_find_duplicate_names", "x86_64", "suse", path_kernel, path_initrd
+    )
+    profile_uid = create_profile("testprofile_find_duplicate_names", distro_uid, "")
+    system_uids = [
+        create_system(f"testsystem_find_duplicate_names{i}", profile_uid)
+        for i in range(2)
+    ]
+    for system_uid in system_uids:
+        interface_handle = remote.new_network_interface(system_uid, token)
+        remote.modify_network_interface(interface_handle, ["name"], "eth0", token)
+        remote.save_network_interface(interface_handle, True, True, "new", token)
+
+    # Act
+    interfaces = remote.find_network_interface(
+        {"name": "eth0"}, expand=True, token=token
+    )
+
+    # Assert
+    assert len(interfaces) == 2
+
+
 def test_get_item_with_name_instead_of_handle(
     remote: CobblerXMLRPCInterface,
     token: str,


### PR DESCRIPTION
## Linked Items

Related to #3999 

## Description

CobblerXMLRPCInterface.__sort() sorted (sort_key(item), item) tuples; when two or more items tied on every requested sort field, Python's tuple comparison fell through to comparing the ITEM objects directly, which raises "TypeError: '<' not supported between instances of ... and ...".

This is a real, reachable case: NetworkInterface names are only unique per-system, not globally, so find_network_interface({"name": "eth0"}) across two systems both named "eth0" always hit this crash. Append "uid" (always unique) to the sort fields as a tie-breaker so the comparison never needs to fall back to the objects themselves.

Found while live-verifying the get_item/remove_item uid migration against a duplicate-name ambiguity scenario in a downstream client.

## Behaviour changes

Old: Network Interfaces cannot be searched for if more than one exists with the same name

New: Items with non-unique names can be searched for.

## Category

This is related to a:

- [x] Bugfix
- [ ] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 
