### PR TITLE
XML-RPC: Name to UID pararmeter migration

### DIFF
--- a/cobbler/actions/buildiso/__init__.py
+++ b/cobbler/actions/buildiso/__init__.py
@@ -16,11 +16,10 @@ from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Tuple
 
 from cobbler import enums, utils
 from cobbler.enums import Archs
-from cobbler.utils import filesystem_helpers, input_converters
+from cobbler.utils import filesystem_helpers
 
 if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
-    from cobbler.cobbler_collections.collection import ITEM, Collection
     from cobbler.items.distro import Distro
     from cobbler.items.profile import Profile
     from cobbler.items.system import System
@@ -222,21 +221,20 @@ class BuildIso:
         filesystem_helpers.copyfile(str(initrd_source), initrd_dest)
 
     def filter_systems(
-        self, selected_items: Optional[List[str]] = None
+        self, selected_items: Optional[List["System"]] = None
     ) -> List["System"]:
         """
-        Return a list of valid system objects selected from all systems by name, or everything if ``selected_items`` is
-        empty.
+        Return a list of valid system objects, or everything if ``selected_items`` is empty.
 
-        :param selected_items: A list of names to include in the returned list.
-        :return: A list of valid systems. If an error occurred this is logged and an empty list is returned.
+        :param selected_items: The systems to include in the returned list. Everything is returned if empty/None.
+        :return: A list of valid systems.
         """
-        if selected_items is None:
-            selected_items = []
-        found_systems = self.filter_items(self.api.systems(), selected_items)
+        candidates: List["System"] = (
+            list(self.api.systems()) if not selected_items else list(selected_items)
+        )
         # Now filter all systems out that are image based as we don't know about their kernel and initrds
         return_systems: List["System"] = []
-        for system in found_systems:
+        for system in candidates:
             # All systems not underneath a profile should be skipped
             parent_obj = system.get_conceptual_parent()
             if (
@@ -248,87 +246,18 @@ class BuildIso:
         return return_systems
 
     def filter_profiles(
-        self, selected_items: Optional[List[str]] = None
+        self, selected_items: Optional[List["Profile"]] = None
     ) -> List["Profile"]:
         """
-        Return a list of valid profile objects selected from all profiles by name, or everything if ``selected_items``
-        is empty.
-        :param selected_items: A list of names to include in the returned list.
-        :return: A list of valid profiles. If an error occurred this is logged and an empty list is returned.
+        Return a list of valid profile objects, or everything if ``selected_items`` is empty.
+
+        :param selected_items: The profiles to include in the returned list. Everything is returned if empty/None.
+        :return: A list of valid profiles.
         """
-        if selected_items is None:
-            selected_items = []
-        return [
-            profile
-            for profile in self.filter_items(self.api.profiles(), selected_items)
-            if profile.enable_menu
-        ]
-
-    def filter_items(
-        self, all_objs: "Collection[ITEM]", selected_items: List[str]
-    ) -> List["ITEM"]:
-        """Return a list of valid profile or system objects selected from all profiles or systems by name, or everything
-        if selected_items is empty.
-
-        :param all_objs: The collection of items to filter.
-        :param selected_items: The list of names
-        :raises ValueError: Second option that this error is raised
-                            when the list of filtered systems or profiles is empty.
-        :return: A list of valid profiles OR systems. If an error occurred this is logged and an empty list is returned.
-        """
-        # No profiles/systems selection is made, let's return everything.
-        if len(selected_items) == 0:
-            return list(all_objs)
-
-        filtered_objects: List["ITEM"] = []
-        for name in selected_items:
-            item_object = all_objs.find(name=name)
-            if item_object is not None and not isinstance(item_object, list):
-                filtered_objects.append(item_object)
-                selected_items.remove(name)
-
-        for bad_name in selected_items:
-            self.logger.warning('"%s" is not a valid profile or system', bad_name)
-
-        if len(filtered_objects) == 0:
-            raise ValueError("No valid systems or profiles were specified.")
-
-        return filtered_objects
-
-    def parse_distro(self, distro_name: str) -> "Distro":
-        """
-        Find and return distro object.
-
-        :param distro_name: Name of the distribution to parse.
-        :raises ValueError: If the distro is not found.
-        """
-        distro_obj = self.api.find_distro(name=distro_name)
-        if distro_obj is None or isinstance(distro_obj, list):
-            raise ValueError(f"Distribution {distro_name} not found or ambigous.")
-        return distro_obj
-
-    def parse_profiles(
-        self, profiles: Optional[List[str]], distro_obj: "Distro"
-    ) -> List["Profile"]:
-        """
-        Parses and filters profile names for a given distro, ensuring all profiles are valid children of the distro.
-
-        :param profiles: The optional list of profile names. If no list is given, all profiles are used.
-        :param distro_obj: The distro object that acts as the parent.
-        """
-        profile_names = input_converters.input_string_or_list_no_inherit(profiles)
-        if profile_names:
-            orphans = set(profile_names) - set(distro_obj.children)
-            if len(orphans) > 0:
-                raise ValueError(
-                    "When building a standalone ISO, all --profiles must be"
-                    " under --distro. Extra --profiles: {}".format(
-                        ",".join(sorted(str(o for o in orphans)))
-                    )
-                )
-            return self.filter_profiles(profile_names)
-        else:
-            return self.filter_profiles(distro_obj.children)  # type: ignore[reportGeneralTypeIssues,arg-type]
+        candidates: List["Profile"] = (
+            list(self.api.profiles()) if not selected_items else list(selected_items)
+        )
+        return [profile for profile in candidates if profile.enable_menu]
 
     def _copy_isolinux_files(self):
         """
@@ -738,9 +667,9 @@ class BuildIso:
 
     def prepare_sources(
         self,
-        distro_name: Optional[str],
-        profiles: Optional[List[str]],
-        systems: Optional[List[str]],
+        distro: Optional["Distro"],
+        profiles: Optional[List["Profile"]],
+        systems: Optional[List["System"]],
         exclude_systems: bool,
     ) -> Tuple["Distro", List["Profile"], List["System"]]:
         """
@@ -749,30 +678,26 @@ class BuildIso:
         If distro is not provided, it is taken from first profile or system item.
         Profiles and systems are returned either as empty list or list of Profile, resp. System
 
-        :param distro_name: Name of the distribution to use or None
-        :param profiles: List of profile names or None to include all
-        :param systems: List of system names or None to include all
+        :param distro: The distribution to use, or None to autodetect from the given profiles/systems.
+        :param profiles: List of profiles to include, or None to include all.
+        :param systems: List of systems to include, or None to include all.
         :param exclude_systems: If set, do not include any system
 
         :raises ValueError: In case of unsupported distro architecture
         :return: Tuple with Distro, List of profiles and List of systems
         """
 
-        system_names = input_converters.input_string_or_list_no_inherit(systems)
-        profile_names = input_converters.input_string_or_list_no_inherit(profiles)
-
-        profile_list = list(self.filter_profiles(profile_names))
+        profile_list = self.filter_profiles(profiles)
         system_list: List["System"] = list()
         if not exclude_systems:
-            system_list = list(self.filter_systems(system_names))
+            system_list = self.filter_systems(systems)
 
-        distro_obj: Optional["Distro"] = None
-        if distro_name:
-            distro_obj = self.parse_distro(distro_name)
-        elif len(profile_list) > 0:
-            distro_obj = profile_list[0].get_conceptual_parent()  # type: ignore[reportGeneralTypeIssues,assignment]
-        elif len(system_list) > 0:
-            distro_obj = system_list[0].get_conceptual_parent()  # type: ignore[reportGeneralTypeIssues,assignment]
+        distro_obj: Optional["Distro"] = distro
+        if distro_obj is None:
+            if len(profile_list) > 0:
+                distro_obj = profile_list[0].get_conceptual_parent()  # type: ignore[reportGeneralTypeIssues,assignment]
+            elif len(system_list) > 0:
+                distro_obj = system_list[0].get_conceptual_parent()  # type: ignore[reportGeneralTypeIssues,assignment]
 
         if distro_obj is None:
             raise ValueError("Unable to find suitable distro and none set by caller")

--- a/cobbler/actions/buildiso/netboot.py
+++ b/cobbler/actions/buildiso/netboot.py
@@ -202,10 +202,10 @@ class NetbootBuildiso(buildiso.BuildIso):
         self,
         iso: str = "autoinst.iso",
         buildisodir: str = "",
-        profiles: Optional[List[str]] = None,
+        profiles: Optional[List["Profile"]] = None,
         xorrisofs_opts: str = "",
-        distro_name: Optional[str] = None,
-        systems: Optional[List[str]] = None,
+        distro: Optional["Distro"] = None,
+        systems: Optional[List["System"]] = None,
         exclude_dns: bool = False,
         esp: Optional[str] = None,
         exclude_systems: bool = False,
@@ -222,8 +222,8 @@ class NetbootBuildiso(buildiso.BuildIso):
         :param buildisodir: This overwrites the directory from the settings in which the iso is built in.
         :param profiles: The filter to generate the ISO only for selected profiles.
         :param xorrisofs_opts: ``xorrisofs`` options to include additionally.
-        :param distro_name: For detecting the architecture of the ISO.
-                            If not provided, taken from first profile or system item
+        :param distro: For detecting the architecture of the ISO.
+                       If not provided, taken from first profile or system item
         :param systems: The filter to generate the ISO only for selected systems.
         :param exclude_dns: Whether the repositories have to be locally available or the internet is reachable.
         :param exclude_systems: Whether system entries should not be exported.
@@ -231,7 +231,7 @@ class NetbootBuildiso(buildiso.BuildIso):
         del kwargs  # just accepted for polymorphism
 
         distro_obj, profile_list, system_list = self.prepare_sources(
-            distro_name, profiles, systems, exclude_systems
+            distro, profiles, systems, exclude_systems
         )
 
         loader_config_parts = self._generate_boot_loader_configs(

--- a/cobbler/actions/buildiso/standalone.py
+++ b/cobbler/actions/buildiso/standalone.py
@@ -222,10 +222,10 @@ class StandaloneBuildiso(buildiso.BuildIso):
         self,
         iso: str = "autoinst.iso",
         buildisodir: str = "",
-        profiles: Optional[List[str]] = None,
-        systems: Optional[List[str]] = None,
+        profiles: Optional[List["Profile"]] = None,
+        systems: Optional[List["System"]] = None,
         xorrisofs_opts: str = "",
-        distro_name: Optional[str] = None,
+        distro: Optional["Distro"] = None,
         airgapped: bool = False,
         source: str = "",
         esp: Optional[str] = None,
@@ -242,7 +242,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         :param profiles: The filter to generate the ISO only for selected profiles. None means all.
         :param systems: The filter to generate the ISO only for selected systems. None means all.
         :param xorrisofs_opts: ``xorrisofs`` options to include additionally.
-        :param distro_name: For detecting the architecture of the ISO. If not provided, taken from first profile or
+        :param distro: For detecting the architecture of the ISO. If not provided, taken from first profile or
             system item.
         :param airgapped: This option implies ``standalone=True``.
         :param source: If the iso should be offline available this is the path to the sources of the image.
@@ -251,7 +251,7 @@ class StandaloneBuildiso(buildiso.BuildIso):
         del kwargs  # just accepted for polymorphism
 
         distro_obj, profile_objs, system_objs = self.prepare_sources(
-            distro_name, profiles, systems, exclude_systems
+            distro, profiles, systems, exclude_systems
         )
 
         filesource = source

--- a/cobbler/actions/reposync.py
+++ b/cobbler/actions/reposync.py
@@ -96,86 +96,106 @@ class RepoSync:
 
     # ===================================================================
 
-    def run(self, name: Optional[str] = None, verbose: bool = True) -> None:
+    def run(self, repo: Optional["Repo"] = None, verbose: bool = True) -> None:
         """
         Syncs the current repo configuration file with the filesystem.
 
-        :param name: The name of the repository to synchronize.
+        :param repo: The repository to synchronize. If not given, every repo marked to be kept updated is
+                     synchronized.
         :param verbose: If the action should be logged verbose or not.
         """
 
         self.logger.info("run, reposync, run!")
 
         self.verbose = verbose
+
+        if repo is not None:
+            # Invoked to sync only a specific repo
+            if not self.run_repo(repo):
+                raise CX(
+                    "overall reposync failed, at least one repo failed to synchronize"
+                )
+            return
+
         report_failure = False
-        for repo in self.repos:
-            if name is not None and repo.name != name:
-                # Invoked to sync only a specific repo, this is not the one
-                continue
-            if name is None and not repo.keep_updated:
+        for current_repo in self.repos:
+            if not current_repo.keep_updated:
                 # Invoked to run against all repos, but this one is off
-                self.logger.info("%s is set to not be updated", repo.name)
+                self.logger.info("%s is set to not be updated", current_repo.name)
                 continue
-
-            repo_mirror = os.path.join(self.settings.webdir, "repo_mirror")
-            repo_path = os.path.join(repo_mirror, repo.name)
-
-            if not os.path.isdir(repo_path) and not repo.mirror.lower().startswith(
-                "rhn://"
-            ):
-                os.makedirs(repo_path)
-
-            # Set the environment keys specified for this repo and save the old one if they modify an existing variable.
-
-            env = repo.environment
-            old_env: Dict[str, Any] = {}
-
-            for k in list(env.keys()):
-                self.logger.debug("setting repo environment: %s=%s", k, env[k])
-                if env[k] is not None:
-                    if os.getenv(k):
-                        old_env[k] = os.getenv(k)
-                    else:
-                        os.environ[k] = env[k]
-
-            # Which may actually NOT reposync if the repo is set to not mirror locally but that's a technicality.
-
-            success = False
-            for reposync_try in range(self.tries + 1, 1, -1):
-                try:
-                    self.sync(repo)
-                    success = True
-                    break
-                except Exception:
-                    success = False
-                    utils.log_exc()
-                    self.logger.warning(
-                        "reposync failed, tries left: %s", (reposync_try - 2)
-                    )
-
-            # Cleanup/restore any environment variables that were added or changed above.
-
-            for k in list(env.keys()):
-                if env[k] is not None:
-                    if k in old_env:
-                        self.logger.debug(
-                            "resetting repo environment: %s=%s", k, old_env[k]
-                        )
-                        os.environ[k] = old_env[k]
-                    else:
-                        self.logger.debug("removing repo environment: %s=%s", k, env[k])
-                        del os.environ[k]
-
-            if not success:
+            if not self.run_repo(current_repo):
                 report_failure = True
-                if not self.nofail:
-                    raise CX("reposync failed, retry limit reached, aborting")
-                self.logger.error("reposync failed, retry limit reached, skipping")
-
-            self.update_permissions(repo_path)
 
         if report_failure:
             raise CX("overall reposync failed, at least one repo failed to synchronize")
+
+    # ==================================================================================
+
+    def run_repo(self, repo: "Repo") -> bool:
+        """
+        Sync a single repo: prepare its mirror directory and environment, attempt :meth:`sync` (retrying up to
+        ``self.tries`` times), restore the environment, and update permissions on the mirror directory.
+
+        :param repo: The repo to synchronize.
+        :raises CX: If the sync ultimately failed and ``self.nofail`` is False.
+        :return: True if the repo synced successfully, otherwise False.
+        """
+        repo_mirror = os.path.join(self.settings.webdir, "repo_mirror")
+        repo_path = os.path.join(repo_mirror, repo.name)
+
+        if not os.path.isdir(repo_path) and not repo.mirror.lower().startswith(
+            "rhn://"
+        ):
+            os.makedirs(repo_path)
+
+        # Set the environment keys specified for this repo and save the old one if they modify an existing variable.
+
+        env = repo.environment
+        old_env: Dict[str, Any] = {}
+
+        for k in list(env.keys()):
+            self.logger.debug("setting repo environment: %s=%s", k, env[k])
+            if env[k] is not None:
+                if os.getenv(k):
+                    old_env[k] = os.getenv(k)
+                else:
+                    os.environ[k] = env[k]
+
+        # Which may actually NOT reposync if the repo is set to not mirror locally but that's a technicality.
+
+        success = False
+        for reposync_try in range(self.tries + 1, 1, -1):
+            try:
+                self.sync(repo)
+                success = True
+                break
+            except Exception:
+                success = False
+                utils.log_exc()
+                self.logger.warning(
+                    "reposync failed, tries left: %s", (reposync_try - 2)
+                )
+
+        # Cleanup/restore any environment variables that were added or changed above.
+
+        for k in list(env.keys()):
+            if env[k] is not None:
+                if k in old_env:
+                    self.logger.debug(
+                        "resetting repo environment: %s=%s", k, old_env[k]
+                    )
+                    os.environ[k] = old_env[k]
+                else:
+                    self.logger.debug("removing repo environment: %s=%s", k, env[k])
+                    del os.environ[k]
+
+        if not success:
+            if not self.nofail:
+                raise CX("reposync failed, retry limit reached, aborting")
+            self.logger.error("reposync failed, retry limit reached, skipping")
+
+        self.update_permissions(repo_path)
+        return success
 
     # ==================================================================================
 

--- a/cobbler/actions/sync.py
+++ b/cobbler/actions/sync.py
@@ -116,9 +116,11 @@ class CobblerSync:
         self.settings = self.api.settings()
         self.repos = self.api.repos()
 
-    def run_sync_systems(self, systems: List[str]):
+    def run_sync_systems(self, systems: List["System"]):
         """
         Syncs the specific systems with the config tree.
+
+        :param systems: The systems to sync.
         """
         self.__common_run()
 

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -3191,6 +3191,35 @@ class CobblerAPI:
 
     # ==========================================================================
 
+    def disable_netboot(self, system: "system_module.System") -> bool:
+        """
+        This is a feature used by the ``pxe_just_once`` support, see manpage. Sets the given system to no-longer PXE.
+        Disabled by default as this requires public API access and is technically a read-write operation.
+
+        :param system: The system to disable netboot for.
+        :return: A boolean indicated the success of the action.
+        """
+        # used by nopxe.cgi
+        if not self.settings().pxe_just_once:
+            # feature disabled!
+            return False
+        # triggers should be enabled when calling nopxe
+        triggers_enabled = self.settings().nopxe_with_triggers
+        system.netboot_enabled = False
+        # disabling triggers and sync to make this extremely fast.
+        self.systems().add(
+            system,
+            save=True,
+            with_triggers=triggers_enabled,
+            with_sync=False,
+            quick_pxe_update=True,
+        )
+        # re-generate dhcp configuration
+        self.sync_dhcp()
+        return True
+
+    # ==========================================================================
+
     def get_valid_obj_boot_loaders(
         self, obj: Union["distro.Distro", "image_module.Image"]
     ) -> List[enums.BootLoader]:

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2846,20 +2846,23 @@ class CobblerAPI:
     # ==========================================================================
 
     def reposync(
-        self, name: Optional[str] = None, tries: int = 1, nofail: bool = False
+        self,
+        repo_obj: Optional["repo.Repo"] = None,
+        tries: int = 1,
+        nofail: bool = False,
     ) -> None:
         """
         Take the contents of ``/var/lib/cobbler/repos`` and update them -- or create the initial copy if no contents
         exist yet.
 
-        :param name: The name of the repository to run reposync for.
+        :param repo_obj: The repository to run reposync for.
         :param tries: How many tries should be executed before the action fails.
         :param nofail: If True then the action will fail, otherwise the action will just be skipped. This respects the
                        ``tries`` parameter.
         """
-        self.log("reposync", [name])
+        self.log("reposync", [repo_obj.name if repo_obj else None])
         action_reposync = reposync.RepoSync(self, tries=tries, nofail=nofail)
-        action_reposync.run(name)
+        action_reposync.run(repo_obj)
 
     # ==========================================================================
 

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2546,7 +2546,12 @@ class CobblerAPI:
             filename, system, profile, distro, arch, image, metadata, bootloader_format
         )
 
-    def generate_ipxe(self, profile: str, image: str, system: str) -> str:
+    def generate_ipxe(
+        self,
+        profile: Optional["profile_module.Profile"] = None,
+        image: Optional["image_module.Image"] = None,
+        system: Optional["system_module.System"] = None,
+    ) -> str:
         """
         Generate the ipxe configuration files. The system wins over the profile. Profile and System win over Image.
 
@@ -2557,23 +2562,27 @@ class CobblerAPI:
         """
         self.log("generate_ipxe")
         data = ""
-        if profile is None and image is None and system is None:  # type: ignore
+        if profile is None and image is None and system is None:
             boot_menu = self.tftpgen.make_pxe_menu()
             if "ipxe" in boot_menu:
                 data = boot_menu["ipxe"]
                 if not isinstance(data, str):
                     raise ValueError("ipxe boot menu didn't have right type!")
         elif system:
-            data = self.tftpgen.generate_ipxe("system", system)
+            data = self.tftpgen.generate_ipxe(system=system)
         elif profile:
-            data = self.tftpgen.generate_ipxe("profile", profile)
+            data = self.tftpgen.generate_ipxe(profile=profile)
         elif image:
-            data = self.tftpgen.generate_ipxe("image", image)
+            data = self.tftpgen.generate_ipxe(image=image)
         return data
 
     # ==========================================================================
 
-    def generate_bootcfg(self, profile: str = "", system: str = "") -> str:
+    def generate_bootcfg(
+        self,
+        profile: Optional["profile_module.Profile"] = None,
+        system: Optional["system_module.System"] = None,
+    ) -> str:
         """
         Generate a boot configuration. The system wins over the profile.
 
@@ -2583,28 +2592,33 @@ class CobblerAPI:
         """
         self.log("generate_bootcfg")
         if system:
-            return self.tftpgen.generate_bootcfg("system", system)
-        return self.tftpgen.generate_bootcfg("profile", profile)
+            return self.tftpgen.generate_bootcfg(system=system)
+        if profile:
+            return self.tftpgen.generate_bootcfg(profile=profile)
+        return ""
 
     # ==========================================================================
 
     def generate_script(
-        self, profile: Optional[str], system: Optional[str], name: str
+        self,
+        profile: Optional["profile_module.Profile"],
+        system: Optional["system_module.System"],
+        name: str,
     ) -> str:
         """
         Generate an autoinstall script for the specified profile or system. The system wins over the profile.
 
-        :param profile: The profile name to generate the script for.
-        :param system: The system name to generate the script for.
+        :param profile: The profile to generate the script for.
+        :param system: The system to generate the script for.
         :param name: The name of the script which should be generated. Must only contain alphanumeric characters, dots
                      and underscores.
         :return: The generated script or an error message.
         """
         self.log("generate_script")
         if system:
-            return self.tftpgen.generate_script("system", system, name)
+            return self.tftpgen.generate_script(system=system, script_name=name)
         if profile:
-            return self.tftpgen.generate_script("profile", profile, name)
+            return self.tftpgen.generate_script(profile=profile, script_name=name)
         return ""
 
     # ==========================================================================

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2459,6 +2459,47 @@ class CobblerAPI:
 
     # ==========================================================================
 
+    def get_repos_compatible_with_profile(
+        self, profile: "profile_module.Profile"
+    ) -> List[Dict[str, Any]]:
+        """
+        Get repos that can be used with a given profile.
+
+        :param profile: The profile to check for compatibility.
+        :return: The list of compatible repositories.
+        """
+        results: List[Dict[str, Any]] = []
+        distro_obj: Optional["distro.Distro"] = profile.get_conceptual_parent()  # type: ignore[assignment]
+        if distro_obj is None:
+            raise ValueError("Distro not found!")
+        for current_repo in self.repos():
+            # There be dragons!
+            # Accept all repos that are src/noarch but otherwise filter what repos are compatible with the profile
+            # based on the arch of the distro.
+            # FIXME: Use the enum directly
+            if current_repo.arch.value in [
+                "",
+                "noarch",
+                "src",
+            ]:
+                results.append(current_repo.to_dict())
+            else:
+                # some backwards compatibility fuzz
+                # repo.arch is mostly a text field
+                # distro.arch is i386/x86_64
+                if current_repo.arch.value in ["i386", "x86", "i686"]:
+                    if distro_obj.arch.value in ["i386", "x86"]:
+                        results.append(current_repo.to_dict())
+                elif current_repo.arch.value in ["x86_64"]:
+                    if distro_obj.arch.value in ["x86_64"]:
+                        results.append(current_repo.to_dict())
+                else:
+                    if distro_obj.arch.value == current_repo.arch.value:
+                        results.append(current_repo.to_dict())
+        return results
+
+    # ==========================================================================
+
     def get_template_file_for_profile(self, obj: "BootableItem", path: str) -> str:
         """
         Get the template for the specified profile.

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -3052,10 +3052,10 @@ class CobblerAPI:
     def build_iso(
         self,
         iso: str = "autoinst.iso",
-        profiles: Optional[List[str]] = None,
-        systems: Optional[List[str]] = None,
+        profiles: Optional[List["profile_module.Profile"]] = None,
+        systems: Optional[List["system_module.System"]] = None,
         buildisodir: str = "",
-        distro_name: Optional[str] = None,
+        distro: Optional["distro.Distro"] = None,
         standalone: bool = False,
         airgapped: bool = False,
         source: str = "",
@@ -3071,7 +3071,7 @@ class CobblerAPI:
         :param profiles: Use these profiles only
         :param systems: Use these systems only
         :param buildisodir: This overwrites the directory from the settings in which the iso is built in.
-        :param distro_name: Use this distro architecture. If not used, autodetected from profiles or systems.
+        :param distro: Use this distro architecture. If not used, autodetected from profiles or systems.
         :param standalone: This means that no network connection is needed to install the generated iso.
         :param airgapped: This option implies ``standalone=True``.
         :param source: If the iso should be offline available this is the path to the sources of the image.
@@ -3094,7 +3094,7 @@ class CobblerAPI:
             buildisodir=buildisodir,
             profiles=profiles,
             xorrisofs_opts=xorrisofs_opts,
-            distro_name=distro_name,
+            distro=distro,
             airgapped=airgapped,
             source=source,
             systems=systems,

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2624,11 +2624,11 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    def is_autoinstall_in_use(self, autoinstall: str):
+    def is_autoinstall_in_use(self, autoinstall: "template.Template"):
         """
         Check if the auto-installation template is referenced by at least one Profile or System.
 
-        :param ai: The name of the template.
+        :param autoinstall: The template to check for references.
         :return: True if this is the case, otherwise False.
         """
         return self.autoinstall_mgr.is_autoinstall_in_use(autoinstall)

--- a/cobbler/api.py
+++ b/cobbler/api.py
@@ -2678,7 +2678,9 @@ class CobblerAPI:
 
     # ==========================================================================
 
-    def sync_systems(self, systems: List[str], verbose: bool = False) -> None:
+    def sync_systems(
+        self, systems: List["system_module.System"], verbose: bool = False
+    ) -> None:
         """
         Take the values currently written to the configuration files in /etc, and /var, and build out the information
         tree found in /tftpboot. Any operations done in the API that have not been saved with serialize() will NOT be
@@ -2691,14 +2693,14 @@ class CobblerAPI:
         if not (
             systems
             and isinstance(systems, list)  # type: ignore
-            and all(isinstance(sys_name, str) for sys_name in systems)  # type: ignore
+            and all(isinstance(sys_obj, system_module.System) for sys_obj in systems)  # type: ignore
         ):
             if len(systems) < 1:
                 self.logger.debug(
                     "sync_systems needs at least one system to do something. Bailing out early."
                 )
                 return
-            raise TypeError("Systems must be a list of one or more strings.")
+            raise TypeError("Systems must be a list of one or more System objects.")
         self.logger.info(
             "Waiting lock to be available to perform the sync action (this might take some time)"
         )

--- a/cobbler/autoinstall/manager.py
+++ b/cobbler/autoinstall/manager.py
@@ -49,19 +49,15 @@ class AutoInstallationManager:
         self.logger = logging.getLogger()
         self.api = api
 
-    def is_autoinstall_in_use(self, name: str) -> bool:
+    def is_autoinstall_in_use(self, template: "Template") -> bool:
         """
         Check if the auto-installation template is referenced by at least one Profile or System.
 
-        :param name: The name of the template.
+        :param template: The template to check for references.
         :returns: True if the template is referenced by at least a single object.
         """
-        search_result_template = self.api.find_template(False, False, name=name)
-        if search_result_template is None or isinstance(search_result_template, list):
-            raise ValueError("Requested autoinstall template not found!")
-
         search_result_profile = self.api.find_profile(
-            True, False, autoinstall=search_result_template.uid
+            True, False, autoinstall=template.uid
         )
         if search_result_profile is not None and not isinstance(
             search_result_profile, list
@@ -73,7 +69,7 @@ class AutoInstallationManager:
             return True
 
         search_result_system = self.api.find_system(
-            True, False, autoinstall=search_result_template.uid
+            True, False, autoinstall=template.uid
         )
         if search_result_system is not None and not isinstance(
             search_result_system, list

--- a/cobbler/cobbler_collections/collection.py
+++ b/cobbler/cobbler_collections/collection.py
@@ -611,14 +611,11 @@ class Collection(Generic[ITEM]):
                 ref.enable_menu = False
             self.lite_sync.add_single_profile(ref, rebuild_menu=rebuild_menu)
             self.api.sync_systems(
-                systems=[
-                    x.uid  # type: ignore
-                    for x in self.api.find_system(  # type: ignore
-                        return_list=True,
-                        no_errors=False,
-                        **{"profile": ref.uid},
-                    )
-                ]  # type: ignore
+                systems=self.api.find_system(  # type: ignore
+                    return_list=True,
+                    no_errors=False,
+                    **{"profile": ref.uid},
+                )
             )
         elif isinstance(ref, distro.Distro):
             self.lite_sync.add_single_distro(ref, rebuild_menu=rebuild_menu)

--- a/cobbler/items/network_interface.py
+++ b/cobbler/items/network_interface.py
@@ -666,11 +666,9 @@ class NetworkInterface(BaseItem):
         """
         Return the system the network interface belongs to.
         """
-        result = self.api.find_system(name=self._system_uid, return_list=False)
+        result = self.api.systems().listing.get(self._system_uid)
         if result is None:
             raise ValueError(
                 f"System ({self._system_uid}) associated with interface ({self.uid}) not present!"
             )
-        if isinstance(result, list):
-            raise TypeError("Result must be a single item!")
         return result

--- a/cobbler/modules/managers/__init__.py
+++ b/cobbler/modules/managers/__init__.py
@@ -179,14 +179,14 @@ class TftpManagerModule(ManagerModule):
     """
 
     @abstractmethod
-    def sync_systems(self, systems: List[str], verbose: bool = True) -> None:
+    def sync_systems(self, systems: List["System"], verbose: bool = True) -> None:
         """
         Synchronize TFTP configuration for the specified systems.
 
         This method should be implemented by subclasses to update TFTP boot files and configuration for the given list
         of systems.
 
-        :param systems: List of system identifiers to synchronize.
+        :param systems: List of systems to synchronize.
         :param verbose: If True, provide detailed output during synchronization.
         """
 

--- a/cobbler/modules/managers/dynamic_tftp.py
+++ b/cobbler/modules/managers/dynamic_tftp.py
@@ -97,7 +97,7 @@ class _DynamicTftpManager(TftpManagerModule):
             "image files are served on demand instead"
         )
 
-    def sync_systems(self, systems: List[str], verbose: bool = True) -> None:
+    def sync_systems(self, systems: List["System"], verbose: bool = True) -> None:
         """
         No-op: system configuration is rendered on demand by
         :meth:`cobbler.tftpgen.TFTPGen.generate_tftp_file`, so nothing needs to be written to the TFTP root.

--- a/cobbler/modules/managers/in_tftpd.py
+++ b/cobbler/modules/managers/in_tftpd.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from cobbler import utils
 from cobbler.cexceptions import CX
+from cobbler.items.system import System
 from cobbler.modules.managers import TftpManagerModule
 from cobbler.utils import filesystem_helpers
 
@@ -18,7 +19,6 @@ if TYPE_CHECKING:
     from cobbler.api import CobblerAPI
     from cobbler.items.distro import Distro
     from cobbler.items.image import Image
-    from cobbler.items.system import System
 
 
 MANAGER = None
@@ -146,7 +146,7 @@ class _InTftpdManager(TftpManagerModule):
         """
         self.api.tftpgen.copy_single_image_files(image)
 
-    def sync_systems(self, systems: List[str], verbose: bool = True) -> None:
+    def sync_systems(self, systems: List["System"], verbose: bool = True) -> None:
         """
         Write out specified systems as separate files to the TFTP server folder.
 
@@ -155,26 +155,15 @@ class _InTftpdManager(TftpManagerModule):
         """
         if not (
             isinstance(systems, list)  # type: ignore
-            and all(isinstance(sys_name, str) for sys_name in systems)  # type: ignore
+            and all(isinstance(sys_obj, System) for sys_obj in systems)  # type: ignore
         ):
-            raise TypeError("systems needs to be a list of strings")
+            raise TypeError("systems needs to be a list of System objects")
 
         if not isinstance(verbose, bool):  # type: ignore
             raise TypeError("verbose needs to be of type bool")
 
-        system_objs: List["System"] = []
-        for system_name in systems:
-            # get the system object:
-            system_obj = self.api.find_system(name=system_name)
-            if system_obj is None:
-                self.logger.info("did not find any system named %s", system_name)
-                continue
-            if isinstance(system_obj, list):
-                raise ValueError("Ambiguous match detected!")
-            system_objs.append(system_obj)
-
         menu_items = self.api.tftpgen.get_menu_items()
-        for system in system_objs:
+        for system in systems:
             self.sync_single_system(system, menu_items)
 
         self.logger.info("generating PXE menu structure")

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3890,32 +3890,32 @@ class CobblerXMLRPCInterface:
             return f"# object not found: {system_uid}"
         return self.api.get_repo_config_for_system(obj)
 
-    def get_template_file_for_profile(self, profile_name: str, path: str, **rest: Any):
+    def get_template_file_for_profile(self, profile_uid: str, path: str, **rest: Any):
         """
         Return the templated file requested for this profile
 
-        :param profile_name: The name of the profile to get the template file for.
+        :param profile_uid: The id of the profile to get the template file for.
         :param path: The path to the template which is requested.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The template file as a str representation.
         """
-        obj = self.api.find_profile(name=profile_name)
+        obj = self.api.find_profile(uid=profile_uid)
         if obj is None or isinstance(obj, list):
-            return f"# object not found: {profile_name}"
+            return f"# object not found: {profile_uid}"
         return self.api.get_template_file_for_profile(obj, path)
 
-    def get_template_file_for_system(self, system_name: str, path: str, **rest: Any):
+    def get_template_file_for_system(self, system_uid: str, path: str, **rest: Any):
         """
         Return the templated file requested for this system
 
-        :param system_name: The name of the system to get the template file for.
+        :param system_uid: The id of the system to get the template file for.
         :param path: The path to the template which is requested.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The template file as a str representation.
         """
-        obj = self.api.find_system(name=system_name)
+        obj = self.api.find_system(uid=system_uid)
         if obj is None or isinstance(obj, list):
-            return f"# object not found: {system_name}"
+            return f"# object not found: {system_uid}"
         return self.api.get_template_file_for_system(obj, path)
 
     def register_new_system(

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3864,30 +3864,30 @@ class CobblerXMLRPCInterface:
             return [value.value for value in parent.boot_loaders]  # type: ignore
         return [value.value for value in self.api.get_valid_obj_boot_loaders(parent)]  # type: ignore[arg-type]
 
-    def get_repo_config_for_profile(self, profile_name: str, **rest: Any):
+    def get_repo_config_for_profile(self, profile_uid: str, **rest: Any):
         """
         Return the yum configuration a given profile should use to obtain all of it's Cobbler associated repos.
 
-        :param profile_name: The name of the profile for which the repository config should be looked up.
+        :param profile_uid: The id of the profile for which the repository config should be looked up.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The repository configuration for the profile.
         """
-        obj = self.api.find_profile(name=profile_name)
+        obj = self.api.find_profile(uid=profile_uid)
         if obj is None or isinstance(obj, list):
-            return f"# object not found: {profile_name}"
+            return f"# object not found: {profile_uid}"
         return self.api.get_repo_config_for_profile(obj)
 
-    def get_repo_config_for_system(self, system_name: str, **rest: Any):
+    def get_repo_config_for_system(self, system_uid: str, **rest: Any):
         """
         Return the yum configuration a given profile should use to obtain all of it's Cobbler associated repos.
 
-        :param system_name: The name of the system for which the repository config should be looked up.
+        :param system_uid: The id of the system for which the repository config should be looked up.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The repository configuration for the system.
         """
-        obj = self.api.find_system(name=system_name)
+        obj = self.api.find_system(uid=system_uid)
         if obj is None or isinstance(obj, list):
-            return f"# object not found: {system_name}"
+            return f"# object not found: {system_uid}"
         return self.api.get_repo_config_for_system(obj)
 
     def get_template_file_for_profile(self, profile_name: str, path: str, **rest: Any):

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -4416,54 +4416,26 @@ class CobblerXMLRPCInterface:
         return self.xmlrpc_hacks(data)
 
     def get_repos_compatible_with_profile(
-        self, profile: str, token: Optional[str] = None, **rest: Any
+        self, profile_uid: str, token: Optional[str] = None, **rest: Any
     ) -> List[Dict[Any, Any]]:
         """
-        Get repos that can be used with a given profile name.
+        Get repos that can be used with a given profile.
 
-        :param profile: The profile to check for compatibility.
+        :param profile_uid: The id of the profile to check for compatibility.
         :param token: The API-token obtained via the login() method.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The list of compatible repositories.
         """
         self._log("get_repos_compatible_with_profile", token=token)
-        profile_obj = self.api.find_profile(name=profile)
+        profile_obj = self.api.find_profile(uid=profile_uid)
         if profile_obj is None or isinstance(profile_obj, list):
             self.logger.info(
-                'The profile name supplied ("%s") for get_repos_compatible_with_profile was not'
+                'The profile id supplied ("%s") for get_repos_compatible_with_profile was not'
                 "existing",
-                profile,
+                profile_uid,
             )
             return []
-        results: List[Dict[Any, Any]] = []
-        distro: Optional["Distro"] = profile_obj.get_conceptual_parent()  # type: ignore
-        if distro is None:
-            raise ValueError("Distro not found!")
-        for current_repo in self.api.repos():
-            # There be dragons!
-            # Accept all repos that are src/noarch but otherwise filter what repos are compatible with the profile based
-            # on the arch of the distro.
-            # FIXME: Use the enum directly
-            if current_repo.arch.value in [
-                "",
-                "noarch",
-                "src",
-            ]:
-                results.append(current_repo.to_dict())
-            else:
-                # some backwards compatibility fuzz
-                # repo.arch is mostly a text field
-                # distro.arch is i386/x86_64
-                if current_repo.arch.value in ["i386", "x86", "i686"]:
-                    if distro.arch.value in ["i386", "x86"]:
-                        results.append(current_repo.to_dict())
-                elif current_repo.arch.value in ["x86_64"]:
-                    if distro.arch.value in ["x86_64"]:
-                        results.append(current_repo.to_dict())
-                else:
-                    if distro.arch.value == current_repo.arch.value:
-                        results.append(current_repo.to_dict())
-        return results
+        return self.api.get_repos_compatible_with_profile(profile_obj)  # type: ignore[arg-type]
 
     def find_system_by_dns_name(self, dns_name: str) -> Dict[str, Any]:
         """

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -4009,43 +4009,23 @@ class CobblerXMLRPCInterface:
         return 0
 
     def disable_netboot(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> bool:
         """
-        This is a feature used by the ``pxe_just_once`` support, see manpage. Sets system named "name" to no-longer PXE.
+        This is a feature used by the ``pxe_just_once`` support, see manpage. Sets the given system to no-longer PXE.
         Disabled by default as this requires public API access and is technically a read-write operation.
 
-        :param name: The name of the system to disable netboot for.
+        :param object_id: The id of the system to disable netboot for.
         :param token: The API-token obtained via the login() method.
         :param rest: This parameter is unused.
         :return: A boolean indicated the success of the action.
         """
-        self._log("disable_netboot", token=token, name=name)
-        # used by nopxe.cgi
-        if not self.api.settings().pxe_just_once:
-            # feature disabled!
-            return False
-        # triggers should be enabled when calling nopxe
-        triggers_enabled = self.api.settings().nopxe_with_triggers
-        obj = self.api.systems().find(name=name)
-        if obj is None:
+        self._log("disable_netboot", token=token, object_id=object_id)
+        obj = self.api.find_system(uid=object_id)
+        if obj is None or isinstance(obj, list):
             # system not found!
             return False
-        if isinstance(obj, list):
-            # Duplicate entries found - can't be but mypy requires this check
-            return False
-        obj.netboot_enabled = False
-        # disabling triggers and sync to make this extremely fast.
-        self.api.systems().add(
-            obj,
-            save=True,
-            with_triggers=triggers_enabled,
-            with_sync=False,
-            quick_pxe_update=True,
-        )
-        # re-generate dhcp configuration
-        self.api.sync_dhcp()
-        return True
+        return self.api.disable_netboot(obj)
 
     def upload_log_data(
         self,

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3688,11 +3688,10 @@ class CobblerXMLRPCInterface:
 
         .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.dump_vars`
         """
-        obj = self.api.find_items(
-            "", {"uid": item_uuid}, return_list=False, no_errors=True
-        )
-        if obj is None or isinstance(obj, list):
-            raise ValueError(f'Item with uuid "{item_uuid}" does not exist!')
+        try:
+            obj = cast(item.BootableItem, self.__get_object(item_uuid))
+        except ValueError as error:
+            raise ValueError(f'Item with uuid "{item_uuid}" does not exist!') from error
         result = self.api.dump_vars(obj, formatted_output, remove_dicts)
         self._log(str(result))
         return result

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1019,6 +1019,22 @@ class CobblerXMLRPCInterface:
             raise ValueError("Object not found or ambigous match!")
         return obj
 
+    def __resolve_optional_uid(
+        self, find_method: Callable[..., Any], uid: Optional[str]
+    ) -> Optional[Any]:
+        """
+        Helper function. Resolve an optional uid to its object via the given collection-specific find method,
+        returning None if the uid is None or no unambiguous match was found.
+
+        :param find_method: One of the ``self.api.find_<type>`` methods.
+        :param uid: The id to resolve, or None.
+        :return: The resolved object, or None.
+        """
+        if uid is None:
+            return None
+        result = find_method(uid=uid)
+        return None if isinstance(result, list) else result
+
     def get_item_resolved_value(
         self, item_uuid: str, attribute: List[str]
     ) -> Union[str, int, float, List[Any], Dict[Any, Any]]:
@@ -3601,51 +3617,57 @@ class CobblerXMLRPCInterface:
 
     def generate_ipxe(
         self,
-        profile: Optional[str] = None,
-        image: Optional[str] = None,
-        system: Optional[str] = None,
+        profile_uid: Optional[str] = None,
+        image_uid: Optional[str] = None,
+        system_uid: Optional[str] = None,
         **rest: Any,
     ) -> str:
         """
         Generate the ipxe configuration.
 
-        :param profile: The profile to generate iPXE config for.
-        :param image: The image to generate iPXE config for.
-        :param system: The system to generate iPXE config for.
+        :param profile_uid: The id of the profile to generate iPXE config for.
+        :param image_uid: The id of the image to generate iPXE config for.
+        :param system_uid: The id of the system to generate iPXE config for.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The configuration as a str representation.
         """
         self._log("generate_ipxe")
-        return self.api.generate_ipxe(profile, image, system)  # type: ignore
+        profile_obj = self.__resolve_optional_uid(self.api.find_profile, profile_uid)
+        image_obj = self.__resolve_optional_uid(self.api.find_image, image_uid)
+        system_obj = self.__resolve_optional_uid(self.api.find_system, system_uid)
+        return self.api.generate_ipxe(profile_obj, image_obj, system_obj)
 
     def generate_bootcfg(
-        self, profile: Optional[str] = None, system: Optional[str] = None, **rest: Any
+        self,
+        profile_uid: Optional[str] = None,
+        system_uid: Optional[str] = None,
+        **rest: Any,
     ) -> str:
         """
         This generates the bootcfg for a system which is related to a certain profile.
 
-        :param profile: The profile which is associated to the system.
-        :param system: The system which the bootcfg should be generated for.
+        :param profile_uid: The id of the profile which is associated to the system.
+        :param system_uid: The id of the system which the bootcfg should be generated for.
         :param rest: This is dropped in this method since it is not needed here.
         :return: The generated bootcfg.
         """
         self._log("generate_bootcfg")
-        profile_name = "" if profile is None else profile
-        system_name = "" if system is None else system
-        return self.api.generate_bootcfg(profile_name, system_name)
+        profile_obj = self.__resolve_optional_uid(self.api.find_profile, profile_uid)
+        system_obj = self.__resolve_optional_uid(self.api.find_system, system_uid)
+        return self.api.generate_bootcfg(profile_obj, system_obj)
 
     def generate_script(
         self,
-        profile: Optional[str] = None,
-        system: Optional[str] = None,
+        profile_uid: Optional[str] = None,
+        system_uid: Optional[str] = None,
         name: str = "",
     ) -> str:
         """
         This generates the autoinstall script for a system or profile. Profile and System cannot be both given, if they
         are, Profile wins.
 
-        :param profile: The profile name to generate the script for.
-        :param system: The system name to generate the script for.
+        :param profile_uid: The id of the profile to generate the script for.
+        :param system_uid: The id of the system to generate the script for.
         :param name: Name of the generated script. Must only contain alphanumeric characters, dots and underscores.
         :return: Some generated script.
         """
@@ -3653,7 +3675,9 @@ class CobblerXMLRPCInterface:
         if not validate_autoinstall_script_name(name):
             raise ValueError('"name" handed to generate_script was not valid!')
         self._log(f'generate_script, name is "{name}"')
-        return self.api.generate_script(profile, system, name)
+        profile_obj = self.__resolve_optional_uid(self.api.find_profile, profile_uid)
+        system_obj = self.__resolve_optional_uid(self.api.find_system, system_uid)
+        return self.api.generate_script(profile_obj, system_obj, name)
 
     def dump_vars(
         self, item_uuid: str, formatted_output: bool = False, remove_dicts: bool = True

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -343,7 +343,7 @@ class CobblerXMLRPCInterface:
         """
         Run a lite Cobbler sync in the background with only systems specified.
 
-        :param options: Unknown what this parameter does.
+        :param options: A dict with a "systems" key (list of system uids) and a "verbose" key.
         :param token: The API-token obtained via the login() method.
         :return: The id of the task that was started.
         """
@@ -351,8 +351,17 @@ class CobblerXMLRPCInterface:
         def runner(self: "CobblerThread"):
             if isinstance(self.options, list):
                 raise ValueError("options for background_syncsystems need to be dict!")
+            system_objs: List["system.System"] = []
+            for system_uid in self.options.get("systems", []):
+                system_obj = self.remote.api.find_system(uid=system_uid)
+                if system_obj is None or isinstance(system_obj, list):
+                    self.logger.info(
+                        'did not find any system with uid "%s"', system_uid
+                    )
+                    continue
+                system_objs.append(system_obj)
             self.remote.api.sync_systems(
-                self.options.get("systems", []), self.options.get("verbose", False)
+                system_objs, self.options.get("verbose", False)
             )
 
         return self.__start_task(runner, token, "syncsystems", "Syncsystems", options)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3671,7 +3671,9 @@ class CobblerXMLRPCInterface:
         return result
 
     def get_blended_data(
-        self, profile: Optional[str] = None, system: Optional[str] = None
+        self,
+        profile_uid: Optional[str] = None,
+        system_uid: Optional[str] = None,
     ):
         """
         Combine all data which is available from a profile and system together and return it.
@@ -3679,20 +3681,20 @@ class CobblerXMLRPCInterface:
         .. deprecated:: 4.0.0
            Please make use of the dump_vars endpoint.
 
-        :param profile: The profile of the system.
-        :param system: The system for which the data should be rendered.
+        :param profile_uid: The id of the profile of the system.
+        :param system_uid: The id of the system for which the data should be rendered.
         :return: All values which could be blended together through the inheritance chain.
         """
         obj: "BootableItem"
-        if profile is not None and profile != "":
-            search_result = self.api.find_profile(name=profile)
+        if profile_uid is not None and profile_uid != "":
+            search_result = self.api.find_profile(uid=profile_uid)
             if search_result is None or isinstance(search_result, list):
-                raise CX(f"profile not found: {profile}")
+                raise CX(f"profile not found: {profile_uid}")
             obj = search_result
-        elif system is not None and system != "":
-            search_result = self.api.find_system(name=system)  # type: ignore
+        elif system_uid is not None and system_uid != "":
+            search_result = self.api.find_system(uid=system_uid)  # type: ignore
             if search_result is None or isinstance(search_result, list):
-                raise CX(f"system not found: {system}")
+                raise CX(f"system not found: {system_uid}")
             obj = search_result
         else:
             raise CX("internal error, no system or profile specified")

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -1040,6 +1040,13 @@ class CobblerXMLRPCInterface:
     ) -> Union[str, int, float, List[Any], Dict[Any, Any]]:
         """
         .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.get_item_resolved_value`
+
+        .. note:: Unlike ``get_item``/``modify_item``/etc., this does not resolve ``item_uuid`` through
+                  ``__get_object`` and therefore does not see transaction-local or not-yet-saved items. That
+                  resolution happens inside ``CobblerAPI.get_item_resolved_value``, a public, uuid-based entry point
+                  meant for any Python caller, not just this XML-RPC session -- it cannot be made aware of this
+                  class's transaction/``unsaved_items`` cache without leaking that XML-RPC-only concept into the
+                  general Python API.
         """
         self._log(
             f"get_item_resolved_value({item_uuid})", attribute=".".join(attribute)
@@ -1108,6 +1115,9 @@ class CobblerXMLRPCInterface:
     ) -> bool:
         """
         .. seealso:: Logically identical to :func:`~cobbler.api.CobblerAPI.set_item_resolved_value`
+
+        .. note:: See the note on ``get_item_resolved_value`` above -- this does not resolve ``item_uuid`` through
+                  ``__get_object`` for the same reason.
         """
         self._log(
             f"get_item_resolved_value({item_uuid})", attribute=".".join(attribute)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -483,7 +483,7 @@ class CobblerXMLRPCInterface:
         """
         Power a system asynchronously in the background.
 
-        :param options: Not known what this parameter does.
+        :param options: A dict with a "systems" key (list of system uids) and a "power" key (on/off/status/reboot).
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :return: The id of the task which was started.
         """
@@ -492,17 +492,17 @@ class CobblerXMLRPCInterface:
             if isinstance(self.options, list):
                 raise ValueError("options for background_power_system need to be dict!")
 
-            for system_name in self.options.get("systems", []):
+            for system_uid in self.options.get("systems", []):
                 try:
-                    system_obj = self.remote.api.find_system(name=system_name)
+                    system_obj = self.remote.api.find_system(uid=system_uid)
                     if system_obj is None or isinstance(system_obj, list):
-                        raise ValueError(f'System with name "{system_name}" not found')
+                        raise ValueError(f'System with uid "{system_uid}" not found')
                     self.remote.api.power_system(
                         system_obj, self.options.get("power", "")
                     )
                 except Exception as error:
                     self.logger.warning(
-                        f"failed to execute power task on {str(system_name)}, exception: {str(error)}"
+                        f"failed to execute power task on {str(system_uid)}, exception: {str(error)}"
                     )
 
         self.check_access(token, "power_system")

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -4967,8 +4967,10 @@ class CobblerXMLRPCInterface:
         :param token: The API-token obtained via the login() method.
         :return: True if the operation succeeds.
         """
-        # We pass return_list=False, thus the return type is Optional[System]
-        obj: Optional["system.System"] = self.api.find_system(uid=object_id, return_list=False)  # type: ignore
+        try:
+            obj: Optional["system.System"] = self.__get_object(object_id, token)  # type: ignore
+        except ValueError:
+            obj = None
         self.check_access(
             token, "clear_system_logs", obj.name if obj else "object not found"
         )

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -486,7 +486,8 @@ class CobblerXMLRPCInterface:
         """
         Run a reposync in the background.
 
-        :param options: Not known what this parameter does.
+        :param options: A dict with a "repos" key (list of repo uids) or an "only" key (a single repo uid), and
+                         optional "tries"/"nofail" keys.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :return: The id of the task which was started.
         """
@@ -496,20 +497,26 @@ class CobblerXMLRPCInterface:
             if isinstance(self.options, list):
                 raise ValueError("options for background_reposync need to be dict!")
 
-            repos = options.get("repos", [])
+            repo_uids = options.get("repos", [])
             only = options.get("only", None)
             if only is not None:
-                repos = [only]
-            nofail = options.get("nofail", len(repos) > 0)
+                repo_uids = [only]
+            nofail = options.get("nofail", len(repo_uids) > 0)
 
-            if len(repos) > 0:
-                for name in repos:
+            if len(repo_uids) > 0:
+                for repo_uid in repo_uids:
+                    repo_obj = self.remote.api.find_repo(uid=repo_uid)
+                    if repo_obj is None or isinstance(repo_obj, list):
+                        self.logger.warning('"%s" is not a valid repo uid', repo_uid)
+                        continue
                     self.remote.api.reposync(
-                        tries=self.options.get("tries", 3), name=name, nofail=nofail
+                        tries=self.options.get("tries", 3),
+                        repo_obj=repo_obj,
+                        nofail=nofail,
                     )
             else:
                 self.remote.api.reposync(
-                    tries=self.options.get("tries", 3), name=None, nofail=nofail
+                    tries=self.options.get("tries", 3), repo_obj=None, nofail=nofail
                 )
 
         return self.__start_task(runner, token, "reposync", "Reposync", options)

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3783,76 +3783,76 @@ class CobblerXMLRPCInterface:
         return self.xmlrpc_hacks(results)  # type: ignore
 
     def get_valid_distro_boot_loaders(
-        self, distro_name: Optional[str], token: Optional[str] = None
+        self, distro_uid: Optional[str], token: Optional[str] = None
     ) -> List[str]:
         """
         Return the list of valid boot loaders for the distro
 
         :param token: The API-token obtained via the login() method.
-        :param distro_name: The name of the distro for which the boot loaders should be looked up.
+        :param distro_uid: The id of the distro for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
         self._log("get_valid_distro_boot_loaders", token=token)
-        if distro_name is None:
+        if distro_uid is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
-        obj = self.api.find_distro(name=distro_name)
+        obj = self.api.find_distro(uid=distro_uid)
         if obj is None or isinstance(obj, list):
-            return [f"# object not found: {distro_name}"]
+            return [f"# object not found: {distro_uid}"]
         return [value.value for value in self.api.get_valid_obj_boot_loaders(obj)]  # type: ignore[arg-type]
 
     def get_valid_image_boot_loaders(
-        self, image_name: Optional[str], token: Optional[str] = None
+        self, image_uid: Optional[str], token: Optional[str] = None
     ) -> List[str]:
         """
         Return the list of valid boot loaders for the image
 
         :param token: The API-token obtained via the login() method.
-        :param image_name: The name of the image for which the boot loaders should be looked up.
+        :param image_uid: The id of the image for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
         self._log("get_valid_image_boot_loaders", token=token)
-        if image_name is None:
+        if image_uid is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
-        obj = self.api.find_image(name=image_name)
+        obj = self.api.find_image(uid=image_uid)
         if obj is None:
-            return [f"# object not found: {image_name}"]
+            return [f"# object not found: {image_uid}"]
         return [value.value for value in self.api.get_valid_obj_boot_loaders(obj)]  # type: ignore[arg-type]
 
     def get_valid_profile_boot_loaders(
-        self, profile_name: Optional[str], token: Optional[str] = None
+        self, profile_uid: Optional[str], token: Optional[str] = None
     ) -> List[str]:
         """
         Return the list of valid boot loaders for the profile
 
         :param token: The API-token obtained via the login() method.
-        :param profile_name: The name of the profile for which the boot loaders should be looked up.
+        :param profile_uid: The id of the profile for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.
         """
         self._log("get_valid_profile_boot_loaders", token=token)
-        if profile_name is None:
+        if profile_uid is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
-        obj = self.api.find_profile(name=profile_name)
+        obj = self.api.find_profile(uid=profile_uid)
         if obj is None or isinstance(obj, list):
-            return [f"# object not found: {profile_name}"]
+            return [f"# object not found: {profile_uid}"]
         distro = obj.get_conceptual_parent()
         return [value.value for value in self.api.get_valid_obj_boot_loaders(distro)]  # type: ignore[arg-type]
 
     def get_valid_system_boot_loaders(
-        self, system_name: Optional[str], token: Optional[str] = None
+        self, system_uid: Optional[str], token: Optional[str] = None
     ) -> List[str]:
         """
         Return the list of valid boot loaders for the system
 
         :param token: The API-token obtained via the login() method.
-        :param system_name: The name of the system for which the boot loaders should be looked up.
+        :param system_uid: The id of the system for which the boot loaders should be looked up.
         :return: Get a list of all valid boot loaders.get_valid_archs
         """
         self._log("get_valid_system_boot_loaders", token=token)
-        if system_name is None:
+        if system_uid is None:
             return [value.value for value in utils.get_supported_system_boot_loaders()]
-        obj = self.api.find_system(name=system_name)
+        obj = self.api.find_system(uid=system_uid)
         if obj is None or isinstance(obj, list):
-            return [f"# object not found: {system_name}"]
+            return [f"# object not found: {system_uid}"]
         parent = obj.get_conceptual_parent()
 
         if parent and parent.COLLECTION_TYPE == "profile":  # type: ignore[reportUnnecessaryComparison]

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -267,18 +267,44 @@ class CobblerXMLRPCInterface:
         Generates an ISO in /var/www/cobbler/pub that can be used to install profiles without using PXE.
 
         :param options: This parameter does contain the options passed from the CLI or remote API who called this.
+                         "profiles"/"systems" are lists of uids, "distro" is a uid.
         :param token: The API-token obtained via the login() method. The API-token obtained via the login() method.
         :return: The id of the task which was started.
         """
         webdir = self.api.settings().webdir
 
         def runner(self: CobblerThread):
+            def resolve_uids(
+                find_method: Callable[..., Any], uids: Optional[List[str]]
+            ) -> Optional[List[Any]]:
+                if not uids:
+                    return None
+                resolved: List[Any] = []
+                for uid in uids:
+                    obj = find_method(uid=uid)
+                    if obj is None or isinstance(obj, list):
+                        self.logger.warning('"%s" is not a valid uid', uid)
+                        continue
+                    resolved.append(obj)
+                return resolved
+
+            distro_uid = self.options.get("distro", None)
+            distro_obj = None
+            if distro_uid:
+                distro_obj = self.remote.api.find_distro(uid=distro_uid)
+                if distro_obj is None or isinstance(distro_obj, list):
+                    raise ValueError(f'Distro with uid "{distro_uid}" not found')
+
             self.remote.api.build_iso(
                 self.options.get("iso", webdir + "/pub/generated.iso"),
-                self.options.get("profiles", None),
-                self.options.get("systems", None),
+                resolve_uids(
+                    self.remote.api.find_profile, self.options.get("profiles", None)
+                ),
+                resolve_uids(
+                    self.remote.api.find_system, self.options.get("systems", None)
+                ),
                 self.options.get("buildisodir", ""),
-                self.options.get("distro", None),
+                distro_obj,
                 self.options.get("standalone", False),
                 self.options.get("airgapped", False),
                 self.options.get("source", ""),

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -4217,7 +4217,9 @@ class CobblerXMLRPCInterface:
 
         :param mode: The mode of the triggers. May be "pre", "post" or "firstboot".
         :param objtype: The type of object. This should correspond to the collection type.
-        :param name: The name of the object.
+        :param name: The name of the object. Intentionally a name rather than a uid, unlike most of the rest of this
+                     class: the value is forwarded verbatim to the trigger script and never looked up, so a uid would
+                     only add a resolution cost (see the comment below) without any correctness benefit.
         :param ip: The ip of the objet.
         :param token: The API-token obtained via the login() method.
         :param rest: This is dropped in this method since it is not needed here.

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -4475,58 +4475,58 @@ class CobblerXMLRPCInterface:
         system = self.api.find_system(dns_name=dns_name)
         if system is None or isinstance(system, list):
             return {}
-        return self.get_system_as_rendered(system.name)  # type: ignore
+        return self.get_system_as_rendered(system.uid)  # type: ignore
 
     def get_distro_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get distribution after passing through Cobbler's inheritance engine.
 
-        :param name: distro name
+        :param object_id: The id of the distro to get.
         :param token: authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a distribution.
         """
 
-        self._log("get_distro_as_rendered", name=name, token=token)
-        obj = self.api.find_distro(name=name)
+        self._log("get_distro_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_distro(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
         return self.xmlrpc_hacks({})
 
     def get_profile_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get profile after passing through Cobbler's inheritance engine.
 
-        :param name: profile name
+        :param object_id: The id of the profile to get.
         :param token: authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a profile.
         """
 
-        self._log("get_profile_as_rendered", name=name, token=token)
-        obj = self.api.find_profile(name=name)
+        self._log("get_profile_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_profile(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
         return self.xmlrpc_hacks({})
 
     def get_system_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get profile after passing through Cobbler's inheritance engine.
 
-        :param name: system name
+        :param object_id: The id of the system to get.
         :param token: authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a system.
         """
 
-        self._log("get_system_as_rendered", name=name, token=token)
-        obj = self.api.find_system(name=name)
+        self._log("get_system_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_system(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             _dict = utils.blender(self.api, True, obj)
             # Generate a pxelinux.cfg?
@@ -4557,109 +4557,109 @@ class CobblerXMLRPCInterface:
         return self.xmlrpc_hacks({})
 
     def get_repo_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get repository after passing through Cobbler's inheritance engine.
 
-        :param name: repository name
+        :param object_id: The id of the repository to get.
         :param token: authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a repository.
         """
 
-        self._log("get_repo_as_rendered", name=name, token=token)
-        obj = self.api.find_repo(name=name)
+        self._log("get_repo_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_repo(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
         return self.xmlrpc_hacks({})
 
     def get_image_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get repository after passing through Cobbler's inheritance engine.
 
-        :param name: image name
+        :param object_id: The id of the image to get.
         :param token: authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as an image.
         """
 
-        self._log("get_image_as_rendered", name=name, token=token)
-        obj = self.api.find_image(name=name)
+        self._log("get_image_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_image(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
         return self.xmlrpc_hacks({})
 
     def get_menu_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get menu after passing through Cobbler's inheritance engine
 
-        :param name: Menu name
+        :param object_id: The id of the menu to get.
         :param token: Authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a file.
         """
 
-        self._log("get_menu_as_rendered", name=name, token=token)
-        obj = self.api.find_menu(name=name)
+        self._log("get_menu_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_menu(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))
         return self.xmlrpc_hacks({})
 
     def get_distro_group_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get distro group after passing through Cobbler's inheritance engine
 
-        :param name: DistroGroup name
+        :param object_id: The id of the DistroGroup to get.
         :param token: Authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a file.
         """
 
-        self._log("get_distro_group_as_rendered", name=name, token=token)
-        obj = self.api.find_distro_group(name=name)
+        self._log("get_distro_group_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_distro_group(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
         return self.xmlrpc_hacks({})
 
     def get_profile_group_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get profile group after passing through Cobbler's inheritance engine
 
-        :param name: ProfileGroup name
+        :param object_id: The id of the ProfileGroup to get.
         :param token: Authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a file.
         """
 
-        self._log("get_profile_group_as_rendered", name=name, token=token)
-        obj = self.api.find_profile_group(name=name)
+        self._log("get_profile_group_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_profile_group(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
         return self.xmlrpc_hacks({})
 
     def get_system_group_as_rendered(
-        self, name: str, token: Optional[str] = None, **rest: Any
+        self, object_id: str, token: Optional[str] = None, **rest: Any
     ) -> Union[List[Any], Dict[Any, Any], int, str, float]:
         """
         Get system group after passing through Cobbler's inheritance engine
 
-        :param name: SystemGroup name
+        :param object_id: The id of the SystemGroup to get.
         :param token: Authentication token
         :param rest: This is dropped in this method since it is not needed here.
         :return: Get a template rendered as a file.
         """
 
-        self._log("get_system_group_as_rendered", name=name, token=token)
-        obj = self.api.find_system_group(name=name)
+        self._log("get_system_group_as_rendered", object_id=object_id, token=token)
+        obj = self.api.find_system_group(uid=object_id)
         if obj is not None and not isinstance(obj, list):
             return self.xmlrpc_hacks(utils.blender(self.api, True, obj))  # type: ignore
         return self.xmlrpc_hacks({})

--- a/cobbler/remote.py
+++ b/cobbler/remote.py
@@ -3536,18 +3536,21 @@ class CobblerXMLRPCInterface:
         )
 
     def is_autoinstall_in_use(
-        self, ai: str, token: Optional[str] = None, **rest: Any
+        self, autoinstall_uid: str, token: Optional[str] = None, **rest: Any
     ) -> bool:
         """
-        Check if the auto-installation for a system is in use.
+        Check if the auto-installation template is referenced by at least one Profile or System.
 
-        :param ai: The name of the system which could potentially be in autoinstall mode.
+        :param autoinstall_uid: The id of the autoinstall template to check for references.
         :param token: The API-token obtained via the login() method.
         :param rest: This is dropped in this method since it is not needed here.
         :return: True if this is the case, otherwise False.
         """
         self._log("is_autoinstall_in_use", token=token)
-        return self.api.is_autoinstall_in_use(ai)
+        template_obj = self.api.find_template(False, False, uid=autoinstall_uid)
+        if template_obj is None or isinstance(template_obj, list):
+            raise ValueError("Requested autoinstall template not found!")
+        return self.api.is_autoinstall_in_use(template_obj)
 
     def generate_autoinstall(
         self,

--- a/cobbler/services/svc.py
+++ b/cobbler/services/svc.py
@@ -195,7 +195,17 @@ class CobblerSvc:
             if found:
                 system = found[0]
 
-        data = self.remote.generate_ipxe(profile, image, system)
+        profile_uid = self.remote.get_profile_handle(profile) if profile else None
+        image_uid = self.remote.get_image_handle(image) if image else None
+        system_uid = self.remote.get_system_handle(system) if system else None
+        if profile_uid == "~":
+            profile_uid = None
+        if image_uid == "~":
+            image_uid = None
+        if system_uid == "~":
+            system_uid = None
+
+        data = self.remote.generate_ipxe(profile_uid, image_uid, system_uid)
         if isinstance(data, str):
             return data
         return "ERROR: Server returned unexpected data!"
@@ -211,7 +221,13 @@ class CobblerSvc:
         :param kwargs: This parameter is unused.
         :return:
         """
-        data = self.remote.generate_bootcfg(profile, system)
+        profile_uid = self.remote.get_profile_handle(profile) if profile else None
+        system_uid = self.remote.get_system_handle(system) if system else None
+        if profile_uid == "~":
+            profile_uid = None
+        if system_uid == "~":
+            system_uid = None
+        data = self.remote.generate_bootcfg(profile_uid, system_uid)
         if isinstance(data, str):
             return data
         return "ERROR: Server returned unexpected data!"
@@ -229,8 +245,14 @@ class CobblerSvc:
                      array. The element from position zero is taken.
         :return: The generated script.
         """
+        profile_uid = self.remote.get_profile_handle(profile) if profile else None
+        system_uid = self.remote.get_system_handle(system) if system else None
+        if profile_uid == "~":
+            profile_uid = None
+        if system_uid == "~":
+            system_uid = None
         data = self.remote.generate_script(
-            profile, system, kwargs["query_string"]["script"][0]
+            profile_uid, system_uid, kwargs["query_string"]["script"][0]
         )
         if isinstance(data, str):
             return data

--- a/cobbler/services/svc.py
+++ b/cobbler/services/svc.py
@@ -307,9 +307,17 @@ class CobblerSvc:
         :return: The generated repository config.
         """
         if profile is not None:
-            data = self.remote.get_repo_config_for_profile(profile)
+            profile_uid = self.remote.get_profile_handle(profile)
+            if profile_uid == "~":
+                data = f"# object not found: {profile}"
+            else:
+                data = self.remote.get_repo_config_for_profile(profile_uid)
         elif system is not None:
-            data = self.remote.get_repo_config_for_system(system)
+            system_uid = self.remote.get_system_handle(system)
+            if system_uid == "~":
+                data = f"# object not found: {system}"
+            else:
+                data = self.remote.get_repo_config_for_system(system_uid)
         else:
             data = "# must specify profile or system name"
         if not isinstance(data, str):

--- a/cobbler/services/svc.py
+++ b/cobbler/services/svc.py
@@ -286,9 +286,17 @@ class CobblerSvc:
             return "# must specify a template path"
 
         if profile is not None:
-            data = self.remote.get_template_file_for_profile(profile, path)
+            profile_uid = self.remote.get_profile_handle(profile)
+            if profile_uid == "~":
+                data = f"# object not found: {profile}"
+            else:
+                data = self.remote.get_template_file_for_profile(profile_uid, path)
         elif system is not None:
-            data = self.remote.get_template_file_for_system(system, path)
+            system_uid = self.remote.get_system_handle(system)
+            if system_uid == "~":
+                data = f"# object not found: {system}"
+            else:
+                data = self.remote.get_template_file_for_system(system_uid, path)
         else:
             data = "# must specify profile or system name"
         if not isinstance(data, str):

--- a/cobbler/services/svc.py
+++ b/cobbler/services/svc.py
@@ -369,7 +369,12 @@ class CobblerSvc:
         :param kwargs: This parameter is unused.
         :return: A boolean status if the action succeed or not.
         """
-        return str(self.remote.disable_netboot(system))
+        if system is None:
+            return str(False)
+        system_uid = self.remote.get_system_handle(system)
+        if system_uid == "~":
+            return str(False)
+        return str(self.remote.disable_netboot(system_uid))
 
     def list(self, what: str = "systems", **kwargs: Any) -> str:
         """

--- a/cobbler/tftpgen.py
+++ b/cobbler/tftpgen.py
@@ -23,6 +23,7 @@ except ImportError:
 from cobbler import enums, grub, utils
 from cobbler.cexceptions import CX
 from cobbler.enums import Archs, ImageTypes
+from cobbler.items.system import System
 from cobbler.utils import filesystem_helpers, input_converters, kernel_command_line
 from cobbler.validate import validate_autoinstall_script_name
 
@@ -39,7 +40,6 @@ if TYPE_CHECKING:
     from cobbler.items.menu import Menu
     from cobbler.items.network_interface import NetworkInterface
     from cobbler.items.profile import Profile
-    from cobbler.items.system import System
     from cobbler.items.template import Template
 
 
@@ -616,8 +616,7 @@ class TFTPGen:
                     bootloader_format=enums.BootLoader.GRUB,
                 )
             if path == pathlib.Path("/esxi/system", system.name, "boot.cfg"):
-                # FIXME: generate_bootcfg shouldn't waste time searching for the system again
-                return self.generate_bootcfg("system", system.name)
+                return self.generate_bootcfg(system=system)
 
         return None
 
@@ -1330,7 +1329,7 @@ class TFTPGen:
                     bootcfg_path = os.path.join("system", system.name, "boot.cfg")
                 # write the boot.cfg file in the bootcfg_path
                 if bootloader_format == enums.BootLoader.PXE:
-                    self._write_bootcfg_file("system", system.name, bootcfg_path)
+                    self._write_bootcfg_file(bootcfg_path, system=system)
                 # make bootcfg_path available for templating
                 metadata["bootcfg_path"] = bootcfg_path
             else:
@@ -1877,36 +1876,30 @@ class TFTPGen:
 
         return results
 
-    def generate_ipxe(self, what: str, name: str) -> str:
+    def generate_ipxe(
+        self,
+        profile: Optional["Profile"] = None,
+        image: Optional["Image"] = None,
+        system: Optional["System"] = None,
+    ) -> str:
         """
         Generate the ipxe files.
 
-        :param what: Either "profile" or "system". All other item types not valid.
-        :param name: The name of the profile or system.
+        :param profile: The profile to generate the ipxe config for.
+        :param image: The image to generate the ipxe config for.
+        :param system: The system to generate the ipxe config for.
         :return: The rendered template.
         """
-        if what.lower() not in ("profile", "image", "system"):
-            return "# ipxe is only valid for profiles, images and systems"
-
         distro: Optional["Distro"] = None
-        image: Optional["Image"] = None
-        profile: Optional["Profile"] = None
-        system: Optional["System"] = None
-        if what == "profile":
-            profile = self.api.find_profile(name=name)  # type: ignore
-            if profile:
-                distro = profile.get_conceptual_parent()  # type: ignore
-        elif what == "image":
-            image = self.api.find_image(name=name)  # type: ignore
-        else:
-            system = self.api.find_system(name=name)  # type: ignore
-            if system:
-                profile = system.get_conceptual_parent()  # type: ignore
+        if system:
+            profile = system.get_conceptual_parent()  # type: ignore
             if profile and profile.COLLECTION_TYPE == "profile":
                 distro = profile.get_conceptual_parent()  # type: ignore
             else:
                 image = profile  # type: ignore
                 profile = None
+        elif profile:
+            distro = profile.get_conceptual_parent()  # type: ignore
 
         if distro:
             arch = distro.arch
@@ -1930,25 +1923,28 @@ class TFTPGen:
         result_split[0] = "#!ipxe\n"
         return "".join(result_split)
 
-    def generate_bootcfg(self, what: str, name: str) -> str:
+    def generate_bootcfg(
+        self,
+        profile: Optional["Profile"] = None,
+        system: Optional["System"] = None,
+    ) -> str:
         """
-        Generate a bootcfg for a system of profile.
+        Generate a bootcfg for a system or profile.
 
-        :param what: The type for what the bootcfg is generated for. Must be "profile" or "system".
-        :param name: The name of the item which the bootcfg should be generated for.
+        :param profile: The profile to generate the bootcfg for.
+        :param system: The system to generate the bootcfg for.
         :return: The fully rendered bootcfg as a string.
         """
-        if what.lower() not in ("profile", "system"):
-            return "# bootcfg is only valid for profiles and systems"
-
-        obj: Optional[Union["Profile", "System"]]
-        if what == "profile":
-            obj = self.api.find_profile(name=name)  # type: ignore
-            distro = obj.get_conceptual_parent()  # type: ignore
-        else:
-            obj = self.api.find_system(name=name)  # type: ignore
-            profile = obj.get_conceptual_parent()  # type: ignore
+        obj: Union["Profile", "System"]
+        if system:
+            obj = system
+            profile = system.get_conceptual_parent()  # type: ignore
             distro = profile.get_conceptual_parent()  # type: ignore
+        elif profile:
+            obj = profile
+            distro = profile.get_conceptual_parent()  # type: ignore
+        else:
+            return "# bootcfg is only valid for profiles and systems"
 
         blended = utils.blender(self.api, False, obj)  # type: ignore
 
@@ -1973,17 +1969,16 @@ class TFTPGen:
             blended["img_path"] = os.path.join("/images", distro.name)  # type: ignore
 
         # generate the kernel options:
-        if what == "system":
+        if isinstance(obj, System):
             kopts = self.build_kernel_options(
-                obj,  # type: ignore
+                obj,
                 profile,  # type: ignore
                 distro,  # type: ignore
                 None,
                 distro.arch,  # type: ignore
             )
-        elif what == "profile":
+        else:
             kopts = self.build_kernel_options(None, obj, distro, None, distro.arch)  # type: ignore
-        # pylint: disable-next=possibly-used-before-assignment
         blended["kopts"] = kopts  # type: ignore
         blended["kernel_file"] = os.path.basename(distro.kernel)  # type: ignore
 
@@ -2007,28 +2002,27 @@ class TFTPGen:
 
         return self.api.templar.render(bootcfg_template.content, blended, None)
 
-    def generate_script(self, what: str, objname: str, script_name: str) -> str:
+    def generate_script(
+        self,
+        profile: Optional["Profile"] = None,
+        system: Optional["System"] = None,
+        script_name: str = "",
+    ) -> str:
         """
         Generate a script from a autoinstall script template for a given profile or system.
 
-        :param what: The type for what the bootcfg is generated for. Must be "profile" or "system".
-        :param objname: The name of the item which the bootcfg should be generated for.
+        :param profile: The profile to generate the script for.
+        :param system: The system to generate the script for.
         :param script_name: The name of the template which should be rendered for the system or profile.
         :return: The fully rendered script as a string.
         """
-        obj: Optional[Union["Profile", "System"]]
-        if what == "profile":
-            obj = self.api.find_profile(name=objname)  # type: ignore
-        elif what == "system":
-            obj = self.api.find_system(name=objname)  # type: ignore
-        else:
-            raise ValueError('"what" needs to be either "profile" or "system"!')
+        obj: Optional[Union["Profile", "System"]] = system or profile
 
         if not validate_autoinstall_script_name(script_name):
             raise ValueError('"script_name" handed to generate_script was not valid!')
 
-        if not obj or isinstance(obj, list):
-            return f'# "{what}" named "{objname}" not found'
+        if obj is None:
+            return f'# no profile or system given for script "{script_name}"'
 
         distro: Optional["Distro"] = obj.get_conceptual_parent()  # type: ignore
         if distro is None or isinstance(distro, list):
@@ -2153,7 +2147,12 @@ class TFTPGen:
 
         return initrd
 
-    def _write_bootcfg_file(self, what: str, name: str, filename: str) -> str:
+    def _write_bootcfg_file(
+        self,
+        filename: str,
+        profile: Optional["Profile"] = None,
+        system: Optional["System"] = None,
+    ) -> str:
         """
         Write a boot.cfg file for the ESXi boot loader(s), and create a symlink to
         esxi UEFI bootloaders (mboot.efi)
@@ -2170,16 +2169,16 @@ class TFTPGen:
                           boot.cfg
                           mboot.efi
 
-        :param what: Either "profile" or "system". Profiles are not currently used.
-        :param name: The name of the item which the file should be generated for.
         :param filename: relative boot.cfg path from tftp.
+        :param profile: The profile to generate the boot.cfg for. Not currently used by any caller.
+        :param system: The system to generate the boot.cfg for.
         :return: The generated filecontent for the required item.
         """
 
-        if what.lower() not in ("profile", "system"):
+        if profile is None and system is None:
             return "# only valid for profiles and systems"
 
-        buffer = self.generate_bootcfg(what, name)
+        buffer = self.generate_bootcfg(profile=profile, system=system)
         bootloc_esxi = os.path.join(self.bootloc, "esxi")
         bootcfg_path = os.path.join(bootloc_esxi, filename)
 

--- a/tests/actions/buildiso/buildiso_test.py
+++ b/tests/actions/buildiso/buildiso_test.py
@@ -250,7 +250,7 @@ def test_filter_system(
     test_system_image: System = create_system(
         image_uid=test_image.uid, name="test_filter_system_image_image"
     )
-    itemlist = [test_system_profile.name, test_system_image.name]
+    itemlist = [test_system_profile, test_system_image]
     build_iso = NetbootBuildiso(cobbler_api)
     expected_result = [test_system_profile]
 
@@ -272,7 +272,7 @@ def test_filter_profile(
     # Arrange
     test_distro = create_distro()
     test_profile = create_profile(test_distro.uid)
-    itemlist = [test_profile.name]
+    itemlist = [test_profile]
     build_iso = buildiso.BuildIso(cobbler_api)
     expected_result = [test_profile]
 
@@ -295,7 +295,7 @@ def test_filter_profile_disabled(
     test_distro = create_distro()
     test_profile = create_profile(test_distro.uid)
     test_profile.enable_menu = False  # type: ignore
-    itemlist = [test_profile.name]
+    itemlist = [test_profile]
     build_iso = buildiso.BuildIso(cobbler_api)
     expected_result: List[Any] = []  # No enabled profiles
 
@@ -322,7 +322,7 @@ def test_netboot_run(
     iso_location = tmpdir.join("autoinst.iso")
 
     # Act
-    build_iso.run(iso=str(iso_location), distro_name=test_distro.name)
+    build_iso.run(iso=str(iso_location), distro=test_distro)
 
     # Assert
     assert iso_location.exists()
@@ -367,7 +367,7 @@ def test_standalone_run(
 
     # Act
     build_iso.run(
-        iso=str(iso_location), distro_name=test_distro.name, source=str(iso_source)  # type: ignore
+        iso=str(iso_location), distro=test_distro, source=str(iso_source)  # type: ignore
     )
 
     # Assert

--- a/tests/actions/reposync_test.py
+++ b/tests/actions/reposync_test.py
@@ -143,6 +143,65 @@ def test_run(mocker: "MockerFixture", reposync_object: reposync.RepoSync, repo: 
     assert len(env_vars) == 0
 
 
+def test_run_single_repo(
+    mocker: "MockerFixture", reposync_object: reposync.RepoSync, repo: Repo
+):
+    # Arrange
+    env_vars: Dict[str, Any] = {}
+    other_repo = Repo(reposync_object.api)
+    other_repo.name = "other_repo"
+    mocker.patch("os.makedirs")
+    mocker.patch("os.path.isdir", return_value=True)
+    mocker.patch(
+        "os.path.join",
+        side_effect=[
+            "/srv/www/cobbler/repo_mirror",
+            "/srv/www/cobbler/repo_mirror/%s" % repo.name,
+        ],
+    )
+    mocker.patch("os.environ", return_value=env_vars)
+    sync_mock = mocker.patch.object(reposync_object, "sync")
+    mocker.patch.object(reposync_object, "update_permissions")
+    reposync_object.repos = [other_repo, repo]  # type: ignore
+
+    # Act
+    reposync_object.run(repo)
+
+    # Assert
+    # Only the given repo is synced, the rest of self.repos is not consulted.
+    sync_mock.assert_called_once_with(repo)
+    # This has to be 0 since all env vars need to be removed after reposync has run.
+    assert len(env_vars) == 0
+
+
+def test_run_single_repo_nofail_reports_overall_failure(
+    mocker: "MockerFixture", reposync_object: reposync.RepoSync, repo: Repo
+):
+    """
+    A single-repo run that fails with nofail=True must still raise the "overall reposync failed" error, matching
+    the behavior of an all-repos run with at least one failure -- not just log-and-swallow the failure.
+    """
+    # Arrange
+    env_vars: Dict[str, Any] = {}
+    reposync_object.nofail = True
+    mocker.patch("os.makedirs")
+    mocker.patch("os.path.isdir", return_value=True)
+    mocker.patch(
+        "os.path.join",
+        side_effect=[
+            "/srv/www/cobbler/repo_mirror",
+            "/srv/www/cobbler/repo_mirror/%s" % repo.name,
+        ],
+    )
+    mocker.patch("os.environ", return_value=env_vars)
+    mocker.patch.object(reposync_object, "sync", side_effect=Exception("boom"))
+    mocker.patch.object(reposync_object, "update_permissions")
+
+    # Act & Assert
+    with pytest.raises(cexceptions.CX, match="overall reposync failed"):
+        reposync_object.run(repo)
+
+
 def test_gen_urlgrab_ssl_opts(reposync_object: reposync.RepoSync):
     # Arrange
     input_dict: Dict[str, Any] = {}

--- a/tests/actions/sync_test.py
+++ b/tests/actions/sync_test.py
@@ -11,6 +11,7 @@ import pytest
 
 from cobbler.actions import sync
 from cobbler.api import CobblerAPI
+from cobbler.items.system import System
 
 if TYPE_CHECKING:
     from pytest_mock import MockerFixture
@@ -217,7 +218,7 @@ def test_run_sync_systems(cobbler_api: CobblerAPI):
     test_sync = sync.CobblerSync(cobbler_api)
 
     # Act
-    test_sync.run_sync_systems(["t1.systems.de"])
+    test_sync.run_sync_systems([System(cobbler_api)])
     # Assert
     # correct order with correct parameters
     assert False

--- a/tests/api/sync_test.py
+++ b/tests/api/sync_test.py
@@ -2,7 +2,7 @@
 Testmodule to verify that the API for "cobbler sync" related operations is working successfully.
 """
 
-from typing import TYPE_CHECKING, Any, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, List, Optional
 from unittest.mock import MagicMock, Mock, PropertyMock, create_autospec
 
 import pytest
@@ -12,7 +12,10 @@ import cobbler.modules.managers.bind
 import cobbler.modules.managers.in_httpd
 import cobbler.modules.managers.isc
 from cobbler.api import CobblerAPI
+from cobbler.items.distro import Distro
 from cobbler.items.image import Image
+from cobbler.items.profile import Profile
+from cobbler.items.system import System
 
 from tests.conftest import does_not_raise
 
@@ -167,21 +170,43 @@ def test_get_sync_default_httpd_manager(cobbler_api: CobblerAPI):
 @pytest.mark.parametrize(
     "input_verbose,input_systems,expected_exception",
     [
-        (None, ["t1.systems.de"], does_not_raise()),
-        (True, ["t1.systems.de"], does_not_raise()),
-        (False, ["t1.systems.de"], does_not_raise()),
         (False, [], does_not_raise()),
         (False, [42], pytest.raises(TypeError)),
         (False, None, pytest.raises(TypeError)),
         (False, "t1.systems.de", pytest.raises(TypeError)),
     ],
 )
-def test_sync_systems(
+def test_sync_systems_invalid(
     cobbler_api: CobblerAPI,
     input_verbose: bool,
     input_systems: Any,
     expected_exception: Any,
     mocker: "MockerFixture",
+):
+    """
+    Verify that sync_systems validates the type of its "systems" argument.
+    """
+    # Arrange
+    stub = create_autospec(spec=cobbler.actions.sync.CobblerSync)
+    mocker.patch.object(cobbler_api, "get_sync", return_value=stub)
+    mocker.patch("cobbler.utils.filelock")
+
+    # Act
+    with expected_exception:
+        cobbler_api.sync_systems(input_systems, input_verbose)
+
+    # Assert
+    assert stub.run_sync_systems.call_count == 0
+
+
+@pytest.mark.parametrize("input_verbose", [None, True, False])
+def test_sync_systems(
+    cobbler_api: CobblerAPI,
+    input_verbose: bool,
+    mocker: "MockerFixture",
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str], System],
 ):
     """
     Verify that the main function dedicated to syncing systems is functional.
@@ -190,19 +215,16 @@ def test_sync_systems(
     stub = create_autospec(spec=cobbler.actions.sync.CobblerSync)
     mocker.patch.object(cobbler_api, "get_sync", return_value=stub)
     filelock_mock = mocker.patch("cobbler.utils.filelock")
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_system = create_system(test_profile.uid)
 
     # Act
-    with expected_exception:
-        cobbler_api.sync_systems(input_systems, input_verbose)
+    cobbler_api.sync_systems([test_system], input_verbose)  # type: ignore
 
-        # Assert
-        if len(input_systems) > 0:
-            filelock_mock.assert_called_once_with("/var/lib/cobbler/lock")
-        if len(input_systems) > 0:
-            stub.run_sync_systems.assert_called_once()
-            stub.run_sync_systems.assert_called_with(input_systems)
-        else:
-            assert stub.run_sync_systems.call_count == 0
+    # Assert
+    filelock_mock.assert_called_once_with("/var/lib/cobbler/lock")
+    stub.run_sync_systems.assert_called_once_with([test_system])
 
 
 def test_image_rename(cobbler_api: CobblerAPI):

--- a/tests/autoinstall/manager_test.py
+++ b/tests/autoinstall/manager_test.py
@@ -36,9 +36,11 @@ def test_is_autoinstall_in_use(cobbler_api: CobblerAPI):
     """
     # Arrange
     test_manager = manager.AutoInstallationManager(cobbler_api)
+    template = cobbler_api.find_template(False, False, name="built-in-legacy.ks")
+    assert isinstance(template, Template)
 
     # Act
-    result = test_manager.is_autoinstall_in_use("built-in-legacy.ks")
+    result = test_manager.is_autoinstall_in_use(template)
 
     # Assert
     assert not result

--- a/tests/integration/basic_test.py
+++ b/tests/integration/basic_test.py
@@ -55,7 +55,7 @@ def test_basic_buildiso(
 
     # Act
     tid = remote.background_buildiso(
-        {"iso": str(iso_path), "distro": distro_name, "buildisodir": str(buildisodir)},
+        {"iso": str(iso_path), "distro": distro_id, "buildisodir": str(buildisodir)},
         token,
     )
     wait_task_end(tid, remote)

--- a/tests/integration/buildiso_test.py
+++ b/tests/integration/buildiso_test.py
@@ -143,10 +143,11 @@ def test_buildiso_integration(
     # Act
     iso_path = str(tmp_path / "autoinst.iso")
     if flavor == "airgapped":
+        distro_uid = remote.get_distro_handle("leap-x86_64")
         tid = remote.background_buildiso(
             {
                 "airgapped": True,
-                "distro": "leap-x86_64",
+                "distro": distro_uid,
                 "source": str(mount_point),
                 "buildisodir": "/var/cache/cobbler/buildiso",
                 "iso": iso_path,
@@ -154,10 +155,11 @@ def test_buildiso_integration(
             token,
         )
     elif flavor == "full":
+        distro_uid = remote.get_distro_handle("leap-x86_64")
         tid = remote.background_buildiso(
             {
                 "standalone": True,
-                "distro": "leap-x86_64",
+                "distro": distro_uid,
                 "source": str(mount_point),
                 "buildisodir": "/var/cache/cobbler/buildiso",
                 "iso": iso_path,
@@ -165,9 +167,10 @@ def test_buildiso_integration(
             token,
         )
     elif flavor == "net":
+        distro_uid = remote.get_distro_handle("leap-x86_64")
         tid = remote.background_buildiso(
             {
-                "distro": "leap-x86_64",
+                "distro": distro_uid,
                 "buildisodir": "/var/cache/cobbler/buildiso",
                 "iso": iso_path,
             },
@@ -176,19 +179,21 @@ def test_buildiso_integration(
     elif flavor == "non-standard-directory":
         custom_mount_point = pathlib.Path("/var/cache/cobbler/buildiso-test")
         custom_mount_point.mkdir(exist_ok=True)
+        distro_uid = remote.get_distro_handle("leap-x86_64")
         tid = remote.background_buildiso(
             {
-                "distro": "leap-x86_64",
+                "distro": distro_uid,
                 "buildisodir": str(custom_mount_point),
                 "iso": iso_path,
             },
             token,
         )
     elif flavor == "ppc64le":
+        distro_uid = remote.get_distro_handle("leap-ppc64le")
         tid = remote.background_buildiso(
             {
                 "profile": "leap-ppc64le",
-                "distro": "leap-ppc64le",
+                "distro": distro_uid,
                 "source": str(mount_point),
                 "buildisodir": "/var/cache/cobbler/buildiso",
                 "iso": iso_path,

--- a/tests/items/network_interface_test.py
+++ b/tests/items/network_interface_test.py
@@ -49,6 +49,40 @@ def test_network_interface_object_creation(cobbler_api: CobblerAPI):
     assert isinstance(interface, NetworkInterface)
 
 
+def test_system(
+    cobbler_api: CobblerAPI,
+    create_distro: Callable[[], Distro],
+    create_profile: Callable[[str], Profile],
+    create_system: Callable[[str], System],
+):
+    """
+    Test to verify that the system property resolves the owning system by uid.
+    """
+    # Arrange
+    test_distro = create_distro()
+    test_profile = create_profile(test_distro.uid)
+    test_system = create_system(test_profile.uid)
+    interface = NetworkInterface(cobbler_api, test_system.uid)
+
+    # Act
+    result = interface.system
+
+    # Assert
+    assert result is test_system
+
+
+def test_system_not_present(cobbler_api: CobblerAPI):
+    """
+    Test to verify that the system property raises when the referenced system does not exist.
+    """
+    # Arrange
+    interface = NetworkInterface(cobbler_api, "does-not-exist")
+
+    # Act & Assert
+    with pytest.raises(ValueError):
+        interface.system  # pylint: disable=pointless-statement
+
+
 def test_network_interface_to_dict(cobbler_api: CobblerAPI):
     """
     Test to verify that the to_dict method of NetworkInterface works as expected.

--- a/tests/modules/managers/dynamic_tftp_test.py
+++ b/tests/modules/managers/dynamic_tftp_test.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Generator
 import pytest
 
 from cobbler.api import CobblerAPI
+from cobbler.items.system import System
 from cobbler.modules.managers import dynamic_tftp
 from cobbler.settings import Settings
 from cobbler.tftpgen import TFTPGen
@@ -152,7 +153,7 @@ def test_manager_sync_systems(api_mock_dynamic_tftp: CobblerAPI):
     tftpgen_mock = api_mock_dynamic_tftp.tftpgen
 
     # Act
-    manager_obj.sync_systems(["t1.example.org"], True)
+    manager_obj.sync_systems([System(api_mock_dynamic_tftp)], True)
 
     # Assert
     assert tftpgen_mock.method_calls == []  # type: ignore[reportUnknownMemberType,reportAttributeAccessIssue]

--- a/tests/modules/managers/in_tftpd_test.py
+++ b/tests/modules/managers/in_tftpd_test.py
@@ -3,7 +3,7 @@ Tests that validate the functionality of the module that is responsible for mana
 ISC DHCP server.
 """
 
-from typing import TYPE_CHECKING, Any, Generator, List
+from typing import TYPE_CHECKING, Any, Generator
 
 import pytest
 
@@ -200,16 +200,11 @@ def test_manager_add_single_image(api_mock_tftp: CobblerAPI):
     assert tftpgen_mock.copy_single_image_files.call_count == 1  # type: ignore[reportFunctionMemberAccess,attr-defined]
 
 
-@pytest.mark.parametrize(
-    "input_systems, input_verbose, expected_output",
-    [(["t1.example.org"], True, "t1.example.org")],
-)
+@pytest.mark.parametrize("input_verbose", [True, False])
 def test_sync_systems(
     mocker: "MockerFixture",
     api_mock_tftp: CobblerAPI,
-    input_systems: List[str],
     input_verbose: bool,
-    expected_output: str,
 ):
     """
     Test to verify the sync_systems method of the InTftpdManager class.
@@ -218,6 +213,7 @@ def test_sync_systems(
     manager_obj = in_tftpd.get_manager(api_mock_tftp)
     tftpgen_mock = api_mock_tftp.tftpgen
     single_system_mock = mocker.patch.object(manager_obj, "sync_single_system")
+    input_systems = [System(api_mock_tftp)]
 
     # Act
     manager_obj.sync_systems(input_systems, input_verbose)

--- a/tests/special_cases/built_in_scripts_test.py
+++ b/tests/special_cases/built_in_scripts_test.py
@@ -32,7 +32,7 @@ def test_built_in_preseed_early_default(
     test_profile = create_profile(test_distro.uid)
 
     # Act
-    result = cobbler_api.generate_script(test_profile.name, None, template)
+    result = cobbler_api.generate_script(test_profile, None, template)
 
     # Assert
     assert result == "\n".join(expected_result)
@@ -73,7 +73,7 @@ def test_built_in_preseed_late_default(
     test_profile = create_profile(test_distro.uid)
 
     # Act
-    result = cobbler_api.generate_script(test_profile.name, None, template)
+    result = cobbler_api.generate_script(test_profile, None, template)
 
     # Assert
     assert result == "\n".join(expected_result)
@@ -100,7 +100,7 @@ def test_built_in_preseed_nochroot_late_default(
     test_profile = create_profile(test_distro.uid)
 
     # Act
-    result = cobbler_api.generate_script(test_profile.name, None, template)
+    result = cobbler_api.generate_script(test_profile, None, template)
 
     # Assert
     assert result == "\n".join(expected_result)
@@ -126,7 +126,7 @@ def test_built_in_xcp_pre_install(
     test_profile = create_profile(test_distro.uid)
 
     # Act
-    result = cobbler_api.generate_script(test_profile.name, None, template)
+    result = cobbler_api.generate_script(test_profile, None, template)
 
     # Assert
     assert result == "\n".join(expected_result)
@@ -152,7 +152,7 @@ def test_built_in_xcp_post_install(
     test_profile = create_profile(test_distro.uid)
 
     # Act
-    result = cobbler_api.generate_script(test_profile.name, None, template)
+    result = cobbler_api.generate_script(test_profile, None, template)
 
     # Assert
     assert result == "\n".join(expected_result)

--- a/tests/special_cases/security_test.py
+++ b/tests/special_cases/security_test.py
@@ -81,7 +81,7 @@ def test_arbitrary_file_disclosure_1(
 
     # Act
     profiles = cobbler_api.get_profiles()
-    target: str = profiles[0]["name"]  # type: ignore
+    target: str = profiles[0]["uid"]  # type: ignore
     try:
         result: str = cobbler_api.generate_script(target, "", "/etc/shadow")  # type: ignore
 
@@ -105,7 +105,7 @@ def test_template_injection_1(
 
     # Act
     profiles = cobbler_api.get_profiles()
-    target: str = profiles[0]["name"]  # type: ignore
+    target: str = profiles[0]["uid"]  # type: ignore
     try:
         print("[+] Stage 1 : Poisoning log with Cheetah template RCE")
         result_stage_1: str = cobbler_api.generate_script(

--- a/tests/tftpgen_test.py
+++ b/tests/tftpgen_test.py
@@ -773,7 +773,7 @@ def test_generate_ipxe(
     )
 
     # Act
-    result = test_gen.generate_ipxe("profile", test_profile.name)
+    result = test_gen.generate_ipxe(test_profile)
 
     # Assert
     mock_write_pxe_file.assert_called_with(
@@ -806,7 +806,7 @@ def test_generate_bootcfg(
     test_gen.api.templar = mocker.MagicMock(spec=Templar, autospec=True)
 
     # Act
-    result = test_gen.generate_bootcfg("profile", test_profile.name)
+    result = test_gen.generate_bootcfg(test_profile)
 
     # Assert
     assert isinstance(result, str)
@@ -835,7 +835,7 @@ def test_generate_script(
 
     # Act
     result = test_gen.generate_script(
-        "profile", test_profile.name, "built-in-preseed_early_default"
+        profile=test_profile, script_name="built-in-preseed_early_default"
     )
 
     # Assert
@@ -909,7 +909,7 @@ def test_write_bootcfg_file(
 
     # Act
     # pylint: disable-next=protected-access
-    result = test_gen._write_bootcfg_file("profile", "test", "example.txt")  # type: ignore[reportPrivateUsage]
+    result = test_gen._write_bootcfg_file("example.txt", profile=mocker.MagicMock())  # type: ignore[reportPrivateUsage]
 
     # Assert
     assert result == expected_result

--- a/tests/xmlrpcapi/distro_group_test.py
+++ b/tests/xmlrpcapi/distro_group_test.py
@@ -162,7 +162,7 @@ def test_get_distro_group_as_rendered(remote: CobblerXMLRPCInterface, token: str
     remote.save_distro_group(handle, True, True, "new", token)
 
     # Act
-    result = remote.get_distro_group_as_rendered("test_distro_group", token)
+    result = remote.get_distro_group_as_rendered(handle, token)
 
     # Assert
     assert result is not None

--- a/tests/xmlrpcapi/distro_test.py
+++ b/tests/xmlrpcapi/distro_test.py
@@ -215,3 +215,46 @@ def test_remove_distro(
 
     # Assert
     assert result
+
+
+def test_get_valid_distro_boot_loaders(
+    request: "pytest.FixtureRequest",
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: get the valid boot loaders for a distro
+    """
+    # Arrange
+    distro_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    kernel_path = os.path.join(folder, fk_kernel)
+    initrd_path = os.path.join(folder, fk_initrd)
+    distro_uid = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
+
+    # Act
+    result = remote.get_valid_distro_boot_loaders(distro_uid, token)
+
+    # Assert
+    assert isinstance(result, list)
+    assert result != []
+
+
+def test_get_valid_distro_boot_loaders_no_distro(
+    remote: CobblerXMLRPCInterface, token: str
+):
+    """
+    Test: get the valid boot loaders when no distro id is given returns all supported boot loaders
+    """
+    # Act
+    result = remote.get_valid_distro_boot_loaders(None, token)
+
+    # Assert
+    assert isinstance(result, list)
+    assert result != []

--- a/tests/xmlrpcapi/image_test.py
+++ b/tests/xmlrpcapi/image_test.py
@@ -126,3 +126,35 @@ class TestImage:
 
         # Assert
         assert result
+
+    def test_get_valid_image_boot_loaders(
+        self,
+        remote: CobblerXMLRPCInterface,
+        token: str,
+        create_image: Callable[[], Image],
+    ):
+        """
+        Test: get the valid boot loaders for an image
+        """
+        # Arrange
+        test_image = create_image()
+
+        # Act
+        result = remote.get_valid_image_boot_loaders(test_image.uid, token)
+
+        # Assert
+        assert isinstance(result, list)
+        assert result != []
+
+    def test_get_valid_image_boot_loaders_no_image(
+        self, remote: CobblerXMLRPCInterface, token: str
+    ):
+        """
+        Test: get the valid boot loaders when no image id is given returns all supported boot loaders
+        """
+        # Act
+        result = remote.get_valid_image_boot_loaders(None, token)
+
+        # Assert
+        assert isinstance(result, list)
+        assert result != []

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -292,10 +292,10 @@ def test_get_blended_data(
     name_system = "test_system_blended"
     distro_uid = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
     profile_uid = create_profile(name_profile, distro_uid, "text")
-    create_system(name_system, profile_uid)
+    system_uid = create_system(name_system, profile_uid)
 
     # Act
-    result = remote.get_blended_data(name_profile, name_system)
+    result = remote.get_blended_data(profile_uid, system_uid)
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -221,10 +221,10 @@ def test_get_item_as_rendered(
     path_kernel = os.path.join(basepath, fk_kernel)
     path_initrd = os.path.join(basepath, fk_initrd)
     name = "test_item_as_rendered"
-    create_distro(name, "x86_64", "suse", path_kernel, path_initrd)
+    distro_uid = create_distro(name, "x86_64", "suse", path_kernel, path_initrd)
 
     # Act
-    result = remote.get_distro_as_rendered(name, token)
+    result = remote.get_distro_as_rendered(distro_uid, token)
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -195,11 +195,11 @@ def test_generate_script(
     name_profile = "test_profile_template_for_system"
     name_autoinstall_script = "test_generate_script"
     distro_uid = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
-    create_profile(name_profile, distro_uid, "text")
+    profile_uid = create_profile(name_profile, distro_uid, "text")
     # TODO: Create Autoinstall Script
 
     # Act
-    result = remote.generate_script(name_profile, None, name_autoinstall_script)
+    result = remote.generate_script(profile_uid, None, name_autoinstall_script)
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -461,8 +461,11 @@ def test_is_autoinstall_in_use(remote: CobblerXMLRPCInterface, token: str):
     """
     Test to verify that it can be sucessfully check if a given autoinstall is currently in use.
     """
-    # Arrange & Act
-    result = remote.is_autoinstall_in_use("built-in-powerkvm.ks", token)
+    # Arrange
+    template_uid = remote.get_template_handle("built-in-powerkvm.ks")
+
+    # Act
+    result = remote.is_autoinstall_in_use(template_uid, token)
 
     # Assert
     assert not result

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -412,12 +412,12 @@ def test_get_template_file_for_profile(
     name_template = "test_template_for_profile"
     content_template = "# Testtemplate"
     distro_uid = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
-    create_profile(name_profile, distro_uid, "text")
+    profile_uid = create_profile(name_profile, distro_uid, "text")
     create_autoinstall_template(name_template, content_template)
 
     # Act
     # TODO: Fix test & functionality!
-    result = remote.get_template_file_for_profile(name_profile, name_template)
+    result = remote.get_template_file_for_profile(profile_uid, name_template)
 
     # Assert
     assert result == content_template
@@ -447,11 +447,11 @@ def test_get_template_file_for_system(
     content_template = "# Testtemplate"
     distro_uid = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
     profile_uid = create_profile(name_profile, distro_uid, "text")
-    create_system(name_system, profile_uid)
+    system_uid = create_system(name_system, profile_uid)
     create_autoinstall_template(name_template, content_template)
 
     # Act
-    result = remote.get_template_file_for_system(name_system, name_template)
+    result = remote.get_template_file_for_system(system_uid, name_template)
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -357,7 +357,7 @@ def test_get_repos_compatible_with_profile(
     name_repo_compatible = "test_repo_compatible_profile_1"
     name_repo_incompatible = "test_repo_compatible_profile_2"
     distro_uid = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
-    create_profile(name_profile, distro_uid, "text")
+    profile_uid = create_profile(name_profile, distro_uid, "text")
     repo_compatible = create_repo(name_repo_compatible, "http://localhost", False)
     repo_incompatible = create_repo(name_repo_incompatible, "http://localhost", False)
     remote.modify_repo(repo_compatible, ["arch"], "x86_64", token)
@@ -366,7 +366,7 @@ def test_get_repos_compatible_with_profile(
     remote.save_repo(repo_incompatible, True, True, "bypass", token)
 
     # Act
-    result = remote.get_repos_compatible_with_profile(name_profile, token)
+    result = remote.get_repos_compatible_with_profile(profile_uid, token)
 
     # Assert
     assert result != []

--- a/tests/xmlrpcapi/miscellaneous_test.py
+++ b/tests/xmlrpcapi/miscellaneous_test.py
@@ -71,10 +71,10 @@ def test_disable_netboot(
 
     distro_uid = create_distro(name_distro, "x86_64", "suse", path_kernel, path_initrd)
     profile_uid = create_profile(name_profile, distro_uid, "text")
-    create_system(name_system, profile_uid)
+    system_uid = create_system(name_system, profile_uid)
 
     # Act
-    result = remote.disable_netboot(name_system, token)
+    result = remote.disable_netboot(system_uid, token)
 
     # Assert
     assert result

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -100,6 +100,35 @@ def test_background_power_system(
     wait_task_end(tid, remote)
 
 
+def test_background_syncsystems(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    wait_task_end: WaitTaskEndType,
+    create_kernel_initrd: Callable[[str, str], str],
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+):
+    """
+    Test: run a lite sync for a single system, identified by its uid
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(folder, fk_kernel)
+    path_initrd = os.path.join(folder, fk_initrd)
+    distro_uid = create_distro(
+        "test_distro_background_syncsystems", "x86_64", "suse", path_kernel, path_initrd
+    )
+    profile_uid = create_profile("test_profile_background_syncsystems", distro_uid, "")
+    system_uid = create_system("test_system_background_syncsystems", profile_uid)
+
+    # Act
+    tid = remote.background_syncsystems({"systems": [system_uid]}, token)
+    wait_task_end(tid, remote)
+
+
 def test_sync(
     remote: CobblerXMLRPCInterface, token: str, wait_task_end: WaitTaskEndType
 ):

--- a/tests/xmlrpcapi/non_object_calls_test.py
+++ b/tests/xmlrpcapi/non_object_calls_test.py
@@ -65,6 +65,41 @@ def test_power_system(
         wait_task_end(tid, remote)
 
 
+def test_background_power_system(
+    remote: CobblerXMLRPCInterface,
+    token: str,
+    wait_task_end: WaitTaskEndType,
+    create_kernel_initrd: Callable[[str, str], str],
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+):
+    """
+    Test: power a system asynchronously in the background, identified by its uid
+    """
+    # Arrange
+    fk_kernel = "vmlinuz1"
+    fk_initrd = "initrd1.img"
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    path_kernel = os.path.join(folder, fk_kernel)
+    path_initrd = os.path.join(folder, fk_initrd)
+    distro_uid = create_distro(
+        "test_distro_background_power_system",
+        "x86_64",
+        "suse",
+        path_kernel,
+        path_initrd,
+    )
+    profile_uid = create_profile("test_profile_background_power_system", distro_uid, "")
+    system_uid = create_system("test_system_background_power_system", profile_uid)
+
+    # Act
+    tid = remote.background_power_system(
+        {"systems": [system_uid], "power": "status"}, token
+    )
+    wait_task_end(tid, remote)
+
+
 def test_sync(
     remote: CobblerXMLRPCInterface, token: str, wait_task_end: WaitTaskEndType
 ):

--- a/tests/xmlrpcapi/profile_group_test.py
+++ b/tests/xmlrpcapi/profile_group_test.py
@@ -162,7 +162,7 @@ def test_get_profile_group_as_rendered(remote: CobblerXMLRPCInterface, token: st
     remote.save_profile_group(handle, True, True, "new", token)
 
     # Act
-    result = remote.get_profile_group_as_rendered("test_profile_group", token)
+    result = remote.get_profile_group_as_rendered(handle, token)
 
     # Assert
     assert result is not None

--- a/tests/xmlrpcapi/profile_test.py
+++ b/tests/xmlrpcapi/profile_test.py
@@ -385,14 +385,34 @@ def test_get_valid_profile_boot_loaders_no_profile(
     assert result != []
 
 
-def test_get_repo_config_for_profile(remote: CobblerXMLRPCInterface):
+def test_get_repo_config_for_profile(
+    request: "pytest.FixtureRequest",
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    remote: CobblerXMLRPCInterface,
+):
     """
     Test: get repository configuration of a profile
     """
-    # Arrange --> There is nothing to be arranged
+    # Arrange
+    distro_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    profile_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    kernel_path = os.path.join(folder, fk_kernel)
+    initrd_path = os.path.join(folder, fk_initrd)
+    distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
+    profile_handle = create_profile(profile_name, distro_handle, "")  # type: ignore
 
     # Act
-    result = remote.get_repo_config_for_profile("testprofile0")  # type: ignore
+    result = remote.get_repo_config_for_profile(profile_handle)  # type: ignore
 
-    # Assert --> Let the test pass if the call is okay.
-    assert True
+    # Assert
+    assert isinstance(result, str)
+    assert not result.startswith("# object not found")

--- a/tests/xmlrpcapi/profile_test.py
+++ b/tests/xmlrpcapi/profile_test.py
@@ -337,6 +337,54 @@ def test_remove_profile(
     assert result_profile_remove
 
 
+def test_get_valid_profile_boot_loaders(
+    request: "pytest.FixtureRequest",
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: get the valid boot loaders for a profile
+    """
+    # Arrange
+    distro_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    profile_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    kernel_path = os.path.join(folder, fk_kernel)
+    initrd_path = os.path.join(folder, fk_initrd)
+    distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
+    profile_handle = create_profile(profile_name, distro_handle, "")  # type: ignore
+
+    # Act
+    result = remote.get_valid_profile_boot_loaders(profile_handle, token)  # type: ignore
+
+    # Assert
+    assert isinstance(result, list)
+    assert result != []
+
+
+def test_get_valid_profile_boot_loaders_no_profile(
+    remote: CobblerXMLRPCInterface, token: str
+):
+    """
+    Test: get the valid boot loaders when no profile id is given returns all supported boot loaders
+    """
+    # Act
+    result = remote.get_valid_profile_boot_loaders(None, token)
+
+    # Assert
+    assert isinstance(result, list)
+    assert result != []
+
+
 def test_get_repo_config_for_profile(remote: CobblerXMLRPCInterface):
     """
     Test: get repository configuration of a profile

--- a/tests/xmlrpcapi/system_group_test.py
+++ b/tests/xmlrpcapi/system_group_test.py
@@ -162,7 +162,7 @@ def test_get_system_group_as_rendered(remote: CobblerXMLRPCInterface, token: str
     remote.save_system_group(handle, True, True, "new", token)
 
     # Act
-    result = remote.get_system_group_as_rendered("test_system_group", token)
+    result = remote.get_system_group_as_rendered(handle, token)
 
     # Assert
     assert result is not None

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -249,6 +249,59 @@ def test_remove_system(
     assert result
 
 
+def test_get_valid_system_boot_loaders(
+    request: "pytest.FixtureRequest",
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+    remote: CobblerXMLRPCInterface,
+    token: str,
+):
+    """
+    Test: get the valid boot loaders for a system
+    """
+    # Arrange
+    distro_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    profile_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    system_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    kernel_path = os.path.join(folder, fk_kernel)
+    initrd_path = os.path.join(folder, fk_initrd)
+    distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
+    profile_handle = create_profile(profile_name, distro_handle, "")  # type: ignore
+    system_handle = create_system(system_name, profile_handle)  # type: ignore
+
+    # Act
+    result = remote.get_valid_system_boot_loaders(system_handle, token)  # type: ignore
+
+    # Assert
+    assert isinstance(result, list)
+    assert result != []
+
+
+def test_get_valid_system_boot_loaders_no_system(
+    remote: CobblerXMLRPCInterface, token: str
+):
+    """
+    Test: get the valid boot loaders when no system id is given returns all supported boot loaders
+    """
+    # Act
+    result = remote.get_valid_system_boot_loaders(None, token)
+
+    # Assert
+    assert isinstance(result, list)
+    assert result != []
+
+
 def test_get_repo_config_for_system(remote: CobblerXMLRPCInterface):
     """
     Test: get repository configuration of a system

--- a/tests/xmlrpcapi/system_test.py
+++ b/tests/xmlrpcapi/system_test.py
@@ -302,18 +302,42 @@ def test_get_valid_system_boot_loaders_no_system(
     assert result != []
 
 
-def test_get_repo_config_for_system(remote: CobblerXMLRPCInterface):
+def test_get_repo_config_for_system(
+    request: "pytest.FixtureRequest",
+    create_kernel_initrd: Callable[[str, str], str],
+    fk_kernel: str,
+    fk_initrd: str,
+    create_distro: Callable[[str, str, str, str, str], str],
+    create_profile: Callable[[str, str, str], str],
+    create_system: Callable[[str, str], str],
+    remote: CobblerXMLRPCInterface,
+):
     """
     Test: get repository configuration of a system
     """
-
-    # Arrange --> There is nothing to be arranged
+    # Arrange
+    distro_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    profile_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    system_name = (  # type: ignore
+        request.node.originalname if request.node.originalname else request.node.name  # type: ignore
+    )
+    folder = create_kernel_initrd(fk_kernel, fk_initrd)
+    kernel_path = os.path.join(folder, fk_kernel)
+    initrd_path = os.path.join(folder, fk_initrd)
+    distro_handle = create_distro(distro_name, "x86_64", "suse", kernel_path, initrd_path)  # type: ignore
+    profile_handle = create_profile(profile_name, distro_handle, "")  # type: ignore
+    system_handle = create_system(system_name, profile_handle)  # type: ignore
 
     # Act
-    result = remote.get_repo_config_for_system("testprofile0")  # type: ignore
+    result = remote.get_repo_config_for_system(system_handle)  # type: ignore
 
-    # Assert --> Let the test pass if the call is okay.
-    assert True
+    # Assert
+    assert isinstance(result, str)
+    assert not result.startswith("# object not found")
 
 
 def test_dns_name_servers_inheritance(


### PR DESCRIPTION
## Linked Items

Relates to #3999 

## Description

This PR migrates the XML-RPC API methods from name to UID as a primary identifier for items. This is so that non-unique item names cannot cause an ambiguous match error and so the experience is unified.

## Behaviour changes

Old: The XML-RPC API had both names and UIDs used to identify items

New: The XML-RPC API uses UIDs in almost all cases to identify items

## Category

This is related to a:

- [ ] Bugfix
- [x] Feature
- [ ] Packaging
- [ ] Docs
- [ ] Code Quality
- [ ] Refactoring
- [ ] Miscellaneous

## Tests

- [x] Unit-Tests were created
- [ ] System-Tests were created
- [ ] Code is already covered by Unit-Tests
- [ ] Code is already covered by System-Tests
- [ ] No tests required 